### PR TITLE
fix: extract Codex child output in meta-agent session results

### DIFF
--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -21,6 +21,7 @@ import {
   shutdownMetaAgentServer,
 } from '../mcp/metaAgentServer';
 import { computeNotificationSignature } from './metaAgentNotificationSignature';
+import { extractMessageText, extractUserPrompts } from './metaAgentMessageText';
 
 type SessionStatusValue = 'idle' | 'running' | 'waiting_for_input' | 'error' | 'interrupted';
 type PromptType = 'permission_request' | 'ask_user_question_request' | 'exit_plan_mode_request';
@@ -882,7 +883,7 @@ export class MetaAgentService {
     }
 
     const messages = await AgentMessagesRepository.list(sessionId, { limit: 500 });
-    const userPrompts = this.extractUserPrompts(messages);
+    const userPrompts = extractUserPrompts(messages);
     const recentMessages = this.extractRecentMessages(messages, 3);
     const pendingPrompt = await this.getPendingInteractivePrompt(sessionId);
 
@@ -1116,27 +1117,11 @@ export class MetaAgentService {
     }
   }
 
-  private extractUserPrompts(messages: Array<{ direction: string; content: string }>): string[] {
-    const prompts: string[] = [];
-    for (const message of messages) {
-      if (message.direction !== 'input') continue;
-      try {
-        const parsed = JSON.parse(message.content);
-        if (typeof parsed.prompt === 'string' && parsed.prompt.trim()) {
-          prompts.push(parsed.prompt.trim());
-        }
-      } catch {
-        continue;
-      }
-    }
-    return prompts;
-  }
-
-  private extractLastAgentResponse(messages: Array<{ direction: string; content: string }>, maxLength: number = 500): string | null {
+  private extractLastAgentResponse(messages: Array<{ direction: string; content: string; metadata?: Record<string, unknown> | null }>, maxLength: number = 500): string | null {
     for (let index = messages.length - 1; index >= 0; index -= 1) {
       const message = messages[index];
       if (message.direction !== 'output') continue;
-      const extracted = this.extractMessageText(message.content);
+      const extracted = extractMessageText(message.content, message.metadata);
       if (extracted) {
         return extracted.length > maxLength ? `${extracted.slice(0, maxLength)}...` : extracted;
       }
@@ -1145,13 +1130,13 @@ export class MetaAgentService {
   }
 
   private extractRecentMessages(
-    messages: Array<{ direction: string; content: string }>,
+    messages: Array<{ direction: string; content: string; metadata?: Record<string, unknown> | null }>,
     limit: number
   ): Array<{ direction: 'input' | 'output'; text: string }> {
     const collected: Array<{ direction: 'input' | 'output'; text: string }> = [];
     for (let index = messages.length - 1; index >= 0 && collected.length < limit; index -= 1) {
       const message = messages[index];
-      const text = this.extractMessageText(message.content);
+      const text = extractMessageText(message.content, message.metadata);
       if (!text) {
         continue;
       }
@@ -1161,44 +1146,6 @@ export class MetaAgentService {
       });
     }
     return collected.reverse();
-  }
-
-  private extractMessageText(rawContent: string): string | null {
-    try {
-      const parsed = JSON.parse(rawContent);
-
-      if (typeof parsed.prompt === 'string' && parsed.prompt.trim()) {
-        return parsed.prompt.trim();
-      }
-
-      if (parsed.type === 'text' && typeof parsed.content === 'string' && parsed.content.trim()) {
-        return parsed.content.trim();
-      }
-
-      if (parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
-        const text = parsed.message.content
-          .filter((block: any) => block.type === 'text' && typeof block.text === 'string')
-          .map((block: any) => block.text.trim())
-          .filter(Boolean)
-          .join('\n');
-        return text || null;
-      }
-
-      if (parsed.type === 'nimbalyst_tool_use' && parsed.name === 'AskUserQuestion') {
-        return 'Interactive prompt: AskUserQuestion';
-      }
-
-      if (parsed.type === 'permission_request') {
-        return `Permission request: ${parsed.toolName || parsed.requestId || 'unknown tool'}`;
-      }
-
-      if (parsed.type === 'exit_plan_mode_request') {
-        return `Plan ready for review${parsed.planFilePath ? `: ${parsed.planFilePath}` : ''}`;
-      }
-    } catch {
-      return null;
-    }
-    return null;
   }
 
   private extractErrorMessage(messages: Array<{ direction: string; content: string }>): string | null {

--- a/packages/electron/src/main/services/__tests__/metaAgentMessageText.test.ts
+++ b/packages/electron/src/main/services/__tests__/metaAgentMessageText.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+import { extractMessageText, extractUserPrompts } from '../metaAgentMessageText';
+
+describe('extractMessageText', () => {
+  describe('synthetic prompts and plain text', () => {
+    it('returns prompt field for { prompt } shape', () => {
+      const text = extractMessageText(JSON.stringify({ prompt: '  Hello world  ' }));
+      expect(text).toBe('Hello world');
+    });
+
+    it('returns content for { type: "text", content } shape', () => {
+      const text = extractMessageText(JSON.stringify({ type: 'text', content: 'plain' }));
+      expect(text).toBe('plain');
+    });
+
+    it('returns trimmed plain string when not JSON', () => {
+      expect(extractMessageText('  raw text  ')).toBe('raw text');
+    });
+
+    it('returns null for empty input', () => {
+      expect(extractMessageText('')).toBeNull();
+      expect(extractMessageText('   ')).toBeNull();
+    });
+  });
+
+  describe('Claude / Claude Code shape', () => {
+    it('joins text blocks from assistant.message.content', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'text', text: 'First line' },
+            { type: 'tool_use', name: 'Read' },
+            { type: 'text', text: 'Second line' },
+          ],
+        },
+      }));
+      expect(text).toBe('First line\nSecond line');
+    });
+
+    it('returns null when assistant message has no text blocks', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'Read' }] },
+      }));
+      expect(text).toBeNull();
+    });
+  });
+
+  describe('OpenAI Codex / OpenCode shapes', () => {
+    it('extracts last_agent_message from task_complete event', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'task_complete',
+        last_agent_message: 'All done.',
+      }));
+      expect(text).toBe('All done.');
+    });
+
+    it('extracts text from item.completed agent_message item', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'item.completed',
+        item: {
+          type: 'agent_message',
+          text: 'The fix is in place.',
+        },
+      }));
+      expect(text).toBe('The fix is in place.');
+    });
+
+    it('extracts text from item.completed with content array of text blocks', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'item.completed',
+        item: {
+          type: 'agent_message',
+          content: [
+            { type: 'text', text: 'Part one.' },
+            { type: 'text', text: 'Part two.' },
+          ],
+        },
+      }));
+      expect(text).toBe('Part one.\nPart two.');
+    });
+
+    it('extracts text from item.updated streaming event', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'item.updated',
+        item: {
+          type: 'agent_message',
+          text: 'Streaming chunk',
+        },
+      }));
+      expect(text).toBe('Streaming chunk');
+    });
+
+    it('extracts text from reasoning items', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'item.completed',
+        item: {
+          type: 'reasoning',
+          text: 'Thinking about it...',
+        },
+      }));
+      expect(text).toBe('Thinking about it...');
+    });
+
+    it('extracts text from event_msg agent_message_delta payload', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'event_msg',
+        payload: {
+          type: 'agent_message_delta',
+          delta: 'partial response',
+        },
+      }));
+      expect(text).toBe('partial response');
+    });
+
+    it('extracts text from delta with content array', () => {
+      const text = extractMessageText(JSON.stringify({
+        delta: {
+          content: [{ type: 'output_text', text: 'streamed' }],
+        },
+      }));
+      expect(text).toBe('streamed');
+    });
+
+    it('returns null for token_count events with no text', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: { input_tokens: 100, output_tokens: 50 },
+        },
+      }));
+      expect(text).toBeNull();
+    });
+
+    it('returns null for thread.started events', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'thread.started',
+        thread_id: 'abc-123',
+      }));
+      expect(text).toBeNull();
+    });
+
+    it('returns null for command_execution tool calls', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-1',
+          type: 'command_execution',
+          command: 'ls -la',
+          aggregated_output: 'file1\nfile2',
+          exit_code: 0,
+          status: 'completed',
+        },
+      }));
+      expect(text).toBeNull();
+    });
+  });
+
+  describe('system reminder filtering', () => {
+    it('returns null when metadata.promptType is system_reminder', () => {
+      const text = extractMessageText(
+        '<SYSTEM_REMINDER>Call the session metadata tool now before continuing.</SYSTEM_REMINDER>',
+        { promptType: 'system_reminder', reminderKind: 'session_naming' },
+      );
+      expect(text).toBeNull();
+    });
+
+    it('still extracts plain user prompts when metadata.promptType is absent', () => {
+      const text = extractMessageText('Plain Codex user prompt', { mode: 'agent' });
+      expect(text).toBe('Plain Codex user prompt');
+    });
+  });
+
+  describe('interactive prompt summaries', () => {
+    it('summarizes AskUserQuestion', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'nimbalyst_tool_use',
+        name: 'AskUserQuestion',
+      }));
+      expect(text).toBe('Interactive prompt: AskUserQuestion');
+    });
+
+    it('summarizes permission_request with toolName', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'permission_request',
+        toolName: 'Bash',
+      }));
+      expect(text).toBe('Permission request: Bash');
+    });
+
+    it('summarizes exit_plan_mode_request with planFilePath', () => {
+      const text = extractMessageText(JSON.stringify({
+        type: 'exit_plan_mode_request',
+        planFilePath: 'plans/feature.md',
+      }));
+      expect(text).toBe('Plan ready for review: plans/feature.md');
+    });
+  });
+});
+
+describe('extractUserPrompts', () => {
+  it('extracts JSON-wrapped prompts (Claude / Claude Code shape)', () => {
+    const prompts = extractUserPrompts([
+      { direction: 'input', content: JSON.stringify({ prompt: 'First task' }) },
+      { direction: 'output', content: JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'reply' }] } }) },
+      { direction: 'input', content: JSON.stringify({ prompt: 'Second task' }) },
+    ]);
+    expect(prompts).toEqual(['First task', 'Second task']);
+  });
+
+  it('extracts raw plain-text prompts (Codex shape)', () => {
+    const prompts = extractUserPrompts([
+      { direction: 'input', content: 'In 2 sentences, what does the @nimbalyst/runtime package do? Then say DONE.', metadata: { mode: 'agent' } },
+    ]);
+    expect(prompts).toEqual(['In 2 sentences, what does the @nimbalyst/runtime package do? Then say DONE.']);
+  });
+
+  it('handles a mix of Claude and Codex inputs in order', () => {
+    const prompts = extractUserPrompts([
+      { direction: 'input', content: 'Plain Codex prompt', metadata: { mode: 'agent' } },
+      { direction: 'input', content: JSON.stringify({ prompt: 'Wrapped Claude prompt' }) },
+    ]);
+    expect(prompts).toEqual(['Plain Codex prompt', 'Wrapped Claude prompt']);
+  });
+
+  it('skips system reminders by metadata.promptType', () => {
+    const prompts = extractUserPrompts([
+      { direction: 'input', content: 'Real user prompt', metadata: { mode: 'agent' } },
+      {
+        direction: 'input',
+        content: '<SYSTEM_REMINDER>Call session metadata.</SYSTEM_REMINDER>',
+        metadata: { promptType: 'system_reminder', reminderKind: 'session_naming' },
+      },
+      { direction: 'input', content: 'Another real prompt', metadata: { mode: 'agent' } },
+    ]);
+    expect(prompts).toEqual(['Real user prompt', 'Another real prompt']);
+  });
+
+  it('ignores output-direction messages', () => {
+    const prompts = extractUserPrompts([
+      { direction: 'output', content: 'assistant text' },
+      { direction: 'input', content: 'user text' },
+    ]);
+    expect(prompts).toEqual(['user text']);
+  });
+
+  it('skips empty / whitespace-only content', () => {
+    const prompts = extractUserPrompts([
+      { direction: 'input', content: '   ', metadata: { mode: 'agent' } },
+      { direction: 'input', content: JSON.stringify({ prompt: '   ' }) },
+      { direction: 'input', content: 'real', metadata: { mode: 'agent' } },
+    ]);
+    expect(prompts).toEqual(['real']);
+  });
+});

--- a/packages/electron/src/main/services/metaAgentMessageText.ts
+++ b/packages/electron/src/main/services/metaAgentMessageText.ts
@@ -1,0 +1,218 @@
+export interface AgentMessageLike {
+  direction: string;
+  content: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Extracts a short text representation from an `ai_agent_messages.content`
+ * row written by an AI provider. Returns null if no text can be extracted
+ * or if the message is a non-user system reminder.
+ *
+ * Used by MetaAgentService to summarize a child session's recent activity
+ * for the parent (lastResponse, recentMessages, [Child Session Update]).
+ *
+ * Must understand both Claude / Claude Code raw shapes AND OpenAI Codex /
+ * OpenCode raw SDK event shapes -- see TRANSCRIPT_ARCHITECTURE.md and
+ * packages/runtime/src/ai/server/providers/codex/codexEventParser.ts for the
+ * canonical Codex shape catalog. Keep this in sync when new shapes are added
+ * there.
+ */
+export function extractMessageText(
+  rawContent: string,
+  metadata?: Record<string, unknown> | null,
+): string | null {
+  if (metadata && metadata.promptType === 'system_reminder') {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawContent);
+  } catch {
+    const text = typeof rawContent === 'string' ? rawContent.trim() : '';
+    return text || null;
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+
+  const record = parsed as Record<string, unknown>;
+
+  if (typeof record.prompt === 'string' && record.prompt.trim()) {
+    return record.prompt.trim();
+  }
+
+  if (record.type === 'text' && typeof record.content === 'string' && record.content.trim()) {
+    return record.content.trim();
+  }
+
+  if (record.type === 'assistant' && isObject(record.message) && Array.isArray(record.message.content)) {
+    const text = (record.message.content as unknown[])
+      .filter((b): b is { type: string; text: string } =>
+        isObject(b) && (b as Record<string, unknown>).type === 'text' && typeof (b as Record<string, unknown>).text === 'string',
+      )
+      .map((b) => b.text.trim())
+      .filter(Boolean)
+      .join('\n');
+    if (text) {
+      return text;
+    }
+  }
+
+  if (record.type === 'nimbalyst_tool_use' && record.name === 'AskUserQuestion') {
+    return 'Interactive prompt: AskUserQuestion';
+  }
+
+  if (record.type === 'permission_request') {
+    const tool = typeof record.toolName === 'string' ? record.toolName : (typeof record.requestId === 'string' ? record.requestId : 'unknown tool');
+    return `Permission request: ${tool}`;
+  }
+
+  if (record.type === 'exit_plan_mode_request') {
+    const planFilePath = typeof record.planFilePath === 'string' ? record.planFilePath : null;
+    return `Plan ready for review${planFilePath ? `: ${planFilePath}` : ''}`;
+  }
+
+  const codex = extractCodexText(record);
+  if (codex) {
+    return codex;
+  }
+
+  return null;
+}
+
+/**
+ * Extract user prompt strings (in order) from a session's raw input messages.
+ *
+ * Handles both wire shapes seen in `ai_agent_messages.content`:
+ * - Claude / Claude Code wraps inputs as `JSON.stringify({ prompt, ... })`.
+ * - OpenAI Codex / OpenCode log inputs as the raw prompt string itself.
+ *
+ * System reminders (e.g. session-naming nudges) carry
+ * `metadata.promptType === 'system_reminder'` and are filtered out so they
+ * don't pollute `originalPrompt` / `userPrompts` / parent notifications.
+ */
+export function extractUserPrompts(messages: ReadonlyArray<AgentMessageLike>): string[] {
+  const prompts: string[] = [];
+  for (const message of messages) {
+    if (message.direction !== 'input') continue;
+    if (message.metadata && message.metadata.promptType === 'system_reminder') continue;
+
+    let text: string | null = null;
+    let parsedAsJson = false;
+    try {
+      const parsed = JSON.parse(message.content);
+      parsedAsJson = parsed !== null && typeof parsed === 'object';
+      if (parsedAsJson) {
+        const prompt = (parsed as Record<string, unknown>).prompt;
+        if (typeof prompt === 'string' && prompt.trim()) {
+          text = prompt.trim();
+        }
+      }
+    } catch {
+      // Not JSON -- fall through to the plain-text branch below
+    }
+
+    if (!text && !parsedAsJson && typeof message.content === 'string') {
+      const trimmed = message.content.trim();
+      if (trimmed) text = trimmed;
+    }
+
+    if (text) prompts.push(text);
+  }
+  return prompts;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function trimmedString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function extractFromContentArray(value: unknown): string | null {
+  if (!Array.isArray(value)) return null;
+  const parts: string[] = [];
+  for (const block of value) {
+    if (typeof block === 'string') {
+      const t = block.trim();
+      if (t) parts.push(t);
+      continue;
+    }
+    if (!isObject(block)) continue;
+    const blockType = block.type;
+    if ((blockType === 'text' || blockType === 'output_text') && typeof block.text === 'string') {
+      const t = block.text.trim();
+      if (t) parts.push(t);
+      continue;
+    }
+    const direct = trimmedString(block.text) ?? trimmedString(block.content) ?? trimmedString(block.value);
+    if (direct) parts.push(direct);
+  }
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+/**
+ * Extract assistant text from a Codex / OpenCode raw SDK event.
+ *
+ * Mirrors the subset of shapes that codexEventParser.parseCodexEvent treats
+ * as text-bearing. Tool calls, usage, and reasoning-without-text are
+ * intentionally ignored -- the meta-agent only cares about user-visible
+ * assistant prose for its summaries.
+ */
+function extractCodexText(record: Record<string, unknown>): string | null {
+  const eventType = typeof record.type === 'string' ? record.type : '';
+
+  if (eventType === 'task_complete') {
+    const text = trimmedString(record.last_agent_message);
+    if (text) return text;
+  }
+
+  const item = record.item;
+  if (isObject(item)) {
+    const itemType = typeof item.type === 'string' ? item.type : '';
+    const isMessageLike =
+      itemType === 'agent_message' ||
+      itemType === 'reasoning' ||
+      itemType.includes('message') ||
+      eventType === 'item.completed' ||
+      eventType === 'item.updated';
+    if (isMessageLike) {
+      const text = trimmedString(item.text) ?? extractFromContentArray(item.content);
+      if (text) return text;
+    }
+  }
+
+  if (eventType === 'event_msg' && isObject(record.payload)) {
+    const payload = record.payload as Record<string, unknown>;
+    const payloadType = typeof payload.type === 'string' ? payload.type : '';
+    if (payloadType.includes('message') || payloadType.includes('text')) {
+      const text =
+        trimmedString(payload.text) ??
+        trimmedString(payload.delta) ??
+        trimmedString(payload.message) ??
+        extractFromContentArray(payload.content);
+      if (text) return text;
+    }
+  }
+
+  if (record.delta != null) {
+    const deltaText = trimmedString(record.delta);
+    if (deltaText) return deltaText;
+    if (isObject(record.delta)) {
+      const text = trimmedString((record.delta as Record<string, unknown>).text) ??
+        extractFromContentArray((record.delta as Record<string, unknown>).content);
+      if (text) return text;
+    }
+  }
+
+  const direct = trimmedString(record.text);
+  if (direct) return direct;
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Meta-agent parents can't see the output of OpenAI Codex children. `get_session_result` returns null `lastResponse` and empty `recentMessages` / `userPrompts` / `originalPrompt`, and the `[Child Session Update]` notifications the parent receives are empty too.

Closes #144.

> Stacked on #142. NIM-11 was developed against the post-#142 `MetaAgentService` and shares the `./metaAgentNotificationSignature` import added there. Please merge #142 first; I'll rebase onto `main` once it lands.

## Two parallel bugs in `MetaAgentService.ts`

1. `extractMessageText` only handled Claude's `{type:'assistant', message:{content:[...]}}` shape. Codex stores raw SDK events, so its assistant text is at `{type:'item.completed', item:{type:'agent_message', text}}` and `{type:'task_complete', last_agent_message}`. Neither matched.
2. `extractUserPrompts` did `JSON.parse(content).prompt`. `OpenAICodexProvider.ts:779` logs Codex inputs as the raw prompt string, not `JSON.stringify({prompt})`. Every input row threw and was skipped.

## What changed

- Pulled both functions into a new `metaAgentMessageText.ts` so they're unit-testable on their own.
- Added the Codex shapes to `extractMessageText`: `task_complete`, `item.completed`/`item.updated` with `agent_message` or `reasoning` items, `event_msg` payloads, root-level `delta`, bare `text`. Tool-only events like `command_execution` and `mcp_tool_call` still return null.
- `extractMessageText` now takes optional `metadata` and skips rows where `metadata.promptType === 'system_reminder'` so session-naming nudges stop leaking into parent notifications.
- `MetaAgentService.extractRecentMessages` and `extractLastAgentResponse` pass `message.metadata` through so the filter actually fires.

## Test plan

- [x] 27 new unit tests in `__tests__/metaAgentMessageText.test.ts` covering Claude shapes, every Codex shape above, system-reminder filtering, and the JSON-with-empty-prompt-vs-raw-text edge case.
- [x] Existing `metaAgentNotificationSignature.test.ts` still passes.
- [x] Full electron service suite: 193 pass, 3 skipped, 0 fail.
- [x] `cd packages/electron && npx tsc --noEmit` -- clean.

## Validation

Built a packaged app locally from `upstream/main` + #142 + this PR. Spawned a Codex child (`openai-codex:gpt-5.4`, `isolated: true`, `notifyOnComplete: true`) with the prompt *"In 2 sentences, what does the @nimbalyst/runtime package do? Then say DONE."*

`get_session_result` after completion:

- `provider: "openai-codex"`
- `lastResponse`: the full assistant answer
- `recentMessages`: 3 entries, all assistant prose, no `<SYSTEM_REMINDER>` rows
- `originalPrompt` and `userPrompts`: the original prompt

I also queried `ai_agent_messages` directly for an older failing Codex session to confirm what the on-disk shapes actually look like: inputs are raw plain-text strings with `metadata.mode = 'agent'` (or `metadata.promptType = 'system_reminder'`), outputs are `JSON.stringify(rawCodexEvent)` with `metadata.codexProvider = true`, and assistant text always sits at `item.text` for `agent_message` items.

## Notes for reviewers

The helper handles only text extraction -- it deliberately does not import `parseCodexEvent` or try to handle tool calls, usage, or reasoning beyond text. The full canonical parser lives at `packages/runtime/src/ai/server/providers/codex/codexEventParser.ts`; this helper just covers the text-bearing subset of shapes. If new Codex shapes get added there, they probably want adding here too.

peace, B.Sweet