### PR TITLE
chore: add issue templates and contribution config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: Something isn't working in Nimbalyst
+title: "[Bug]: "
+labels: ["type:bug", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill in the details below so we can reproduce and fix it.
+        For usage questions, please use [Discussions → Q&A](https://github.com/Nimbalyst/nimbalyst/discussions/categories/q-a) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Nimbalyst version
+      placeholder: e.g. 0.58.3
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - iOS
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots (optional)
+      description: Paste relevant logs or attach screenshots.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or help using Nimbalyst
+    url: https://github.com/Nimbalyst/nimbalyst/discussions/categories/q-a
+    about: Please ask in Discussions → Q&A.
+  - name: Vague idea or "wouldn't it be cool if..."
+    url: https://github.com/Nimbalyst/nimbalyst/discussions/categories/ideas
+    about: Half-baked ideas belong in Discussions → Ideas. Maintainers will convert mature ideas into Issues.
+  - name: Show what you built
+    url: https://github.com/Nimbalyst/nimbalyst/discussions/categories/show-and-tell
+    about: Built something cool with Nimbalyst? Share it in Show and tell.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest a concrete new feature or capability
+title: "[Feature]: "
+labels: ["type:feature", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a vague idea or "wouldn't it be cool if..."? Start in [Discussions → Ideas](https://github.com/Nimbalyst/nimbalyst/discussions/categories/ideas) instead.
+        This template is for concrete feature requests with a clear problem and proposed solution.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the user pain or workflow gap. Avoid jumping to a solution.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you build? Sketch the UX or behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else (optional)
+      description: Mockups, links to similar features in other tools, related issues.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@
 
 https://github.com/user-attachments/assets/b0ef69a4-d426-4c5c-8f64-be920fb431cc
 
+## Contributing
+
+- 🐛 **Found a bug?** → [Open an issue](https://github.com/Nimbalyst/nimbalyst/issues/new?template=bug_report.yml)
+- ✨ **Have a concrete feature request?** → [Open an issue](https://github.com/Nimbalyst/nimbalyst/issues/new?template=feature_request.yml)
+- 💡 **Have a vague idea or question?** → [Join the discussion](https://github.com/Nimbalyst/nimbalyst/discussions)
+- 🗺️ **Curious what we're building?** → [See the roadmap](TBD-PROJECT-URL)
+
+We rank features and bugs by 👍 reactions. Don't comment "+1" — react with 👍 instead.
+[Sort issues by reactions →](https://github.com/Nimbalyst/nimbalyst/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc)
+
 ## Features
 <b>Visual Editors:</b> Built-in WYSIWYG editors where you and your coding agents collaborate visually. Approve agent changes as red/green diffs, edit, annotate, and iterate.
 - Markdown
@@ -89,10 +99,6 @@ Download the latest version for your platform:
 ## Auto-Updates
 
 Nimbalyst automatically checks for updates and notifies you when a new version is available. You can also manually check via Help → Check for Updates.
-
-## Bug Reports & Feature Requests
-
-Found a bug or have a feature request? Please [create an issue](https://github.com/nimbalyst/nimbalyst/issues/new/choose).
 
 ## Community
 - [Documentation](https://docs.nimbalyst.com/) - Watch videos and read documentation


### PR DESCRIPTION
## Summary
- add bug report and feature request issue forms
- disable blank issues in favor of issues vs discussions routing
- add a contributing section to the README with issue/discussion guidance

## Notes
- roadmap link remains `TBD-PROJECT-URL` until the public project exists
- labels and discussion configuration are being handled separately