### PR TITLE
feat: expose xhigh effort level option

### DIFF
--- a/packages/runtime/src/ai/server/effortLevels.ts
+++ b/packages/runtime/src/ai/server/effortLevels.ts
@@ -2,21 +2,22 @@
  * Effort level constants for adaptive reasoning (Opus 4.6 and Sonnet 4.6).
  * Matches the Claude Code CLI's /model effort slider and CLAUDE_CODE_EFFORT_LEVEL env var.
  *
- * Levels: low, medium, high (default), max
+ * Levels: low, medium, high (default), xhigh, max
  */
 
-export type EffortLevel = 'low' | 'medium' | 'high' | 'max';
+export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 export const EFFORT_LEVELS: { key: EffortLevel; label: string }[] = [
   { key: 'low', label: 'Low' },
   { key: 'medium', label: 'Medium' },
   { key: 'high', label: 'High' },
+  { key: 'xhigh', label: 'xHigh' },
   { key: 'max', label: 'Max' },
 ];
 
 export const DEFAULT_EFFORT_LEVEL: EffortLevel = 'high';
 
-const VALID_EFFORT_LEVELS = new Set<string>(['low', 'medium', 'high', 'max']);
+const VALID_EFFORT_LEVELS = new Set<string>(['low', 'medium', 'high', 'xhigh', 'max']);
 
 /**
  * Validate and return a valid EffortLevel, or the default if invalid.


### PR DESCRIPTION
## Summary

The Effort Level selector exposed only four options (low, medium, high, max), but the underlying Claude Code CLI's `/effort` slider supports five (low, medium, high, xhigh, max). This PR adds `xhigh` so users can select the reasoning tier that sits between `high` and `max`.

The change is contained to `packages/runtime/src/ai/server/effortLevels.ts`: the `EffortLevel` type union, the `EFFORT_LEVELS` array (so `EffortLevelSelector` renders the new option automatically) and the `VALID_EFFORT_LEVELS` set used by `parseEffortLevel`. The selected level is forwarded unchanged through the `CLAUDE_CODE_EFFORT_LEVEL` env var in `sdkOptionsBuilder.ts`, which the CLI already accepts.

## Related issue

Closes #132

## Testing

- `npm run typecheck` in `packages/runtime` passes.
- Manually verified `xHigh` appears in the Effort Level dropdown in the AI input and that selecting it persists via session metadata.
- No unit or e2e tests reference effort levels, so no test updates were required.

## Notes for reviewers

- Label is `xHigh` (lowercase `x`) for visual consistency with the rest of the slider.
- `CodexSDKProtocol.ts` keeps its existing `max -> xhigh` remap untouched; both `max` and `xhigh` from the UI now resolve to `xhigh` for Codex, which matches prior behavior for `max` and adds an explicit path for users who pick `xhigh`.
- iOS `ModelLabel.swift` does not surface effort levels, so no Swift mirror change was needed.