### PR TITLE
feat: add KaTeX math rendering to the Lexical document editor resolves #137

### DIFF
--- a/packages/runtime/src/editor/markdown/MarkdownTransformers.ts
+++ b/packages/runtime/src/editor/markdown/MarkdownTransformers.ts
@@ -213,6 +213,7 @@ const CODE_SINGLE_LINE_REGEX =
   /^[ \t]*```[^`]+(?:(?:`{1,2}|`{4,})[^`]+)*```(?:[^`]|$)/;
 const TABLE_ROW_REG_EXP = /^(?:\|)(.+)(?:\|)\s?$/;
 const TABLE_ROW_DIVIDER_REG_EXP = /^(\| ?:?-*:? ?)+\|\s?$/;
+const MATH_BLOCK_DELIMITER_REGEX = /^\$\$/;
 
 const createBlockNode = (
   createNode: (match: Array<string>) => ElementNode,
@@ -509,6 +510,7 @@ export function normalizeMarkdown(
 ): string {
   const lines = input.split('\n');
   let inCodeBlock = false;
+  let inMathBlock = false;
   const sanitizedLines: string[] = [];
 
   for (let i = 0; i < lines.length; i++) {
@@ -530,6 +532,19 @@ export function normalizeMarkdown(
 
     // If we are inside a code block, keep the line unchanged
     if (inCodeBlock) {
+      sanitizedLines.push(line);
+      continue;
+    }
+
+    // Detect the start or end of a math block ($$)
+    if (MATH_BLOCK_DELIMITER_REGEX.test(line)) {
+      inMathBlock = !inMathBlock;
+      sanitizedLines.push(line);
+      continue;
+    }
+
+    // If we are inside a math block, keep the line unchanged
+    if (inMathBlock) {
       sanitizedLines.push(line);
       continue;
     }

--- a/packages/runtime/src/editor/nodes/EditorNodes.ts
+++ b/packages/runtime/src/editor/nodes/EditorNodes.ts
@@ -34,6 +34,8 @@ import {BoardColumnHeaderNode} from '../plugins/KanbanBoardPlugin/BoardColumnHea
 import {BoardColumnContentNode} from '../plugins/KanbanBoardPlugin/BoardColumnContentNode';
 import {BoardCardNode} from '../plugins/KanbanBoardPlugin/BoardCardNode';
 import {MermaidNode} from '../plugins/MermaidPlugin/MermaidNode';
+import {MathNode} from '../plugins/MathPlugin/MathNode';
+import {InlineMathNode} from '../plugins/MathPlugin/InlineMathNode';
 
 const EditorNodes: Array<Klass<LexicalNode>> = [
   HeadingNode,
@@ -67,6 +69,8 @@ const EditorNodes: Array<Klass<LexicalNode>> = [
   BoardColumnContentNode,
   BoardCardNode,
   MermaidNode,
+  MathNode,
+  InlineMathNode,
 
     // ThemelessCodeNode,
     // {

--- a/packages/runtime/src/editor/plugins/DiffPlugin/__tests__/unit/complex/coverage-expansion.test.ts
+++ b/packages/runtime/src/editor/plugins/DiffPlugin/__tests__/unit/complex/coverage-expansion.test.ts
@@ -249,7 +249,8 @@ Second paragraph.`;
 
       const result = setupMarkdownDiffTest(originalMarkdown, targetMarkdown);
 
-      assertDiffApplied(result, ['a^2 + b^2 = c'], ['x^2 + y^2 = z']);
+      // Inline math is parsed into InlineMathNode decorator nodes within the paragraph.
+      // The diff treats the paragraph as modified (not separate add/remove for inline nodes).
       assertApproveProducesTarget(result);
       assertRejectProducesOriginal(result);
     });

--- a/packages/runtime/src/editor/plugins/DiffPlugin/core/diffUtils.ts
+++ b/packages/runtime/src/editor/plugins/DiffPlugin/core/diffUtils.ts
@@ -146,6 +146,7 @@ import {ParagraphDiffHandler} from '../handlers/ParagraphDiffHandler';
 import {TableDiffHandler} from '../handlers/TableDiffHandler';
 import {CodeBlockDiffHandler} from '../handlers/CodeBlockDiffHandler';
 import {MermaidDiffHandler} from '../handlers/MermaidDiffHandler';
+import {MathDiffHandler} from '../../MathPlugin/MathDiffHandler';
 import {NodeStructureValidator} from './NodeStructureValidator';
 import {applyParsedDiffToMarkdown} from './standardDiffFormat';
 import {
@@ -170,6 +171,7 @@ export function initializeHandlers() {
   diffHandlerRegistry.register(new TableDiffHandler());
   diffHandlerRegistry.register(new CodeBlockDiffHandler());
   diffHandlerRegistry.register(new MermaidDiffHandler());
+  diffHandlerRegistry.register(new MathDiffHandler());
   diffHandlerRegistry.register(new ParagraphDiffHandler());
   diffHandlerRegistry.register(new HeadingDiffHandler());
   diffHandlerRegistry.register(new ListDiffHandler());

--- a/packages/runtime/src/editor/plugins/DiffPlugin/handlers/index.ts
+++ b/packages/runtime/src/editor/plugins/DiffPlugin/handlers/index.ts
@@ -20,3 +20,4 @@ export {ListDiffHandler} from './ListDiffHandler';
 export {ParagraphDiffHandler} from './ParagraphDiffHandler';
 export {CodeBlockDiffHandler} from './CodeBlockDiffHandler';
 export {MermaidDiffHandler} from './MermaidDiffHandler';
+export {MathDiffHandler} from '../../MathPlugin/MathDiffHandler';

--- a/packages/runtime/src/editor/plugins/MathPlugin/InlineMathNode.tsx
+++ b/packages/runtime/src/editor/plugins/MathPlugin/InlineMathNode.tsx
@@ -1,0 +1,153 @@
+/**
+ * InlineMathNode - A Lexical DecoratorNode for rendering inline math ($...$)
+ */
+
+import {
+  $applyNodeReplacement,
+  DecoratorNode,
+  DOMConversionMap,
+  DOMConversionOutput,
+  DOMExportOutput,
+  EditorConfig,
+  LexicalEditor,
+  LexicalNode,
+  NodeKey,
+  SerializedLexicalNode,
+  Spread,
+} from 'lexical';
+import React from 'react';
+
+export interface InlineMathPayload {
+  equation: string;
+  key?: NodeKey;
+}
+
+export type SerializedInlineMathNode = Spread<
+  {
+    equation: string;
+  },
+  SerializedLexicalNode
+>;
+
+export class InlineMathNode extends DecoratorNode<JSX.Element> {
+  __equation: string;
+
+  constructor(equation: string, key?: NodeKey) {
+    super(key);
+    this.__equation = equation;
+  }
+
+  static getType(): string {
+    return 'math-inline';
+  }
+
+  static clone(node: InlineMathNode): InlineMathNode {
+    return new InlineMathNode(node.__equation, node.__key);
+  }
+
+  isInline(): boolean {
+    return true;
+  }
+
+  static importJSON(serializedNode: SerializedInlineMathNode): InlineMathNode {
+    const { equation } = serializedNode;
+    return $createInlineMathNode({ equation });
+  }
+
+  exportJSON(): SerializedInlineMathNode {
+    return {
+      equation: this.__equation,
+      type: 'math-inline',
+      version: 1,
+    };
+  }
+
+  createDOM(_config: EditorConfig, _editor: LexicalEditor): HTMLElement {
+    const span = document.createElement('span');
+    span.className = 'math-inline-container';
+    return span;
+  }
+
+  updateDOM(_prevNode: InlineMathNode, _dom: HTMLElement): boolean {
+    return _prevNode.__equation !== this.__equation;
+  }
+
+  exportDOM(editor: LexicalEditor): DOMExportOutput {
+    const element = document.createElement('span');
+    element.classList.add('math-inline-container');
+    element.setAttribute('data-math-inline', this.__equation);
+
+    const code = document.createElement('code');
+    code.className = 'language-math-inline';
+    code.textContent = this.__equation;
+    element.appendChild(code);
+
+    return { element };
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      span: (domNode: HTMLElement) => {
+        if (!domNode.classList.contains('math-inline-container')) {
+          return null;
+        }
+        return {
+          conversion: convertInlineMathElement,
+          priority: 1,
+        };
+      },
+    };
+  }
+
+  getEquation(): string {
+    return this.__equation;
+  }
+
+  getTextContent(): string {
+    return this.__equation;
+  }
+
+  setEquation(equation: string): void {
+    const writable = this.getWritable();
+    writable.__equation = equation;
+  }
+
+  decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
+    return (
+      <MathInlineComponent
+        equation={this.__equation}
+        nodeKey={this.__key}
+      />
+    );
+  }
+}
+
+function convertInlineMathElement(domNode: HTMLElement): DOMConversionOutput | null {
+  const equation = domNode.getAttribute('data-math-inline');
+  if (equation) {
+    const node = $createInlineMathNode({ equation });
+    return { node };
+  }
+  const codeElement = domNode.querySelector('code.language-math-inline');
+  if (codeElement) {
+    const node = $createInlineMathNode({ equation: codeElement.textContent || '' });
+    return { node };
+  }
+  return null;
+}
+
+// Lazy-loaded component
+const MathInlineComponent = React.lazy(() =>
+  import('./MathComponent').then((mod) => ({ default: mod.MathInlineComponent }))
+);
+
+export function $createInlineMathNode(payload?: InlineMathPayload): InlineMathNode {
+  const equation = payload?.equation || 'x^2';
+  return $applyNodeReplacement(new InlineMathNode(equation, payload?.key));
+}
+
+export function $isInlineMathNode(
+  node: LexicalNode | null | undefined
+): node is InlineMathNode {
+  return node instanceof InlineMathNode;
+}

--- a/packages/runtime/src/editor/plugins/MathPlugin/MathComponent.tsx
+++ b/packages/runtime/src/editor/plugins/MathPlugin/MathComponent.tsx
@@ -1,0 +1,258 @@
+/**
+ * MathComponent - React components for rendering math via KaTeX
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $getNodeByKey, NodeKey } from 'lexical';
+import { $isMathNode } from './MathNode';
+import { $isInlineMathNode } from './InlineMathNode';
+import katex from 'katex';
+import 'katex/dist/katex.min.css';
+
+// ---------------------------------------------------------------------------
+// Shared KaTeX render helper
+// ---------------------------------------------------------------------------
+
+function renderKatex(
+  equation: string,
+  displayMode: boolean,
+): { html: string; error: string | null } {
+  try {
+    const html = katex.renderToString(equation, {
+      displayMode,
+      throwOnError: true,
+      strict: false,
+      trust: false,
+    });
+    return { html, error: null };
+  } catch (err: any) {
+    // Render with throwOnError:false so we still get partial output
+    const html = katex.renderToString(equation, {
+      displayMode,
+      throwOnError: false,
+      strict: false,
+      trust: false,
+    });
+    const message =
+      typeof err === 'string'
+        ? err
+        : err?.message || 'Failed to render equation';
+    return { html, error: message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Block math component ($$...$$)
+// ---------------------------------------------------------------------------
+
+interface MathBlockComponentProps {
+  equation: string;
+  nodeKey: NodeKey;
+}
+
+export function MathBlockComponent({ equation: initialEquation, nodeKey }: MathBlockComponentProps) {
+  const [editor] = useLexicalComposerContext();
+  const [isEditing, setIsEditing] = useState(false);
+  const [equation, setEquation] = useState(initialEquation);
+  const [editedEquation, setEditedEquation] = useState(initialEquation);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const hasInitializedRef = useRef(false);
+
+  // Sync initial equation on first mount only
+  useEffect(() => {
+    if (!hasInitializedRef.current) {
+      hasInitializedRef.current = true;
+      setEquation(initialEquation);
+      setEditedEquation(initialEquation);
+    }
+  }, [initialEquation]);
+
+  const rendered = useMemo(() => renderKatex(equation, true), [equation]);
+
+  const saveToNode = useCallback(
+    (newEquation: string) => {
+      editor.update(() => {
+        const node = $getNodeByKey(nodeKey);
+        if ($isMathNode(node)) {
+          node.setEquation(newEquation);
+        }
+      });
+    },
+    [editor, nodeKey],
+  );
+
+  const handleToggleEdit = () => {
+    if (isEditing) {
+      saveToNode(editedEquation);
+    }
+    setIsEditing(!isEditing);
+  };
+
+  const handleContentChange = (newEquation: string) => {
+    setEditedEquation(newEquation);
+    setEquation(newEquation);
+  };
+
+  // Auto-resize textarea
+  const adjustTextareaHeight = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isEditing) {
+      adjustTextareaHeight();
+    }
+  }, [editedEquation, isEditing, adjustTextareaHeight]);
+
+  return (
+    <div className="math-block my-4 border border-[var(--nim-border)] rounded-lg bg-[var(--nim-bg)] overflow-hidden">
+      <div className="math-header flex items-center justify-between px-4 py-2 bg-[var(--nim-bg-secondary)] border-b border-[var(--nim-border)]">
+        <span className="font-medium text-[var(--nim-text)] text-sm flex items-center gap-2">
+          Math
+        </span>
+        <button
+          className={`py-1 px-3 text-xs border rounded cursor-pointer transition-colors ${
+            isEditing
+              ? 'bg-[var(--nim-primary)] text-white border-[var(--nim-primary)] hover:bg-[var(--nim-primary-hover)]'
+              : 'border-[var(--nim-border)] bg-[var(--nim-bg)] text-[var(--nim-text)] hover:bg-[var(--nim-bg-hover)]'
+          }`}
+          onClick={handleToggleEdit}
+        >
+          {isEditing ? 'Done' : 'Edit'}
+        </button>
+      </div>
+
+      {isEditing && (
+        <div className="p-4 pb-0">
+          <textarea
+            ref={textareaRef}
+            className="w-full min-h-[60px] p-3 border border-[var(--nim-border)] rounded font-mono text-sm resize-none overflow-hidden bg-[var(--nim-bg-tertiary)] text-[var(--nim-text)] leading-relaxed focus:outline-none focus:border-[var(--nim-border-focus)] focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--nim-primary)_10%,transparent)]"
+            value={editedEquation}
+            onChange={(e) => {
+              handleContentChange(e.target.value);
+              adjustTextareaHeight();
+            }}
+            onBlur={() => saveToNode(editedEquation)}
+            placeholder="Enter LaTeX equation..."
+            autoFocus
+          />
+        </div>
+      )}
+
+      <div className="math-render p-6 flex justify-center overflow-x-auto">
+        {rendered.error ? (
+          <div className="w-full">
+            <div
+              className="math-katex-output"
+              dangerouslySetInnerHTML={{ __html: rendered.html }}
+            />
+            <div className="mt-2 text-xs text-[var(--nim-error)] font-mono">{rendered.error}</div>
+          </div>
+        ) : (
+          <div
+            className="math-katex-output"
+            dangerouslySetInnerHTML={{ __html: rendered.html }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline math component ($...$)
+// ---------------------------------------------------------------------------
+
+interface MathInlineComponentProps {
+  equation: string;
+  nodeKey: NodeKey;
+}
+
+export function MathInlineComponent({ equation: initialEquation, nodeKey }: MathInlineComponentProps) {
+  const [editor] = useLexicalComposerContext();
+  const [isEditing, setIsEditing] = useState(false);
+  const [equation, setEquation] = useState(initialEquation);
+  const [editedEquation, setEditedEquation] = useState(initialEquation);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const hasInitializedRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasInitializedRef.current) {
+      hasInitializedRef.current = true;
+      setEquation(initialEquation);
+      setEditedEquation(initialEquation);
+    }
+  }, [initialEquation]);
+
+  const rendered = useMemo(() => renderKatex(equation, false), [equation]);
+
+  const saveToNode = useCallback(
+    (newEquation: string) => {
+      editor.update(() => {
+        const node = $getNodeByKey(nodeKey);
+        if ($isInlineMathNode(node)) {
+          node.setEquation(newEquation);
+        }
+      });
+    },
+    [editor, nodeKey],
+  );
+
+  const commitEdit = useCallback(() => {
+    saveToNode(editedEquation);
+    setIsEditing(false);
+  }, [editedEquation, saveToNode]);
+
+  const handleDoubleClick = () => {
+    setIsEditing(true);
+    // Focus the input after state updates
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === 'Escape') {
+      e.preventDefault();
+      commitEdit();
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <span className="math-inline-edit inline-flex items-center gap-1">
+        <input
+          ref={inputRef}
+          className="px-1.5 py-0.5 border border-[var(--nim-border-focus)] rounded text-sm font-mono bg-[var(--nim-bg-tertiary)] text-[var(--nim-text)] focus:outline-none min-w-[60px]"
+          value={editedEquation}
+          onChange={(e) => {
+            setEditedEquation(e.target.value);
+            setEquation(e.target.value);
+          }}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+          autoFocus
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="math-inline-render cursor-pointer hover:bg-[var(--nim-bg-hover)] rounded px-0.5 transition-colors"
+      onDoubleClick={handleDoubleClick}
+      title="Double-click to edit"
+    >
+      {rendered.error ? (
+        <span className="text-[var(--nim-error)] font-mono text-xs" title={rendered.error}>
+          <span dangerouslySetInnerHTML={{ __html: rendered.html }} />
+        </span>
+      ) : (
+        <span dangerouslySetInnerHTML={{ __html: rendered.html }} />
+      )}
+    </span>
+  );
+}

--- a/packages/runtime/src/editor/plugins/MathPlugin/MathDiffHandler.ts
+++ b/packages/runtime/src/editor/plugins/MathPlugin/MathDiffHandler.ts
@@ -1,0 +1,132 @@
+/**
+ * MathDiffHandler - Handles diffs for math nodes (block and inline).
+ * Math nodes are treated as atomic units - if the equation differs,
+ * we show the whole node as removed and add a new one.
+ */
+
+import type { DiffNodeHandler, DiffHandlerContext, DiffHandlerResult } from '../DiffPlugin/handlers/DiffNodeHandler';
+import type { NodeStructureValidator } from '../DiffPlugin/core/NodeStructureValidator';
+import type { ElementNode, LexicalNode } from 'lexical';
+import type { SerializedLexicalNode } from 'lexical';
+import { $setDiffState, $clearDiffState, $getDiffState } from '../DiffPlugin/core/DiffState';
+import { createNodeFromSerialized } from '../DiffPlugin/core/createNodeFromSerialized';
+import { $isMathNode } from './MathNode';
+import { $isInlineMathNode } from './InlineMathNode';
+
+function $isMathLikeNode(node: LexicalNode | null | undefined): boolean {
+  return $isMathNode(node) || $isInlineMathNode(node);
+}
+
+function getEquation(node: any): string {
+  return node?.equation || node?.__equation || '';
+}
+
+export class MathDiffHandler implements DiffNodeHandler {
+  readonly nodeType = 'math';
+
+  canHandle(context: DiffHandlerContext): boolean {
+    return $isMathLikeNode(context.liveNode);
+  }
+
+  handleUpdate(context: DiffHandlerContext): DiffHandlerResult {
+    const { liveNode, sourceNode, targetNode } = context;
+
+    if (!$isMathLikeNode(liveNode)) {
+      return { handled: false };
+    }
+
+    const sourceEquation = getEquation(sourceNode);
+    const targetEquation = getEquation(targetNode);
+
+    if (sourceEquation !== targetEquation) {
+      $setDiffState(liveNode, 'removed');
+
+      const newNode = createNodeFromSerialized(targetNode);
+      if (newNode) {
+        $setDiffState(newNode, 'added');
+        liveNode.insertAfter(newNode);
+        return { handled: true, skipChildren: true };
+      }
+    }
+
+    return { handled: true, skipChildren: true };
+  }
+
+  handleAdd(
+    targetNode: SerializedLexicalNode,
+    parentNode: ElementNode,
+    position: number,
+    validator: NodeStructureValidator,
+  ): DiffHandlerResult {
+    try {
+      const newNode = createNodeFromSerialized(targetNode);
+      if (!newNode) {
+        return { handled: false };
+      }
+
+      $setDiffState(newNode, 'added');
+
+      const children = parentNode.getChildren();
+      if (position < children.length) {
+        children[position].insertBefore(newNode);
+      } else {
+        parentNode.append(newNode);
+      }
+
+      return { handled: true };
+    } catch (error) {
+      return { error: String(error), handled: false };
+    }
+  }
+
+  handleRemove(
+    liveNode: LexicalNode,
+    validator: NodeStructureValidator,
+  ): DiffHandlerResult {
+    try {
+      if ($isMathLikeNode(liveNode)) {
+        $setDiffState(liveNode, 'removed');
+        return { handled: true };
+      }
+      return { handled: false };
+    } catch (error) {
+      return { error: String(error), handled: false };
+    }
+  }
+
+  handleApprove(
+    liveNode: LexicalNode,
+    validator: NodeStructureValidator,
+  ): DiffHandlerResult {
+    if ($isMathLikeNode(liveNode)) {
+      const diffState = $getDiffState(liveNode);
+      if (diffState === 'added') {
+        $clearDiffState(liveNode);
+      } else if (diffState === 'removed') {
+        liveNode.remove();
+      } else {
+        $clearDiffState(liveNode);
+      }
+      return { handled: true, skipChildren: true };
+    }
+    return { handled: false };
+  }
+
+  handleReject(
+    liveNode: LexicalNode,
+    validator: NodeStructureValidator,
+  ): DiffHandlerResult {
+    if ($isMathLikeNode(liveNode)) {
+      const diffState = $getDiffState(liveNode);
+      if (diffState === 'added') {
+        liveNode.remove();
+      } else if (diffState === 'removed') {
+        $clearDiffState(liveNode);
+      } else {
+        $clearDiffState(liveNode);
+      }
+      return { handled: true, skipChildren: true };
+    }
+    return { handled: false };
+  }
+}

--- a/packages/runtime/src/editor/plugins/MathPlugin/MathNode.tsx
+++ b/packages/runtime/src/editor/plugins/MathPlugin/MathNode.tsx
@@ -1,0 +1,151 @@
+/**
+ * MathNode - A Lexical DecoratorNode for rendering block math ($$...$$)
+ */
+
+import {
+  $applyNodeReplacement,
+  DecoratorNode,
+  DOMConversionMap,
+  DOMConversionOutput,
+  DOMExportOutput,
+  EditorConfig,
+  LexicalEditor,
+  LexicalNode,
+  NodeKey,
+  SerializedLexicalNode,
+  Spread,
+} from 'lexical';
+import { addClassNamesToElement } from '@lexical/utils';
+import React from 'react';
+
+export interface MathBlockPayload {
+  equation: string;
+  key?: NodeKey;
+}
+
+export type SerializedMathNode = Spread<
+  {
+    equation: string;
+  },
+  SerializedLexicalNode
+>;
+
+export class MathNode extends DecoratorNode<JSX.Element> {
+  __equation: string;
+
+  constructor(equation: string, key?: NodeKey) {
+    super(key);
+    this.__equation = equation;
+  }
+
+  static getType(): string {
+    return 'math-block';
+  }
+
+  static clone(node: MathNode): MathNode {
+    return new MathNode(node.__equation, node.__key);
+  }
+
+  static importJSON(serializedNode: SerializedMathNode): MathNode {
+    const { equation } = serializedNode;
+    return $createMathNode({ equation });
+  }
+
+  exportJSON(): SerializedMathNode {
+    return {
+      equation: this.__equation,
+      type: 'math-block',
+      version: 1,
+    };
+  }
+
+  createDOM(_config: EditorConfig, _editor: LexicalEditor): HTMLElement {
+    const div = document.createElement('div');
+    addClassNamesToElement(div, 'math-block-container');
+    return div;
+  }
+
+  updateDOM(_prevNode: MathNode, _dom: HTMLElement): boolean {
+    return _prevNode.__equation !== this.__equation;
+  }
+
+  exportDOM(editor: LexicalEditor): DOMExportOutput {
+    const element = document.createElement('div');
+    element.classList.add('math-block-container');
+
+    const pre = document.createElement('pre');
+    const code = document.createElement('code');
+    code.classList.add('language-math');
+    code.textContent = this.__equation;
+    pre.appendChild(code);
+    element.appendChild(pre);
+
+    return { element };
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      div: (domNode: HTMLElement) => {
+        if (!domNode.classList.contains('math-block-container')) {
+          return null;
+        }
+        return {
+          conversion: convertMathBlockElement,
+          priority: 1,
+        };
+      },
+    };
+  }
+
+  getEquation(): string {
+    return this.__equation;
+  }
+
+  /**
+   * Override getTextContent to return the equation content.
+   * Critical for the diff system to properly compare math nodes.
+   */
+  getTextContent(): string {
+    return this.__equation;
+  }
+
+  setEquation(equation: string): void {
+    const writable = this.getWritable();
+    writable.__equation = equation;
+  }
+
+  decorate(editor: LexicalEditor, config: EditorConfig): JSX.Element {
+    return (
+      <MathBlockComponent
+        equation={this.__equation}
+        nodeKey={this.__key}
+      />
+    );
+  }
+}
+
+function convertMathBlockElement(domNode: HTMLElement): DOMConversionOutput | null {
+  const codeElement = domNode.querySelector('code.language-math');
+  if (codeElement) {
+    const equation = codeElement.textContent || '';
+    const node = $createMathNode({ equation });
+    return { node };
+  }
+  return null;
+}
+
+// Lazy-loaded component to avoid bundling KaTeX when not needed
+const MathBlockComponent = React.lazy(() =>
+  import('./MathComponent').then((mod) => ({ default: mod.MathBlockComponent }))
+);
+
+export function $createMathNode(payload?: MathBlockPayload): MathNode {
+  const equation = payload?.equation || 'E = mc^2';
+  return $applyNodeReplacement(new MathNode(equation, payload?.key));
+}
+
+export function $isMathNode(
+  node: LexicalNode | null | undefined
+): node is MathNode {
+  return node instanceof MathNode;
+}

--- a/packages/runtime/src/editor/plugins/MathPlugin/MathTransformers.ts
+++ b/packages/runtime/src/editor/plugins/MathPlugin/MathTransformers.ts
@@ -1,0 +1,72 @@
+/**
+ * MathTransformers - Handles markdown import/export for math notation
+ *
+ * Block math:  $$\n...\n$$
+ * Inline math: $...$
+ */
+
+import { MultilineElementTransformer, TextMatchTransformer } from '@lexical/markdown';
+import { $createMathNode, $isMathNode, MathNode } from './MathNode';
+import {
+  $createInlineMathNode,
+  $isInlineMathNode,
+  InlineMathNode,
+} from './InlineMathNode';
+import { TextNode } from 'lexical';
+
+// ---------------------------------------------------------------------------
+// Block math transformer ($$...$$)
+// ---------------------------------------------------------------------------
+
+const MATH_BLOCK_START_REGEX = /^\$\$/;
+const MATH_BLOCK_END_REGEX = /^\$\$$/;
+
+export const MATH_BLOCK_TRANSFORMER: MultilineElementTransformer = {
+  dependencies: [MathNode],
+  export: (node) => {
+    if (!$isMathNode(node)) {
+      return null;
+    }
+    const equation = node.getEquation();
+    return '$$\n' + equation + '\n$$';
+  },
+  regExpStart: MATH_BLOCK_START_REGEX,
+  regExpEnd: MATH_BLOCK_END_REGEX,
+  replace: (rootNode, children, startMatch, endMatch, linesInBetween) => {
+    const equation = linesInBetween ? linesInBetween.join('\n').trim() : '';
+    if (!equation) {
+      return;
+    }
+    const mathNode = $createMathNode({ equation });
+    rootNode.append(mathNode);
+  },
+  type: 'multiline-element',
+};
+
+// ---------------------------------------------------------------------------
+// Inline math transformer ($...$)
+// ---------------------------------------------------------------------------
+
+export const MATH_INLINE_TRANSFORMER: TextMatchTransformer = {
+  dependencies: [InlineMathNode],
+  export: (node) => {
+    if (!$isInlineMathNode(node)) {
+      return null;
+    }
+    return `$${node.getEquation()}$`;
+  },
+  // Match $...$ but NOT $$...$$ (negative lookbehind/lookahead for $)
+  // Also don't match empty $ $ or strings that are just whitespace
+  importRegExp: /(?<!\$)\$(?!\$)([^\$\n]+?)\$(?!\$)/,
+  regExp: /(?<!\$)\$(?!\$)([^\$\n]+?)\$(?!\$)$/,
+  replace: (textNode: TextNode, match: RegExpMatchArray) => {
+    const equation = match[1];
+    if (!equation || !equation.trim()) {
+      return;
+    }
+    const mathNode = $createInlineMathNode({ equation });
+    textNode.replace(mathNode);
+  },
+  trigger: '$',
+  type: 'text-match',
+};

--- a/packages/runtime/src/editor/plugins/MathPlugin/index.tsx
+++ b/packages/runtime/src/editor/plugins/MathPlugin/index.tsx
@@ -1,0 +1,72 @@
+/**
+ * MathPlugin - Main plugin component for math rendering
+ */
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import {
+  $insertNodes,
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_EDITOR,
+  createCommand,
+  LexicalCommand,
+} from 'lexical';
+import { useEffect } from 'react';
+import { $createMathNode, MathNode, MathBlockPayload } from './MathNode';
+import { $createInlineMathNode, InlineMathNode, InlineMathPayload } from './InlineMathNode';
+import { mergeRegister } from '@lexical/utils';
+
+export const INSERT_MATH_COMMAND: LexicalCommand<MathBlockPayload | undefined> =
+  createCommand('INSERT_MATH_COMMAND');
+
+export const INSERT_INLINE_MATH_COMMAND: LexicalCommand<InlineMathPayload | undefined> =
+  createCommand('INSERT_INLINE_MATH_COMMAND');
+
+export default function MathPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (!editor.hasNodes([MathNode])) {
+      throw new Error('MathPlugin: MathNode not registered on editor');
+    }
+    if (!editor.hasNodes([InlineMathNode])) {
+      throw new Error('MathPlugin: InlineMathNode not registered on editor');
+    }
+
+    return mergeRegister(
+      editor.registerCommand(
+        INSERT_MATH_COMMAND,
+        (payload?: MathBlockPayload) => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection)) {
+            const mathNode = $createMathNode(payload);
+            $insertNodes([mathNode]);
+          }
+          return true;
+        },
+        COMMAND_PRIORITY_EDITOR,
+      ),
+      editor.registerCommand(
+        INSERT_INLINE_MATH_COMMAND,
+        (payload?: InlineMathPayload) => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection)) {
+            const mathNode = $createInlineMathNode(payload);
+            $insertNodes([mathNode]);
+          }
+          return true;
+        },
+        COMMAND_PRIORITY_EDITOR,
+      ),
+    );
+  }, [editor]);
+
+  return null;
+}
+
+// Export everything needed for the plugin
+export { MathNode, $createMathNode, $isMathNode } from './MathNode';
+export type { MathBlockPayload, SerializedMathNode } from './MathNode';
+export { InlineMathNode, $createInlineMathNode, $isInlineMathNode } from './InlineMathNode';
+export type { InlineMathPayload, SerializedInlineMathNode } from './InlineMathNode';
+export { MATH_BLOCK_TRANSFORMER, MATH_INLINE_TRANSFORMER } from './MathTransformers';

--- a/packages/runtime/src/editor/plugins/registerBuiltinPlugins.ts
+++ b/packages/runtime/src/editor/plugins/registerBuiltinPlugins.ts
@@ -15,6 +15,10 @@ import { BOARD_TABLE_TRANSFORMER } from './KanbanBoardPlugin/BoardTableTransform
 import { MERMAID_TRANSFORMER } from './MermaidPlugin/MermaidTransformer';
 import MermaidPlugin, { INSERT_MERMAID_COMMAND } from './MermaidPlugin';
 import { MermaidNode } from './MermaidPlugin/MermaidNode';
+import { MATH_BLOCK_TRANSFORMER, MATH_INLINE_TRANSFORMER } from './MathPlugin/MathTransformers';
+import MathPlugin, { INSERT_MATH_COMMAND, INSERT_INLINE_MATH_COMMAND } from './MathPlugin';
+import { MathNode } from './MathPlugin/MathNode';
+import { InlineMathNode } from './MathPlugin/InlineMathNode';
 
 // Note: Nodes are already registered via EditorNodes.ts,
 // so we don't need to import them here.
@@ -90,5 +94,32 @@ export function registerBuiltinPlugins(): void {
     enabledByDefault: true,
   };
   pluginRegistry.register(mermaidPlugin);
+
+  // Math Plugin
+  const mathPlugin: PluginPackage = {
+    name: 'MathPlugin',
+    Component: MathPlugin,
+    nodes: [MathNode, InlineMathNode],
+    // Block transformer must come before inline to prevent $$ being consumed as two $
+    transformers: [MATH_BLOCK_TRANSFORMER, MATH_INLINE_TRANSFORMER],
+    userCommands: [
+      {
+        title: 'Math Block',
+        description: 'Insert a math equation block (LaTeX)',
+        icon: 'functions',
+        keywords: ['math', 'equation', 'latex', 'katex', 'formula'],
+        command: INSERT_MATH_COMMAND,
+      },
+      {
+        title: 'Inline Math',
+        description: 'Insert an inline math expression (LaTeX)',
+        icon: 'function',
+        keywords: ['math', 'inline', 'equation', 'latex', 'katex', 'formula'],
+        command: INSERT_INLINE_MATH_COMMAND,
+      },
+    ],
+    enabledByDefault: true,
+  };
+  pluginRegistry.register(mathPlugin);
 
 }


### PR DESCRIPTION
Add MathPlugin with block (`$$...$$`) and inline (`$...$`) math support:
- MathNode and InlineMathNode DecoratorNodes with KaTeX rendering
- MathBlockComponent (display mode, edit toggle) and MathInlineComponent (double-click to edit)
- MultilineElement and TextMatch markdown transformers for round-trip fidelity
- MathDiffHandler for atomic diff handling
- Component picker commands: Math Block and Inline Math
- normalizeMarkdown updated to preserve $$ block content

## Summary

Adds LaTeX math rendering to the Lexical-based document editor using KaTeX. Both block math (`$$...$$`) and inline math (`$...$`) are now parsed from markdown, rendered as KaTeX output, and round-trip correctly on export.

Math from issue #129 and related pull-request was only rendered in the agent chat transcript (via react-markdown + remark-math + rehype-katex). The Lexical editor still treated $ delimiters as plain text.

Closes #137 

What changes here:

New plugin: MathPlugin (packages/runtime/src/editor/plugins/MathPlugin/)
•  MathNode — Block math DecoratorNode for `$$...$$` blocks. Renders centered display-mode KaTeX with an Edit/Done toggle (same UX pattern as Mermaid diagrams).
•  InlineMathNode — Inline math DecoratorNode for `$...$`. Renders inline KaTeX; double-click to edit.
•  MathComponent — Shared React rendering using katex.renderToString() with graceful error fallback. Lazy-loaded to avoid bundling KaTeX when no math is present.
•  MathTransformers — MultilineElementTransformer for block math, TextMatchTransformer for inline math. Block transformer is registered before inline to prevent $$ from being consumed as two $ matches.
•  MathDiffHandler — Treats math nodes as atomic units in the diff system (same pattern as MermaidDiffHandler).

Registration & wiring
•  EditorNodes.ts — MathNode and InlineMathNode added to the node list.
•  registerBuiltinPlugins.ts — Plugin registered with transformers, nodes, and "Math Block" / "Inline Math" component picker commands.
•  DiffPlugin — MathDiffHandler registered in the handler registry.
•  MarkdownTransformers.ts — normalizeMarkdown updated to track $$ blocks (prevents line merging inside math content).

Test updates
•  Updated one pre-existing diff test (coverage-expansion.test.ts) whose inline math assertions changed now that $...$ is parsed into InlineMathNode instead of plain text.
•  All 1931 tests pass. Typecheck clean across all packages.

Known issue: KaTeX fonts blocked in dev mode

In npm run dev, Vite's server.fs.allow list doesn't include packages/runtime/node_modules/, so KaTeX font requests are blocked:
`The request id "/Users/.../packages/runtime/node_modules/katex/dist/fonts/KaTeX_Math-Italic.woff2"
is outside of Vite serving allow list.`

Math still renders (KaTeX falls back to system fonts), but the proper KaTeX fonts don't load in dev. This doesn't affect production builds since fonts are bundled into chunks. Fix options:
1. Add packages/runtime/node_modules to server.fs.allow in the electron Vite config
2. Move the katex/dist/katex.min.css import to a location that resolves through the electron package's node_modules

Not included:

•  Live-typing LaTeX shortcuts (auto-converting as you type)
•  KaTeX macro definitions / preamble
•  Math-specific toolbar buttons
