### PR TITLE
fix: inherit project customClaudeCodePath override inside worktrees

### DIFF
--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -1702,7 +1702,7 @@ app.whenReady().then(async () => {
           parentPath = await resolveWorkspacePathForPermissions(workspacePath);
         } catch (error) {
           logger.main.warn(
-            `[ClaudeCodeProvider] Failed to resolve worktree parent via DB, falling back to regex: ${(error as Error).message}`
+            `[ClaudeCodeProvider] Failed to resolve worktree parent via DB, falling back to regex: ${error instanceof Error ? error.message : String(error)}`
           );
           parentPath = resolveProjectPath(workspacePath);
         }

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -63,7 +63,9 @@ import {
     clearPendingThemeFallback,
     updateWorkspaceState,
     runMigrations,
-    getAppSetting
+    getAppSetting,
+    store,
+    getAIProviderOverrides
 } from './utils/store';
 import { registerMCPConfigHandlers } from './ipc/MCPConfigHandlers';
 import { getOpenCodeConfigService, registerOpenCodeConfigHandlers } from './ipc/OpenCodeConfigHandlers';
@@ -74,7 +76,7 @@ import { MCPConfigService } from './services/MCPConfigService';
 import { registerDatabaseBrowserHandlers } from './ipc/DatabaseBrowserHandlers';
 import { registerTerminalHandlers, shutdownTerminalHandlers } from './ipc/TerminalHandlers';
 import { AIService } from './services/ai/AIService';
-import { detectFileWorkspace, suggestWorkspaceForFile, getAdditionalDirectoriesForWorkspace } from './utils/workspaceDetection';
+import { detectFileWorkspace, suggestWorkspaceForFile, getAdditionalDirectoriesForWorkspace, isWorktreePath, resolveProjectPath } from './utils/workspaceDetection';
 import { cliManager, initEnhancedPath, getEnhancedPath, getShellEnvironment } from './services/CLIManager';
 import { registerWorkspaceWindow, registerExtensionTools, shutdownHttpServer, startMcpHttpServer, updateDocumentState } from './mcp/httpServer';
 import { startSessionContextServer, cleanupSessionContextServer, shutdownSessionContextServer } from './mcp/sessionContextServer';
@@ -124,7 +126,7 @@ import { initTrackerSchemaService, updateTrackerSchemaWorkspace } from './servic
 import { registerTeamHandlers, autoMatchTeamForWorkspace } from './services/TeamService';
 import { registerOrgKeyHandlers } from './services/OrgKeyService';
 import { registerDocumentSyncHandlers } from './ipc/DocumentSyncHandlers';
-import { getPermissionService } from './services/PermissionService';
+import { getPermissionService, resolveWorkspacePathForPermissions } from './services/PermissionService';
 import { ClaudeSettingsManager } from './services/ClaudeSettingsManager';
 import { TrayManager } from './tray/TrayManager';
 import { pathToFileURL } from 'url';
@@ -1676,21 +1678,46 @@ app.whenReady().then(async () => {
     markEnd('session-restore');
 
     // Set up a loader that reads customClaudeCodePath fresh from the store on each query,
-    // so changes in the UI take effect without restarting the app. Project-level overrides
-    // take precedence over the global value when a workspace path is provided.
-    const { store, getAIProviderOverrides } = await import('./utils/store');
-    ClaudeCodeProvider.setCustomClaudeCodePathLoader((workspacePath?: string) => {
+    // so changes in the UI take effect without restarting the app. The lookup tries the
+    // incoming workspace path first (so a worktree-specific override wins) and falls back
+    // to the parent project's override when the path is a worktree, mirroring how
+    // PermissionService resolves trust. Loader is async because parent resolution may hit
+    // the database; failures degrade gracefully to the synchronous regex fallback so a
+    // session is never blocked from starting.
+    ClaudeCodeProvider.setCustomClaudeCodePathLoader(async (workspacePath?: string) => {
       const globalPath = (store.get('customClaudeCodePath', '') as string) || '';
+
       if (!workspacePath) {
         return globalPath;
       }
-      const overrides = getAIProviderOverrides(workspacePath);
-      if (overrides?.customClaudeCodePath !== undefined) {
-        return overrides.customClaudeCodePath;
+
+      const directOverride = getAIProviderOverrides(workspacePath)?.customClaudeCodePath;
+      if (directOverride !== undefined) {
+        return directOverride;
       }
+
+      if (isWorktreePath(workspacePath)) {
+        let parentPath: string;
+        try {
+          parentPath = await resolveWorkspacePathForPermissions(workspacePath);
+        } catch (error) {
+          logger.main.warn(
+            `[ClaudeCodeProvider] Failed to resolve worktree parent via DB, falling back to regex: ${(error as Error).message}`
+          );
+          parentPath = resolveProjectPath(workspacePath);
+        }
+        const parentOverride = getAIProviderOverrides(parentPath)?.customClaudeCodePath;
+        if (parentOverride !== undefined) {
+          logger.main.info(
+            `[ClaudeCodeProvider] customClaudeCodePath: worktree '${workspacePath}' inherited from parent '${parentPath}'`
+          );
+          return parentOverride;
+        }
+      }
+
       return globalPath;
     });
-    logger.main.info('[ClaudeCodeProvider] Initialized customClaudeCodePath loader (workspace-aware)');
+    logger.main.info('[ClaudeCodeProvider] Initialized customClaudeCodePath loader (workspace-aware, worktree-aware)');
 
     // Close splash screen now that initialization is done and a real window is about to show.
     // The last restored window activates the app via its own ready-to-show handler.

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -212,7 +212,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
   // All static fields and setters live in ClaudeCodeDeps.
   // These forwarding setters maintain backward compatibility for callers.
 
-  public static setCustomClaudeCodePathLoader(loader: (() => string) | null): void { ClaudeCodeDeps.setCustomClaudeCodePathLoader(loader); }
+  public static setCustomClaudeCodePathLoader(loader: ((workspacePath?: string) => string | Promise<string>) | null): void { ClaudeCodeDeps.setCustomClaudeCodePathLoader(loader); }
 
   constructor() {
     super();

--- a/packages/runtime/src/ai/server/providers/claudeCode/dependencyInjection.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/dependencyInjection.ts
@@ -37,7 +37,7 @@ export const ClaudeCodeDeps = {
   // Re-read on each query so changes in the UI take effect without restart.
   // Receives the active workspace path so a project-level override can take precedence
   // over the global setting; pass `undefined` to read the global value.
-  customClaudeCodePathLoader: null as ((workspacePath?: string) => string) | null,
+  customClaudeCodePathLoader: null as ((workspacePath?: string) => string | Promise<string>) | null,
 
   // ---- MCP Server Ports ----
 
@@ -120,7 +120,7 @@ export const ClaudeCodeDeps = {
   // ---- Setters ----
   // Called from electron main process at startup
 
-  setCustomClaudeCodePathLoader(loader: ((workspacePath?: string) => string) | null): void {
+  setCustomClaudeCodePathLoader(loader: ((workspacePath?: string) => string | Promise<string>) | null): void {
     this.customClaudeCodePathLoader = loader;
   },
 

--- a/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
@@ -113,7 +113,7 @@ export async function buildSdkOptions(
   }
 
   const resolvedBinaryPath = await resolveClaudeAgentCliPath().catch(() => undefined);
-  const customPath = ClaudeCodeDeps.customClaudeCodePathLoader?.(workspacePath) || '';
+  const customPath = (await ClaudeCodeDeps.customClaudeCodePathLoader?.(workspacePath)) || '';
   const effectivePath = customPath || resolvedBinaryPath;
   console.log(`[CLAUDE-CODE] Binary path: custom=${customPath || '(none)'} resolved=${resolvedBinaryPath ?? '(none)'} effective=${effectivePath ?? '(none)'}`);
 


### PR DESCRIPTION
## Summary

The per-workspace `customClaudeCodePath` override is keyed by the normalized workspace path. Sessions running in a git worktree pass the worktree path (`<root>_worktrees/<name>`) into the loader, which never matches the entry stored under the parent project path. The loader silently fell back to the (empty) global value and the bundled SDK binary, bypassing the wrapper the user configured at the project scope.

This change makes the loader resolve the worktree to its parent project on a miss, reusing the same DB-aware resolution that `PermissionService` already uses for trust. Worktree-specific overrides still win because the direct lookup runs first.

## Lookup order

1. `getAIProviderOverrides(workspacePath)` — direct hit; a worktree-keyed override wins if one is ever written.
2. If `isWorktreePath(workspacePath)`, resolve the parent via `resolveWorkspacePathForPermissions(workspacePath)` (DB lookup against `worktrees.path`), then `getAIProviderOverrides(parentPath)`.
3. Fall back to the global value.

Resilience: the parent resolution call is wrapped in `try/catch`; on any failure (DB not initialized, query error, race during shutdown) the loader falls back to the synchronous `resolveProjectPath` regex so a session is never blocked from starting.

## Other small cleanups

- Replaced the `await import('./utils/store')` inside `app.whenReady` with a top-level static import, per the rule in `CLAUDE.md` against dynamic imports in the main process. The dynamic form also risked picking up a separate module instance with a stale `electron-store` cache.
- Updated `customClaudeCodePathLoader` and the static forwarder on `ClaudeCodeProvider` to accept `string | Promise<string>`, since the loader now needs an async path. The single call site in `sdkOptionsBuilder.ts` is already inside an async function and has been updated to `await` the call.

## Files changed

- `packages/electron/src/main/index.ts` — loader registration; static imports; two-step lookup with try/catch fallback.
- `packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts` — static forwarder signature.
- `packages/runtime/src/ai/server/providers/claudeCode/dependencyInjection.ts` — loader type.
- `packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts` — `await` the loader call.

No new utilities introduced; reuses `resolveWorkspacePathForPermissions`, `isWorktreePath`, `resolveProjectPath`, and `getAIProviderOverrides`.

## Test plan

- [x] TypeScript build of `packages/runtime` (`npm run build`).
- [x] TypeScript typecheck of `packages/electron` (`npx tsc --noEmit -p .`) — pre-existing unrelated `ThemesPanel.tsx` errors only; no new errors.

### Verification logs (anonymized)

Project root:

```
[HH:MM:SS] (MAIN) : [CLAUDE-CODE] Binary path: custom=/home/<user>/.local/bin/<wrapper>.sh resolved=/home/<user>/<nimbalyst-checkout>/packages/electron/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude effective=/home/<user>/.local/bin/<wrapper>.sh
```

Worktree:

```
[HH:MM:SS] (MAIN) : [ClaudeCodeProvider] customClaudeCodePath: worktree '/home/<user>/projects/<project>_worktrees/<worktree>' inherited from parent '/home/<user>/projects/<project>'
[HH:MM:SS] (MAIN) : [CLAUDE-CODE] Binary path: custom=/home/<user>/.local/bin/<wrapper>.sh resolved=/home/<user>/<nimbalyst-checkout>/packages/electron/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude effective=/home/<user>/.local/bin/<wrapper>.sh
```

## Related

Closes #130. Follow-up to #128 / #125.