### PR TITLE
refactor: centralize PGLite TIMESTAMPTZ to epoch-ms via toMillis

### DIFF
--- a/packages/electron/CLAUDE.md
+++ b/packages/electron/CLAUDE.md
@@ -180,14 +180,15 @@ db.query('INSERT INTO ... VALUES ($1)', [new Date()])
 
 3. **DO**: Retrieve timestamps through `toMillis()` function
 ```typescript
-const createdAt = toMillis(row.created_at);  // Returns epoch milliseconds
+const createdAt = toMillis(row.created_at)!;              // Required timestamp
+const claimedAt = toMillis(row.claimed_at) ?? undefined;  // Nullable timestamp
 ```
 
 4. **DO**: Display with `toLocaleString()` for user's local timezone
 
 **Related files:**
 - `src/main/database/worker.js` - Database schema and comments
-- `src/main/services/PGLiteSessionStore.ts` - toMillis() implementation
+- `src/main/utils/timestampUtils.ts` - canonical toMillis() implementation
 
 ## Renderer State Architecture
 

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -8,6 +8,7 @@ import { ModelIdentifier } from '@nimbalyst/runtime/ai/server/types';
 import { AISessionsRepository, AgentMessagesRepository, SessionFilesRepository } from '@nimbalyst/runtime';
 import { getSessionStateManager } from '@nimbalyst/runtime/ai/server/SessionStateManager';
 import { getDefaultAIModel } from '../utils/store';
+import { toMillis } from '../utils/timestampUtils';
 import { createWorktreeStore } from './WorktreeStore';
 import { GitWorktreeService } from './GitWorktreeService';
 import { database as databaseWorker } from '../database/PGLiteDatabaseWorker';
@@ -532,8 +533,8 @@ export class MetaAgentService {
       sessionId: row.id,
       title: row.title || 'Untitled Session',
       status,
-      lastActivity: row.last_activity ? new Date(row.last_activity).getTime() : null,
-      updatedAt: row.updated_at ? new Date(row.updated_at).getTime() : null,
+      lastActivity: toMillis(row.last_activity),
+      updatedAt: toMillis(row.updated_at),
       provider: row.provider,
       model: row.model || null,
       createdBySessionId: row.created_by_session_id || null,
@@ -657,9 +658,9 @@ export class MetaAgentService {
         provider: row.provider,
         model: row.model || null,
         status: row.status || 'idle',
-        lastActivity: row.last_activity ? new Date(row.last_activity).getTime() : null,
-        createdAt: row.created_at instanceof Date ? row.created_at.getTime() : new Date(row.created_at).getTime(),
-        updatedAt: row.updated_at instanceof Date ? row.updated_at.getTime() : new Date(row.updated_at).getTime(),
+        lastActivity: toMillis(row.last_activity),
+        createdAt: toMillis(row.created_at)!,
+        updatedAt: toMillis(row.updated_at)!,
         worktreeId: row.worktree_id || null,
       });
       sessions.push({
@@ -832,7 +833,7 @@ export class MetaAgentService {
       sessionProvider = session.provider;
       sessionModel = session.model || null;
       sessionStatus = (statusRow?.status || 'idle') as SessionStatusValue;
-      sessionLastActivity = statusRow?.last_activity ? new Date(statusRow.last_activity).getTime() : null;
+      sessionLastActivity = toMillis(statusRow?.last_activity);
       sessionCreatedAt = session.createdAt;
       sessionUpdatedAt = session.updatedAt;
       sessionWorktreeId = session.worktreeId || null;
@@ -929,7 +930,7 @@ export class MetaAgentService {
               id: row.id,
               promptId,
               promptType: 'ask_user_question_request',
-              createdAt: row.created_at instanceof Date ? row.created_at.getTime() : new Date(row.created_at).getTime(),
+              createdAt: toMillis(row.created_at)!,
               content: {
                 ...content,
                 questions: content.input?.questions || [],
@@ -943,7 +944,7 @@ export class MetaAgentService {
               id: row.id,
               promptId: content.input?.requestId || promptId,
               promptType: 'permission_request',
-              createdAt: row.created_at instanceof Date ? row.created_at.getTime() : new Date(row.created_at).getTime(),
+              createdAt: toMillis(row.created_at)!,
               content: {
                 type: 'permission_request',
                 requestId: content.input?.requestId || promptId,
@@ -987,7 +988,7 @@ export class MetaAgentService {
             id: row.id,
             promptId,
             promptType: 'exit_plan_mode_request',
-            createdAt: row.created_at instanceof Date ? row.created_at.getTime() : new Date(row.created_at).getTime(),
+            createdAt: toMillis(row.created_at)!,
             content,
           };
         }

--- a/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
+++ b/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
@@ -5,6 +5,8 @@
  * Uses simple row-level atomic updates instead of JSONB array manipulation.
  */
 
+import { toMillis } from '../utils/timestampUtils';
+
 export interface QueuedPrompt {
   id: string;
   sessionId: string;
@@ -73,18 +75,6 @@ type PGliteLike = {
 
 type EnsureReadyFn = () => Promise<void>;
 
-function toMillis(date: Date | string | null | undefined): number {
-  if (!date) return 0;
-  if (date instanceof Date) {
-    return date.getTime();
-  }
-  const str = String(date).trim();
-  const hasTimezone =
-    str.endsWith('Z') || str.includes('+') || /-\d{2}:\d{2}$/.test(str);
-  const parsed = new Date(hasTimezone ? str : str.replace(' ', 'T') + 'Z').getTime();
-  return Number.isNaN(parsed) ? 0 : parsed;
-}
-
 function rowToQueuedPrompt(row: any): QueuedPrompt {
   // Parse JSONB fields
   let attachments = row.attachments;
@@ -112,9 +102,9 @@ function rowToQueuedPrompt(row: any): QueuedPrompt {
     status: row.status,
     attachments,
     documentContext,
-    createdAt: toMillis(row.created_at),
-    claimedAt: row.claimed_at ? toMillis(row.claimed_at) : undefined,
-    completedAt: row.completed_at ? toMillis(row.completed_at) : undefined,
+    createdAt: toMillis(row.created_at)!,
+    claimedAt: toMillis(row.claimed_at) ?? undefined,
+    completedAt: toMillis(row.completed_at) ?? undefined,
     errorMessage: row.error_message || undefined,
   };
 }

--- a/packages/electron/src/main/services/PGLiteSessionFileStore.ts
+++ b/packages/electron/src/main/services/PGLiteSessionFileStore.ts
@@ -4,20 +4,13 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import type { SessionFileStore, FileLink, FileLinkType } from '@nimbalyst/runtime';
+import { toMillis } from '../utils/timestampUtils';
 
 type PGliteLike = {
   query<T = any>(sql: string, params?: any[]): Promise<{ rows: T[] }>;
 };
 
 type EnsureReadyFn = () => Promise<void>;
-
-function toMillis(value: unknown): number {
-  if (!value) return Date.now();
-  if (typeof value === 'number') return value;
-  if (value instanceof Date) return value.getTime();
-  const parsed = new Date(value as any).getTime();
-  return Number.isNaN(parsed) ? Date.now() : parsed;
-}
 
 function rowToFileLink(row: any): FileLink {
   return {
@@ -26,7 +19,7 @@ function rowToFileLink(row: any): FileLink {
     workspaceId: row.workspace_id,
     filePath: row.file_path,
     linkType: row.link_type as FileLinkType,
-    timestamp: toMillis(row.timestamp),
+    timestamp: toMillis(row.timestamp)!,
     metadata: row.metadata || {}
   };
 }

--- a/packages/electron/src/main/services/PGLiteSessionStore.ts
+++ b/packages/electron/src/main/services/PGLiteSessionStore.ts
@@ -2,6 +2,8 @@
  * PGLite implementation of SessionStore interface from runtime package
  */
 
+import { toMillis } from '../utils/timestampUtils';
+
 import type {
   SessionStore,
   SessionMeta,
@@ -18,25 +20,6 @@ type PGliteLike = {
 };
 
 type EnsureReadyFn = () => Promise<void>;
-
-function toMillis(value: unknown): number {
-  if (!value) return Date.now();
-  if (typeof value === 'number') return value;
-
-  // With TIMESTAMPTZ columns, PGLite returns Date objects that already represent
-  // the correct instant in time. Just call getTime() to get epoch milliseconds.
-  if (value instanceof Date) {
-    return value.getTime();
-  }
-
-  // Fallback for string timestamps (shouldn't happen with TIMESTAMPTZ, but just in case)
-  const str = String(value).trim();
-  // Detect timezone: ends with Z, contains +, or has negative offset like -05:00
-  const hasTimezone = str.endsWith('Z') || str.includes('+') || /-\d{2}:\d{2}$/.test(str);
-  const utcStr = hasTimezone ? str : str.replace(' ', 'T') + 'Z';
-  const parsed = new Date(utcStr).getTime();
-  return Number.isNaN(parsed) ? Date.now() : parsed;
-}
 
 
 // Module-level reference for standalone functions
@@ -135,15 +118,15 @@ export async function getAllSessionsForSync(includeMessages = false): Promise<Ar
       isPinned: row.is_pinned ?? false,
       branchedFromSessionId: row.branched_from_session_id || undefined,
       branchPointMessageId: row.branch_point_message_id || undefined,
-      branchedAt: row.branched_at ? toMillis(row.branched_at) : undefined,
+      branchedAt: toMillis(row.branched_at) ?? undefined,
       // workspace_id is required - we filtered out sessions without it above
       workspaceId: row.workspace_id,
       workspacePath: row.workspace_id, // workspace_id is the path in this system
       // NOTE: Do NOT include draftInput in bulk sync - it should only sync when actually changed
       // Including it here causes spurious metadata_updated events for all sessions on startup
       messageCount: 0,
-      updatedAt: toMillis(row.updated_at),
-      createdAt: toMillis(row.created_at),
+      updatedAt: toMillis(row.updated_at)!,
+      createdAt: toMillis(row.created_at)!,
       metadata: row.metadata,
       messages: undefined as SyncedMessage[] | undefined,
     };
@@ -162,7 +145,7 @@ export async function getAllSessionsForSync(includeMessages = false): Promise<Ar
       session.messages = msgRows.map((m: any): AgentMessage => ({
         id: m.id,
         sessionId: m.session_id,
-        createdAt: m.created_at instanceof Date ? m.created_at : new Date(toMillis(m.created_at)),
+        createdAt: m.created_at instanceof Date ? m.created_at : new Date(toMillis(m.created_at)!),
         source: m.source,
         direction: m.direction,
         content: m.content,
@@ -209,7 +192,7 @@ export async function getSessionMessagesForSync(
   return msgRows.map((m: any): AgentMessage => ({
     id: m.id,
     sessionId: m.session_id,
-    createdAt: m.created_at instanceof Date ? m.created_at : new Date(toMillis(m.created_at)),
+    createdAt: m.created_at instanceof Date ? m.created_at : new Date(toMillis(m.created_at)!),
     source: m.source,
     direction: m.direction,
     content: m.content,
@@ -262,7 +245,7 @@ export async function getSessionMessagesForSyncBatch(
 
   for (const m of msgRows) {
     const sessionSince = sinceMap.get(m.session_id) ?? 0;
-    const createdAt = m.created_at instanceof Date ? m.created_at : new Date(toMillis(m.created_at));
+    const createdAt = m.created_at instanceof Date ? m.created_at : new Date(toMillis(m.created_at)!);
     // Filter: only include messages newer than this session's sinceTimestamp
     if (createdAt.getTime() > sessionSince) {
       const arr = result.get(m.session_id);
@@ -474,8 +457,8 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
         worktreeProjectPath: row.worktree_project_path ?? undefined,
         parentSessionId: row.parent_session_id ?? null,  // Hierarchical workstream support
         createdBySessionId: row.created_by_session_id ?? null,
-        createdAt: toMillis(row.created_at),
-        updatedAt: toMillis(row.updated_at),
+        createdAt: toMillis(row.created_at)!,
+        updatedAt: toMillis(row.updated_at)!,
         metadata,
         documentContext: row.document_context ?? undefined,
         providerConfig: row.provider_config ?? undefined,
@@ -487,7 +470,7 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
         // Branch tracking fields - SEPARATE from hierarchical parentSessionId
         branchedFromSessionId: row.branched_from_session_id ?? undefined,
         branchPointMessageId: row.branch_point_message_id ? parseInt(row.branch_point_message_id) : undefined,
-        branchedAt: row.branched_at ? toMillis(row.branched_at) : undefined,
+        branchedAt: toMillis(row.branched_at) ?? undefined,
         branchedFromProviderSessionId: row.branched_from_provider_session_id ?? undefined,
         // Document context service state for transition detection
         lastDocumentState: row.last_document_state ?? undefined,
@@ -530,8 +513,8 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
           worktreeProjectPath: row.worktree_project_path ?? undefined,
           parentSessionId: row.parent_session_id ?? null,
           createdBySessionId: row.created_by_session_id ?? null,
-          createdAt: toMillis(row.created_at),
-          updatedAt: toMillis(row.updated_at),
+          createdAt: toMillis(row.created_at)!,
+          updatedAt: toMillis(row.updated_at)!,
           metadata,
           documentContext: row.document_context ?? undefined,
           providerConfig: row.provider_config ?? undefined,
@@ -542,7 +525,7 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
           isPinned: row.is_pinned ?? false,
           branchedFromSessionId: row.branched_from_session_id ?? undefined,
           branchPointMessageId: row.branch_point_message_id ? parseInt(row.branch_point_message_id) : undefined,
-          branchedAt: row.branched_at ? toMillis(row.branched_at) : undefined,
+          branchedAt: toMillis(row.branched_at) ?? undefined,
           branchedFromProviderSessionId: row.branched_from_provider_session_id ?? undefined,
         } satisfies ChatSession;
       });
@@ -588,10 +571,10 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
       const totalTime = performance.now() - startTime;
       // console.log(`[PGLiteSessionStore] list() - ensureReady: ${ensureTime.toFixed(1)}ms, query: ${queryTime.toFixed(1)}ms, total: ${totalTime.toFixed(1)}ms, rows: ${rows.length}`);
       return rows.map(row => {
-        const createdAt = toMillis(row.created_at);
+        const createdAt = toMillis(row.created_at)!;
         // For workstream parents, use the effective timestamp that includes child activity
-        const updatedAt = toMillis(row.effective_updated_at ?? row.updated_at);
-        const branchedAt = row.branched_at ? toMillis(row.branched_at) : undefined;
+        const updatedAt = toMillis(row.effective_updated_at ?? row.updated_at)!;
+        const branchedAt = toMillis(row.branched_at) ?? undefined;
         const childCount = parseInt(row.child_count) || 0;
         const metadata = row.metadata ?? {};
         return {
@@ -803,9 +786,9 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
         });
 
       return rows.map(row => {
-        const createdAt = toMillis(row.created_at);
-        const updatedAt = toMillis(row.updated_at);
-        const branchedAt = row.branched_at ? toMillis(row.branched_at) : undefined;
+        const createdAt = toMillis(row.created_at)!;
+        const updatedAt = toMillis(row.updated_at)!;
+        const branchedAt = toMillis(row.branched_at) ?? undefined;
         const childCount = parseInt(row.child_count) || 0;
         return {
           id: row.id,
@@ -846,9 +829,9 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
         [sessionId]
       );
       return rows.map(row => {
-        const createdAt = toMillis(row.created_at);
-        const updatedAt = toMillis(row.updated_at);
-        const branchedAt = row.branched_at ? toMillis(row.branched_at) : undefined;
+        const createdAt = toMillis(row.created_at)!;
+        const updatedAt = toMillis(row.updated_at)!;
+        const branchedAt = toMillis(row.branched_at) ?? undefined;
         return {
           id: row.id,
           provider: row.provider,

--- a/packages/electron/src/main/services/PGLiteSessionWakeupsStore.ts
+++ b/packages/electron/src/main/services/PGLiteSessionWakeupsStore.ts
@@ -9,6 +9,8 @@
  * prior row in the same transaction.
  */
 
+import { toMillis } from '../utils/timestampUtils';
+
 export type SessionWakeupStatus =
   | 'pending'
   | 'firing'
@@ -79,18 +81,6 @@ type PGliteLike = {
 
 type EnsureReadyFn = () => Promise<void>;
 
-function toMillis(date: Date | string | null | undefined): number {
-  if (!date) return 0;
-  if (date instanceof Date) {
-    return date.getTime();
-  }
-  const str = String(date).trim();
-  const hasTimezone =
-    str.endsWith('Z') || str.includes('+') || /-\d{2}:\d{2}$/.test(str);
-  const parsed = new Date(hasTimezone ? str : str.replace(' ', 'T') + 'Z').getTime();
-  return Number.isNaN(parsed) ? 0 : parsed;
-}
-
 function rowToWakeup(row: any): SessionWakeup {
   return {
     id: row.id,
@@ -98,10 +88,10 @@ function rowToWakeup(row: any): SessionWakeup {
     workspaceId: row.workspace_id,
     prompt: row.prompt,
     reason: row.reason ?? null,
-    fireAt: toMillis(row.fire_at),
+    fireAt: toMillis(row.fire_at)!,
     status: row.status as SessionWakeupStatus,
-    createdAt: toMillis(row.created_at),
-    firedAt: row.fired_at ? toMillis(row.fired_at) : null,
+    createdAt: toMillis(row.created_at)!,
+    firedAt: toMillis(row.fired_at),
     error: row.error ?? null,
   };
 }

--- a/packages/electron/src/main/services/SuperLoopStore.ts
+++ b/packages/electron/src/main/services/SuperLoopStore.ts
@@ -75,8 +75,8 @@ function rowToSuperLoop(row: SuperLoopRow): SuperLoop {
     completionReason: row.completion_reason ?? undefined,
     isArchived: row.is_archived ?? false,
     isPinned: row.is_pinned ?? false,
-    createdAt: toMillis(row.created_at),
-    updatedAt: toMillis(row.updated_at),
+    createdAt: toMillis(row.created_at)!,
+    updatedAt: toMillis(row.updated_at)!,
   };
 }
 
@@ -91,8 +91,8 @@ function rowToSuperIteration(row: SuperIterationRow): SuperIteration {
     iterationNumber: row.iteration_number,
     status: row.status as SuperIterationStatus,
     exitReason: row.exit_reason ?? undefined,
-    createdAt: toMillis(row.created_at),
-    completedAt: row.completed_at ? toMillis(row.completed_at) : undefined,
+    createdAt: toMillis(row.created_at)!,
+    completedAt: toMillis(row.completed_at) ?? undefined,
   };
 }
 

--- a/packages/electron/src/main/services/WorktreeStore.ts
+++ b/packages/electron/src/main/services/WorktreeStore.ts
@@ -129,8 +129,8 @@ export function createWorktreeStore(db: PGliteLike, ensureDbReady?: EnsureReadyF
         branch: row.branch,
         baseBranch: row.base_branch,
         projectPath: row.workspace_id,
-        createdAt: toMillis(row.created_at),
-        updatedAt: toMillis(row.updated_at),
+        createdAt: toMillis(row.created_at)!,
+        updatedAt: toMillis(row.updated_at)!,
         isPinned: row.is_pinned ?? false,
         isArchived: row.is_archived ?? false,
       };
@@ -165,8 +165,8 @@ export function createWorktreeStore(db: PGliteLike, ensureDbReady?: EnsureReadyF
           branch: row.branch,
           baseBranch: row.base_branch,
           projectPath: row.workspace_id,
-          createdAt: toMillis(row.created_at),
-          updatedAt: toMillis(row.updated_at),
+          createdAt: toMillis(row.created_at)!,
+          updatedAt: toMillis(row.updated_at)!,
           isPinned: row.is_pinned ?? false,
           isArchived: row.is_archived ?? false,
         });
@@ -202,8 +202,8 @@ export function createWorktreeStore(db: PGliteLike, ensureDbReady?: EnsureReadyF
         branch: row.branch,
         baseBranch: row.base_branch,
         projectPath: row.workspace_id,
-        createdAt: toMillis(row.created_at),
-        updatedAt: toMillis(row.updated_at),
+        createdAt: toMillis(row.created_at)!,
+        updatedAt: toMillis(row.updated_at)!,
         isPinned: row.is_pinned ?? false,
         isArchived: row.is_archived ?? false,
       };
@@ -236,8 +236,8 @@ export function createWorktreeStore(db: PGliteLike, ensureDbReady?: EnsureReadyF
         branch: row.branch,
         baseBranch: row.base_branch,
         projectPath: row.workspace_id,
-        createdAt: toMillis(row.created_at),
-        updatedAt: toMillis(row.updated_at),
+        createdAt: toMillis(row.created_at)!,
+        updatedAt: toMillis(row.updated_at)!,
         isPinned: row.is_pinned ?? false,
         isArchived: row.is_archived ?? false,
       }));

--- a/packages/electron/src/main/utils/__tests__/timestampUtils.test.ts
+++ b/packages/electron/src/main/utils/__tests__/timestampUtils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { toMillis } from '../timestampUtils';
+
+describe('toMillis', () => {
+  it('returns getTime() for Date instances', () => {
+    const value = new Date('2026-05-03T12:34:56.789Z');
+
+    expect(toMillis(value)).toBe(value.getTime());
+  });
+
+  it('returns numeric input as-is', () => {
+    expect(toMillis(0)).toBe(0);
+    expect(toMillis(1746275696789)).toBe(1746275696789);
+  });
+
+  it('parses ISO strings with explicit UTC designators', () => {
+    expect(toMillis('2026-05-03T12:34:56Z')).toBe(Date.parse('2026-05-03T12:34:56Z'));
+    expect(toMillis('2026-05-03T12:34:56+02:30')).toBe(Date.parse('2026-05-03T12:34:56+02:30'));
+    expect(toMillis('2026-05-03T12:34:56-07:00')).toBe(Date.parse('2026-05-03T12:34:56-07:00'));
+  });
+
+  it('normalizes naive timestamp strings to UTC before parsing', () => {
+    expect(toMillis('2026-05-03 12:34:56')).toBe(Date.parse('2026-05-03T12:34:56Z'));
+    expect(toMillis('2026-05-03T12:34:56')).toBe(Date.parse('2026-05-03T12:34:56Z'));
+  });
+
+  it('returns null for empty or invalid input', () => {
+    expect(toMillis(null)).toBeNull();
+    expect(toMillis(undefined)).toBeNull();
+    expect(toMillis('')).toBeNull();
+    expect(toMillis('   ')).toBeNull();
+    expect(toMillis('not-a-timestamp')).toBeNull();
+  });
+});

--- a/packages/electron/src/main/utils/timestampUtils.ts
+++ b/packages/electron/src/main/utils/timestampUtils.ts
@@ -11,13 +11,16 @@
  *
  * With TIMESTAMPTZ columns, PGLite returns Date objects that already represent
  * the correct instant in time. Just call getTime() to get epoch milliseconds.
+ * Never reconstruct a Date via Date.UTC(d.getFullYear(), d.getMonth(), ...)
+ * because that reinterprets local calendar components as UTC and double-shifts
+ * the instant. Just call .getTime() on Date inputs.
  *
  * @param value - The timestamp value from the database (Date, string, number, or unknown)
- * @returns Milliseconds since epoch, or Date.now() if value is invalid
+ * @returns Milliseconds since epoch, or null if value is empty or invalid
  */
-export function toMillis(value: unknown): number {
-  if (!value) return Date.now();
+export function toMillis(value: unknown): number | null {
   if (typeof value === 'number') return value;
+  if (value == null) return null;
 
   // With TIMESTAMPTZ columns, PGLite returns Date objects that already represent
   // the correct instant in time. Just call getTime() to get epoch milliseconds.
@@ -27,9 +30,10 @@ export function toMillis(value: unknown): number {
 
   // Fallback for string timestamps (shouldn't happen with TIMESTAMPTZ, but just in case)
   const str = String(value).trim();
+  if (!str) return null;
   // Detect timezone: ends with Z, contains +, or has negative offset like -05:00
   const hasTimezone = str.endsWith('Z') || str.includes('+') || /-\d{2}:\d{2}$/.test(str);
   const utcStr = hasTimezone ? str : str.replace(' ', 'T') + 'Z';
   const parsed = new Date(utcStr).getTime();
-  return Number.isNaN(parsed) ? Date.now() : parsed;
+  return Number.isNaN(parsed) ? null : parsed;
 }


### PR DESCRIPTION
## Summary

Follow up to #140. In the merge thread @ghinkle commented:

> Thanks. good catch. i really need to centralize this timezone handling at some point.

Picking that up here. Scoped tight: single helper consolidation across the existing duplicates, no schema changes.

## What this does

- Makes `packages/electron/src/main/utils/timestampUtils.ts` the only `toMillis()` in the package. Deletes 4 duplicate definitions in `PGLiteQueuedPromptsStore`, `PGLiteSessionWakeupsStore`, `PGLiteSessionStore`, and `PGLiteSessionFileStore`.
- Migrates 9 ad-hoc `new Date(row.x).getTime()` sites in `MetaAgentService.ts`.
- Widens the helper's return type from `number` to `number | null`. The duplicates were silently masking nullable TIMESTAMPTZ columns (`claimed_at`, `completed_at`, `fired_at`) by returning `0` or `Date.now()` for null input. Call sites now thread null through to wire types that already accommodate it (`QueuedPrompt.claimedAt?`, `SessionWakeup.firedAt: number | null`).
- Updates `packages/electron/CLAUDE.md`'s Related-files pointer. It was pointing at one of the deleted duplicates.
- Adds a `timestampUtils` test file. Closes the coverage gap I flagged in #140's notes for reviewers.

## Behavior changes worth surfacing

Three axes of difference get unified across the duplicates, not one. Calling them out so they don't surprise anyone in review:

1. Nullish/invalid input was `0` (post-#140) or `Date.now()`. Now `null`.
2. Numeric input. `PGLiteQueuedPromptsStore` and `PGLiteSessionWakeupsStore` were coercing numbers to strings before parsing. Now passed through directly.
3. Naive string parsing. `PGLiteSessionFileStore` used plain `new Date(value)`, which interprets the string in local time. The canonical helper UTC-normalizes naive strings, so consolidating it silently fixes a latent #139-class bug if that store ever sees string timestamps. It doesn't today, but worth flagging.

Wire types are unchanged. The lie was in the row mappers, not the public types.

## Call site discipline

`!` non-null assertion at NOT NULL column reads. `?? undefined` (or pass-through to `number | null` wire fields) at nullable column reads. Reasoning: schema violations should crash loudly, not paper over with `Date.now()` and silently lie about timestamps.

A handful of `!` sites read columns that are nullable in the schema but always populated via `DEFAULT CURRENT_TIMESTAMP` in practice (`ai_sessions.created_at`, `queued_prompts.created_at`, etc). The assertion encodes the de facto invariant. Tightening the schema to actually be `NOT NULL` is a separate change I didn't want to bundle here.

## Out of scope

A second PR will sweep:

- `ToolCallMatcher.ts` and `ClaudeCodeSessionScanner.ts` ad-hoc sites
- An audit of unconverted read paths in `PGLiteAgentMessagesStore`, `PGLiteDocumentsRepository`, `PGLiteWorkspaceRepository`
- Schema cleanups for columns that should never be null in practice

## Test plan

- [x] `npx vitest run packages/electron/src/main/utils/__tests__/timestampUtils.test.ts`. 5/5 passing.
- [x] `npx tsc --noEmit -p packages/electron`. 0 errors in the diff. Other workspace errors are pre-existing and unrelated.
- [x] Manual smoke. Queue a prompt, schedule a wakeup, confirm timestamps render correctly and the wakeup fires at the expected wall-clock time.

Continues from #140.

Peace B.Sweet
