### PR TITLE
fix: scope Custom Claude Installation override per workspace

### DIFF
--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -1673,10 +1673,21 @@ app.whenReady().then(async () => {
     markEnd('session-restore');
 
     // Set up a loader that reads customClaudeCodePath fresh from the store on each query,
-    // so changes in the UI take effect without restarting the app.
-    const { store } = await import('./utils/store');
-    ClaudeCodeProvider.setCustomClaudeCodePathLoader(() => store.get('customClaudeCodePath', '') as string);
-    logger.main.info('[ClaudeCodeProvider] Initialized customClaudeCodePath loader');
+    // so changes in the UI take effect without restarting the app. Project-level overrides
+    // take precedence over the global value when a workspace path is provided.
+    const { store, getAIProviderOverrides } = await import('./utils/store');
+    ClaudeCodeProvider.setCustomClaudeCodePathLoader((workspacePath?: string) => {
+      const globalPath = (store.get('customClaudeCodePath', '') as string) || '';
+      if (!workspacePath) {
+        return globalPath;
+      }
+      const overrides = getAIProviderOverrides(workspacePath);
+      if (overrides?.customClaudeCodePath !== undefined) {
+        return overrides.customClaudeCodePath;
+      }
+      return globalPath;
+    });
+    logger.main.info('[ClaudeCodeProvider] Initialized customClaudeCodePath loader (workspace-aware)');
 
     // Close splash screen now that initialization is done and a real window is about to show.
     // The last restored window activates the app via its own ready-to-show handler.

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -3454,6 +3454,11 @@ export class AIService {
       const { 'openai-codex': _removed, ...restProviders } = normalizedProviders;
       if (Object.keys(restProviders).length === 0) {
         const { providers: _unusedProviders, ...restOverrides } = overrides;
+        // Drop fields that are explicitly empty so the override object collapses
+        // when the user has cleared every meaningful field.
+        if (restOverrides.customClaudeCodePath === undefined) {
+          delete restOverrides.customClaudeCodePath;
+        }
         return Object.keys(restOverrides).length > 0 ? restOverrides : undefined;
       }
       return { ...overrides, providers: restProviders };

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -3454,8 +3454,10 @@ export class AIService {
       const { 'openai-codex': _removed, ...restProviders } = normalizedProviders;
       if (Object.keys(restProviders).length === 0) {
         const { providers: _unusedProviders, ...restOverrides } = overrides;
-        // Drop fields that are explicitly empty so the override object collapses
-        // when the user has cleared every meaningful field.
+        // Strip the property when the caller passed it explicitly as `undefined`
+        // (e.g. clearing the override): the spread above still copies it as an
+        // own property, which would prevent the empty-overrides check below from
+        // collapsing the object back to `undefined`.
         if (restOverrides.customClaudeCodePath === undefined) {
           delete restOverrides.customClaudeCodePath;
         }

--- a/packages/electron/src/main/utils/aiSettingsMerge.ts
+++ b/packages/electron/src/main/utils/aiSettingsMerge.ts
@@ -18,6 +18,8 @@ export interface GlobalAISettings {
   showToolCalls: boolean;
   aiDebugLogging: boolean;
   showPromptAdditions: boolean;
+  /** Path to a custom Claude Code executable. Empty string means "use bundled SDK". */
+  customClaudeCodePath?: string;
 }
 
 /**
@@ -50,9 +52,11 @@ export interface EffectiveAISettings {
   showToolCalls: boolean;
   aiDebugLogging: boolean;
   showPromptAdditions: boolean;
+  customClaudeCodePath?: string;
   /** Which settings are overridden at project level */
   overrides: {
     defaultProvider: boolean;
+    customClaudeCodePath: boolean;
     providers: Record<string, { enabled?: boolean; models?: boolean; defaultModel?: boolean; apiKey?: boolean }>;
   };
 }
@@ -116,6 +120,7 @@ export function mergeAISettings(
       ...globalSettings,
       overrides: {
         defaultProvider: false,
+        customClaudeCodePath: false,
         providers: {},
       },
     };
@@ -130,6 +135,7 @@ export function mergeAISettings(
       ...globalSettings,
       overrides: {
         defaultProvider: false,
+        customClaudeCodePath: false,
         providers: {},
       },
     };
@@ -143,8 +149,10 @@ export function mergeAISettings(
     showToolCalls: globalSettings.showToolCalls,
     aiDebugLogging: globalSettings.aiDebugLogging,
     showPromptAdditions: globalSettings.showPromptAdditions,
+    customClaudeCodePath: globalSettings.customClaudeCodePath,
     overrides: {
       defaultProvider: false,
+      customClaudeCodePath: false,
       providers: {},
     },
   };
@@ -153,6 +161,12 @@ export function mergeAISettings(
   if (projectOverrides.defaultProvider !== undefined) {
     effective.defaultProvider = projectOverrides.defaultProvider;
     effective.overrides.defaultProvider = true;
+  }
+
+  // Override custom Claude Code executable path if set
+  if (projectOverrides.customClaudeCodePath !== undefined) {
+    effective.customClaudeCodePath = projectOverrides.customClaudeCodePath;
+    effective.overrides.customClaudeCodePath = true;
   }
 
   // Get all provider IDs (union of global and override)

--- a/packages/electron/src/main/utils/store.ts
+++ b/packages/electron/src/main/utils/store.ts
@@ -274,6 +274,8 @@ export interface ProviderOverride {
 export interface AIProviderOverrides {
   /** Override default provider for this project */
   defaultProvider?: string;
+  /** Override the path to a custom Claude Code executable for this project (empty string = use no custom path) */
+  customClaudeCodePath?: string;
   /** Per-provider overrides */
   providers?: Record<string, ProviderOverride>;
 }
@@ -994,7 +996,7 @@ function normalizeAIProviderOverrides(overrides: AIProviderOverrides | undefined
     const { 'openai-codex': _removed, ...restProviders } = normalizedProviders;
     const nextProviders = Object.keys(restProviders).length > 0 ? restProviders : undefined;
 
-    if (!nextProviders && !overrides.defaultProvider) {
+    if (!nextProviders && !overrides.defaultProvider && overrides.customClaudeCodePath === undefined) {
       return undefined;
     }
 

--- a/packages/electron/src/main/utils/store.ts
+++ b/packages/electron/src/main/utils/store.ts
@@ -274,7 +274,10 @@ export interface ProviderOverride {
 export interface AIProviderOverrides {
   /** Override default provider for this project */
   defaultProvider?: string;
-  /** Override the path to a custom Claude Code executable for this project (empty string = use no custom path) */
+  /** Override the path to a custom Claude Code executable for this project.
+   * Absent (undefined) means "inherit the global value"; any string set here is
+   * used as-is and overrides the global setting. To remove an existing override,
+   * delete the field rather than setting it to an empty string. */
   customClaudeCodePath?: string;
   /** Per-provider overrides */
   providers?: Record<string, ProviderOverride>;

--- a/packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePanel.tsx
+++ b/packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePanel.tsx
@@ -24,6 +24,10 @@ interface ClaudeCodePanelProps {
   onSelectAllModels: (selectAll: boolean) => void;
   onTestConnection: () => Promise<void>;
   onConfigChange: (updates: Partial<ProviderConfig>) => void;
+  /** Scope this panel is rendered for: 'user' edits global settings, 'project' edits the workspace override. */
+  scope?: 'user' | 'project';
+  /** Workspace path required when scope is 'project'. */
+  workspacePath?: string;
 }
 
 type AuthMethod = 'login' | 'api-key';
@@ -38,7 +42,9 @@ export function ClaudeCodePanel({
   onModelToggle,
   onSelectAllModels,
   onTestConnection,
-  onConfigChange
+  onConfigChange,
+  scope = 'user',
+  workspacePath,
 }: ClaudeCodePanelProps) {
   const [loginStatus, setLoginStatus] = useState<{
     isLoggedIn: boolean;
@@ -72,8 +78,12 @@ export function ClaudeCodePanel({
   const usageIndicatorEnabled = useAtomValue(claudeUsageIndicatorEnabledAtom);
   const setUsageIndicatorEnabled = useSetAtom(setClaudeUsageIndicatorEnabledAtom);
 
-  // Custom Claude executable path
+  // Custom Claude executable path. In project scope, `customClaudeCodePath` reflects the
+  // workspace override (empty string when no override is set, inheriting the global value);
+  // `globalCustomClaudeCodePath` carries the inherited global value to surface as placeholder.
   const [customClaudeCodePath, setCustomClaudeCodePathState] = useState('');
+  const [globalCustomClaudeCodePath, setGlobalCustomClaudeCodePath] = useState('');
+  const [hasProjectPathOverride, setHasProjectPathOverride] = useState(false);
 
   // Agent teams toggle (experimental) - stored as env var in ~/.claude/settings.json
   const [agentTeamsEnabled, setAgentTeamsEnabled] = useState(false);
@@ -147,7 +157,10 @@ export function ClaudeCodePanel({
     loadEnvVars();
 
     loadSettings();
-  }, [loadEnvVars]);
+    // loadSettings depends on scope/workspacePath; rerun when they change so the
+    // project-scoped panel reflects the active workspace's override.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadEnvVars, scope, workspacePath]);
 
   const checkLoginStatus = async () => {
     try {
@@ -187,23 +200,60 @@ export function ClaudeCodePanel({
   const loadSettings = async () => {
     try {
       const settings = await window.electronAPI.aiGetSettings();
-      setCustomClaudeCodePathState(settings?.customClaudeCodePath ?? '');
+      const globalPath = settings?.customClaudeCodePath ?? '';
+      setGlobalCustomClaudeCodePath(globalPath);
       setPlanTrackingEnabledState(settings?.planTrackingEnabled ?? true);
+
+      if (scope === 'project' && workspacePath) {
+        const result = await window.electronAPI.invoke('ai:getProjectSettings', workspacePath);
+        const projectPath = result?.success ? result?.overrides?.customClaudeCodePath : undefined;
+        if (projectPath !== undefined) {
+          setHasProjectPathOverride(true);
+          setCustomClaudeCodePathState(projectPath);
+        } else {
+          setHasProjectPathOverride(false);
+          setCustomClaudeCodePathState('');
+        }
+      } else {
+        setHasProjectPathOverride(false);
+        setCustomClaudeCodePathState(globalPath);
+      }
     } catch (error) {
       console.error('[ClaudeCodePanel] Failed to load settings:', error);
     }
   };
 
-  // Save custom Claude Code path
+  // Save custom Claude Code path. In project scope this writes to the workspace override;
+  // an empty string clears the override (the project then inherits the global value).
   const handleSaveCustomClaudeCodePath = async (newPath: string) => {
     const previousPath = customClaudeCodePath;
+    const previousHasOverride = hasProjectPathOverride;
     setCustomClaudeCodePathState(newPath);
+
     try {
-      // Send only the changed field -- ai:saveSettings handles partial updates
-      await window.electronAPI.aiSaveSettings({ customClaudeCodePath: newPath });
+      if (scope === 'project' && workspacePath) {
+        const current = await window.electronAPI.invoke('ai:getProjectSettings', workspacePath);
+        const baseOverrides = (current?.success && current?.overrides) ? { ...current.overrides } : {};
+        if (newPath === '') {
+          delete baseOverrides.customClaudeCodePath;
+          setHasProjectPathOverride(false);
+        } else {
+          baseOverrides.customClaudeCodePath = newPath;
+          setHasProjectPathOverride(true);
+        }
+        const saveResult = await window.electronAPI.invoke('ai:saveProjectSettings', workspacePath, baseOverrides);
+        if (!saveResult?.success) {
+          throw new Error(saveResult?.error || 'Failed to save project override');
+        }
+      } else {
+        // Send only the changed field -- ai:saveSettings handles partial updates
+        await window.electronAPI.aiSaveSettings({ customClaudeCodePath: newPath });
+        setGlobalCustomClaudeCodePath(newPath);
+      }
     } catch (error) {
       console.error('[ClaudeCodePanel] Failed to save custom Claude Code path:', error);
       setCustomClaudeCodePathState(previousPath);
+      setHasProjectPathOverride(previousHasOverride);
     }
   };
 
@@ -295,8 +345,9 @@ export function ClaudeCodePanel({
         <div>
           <span className="provider-enable-label text-sm font-medium text-[var(--nim-text)]">Custom Claude Installation</span>
           <p className="text-xs text-[var(--nim-text-muted)] mt-1">
-            Override the default Claude executable path. Use this to point to a custom Claude CLI wrapper
-            (e.g., for corporate SSO authentication).
+            {scope === 'project'
+              ? 'Override the Claude executable path for this project only. Leave empty to inherit the global setting.'
+              : 'Override the default Claude executable path. Use this to point to a custom Claude CLI wrapper (e.g., for corporate SSO authentication).'}
           </p>
         </div>
         <div className="flex items-center gap-2 mt-1">
@@ -311,7 +362,9 @@ export function ClaudeCodePanel({
                 (e.target as HTMLInputElement).blur();
               }
             }}
-            placeholder="/usr/local/bin/claude"
+            placeholder={scope === 'project' && globalCustomClaudeCodePath
+              ? `Inheriting: ${globalCustomClaudeCodePath}`
+              : '/usr/local/bin/claude'}
             className="flex-1 py-1.5 px-2 rounded text-sm bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] text-[var(--nim-text)] font-mono focus:border-[var(--nim-primary)] outline-none"
           />
           <button
@@ -322,7 +375,13 @@ export function ClaudeCodePanel({
           </button>
         </div>
         <p className="text-[11px] text-[var(--nim-text-faint)] leading-relaxed">
-          Leave empty to use the built-in SDK. Changes take effect on the next agent session.
+          {scope === 'project'
+            ? hasProjectPathOverride
+              ? 'Project-specific path active. Clear the field to remove the override and inherit the global value.'
+              : globalCustomClaudeCodePath
+                ? `Inheriting global path: ${globalCustomClaudeCodePath}. Type a value to override for this project only.`
+                : 'No global path set. Type a value to use a custom executable for this project only.'
+            : 'Leave empty to use the built-in SDK. Changes take effect on the next agent session.'}
         </p>
       </div>
 

--- a/packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePanel.tsx
+++ b/packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePanel.tsx
@@ -230,6 +230,15 @@ export function ClaudeCodePanel({
     const previousHasOverride = hasProjectPathOverride;
     setCustomClaudeCodePathState(newPath);
 
+    // Guard against a project-scoped edit accidentally falling through to the
+    // global save path when workspacePath has not been threaded in yet.
+    if (scope === 'project' && !workspacePath) {
+      console.error('[ClaudeCodePanel] Project scope requires workspacePath to save customClaudeCodePath; aborting.');
+      setCustomClaudeCodePathState(previousPath);
+      setHasProjectPathOverride(previousHasOverride);
+      return;
+    }
+
     try {
       if (scope === 'project' && workspacePath) {
         const current = await window.electronAPI.invoke('ai:getProjectSettings', workspacePath);

--- a/packages/electron/src/renderer/components/Settings/SettingsView.tsx
+++ b/packages/electron/src/renderer/components/Settings/SettingsView.tsx
@@ -525,7 +525,15 @@ export function SettingsView({
       case 'claude':
         return wrapWithOverride('claude', 'Claude', <ClaudePanel {...commonProps} />);
       case 'claude-code':
-        return wrapWithOverride('claude-code', 'Claude Agent', <ClaudeCodePanel {...commonProps} />);
+        return wrapWithOverride(
+          'claude-code',
+          'Claude Agent',
+          <ClaudeCodePanel
+            {...commonProps}
+            scope={scope === 'project' ? 'project' : 'user'}
+            workspacePath={scope === 'project' ? workspacePath ?? undefined : undefined}
+          />,
+        );
       case 'openai':
         return wrapWithOverride('openai', 'OpenAI', <OpenAIPanel {...commonProps} />);
       case 'openai-codex':

--- a/packages/electron/src/renderer/store/atoms/appSettings.ts
+++ b/packages/electron/src/renderer/store/atoms/appSettings.ts
@@ -1432,6 +1432,7 @@ export interface ProviderOverride {
  */
 export interface AIProviderOverrides {
   defaultProvider?: string;
+  customClaudeCodePath?: string;
   providers?: Record<string, ProviderOverride>;
 }
 

--- a/packages/runtime/src/ai/server/providers/claudeCode/dependencyInjection.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/dependencyInjection.ts
@@ -35,7 +35,9 @@ export const ClaudeCodeDeps = {
 
   // Loader that reads the custom Claude Code executable path fresh from the settings store.
   // Re-read on each query so changes in the UI take effect without restart.
-  customClaudeCodePathLoader: null as (() => string) | null,
+  // Receives the active workspace path so a project-level override can take precedence
+  // over the global setting; pass `undefined` to read the global value.
+  customClaudeCodePathLoader: null as ((workspacePath?: string) => string) | null,
 
   // ---- MCP Server Ports ----
 
@@ -118,7 +120,7 @@ export const ClaudeCodeDeps = {
   // ---- Setters ----
   // Called from electron main process at startup
 
-  setCustomClaudeCodePathLoader(loader: (() => string) | null): void {
+  setCustomClaudeCodePathLoader(loader: ((workspacePath?: string) => string) | null): void {
     this.customClaudeCodePathLoader = loader;
   },
 

--- a/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
@@ -113,7 +113,7 @@ export async function buildSdkOptions(
   }
 
   const resolvedBinaryPath = await resolveClaudeAgentCliPath().catch(() => undefined);
-  const customPath = ClaudeCodeDeps.customClaudeCodePathLoader?.() || '';
+  const customPath = ClaudeCodeDeps.customClaudeCodePathLoader?.(workspacePath) || '';
   const effectivePath = customPath || resolvedBinaryPath;
   console.log(`[CLAUDE-CODE] Binary path: custom=${customPath || '(none)'} resolved=${resolvedBinaryPath ?? '(none)'} effective=${effectivePath ?? '(none)'}`);
 


### PR DESCRIPTION
## Summary

The "Custom Claude Installation" field in **Settings → Project → Claude Agent** was persisted as a single global key (top-level `customClaudeCodePath` in `ai-settings.json`), so any value set in the Project tab leaked into the User scope and into every other project. It was the only AI setting in the panel that bypassed the per-workspace override mechanism already used by `defaultProvider`, `apiKey`, `models`, `defaultModel`, and `enabled`.

This PR wires `customClaudeCodePath` into the existing override infrastructure, mirroring the `defaultProvider` pattern.

Fixes #125.

## Approach

- **Schema** (`packages/electron/src/main/utils/aiSettingsMerge.ts`, `packages/electron/src/main/utils/store.ts`, `packages/electron/src/renderer/store/atoms/appSettings.ts`): add `customClaudeCodePath` to `GlobalAISettings`, `EffectiveAISettings`, `EffectiveAISettings.overrides`, and `AIProviderOverrides`. Extend `mergeAISettings` with the same conditional override block already used for `defaultProvider`. Update `normalizeAIProviderOverrides` (in `store.ts` and the parallel implementation in `AIService.ts`) so the new field is considered when collapsing an empty override object.
- **Loader** (`packages/runtime/src/ai/server/providers/claudeCode/dependencyInjection.ts`, `packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts`): change the loader signature from `() => string` to `(workspacePath?: string) => string`. `sdkOptionsBuilder` now forwards the active `workspacePath` (already in scope at the `cwd` line). The loader registered in `packages/electron/src/main/index.ts` resolves the project override first and falls back to the global value.
- **UI** (`packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePanel.tsx`, `packages/electron/src/renderer/components/Settings/SettingsView.tsx`): add `scope` and `workspacePath` props to `ClaudeCodePanel` (matching the convention used by `MCPServersPanel`). In project scope the panel reads/writes the workspace override through the existing `ai:getProjectSettings` / `ai:saveProjectSettings` IPC handlers; clearing the field clears the override so the project re-inherits the global value. The placeholder and helper copy surface the inherited global path so the inheritance state is obvious. `SettingsView` passes the matching scope and workspace path when rendering the panel.

## Backward compatibility

The global top-level `customClaudeCodePath` key in `ai-settings.json` is preserved unchanged. Existing users keep their global value with no migration. Project overrides are opt-in and stored under `WorkspaceState.aiProviderOverrides.customClaudeCodePath`.

## Test plan

- [x] `tsc --noEmit` clean in `packages/electron`
- [x] `tsc --noEmit` clean in `packages/runtime`
- [x] `npm run test:unit` passes (1929 passed, 26 skipped, no regressions)
- [x] Manual: User scope sets a custom path; `ai-settings.json` continues to write to the top-level `customClaudeCodePath` key (no behavior change for existing users)
- [x] Manual: Project scope sets a different custom path; the value is written to `aiProviderOverrides.customClaudeCodePath` in the workspace state and the global key is left untouched
- [x] Manual: Starting a Claude Agent session in the overridden project logs `[CLAUDE-CODE] Binary path: custom=<project-path>`; starting a session in another project without an override logs `custom=<global-path>` (no leakage)
- [x] Manual: Clearing the field in project scope removes the override and the project re-inherits the global value on the next session