### PR TITLE
fix: use getTime() for TIMESTAMPTZ wakeups and queued prompts

### DIFF
--- a/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
+++ b/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
@@ -73,26 +73,16 @@ type PGliteLike = {
 
 type EnsureReadyFn = () => Promise<void>;
 
-/**
- * Convert a Date from PGLite to epoch milliseconds.
- * PGLite returns Date objects that are parsed as local time but represent UTC.
- */
 function toMillis(date: Date | string | null | undefined): number {
   if (!date) return 0;
-  if (typeof date === 'string') {
-    return new Date(date).getTime();
+  if (date instanceof Date) {
+    return date.getTime();
   }
-  // PGLite returns Date objects - extract components and treat as UTC
-  const d = date as Date;
-  return Date.UTC(
-    d.getFullYear(),
-    d.getMonth(),
-    d.getDate(),
-    d.getHours(),
-    d.getMinutes(),
-    d.getSeconds(),
-    d.getMilliseconds()
-  );
+  const str = String(date).trim();
+  const hasTimezone =
+    str.endsWith('Z') || str.includes('+') || /-\d{2}:\d{2}$/.test(str);
+  const parsed = new Date(hasTimezone ? str : str.replace(' ', 'T') + 'Z').getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
 }
 
 function rowToQueuedPrompt(row: any): QueuedPrompt {

--- a/packages/electron/src/main/services/PGLiteSessionWakeupsStore.ts
+++ b/packages/electron/src/main/services/PGLiteSessionWakeupsStore.ts
@@ -81,19 +81,14 @@ type EnsureReadyFn = () => Promise<void>;
 
 function toMillis(date: Date | string | null | undefined): number {
   if (!date) return 0;
-  if (typeof date === 'string') {
-    return new Date(date).getTime();
+  if (date instanceof Date) {
+    return date.getTime();
   }
-  const d = date as Date;
-  return Date.UTC(
-    d.getFullYear(),
-    d.getMonth(),
-    d.getDate(),
-    d.getHours(),
-    d.getMinutes(),
-    d.getSeconds(),
-    d.getMilliseconds(),
-  );
+  const str = String(date).trim();
+  const hasTimezone =
+    str.endsWith('Z') || str.includes('+') || /-\d{2}:\d{2}$/.test(str);
+  const parsed = new Date(hasTimezone ? str : str.replace(' ', 'T') + 'Z').getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
 }
 
 function rowToWakeup(row: any): SessionWakeup {


### PR DESCRIPTION
## Summary

Fix timezone handling in the Electron PGLite wakeup and queued prompt stores by treating `TIMESTAMPTZ` `Date` values as real instants and converting them with `getTime()`.

## Related issue

Closes #139

## Testing

Validated the staged patch with `git diff --check`.

I did not run automated tests here because this is a narrow timestamp-conversion fix and I did not find targeted test coverage for these two store helpers.

## Notes for reviewers

The root cause is that both stores were reconstructing `Date` values with `Date.UTC(...)` using local-time getters such as `getHours()` and `getFullYear()`. That reinterprets local calendar components as UTC and shifts the instant by the machine timezone offset.

This PR brings those two stores back in line with the repo's existing `TIMESTAMPTZ` guidance and the `getTime()` approach already used elsewhere in the Electron package.
