### PR TITLE
fix: only forward child session:completed to parent on terminal idle

### DIFF
--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -89,7 +89,6 @@ export class MetaAgentService {
   private sessionManager: SessionManager | null = null;
   private unsubscribeStateListener: (() => void) | null = null;
   private notificationSignatures = new Map<string, string>();
-  private notificationCounter = 0;
   private ipcHandlersRegistered = false;
 
   private constructor() {}
@@ -191,7 +190,6 @@ export class MetaAgentService {
     this.unsubscribeStateListener?.();
     this.unsubscribeStateListener = null;
     this.notificationSignatures.clear();
-    this.notificationCounter = 0;
     await shutdownMetaAgentServer();
     ClaudeCodeProvider.setMetaAgentServerPort(null);
     OpenAICodexProvider.setMetaAgentServerPort(null);
@@ -706,12 +704,45 @@ export class MetaAgentService {
         return;
       }
 
+      // NIM-6: session:completed fires on every turn idle, not only on terminal
+      // completion. If the child still has more prompts queued AFTER the one
+      // that just finished, this idle is a between-turn pause -- another
+      // session:completed will follow once the queue drains. Suppress it; the
+      // parent will be notified on the genuinely terminal idle (queue empty).
+      //
+      // The just-finished prompt is still in `executing` status at the moment
+      // session:completed fires (MessageStreamingHandler marks it `completed`
+      // only after endSession returns). So we count only `pending` rows --
+      // counting `executing` would include the current turn itself and
+      // suppress every notification, including the final terminal one.
+      //
+      // The other event types (error/waiting/interrupted) are always
+      // meaningful and pass through.
+      if (eventType === 'session:completed') {
+        const { rows: pendingRows } = await databaseWorker.query<{ count: string }>(
+          `SELECT COUNT(*)::text AS count FROM queued_prompts
+           WHERE session_id = $1 AND status = 'pending'`,
+          [sessionId]
+        );
+        const pendingCount = Number(pendingRows[0]?.count ?? '0');
+        if (pendingCount > 0) {
+          return;
+        }
+      }
+
       const metaStatusRow = await this.getSessionStatusRow(metaSession.id, metaSession.workspacePath);
       const metaStatus = (metaStatusRow?.status || 'idle') as SessionStatusValue;
 
       const result = await this.buildSessionResultData(sessionId, session.workspacePath);
-      this.notificationCounter += 1;
-      const signature = `${eventType}:${result.status}:${result.lastActivity || 0}:${result.pendingPrompt?.promptId || ''}:${this.notificationCounter}`;
+
+      // NIM-6: real dedup gate. Drop notifications whose semantic content is
+      // identical to the last one delivered for this child. The previous code
+      // mixed in an always-incrementing counter, which made every signature
+      // unique and the dedup useless.
+      const signature = `${eventType}:${result.status}:${result.pendingPrompt?.promptId || ''}:${result.lastResponse || ''}`;
+      if (this.notificationSignatures.get(sessionId) === signature) {
+        return;
+      }
       this.notificationSignatures.set(sessionId, signature);
 
       if (result.pendingPrompt?.promptType === 'exit_plan_mode_request') {

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -19,6 +19,7 @@ import {
   setMetaAgentToolFns,
   shutdownMetaAgentServer,
 } from '../mcp/metaAgentServer';
+import { computeNotificationSignature } from './metaAgentNotificationSignature';
 
 type SessionStatusValue = 'idle' | 'running' | 'waiting_for_input' | 'error' | 'interrupted';
 type PromptType = 'permission_request' | 'ask_user_question_request' | 'exit_plan_mode_request';
@@ -166,6 +167,14 @@ export class MetaAgentService {
       OpenAICodexACPProvider.setMetaAgentServerPort(result.port);
 
       this.unsubscribeStateListener = getSessionStateManager().subscribe((event) => {
+        // NIM-6 follow-up: dedup signatures only describe one turn; clear them
+        // when a child becomes active again so two distinct turns whose final
+        // text happens to match (e.g. "done", "ok") still each notify the
+        // parent.
+        if (event.type === 'session:started' || event.type === 'session:streaming') {
+          this.notificationSignatures.delete(event.sessionId);
+          return;
+        }
         if (event.type === 'session:completed' || event.type === 'session:error' || event.type === 'session:waiting' || event.type === 'session:interrupted') {
           void this.handleChildSessionEvent(event.sessionId, event.type);
         }
@@ -738,8 +747,10 @@ export class MetaAgentService {
       // NIM-6: real dedup gate. Drop notifications whose semantic content is
       // identical to the last one delivered for this child. The previous code
       // mixed in an always-incrementing counter, which made every signature
-      // unique and the dedup useless.
-      const signature = `${eventType}:${result.status}:${result.pendingPrompt?.promptId || ''}:${result.lastResponse || ''}`;
+      // unique and the dedup useless. The signature is reset on
+      // session:started/session:streaming (see start()), so it only collapses
+      // duplicates within a single child turn -- not across turns.
+      const signature = computeNotificationSignature(eventType, result);
       if (this.notificationSignatures.get(sessionId) === signature) {
         return;
       }

--- a/packages/electron/src/main/services/__tests__/metaAgentNotificationSignature.test.ts
+++ b/packages/electron/src/main/services/__tests__/metaAgentNotificationSignature.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeNotificationSignature,
+  type NotificationEventType,
+  type NotificationSignatureInput,
+} from '../metaAgentNotificationSignature';
+
+function input(overrides: Partial<NotificationSignatureInput> = {}): NotificationSignatureInput {
+  return {
+    status: 'idle',
+    pendingPrompt: null,
+    lastResponse: null,
+    errorMessage: null,
+    ...overrides,
+  };
+}
+
+describe('computeNotificationSignature', () => {
+  it('produces identical signatures when every component matches', () => {
+    const a = computeNotificationSignature('session:completed', input({ lastResponse: 'done' }));
+    const b = computeNotificationSignature('session:completed', input({ lastResponse: 'done' }));
+
+    expect(a).toBe(b);
+  });
+
+  it('discriminates by event type', () => {
+    const completed = computeNotificationSignature('session:completed', input());
+    const errored = computeNotificationSignature('session:error', input());
+    const waiting = computeNotificationSignature('session:waiting', input());
+    const interrupted = computeNotificationSignature('session:interrupted', input());
+
+    const signatures = new Set([completed, errored, waiting, interrupted]);
+    expect(signatures.size).toBe(4);
+  });
+
+  it('discriminates by status', () => {
+    const idle = computeNotificationSignature('session:completed', input({ status: 'idle' }));
+    const error = computeNotificationSignature('session:completed', input({ status: 'error' }));
+
+    expect(idle).not.toBe(error);
+  });
+
+  it('discriminates by pending interactive prompt id', () => {
+    const noPrompt = computeNotificationSignature(
+      'session:waiting',
+      input({ pendingPrompt: null }),
+    );
+    const promptA = computeNotificationSignature(
+      'session:waiting',
+      input({ pendingPrompt: { promptId: 'prompt-a' } }),
+    );
+    const promptB = computeNotificationSignature(
+      'session:waiting',
+      input({ pendingPrompt: { promptId: 'prompt-b' } }),
+    );
+
+    expect(noPrompt).not.toBe(promptA);
+    expect(promptA).not.toBe(promptB);
+  });
+
+  it('discriminates by lastResponse text', () => {
+    const oneShot = computeNotificationSignature('session:completed', input({ lastResponse: 'hello' }));
+    const otherShot = computeNotificationSignature('session:completed', input({ lastResponse: 'goodbye' }));
+
+    expect(oneShot).not.toBe(otherShot);
+  });
+
+  it('discriminates by errorMessage even when lastResponse matches', () => {
+    // Regression guard for the dedup signature ignoring errorMessage. Two
+    // distinct errors on the same child whose surrounding lastResponse text
+    // happens to match must not be silenced.
+    const errorA = computeNotificationSignature(
+      'session:error',
+      input({ status: 'error', lastResponse: 'partial output', errorMessage: 'ENOENT: missing file' }),
+    );
+    const errorB = computeNotificationSignature(
+      'session:error',
+      input({ status: 'error', lastResponse: 'partial output', errorMessage: 'EACCES: permission denied' }),
+    );
+
+    expect(errorA).not.toBe(errorB);
+  });
+
+  it('treats null and missing optional fields the same way', () => {
+    const explicitNulls = computeNotificationSignature('session:completed', input({
+      pendingPrompt: null,
+      lastResponse: null,
+      errorMessage: null,
+    }));
+    const undefinedFields = computeNotificationSignature('session:completed', {
+      status: 'idle',
+      pendingPrompt: undefined,
+      lastResponse: undefined,
+      errorMessage: undefined,
+    });
+
+    expect(explicitNulls).toBe(undefinedFields);
+  });
+
+  it('includes every discriminating field in the resulting key', () => {
+    // Belt-and-suspenders: if a future refactor drops a field from the join
+    // by accident, this assertion catches it without depending on the exact
+    // delimiter or field order.
+    const eventType: NotificationEventType = 'session:error';
+    const result = input({
+      status: 'error',
+      pendingPrompt: { promptId: 'pp-123' },
+      lastResponse: 'last text',
+      errorMessage: 'boom',
+    });
+
+    const signature = computeNotificationSignature(eventType, result);
+
+    expect(signature).toContain(eventType);
+    expect(signature).toContain('error');
+    expect(signature).toContain('pp-123');
+    expect(signature).toContain('last text');
+    expect(signature).toContain('boom');
+  });
+});

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -74,6 +74,7 @@ import {
   isBinaryFile,
   getFileExtensionForAnalytics,
 } from './aiServiceUtils';
+import { disableParentNotificationsAfterDirectTakeover } from './childSessionTakeover';
 import type Store from 'electron-store';
 import type { AIService } from './AIService';
 import type { HooklessAgentFileWatcher } from './HooklessAgentFileWatcher';
@@ -245,6 +246,11 @@ export class MessageStreamingHandler {
     if (session.id !== sessionId) {
       console.error(`[AIService] CRITICAL ERROR: Requested session ${sessionId} but got session ${session.id}!`);
       throw new Error(`Session mismatch: requested ${sessionId} but got ${session.id}`);
+    }
+
+    const inputType = (documentContext as any)?.inputType as string | undefined;
+    if (inputType === 'user' && !queuedPromptId) {
+      await this.disableParentNotificationsAfterDirectTakeover(session);
     }
 
     // CRITICAL: If session has a worktree, use its path instead of workspace path
@@ -2405,4 +2411,8 @@ export class MessageStreamingHandler {
       throw error;
     }
   };
+
+  private async disableParentNotificationsAfterDirectTakeover(session: SessionData): Promise<void> {
+    await disableParentNotificationsAfterDirectTakeover(session);
+  }
 }

--- a/packages/electron/src/main/services/ai/__tests__/childSessionTakeover.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/childSessionTakeover.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    updateMetadata: vi.fn(),
+  },
+}));
+
+vi.mock('../../../database/PGLiteDatabaseWorker', () => ({
+  database: {
+    query: vi.fn(),
+  },
+}));
+
+import { AISessionsRepository } from '@nimbalyst/runtime';
+import { database } from '../../../database/PGLiteDatabaseWorker';
+import { disableParentNotificationsAfterDirectTakeover } from '../childSessionTakeover';
+
+describe('disableParentNotificationsAfterDirectTakeover', () => {
+  beforeEach(() => {
+    vi.mocked(AISessionsRepository.updateMetadata).mockReset();
+    vi.mocked(database.query).mockReset();
+  });
+
+  it('does nothing when the session has no parent', async () => {
+    await disableParentNotificationsAfterDirectTakeover({
+      id: 'child-1',
+      createdBySessionId: null,
+      metadata: {},
+    } as any);
+
+    expect(AISessionsRepository.updateMetadata).not.toHaveBeenCalled();
+    expect(database.query).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when parent notifications are already disabled', async () => {
+    await disableParentNotificationsAfterDirectTakeover({
+      id: 'child-2',
+      createdBySessionId: 'parent-2',
+      metadata: { notifyParent: false },
+    } as any);
+
+    expect(AISessionsRepository.updateMetadata).not.toHaveBeenCalled();
+    expect(database.query).not.toHaveBeenCalled();
+  });
+
+  it('disables parent notifications and clears pending child updates', async () => {
+    await disableParentNotificationsAfterDirectTakeover({
+      id: 'child-3',
+      createdBySessionId: 'parent-3',
+      metadata: { notifyParent: true },
+    } as any);
+
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith('child-3', {
+      metadata: {
+        notifyParent: false,
+        notifyParentDisabledBy: 'child-user-takeover',
+      },
+    });
+    expect(database.query).toHaveBeenCalledWith(
+      `DELETE FROM queued_prompts
+     WHERE session_id = $1
+       AND status = 'pending'
+       AND prompt LIKE '[Child Session Update]%'
+       AND prompt LIKE $2`,
+      ['parent-3', '%(child-3)%']
+    );
+  });
+});

--- a/packages/electron/src/main/services/ai/childSessionTakeover.ts
+++ b/packages/electron/src/main/services/ai/childSessionTakeover.ts
@@ -1,0 +1,30 @@
+import type { SessionData } from '@nimbalyst/runtime/ai/server/types';
+import { AISessionsRepository } from '@nimbalyst/runtime';
+import { database as databaseWorker } from '../../database/PGLiteDatabaseWorker';
+
+export async function disableParentNotificationsAfterDirectTakeover(session: SessionData): Promise<void> {
+  if (!session.createdBySessionId) {
+    return;
+  }
+
+  const metadata = (session.metadata as Record<string, unknown> | undefined) ?? {};
+  if (metadata.notifyParent === false) {
+    return;
+  }
+
+  await AISessionsRepository.updateMetadata(session.id, {
+    metadata: {
+      notifyParent: false,
+      notifyParentDisabledBy: 'child-user-takeover',
+    },
+  });
+
+  await databaseWorker.query(
+    `DELETE FROM queued_prompts
+     WHERE session_id = $1
+       AND status = 'pending'
+       AND prompt LIKE '[Child Session Update]%'
+       AND prompt LIKE $2`,
+    [session.createdBySessionId, `%(${session.id})%`]
+  );
+}

--- a/packages/electron/src/main/services/metaAgentNotificationSignature.ts
+++ b/packages/electron/src/main/services/metaAgentNotificationSignature.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure helper for MetaAgentService's [Child Session Update] notification
+ * dedup gate. Lives in its own file so it can be unit-tested without
+ * pulling in Electron, the AI providers, or the PGLite worker.
+ */
+
+export type NotificationEventType =
+  | 'session:completed'
+  | 'session:error'
+  | 'session:waiting'
+  | 'session:interrupted';
+
+export interface NotificationSignatureInput {
+  status: string;
+  pendingPrompt?: { promptId: string } | null;
+  lastResponse?: string | null;
+  errorMessage?: string | null;
+}
+
+/**
+ * Build a stable dedup key for a parent notification. Two events whose
+ * components all match collapse into one notification; any differing
+ * component (including errorMessage so two distinct errors with the same
+ * lastResponse still get through) produces a distinct signature.
+ *
+ * The signature is reset on session:started/session:streaming in
+ * MetaAgentService so it only collapses duplicates within a single child
+ * turn -- not across turns. Without that reset, a child whose two
+ * consecutive turns happen to end with the same final text (e.g. "done")
+ * would silence the second notification.
+ */
+export function computeNotificationSignature(
+  eventType: NotificationEventType,
+  result: NotificationSignatureInput
+): string {
+  return [
+    eventType,
+    result.status,
+    result.pendingPrompt?.promptId ?? '',
+    result.lastResponse ?? '',
+    result.errorMessage ?? '',
+  ].join(':');
+}

--- a/packages/electron/src/renderer/components/AgentMode/GitOperationsPanel.tsx
+++ b/packages/electron/src/renderer/components/AgentMode/GitOperationsPanel.tsx
@@ -429,6 +429,7 @@ export const GitOperationsPanel: React.FC<GitOperationsPanelProps> = React.memo(
           fileType: undefined,
           attachments: undefined,
           mode: 'agent',
+          inputType: 'user' as const,
         };
         await window.electronAPI.invoke('ai:sendMessage', message, docContext, sessionId, workspacePath);
       } catch (error) {

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -836,6 +836,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
         ...serializeDocumentContext(effectiveContext),
         attachments: attachments.length > 0 ? attachments : undefined,
         mode: overrideMode,
+        inputType: 'user' as const,
       };
 
       await window.electronAPI.invoke('ai:sendMessage', message, docContext, sessionId, workspacePath);
@@ -920,6 +921,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
       const docContext = {
         ...serializeDocumentContext(effectiveContext),
         mode: aiMode,
+        inputType: 'user' as const,
       };
 
       await window.electronAPI.invoke('ai:sendMessage', message, docContext, sessionId, workspacePath);
@@ -1386,7 +1388,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
           await window.electronAPI.invoke(
             'ai:sendMessage',
             feedbackMessage,
-            undefined,
+            { inputType: 'user' },
             sessionId,
             workspacePath
           );


### PR DESCRIPTION
## Summary

`MetaAgentService` was forwarding every child idle transition to the parent as a `[Child Session Update]` queued prompt. A child running through N queued prompts produced N parent notifications instead of one. A second defect in the dedup signature meant identical-state duplicates were never collapsed.

This PR adds a queue-empty gate on `session:completed` so between-turn idles are suppressed (the parent only hears about the genuinely terminal idle), and repairs the dedup signature so identical-state events collapse while distinct turns still each notify.

## Related issue

Closes #141

## Testing

- Added `packages/electron/src/main/services/__tests__/metaAgentNotificationSignature.test.ts` covering the dedup signature contract: discrimination by event type, status, pending prompt id, lastResponse, and errorMessage; identical-component collapse; null/undefined parity.
- Full vitest suite: `npx vitest run` -- 1990 passed, 26 skipped, 0 failures.
- Typecheck: `cd packages/electron && npx tsc --noEmit` -- clean.
- Live reproduction on dev mode with an isolated userData dir: a 3-prompt back-to-back parent -> child interaction now produces exactly one `[Child Session Update]` row in `queued_prompts` for the parent, on the genuinely terminal idle. Pre-fix on packaged 0.58.17 the same scenario produced 3.

## Notes for reviewers

The queue-empty gate counts only `queued_prompts.status = 'pending'`. The currently-executing prompt is intentionally excluded because at the moment `session:completed` fires the prompt that just finished is still in `executing` -- `MessageStreamingHandler` marks it `completed` only after `endSession()` returns. Counting `executing` would include the cause of the event we are processing and silence every notification, including the final terminal one. (This was the failure mode of an earlier internal iteration; the test on dev mode caught it before this PR.)

The signature is intentionally per-turn rather than per-session-lifetime. Without the reset on `session:started` / `session:streaming`, two consecutive turns whose final assistant text happens to match (e.g. both ended with `done`) would silence the second notification. Including `errorMessage` is the same idea: two distinct errors with the same `lastResponse` text must not be collapsed.

Other event types (`session:error`, `session:waiting`, `session:interrupted`) bypass the queue-empty gate -- they are always meaningful or action-required.

The signature helper is a standalone file with no Electron / runtime dependencies so it can be unit-tested without mocking the world.

The DB-grounded evidence from a 14-day window on a packaged 0.58.17 instance: 10 duplicate-prompt clusters in `queued_prompts`, 9 of them `[Child Session Update]`. Worst case was 5 identical notifications for one child session over 632 seconds.