### PR TITLE
fix(shortcuts): show platform-correct keyboard shortcuts on Windows and Linux

### DIFF
--- a/packages/electron/src/renderer/components/QuickOpen.tsx
+++ b/packages/electron/src/renderer/components/QuickOpen.tsx
@@ -4,6 +4,7 @@ import { usePostHog } from 'posthog-js/react';
 import { MaterialSymbol } from '@nimbalyst/runtime';
 import { getFileName, getRelativeDir } from '../utils/pathUtils';
 import { revealFolderAtom } from '../store';
+import { KeyboardShortcuts, getShortcutDisplay } from '../../shared/KeyboardShortcuts';
 
 interface FileItem {
   path: string;
@@ -649,7 +650,7 @@ export const QuickOpen: React.FC<QuickOpenProps> = ({
               <kbd
                 className="px-1.5 py-0.5 rounded font-mono text-[10px] bg-nim border border-nim text-nim"
               >
-                ⌘⇧F
+                {getShortcutDisplay(KeyboardShortcuts.window.contentSearch)}
               </kbd>
               Content search
             </span>

--- a/packages/electron/src/renderer/components/SessionQuickOpen.tsx
+++ b/packages/electron/src/renderer/components/SessionQuickOpen.tsx
@@ -5,6 +5,7 @@ import { getRelativeTimeString } from '../utils/dateFormatting';
 import { sessionOrChildProcessingAtom, sessionUnreadAtom, sessionPendingPromptAtom } from '../store';
 import { fileMentionOptionsAtom, searchFileMentionAtom } from '../store/atoms/fileMention';
 import type { TypeaheadOption } from './Typeahead/GenericTypeahead';
+import { KeyboardShortcuts, getShortcutDisplay } from '../../shared/KeyboardShortcuts';
 
 import type { SessionMeta as SessionItem } from '../store';
 
@@ -525,7 +526,7 @@ export const SessionQuickOpen: React.FC<SessionQuickOpenProps> = ({
             </span>
           ) : (
             <span className="session-quick-open-hint text-[11px] text-[var(--nim-text-faint)] flex items-center gap-1">
-              <kbd className="py-0.5 px-1.5 rounded-[3px] font-mono text-[10px] bg-[var(--nim-bg)] border border-[var(--nim-border)] text-[var(--nim-text)]">⌘⇧L</kbd> Search prompts
+              <kbd className="py-0.5 px-1.5 rounded-[3px] font-mono text-[10px] bg-[var(--nim-bg)] border border-[var(--nim-border)] text-[var(--nim-text)]">{getShortcutDisplay(KeyboardShortcuts.window.promptQuickOpen)}</kbd> Search prompts
             </span>
           )}
         </div>

--- a/packages/electron/src/renderer/components/TabManager/TabBar.tsx
+++ b/packages/electron/src/renderer/components/TabManager/TabBar.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../hooks/useTabState';
 import { CommonFileActions } from '../CommonFileActions';
 import { historyDialogFileAtom } from '../../store';
+import { KeyboardShortcuts, getShortcutDisplay } from '../../../shared/KeyboardShortcuts';
 
 // Separate component for dirty indicator - subscribes to its own tab's dirty state
 // This allows only this component to re-render when dirty state changes
@@ -718,7 +719,7 @@ export const TabBar: React.FC<TabBarProps> = ({
               className="ai-chat-toggle-button flex items-center justify-center w-7 h-7 border border-[var(--nim-border)] bg-[var(--nim-bg-secondary)] text-[var(--nim-primary)] cursor-pointer rounded p-0 transition-all duration-200 hover:bg-[var(--nim-bg-tertiary)] hover:scale-105 active:scale-95"
               data-testid="ai-sidebar-toggle"
               onClick={onToggleAIChat}
-              title={isAIChatCollapsed ? "Open AI Assistant (⌘⇧A)" : "Close AI Assistant (⌘⇧A)"}
+              title={`${isAIChatCollapsed ? 'Open' : 'Close'} AI Assistant (${getShortcutDisplay(KeyboardShortcuts.view.toggleAIChat)})`}
               aria-label={isAIChatCollapsed ? "Open AI Assistant" : "Close AI Assistant"}
             >
               <svg width="16" height="16" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/packages/electron/src/shared/KeyboardShortcuts.ts
+++ b/packages/electron/src/shared/KeyboardShortcuts.ts
@@ -93,10 +93,23 @@ export const KeyboardShortcuts = {
 } as const;
 
 /**
- * Get platform-specific shortcut display (for renderer)
- * On macOS, modifiers are shown without + separators (e.g., ⌘⇧A not ⌘+⇧+A)
+ * Get platform-specific shortcut display (for renderer).
+ * On macOS, modifiers are shown without + separators (e.g., ⌘⇧A not ⌘+⇧+A).
+ * On Windows/Linux, Cmd is rewritten to Ctrl and Option to Alt, with the
+ * familiar `+` joiner kept (e.g., Ctrl+Shift+A).
+ *
+ * The `isMac` parameter defaults to a `navigator.platform` check so renderer
+ * call sites get the right output automatically. Pass it explicitly in tests
+ * to avoid monkey-patching `navigator`.
  */
-export function getShortcutDisplay(shortcut: string): string {
+export function getShortcutDisplay(
+  shortcut: string,
+  isMac: boolean = typeof navigator !== 'undefined'
+    && navigator.platform.startsWith('Mac'),
+): string {
+  if (!isMac) {
+    return shortcut.replace('Cmd', 'Ctrl').replace('Option', 'Alt');
+  }
   return shortcut
     .replace('Cmd', '⌘')
     .replace('Ctrl', '⌃')

--- a/packages/electron/src/shared/__tests__/KeyboardShortcuts.test.ts
+++ b/packages/electron/src/shared/__tests__/KeyboardShortcuts.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  KeyboardShortcuts,
+  getElectronAccelerator,
+  getShortcutDisplay,
+} from '../KeyboardShortcuts';
+
+describe('getShortcutDisplay', () => {
+  describe('on macOS', () => {
+    it('renders Cmd as ⌘ and drops the + separators', () => {
+      expect(getShortcutDisplay('Cmd+Shift+L', true)).toBe('⌘⇧L');
+    });
+
+    it('renders Option as ⌥ and Alt as ⌥', () => {
+      expect(getShortcutDisplay('Cmd+Option+W', true)).toBe('⌘⌥W');
+      expect(getShortcutDisplay('Cmd+Alt+I', true)).toBe('⌘⌥I');
+    });
+
+    it('renders Ctrl as ⌃ when present', () => {
+      expect(getShortcutDisplay('Ctrl+Cmd+F', true)).toBe('⌃⌘F');
+    });
+
+    it('handles single-modifier shortcuts', () => {
+      expect(getShortcutDisplay('Cmd+S', true)).toBe('⌘S');
+      expect(getShortcutDisplay('Shift+Tab', true)).toBe('⇧Tab');
+    });
+  });
+
+  describe('on non-macOS platforms', () => {
+    it('rewrites Cmd to Ctrl and keeps the + separators', () => {
+      expect(getShortcutDisplay('Cmd+Shift+L', false)).toBe('Ctrl+Shift+L');
+    });
+
+    it('rewrites Option to Alt and keeps Alt as Alt', () => {
+      expect(getShortcutDisplay('Cmd+Option+W', false)).toBe('Ctrl+Alt+W');
+      expect(getShortcutDisplay('Cmd+Alt+I', false)).toBe('Ctrl+Alt+I');
+    });
+
+    it('passes Shift through unchanged', () => {
+      expect(getShortcutDisplay('Cmd+Shift+A', false)).toBe('Ctrl+Shift+A');
+    });
+
+    it('does not produce any Mac glyphs', () => {
+      const out = getShortcutDisplay('Cmd+Option+Shift+Ctrl+X', false);
+      expect(out).not.toMatch(/[⌘⇧⌥⌃]/);
+    });
+  });
+
+  describe('with the real KeyboardShortcuts constants', () => {
+    it('promptQuickOpen renders correctly on each platform', () => {
+      expect(
+        getShortcutDisplay(KeyboardShortcuts.window.promptQuickOpen, true),
+      ).toBe('⌘⇧L');
+      expect(
+        getShortcutDisplay(KeyboardShortcuts.window.promptQuickOpen, false),
+      ).toBe('Ctrl+Shift+L');
+    });
+
+    it('toggleAIChat renders correctly on each platform', () => {
+      expect(
+        getShortcutDisplay(KeyboardShortcuts.view.toggleAIChat, true),
+      ).toBe('⌘⇧A');
+      expect(
+        getShortcutDisplay(KeyboardShortcuts.view.toggleAIChat, false),
+      ).toBe('Ctrl+Shift+A');
+    });
+
+    it('contentSearch renders correctly on each platform', () => {
+      expect(
+        getShortcutDisplay(KeyboardShortcuts.window.contentSearch, true),
+      ).toBe('⌘⇧F');
+      expect(
+        getShortcutDisplay(KeyboardShortcuts.window.contentSearch, false),
+      ).toBe('Ctrl+Shift+F');
+    });
+  });
+});
+
+describe('getElectronAccelerator', () => {
+  it('rewrites Cmd to CmdOrCtrl so Electron handles platform mapping', () => {
+    expect(getElectronAccelerator('Cmd+S')).toBe('CmdOrCtrl+S');
+    expect(getElectronAccelerator('Cmd+Shift+L')).toBe('CmdOrCtrl+Shift+L');
+  });
+
+  it('leaves shortcuts without Cmd unchanged', () => {
+    expect(getElectronAccelerator('Ctrl+`')).toBe('Ctrl+`');
+    expect(getElectronAccelerator('F11')).toBe('F11');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #149: `getShortcutDisplay()` was platform-blind and always emitted Mac glyphs (`⌘`, `⇧`, `⌥`, `⌃`) regardless of OS, so non-Mac users saw Mac-style shortcuts in tooltips, kbd chips, and walkthroughs. Three other UI sites hardcoded the same Mac glyphs as string literals.

Changes:

1. `packages/electron/src/shared/KeyboardShortcuts.ts` - `getShortcutDisplay()` takes an optional `isMac` argument that defaults to a `navigator.platform` check. On Mac it keeps the existing glyph output. On Windows and Linux it rewrites `Cmd` to `Ctrl` and `Option` to `Alt`, keeping the familiar `+` separators. The default makes every existing caller correct without a code change.
2. `packages/electron/src/renderer/components/SessionQuickOpen.tsx:528` - replaces the literal `⌘⇧L` chip with `getShortcutDisplay(KeyboardShortcuts.window.promptQuickOpen)`.
3. `packages/electron/src/renderer/components/QuickOpen.tsx:652` - replaces the literal `⌘⇧F` chip with `getShortcutDisplay(KeyboardShortcuts.window.contentSearch)`.
4. `packages/electron/src/renderer/components/TabManager/TabBar.tsx:721` - rebuilds the AI Assistant button title via the helper instead of hardcoding `(⌘⇧A)`.
5. New unit tests at `packages/electron/src/shared/__tests__/KeyboardShortcuts.test.ts` covering both `isMac` branches.

Out of scope (kept for a follow-up so this PR stays small):

- Six places that hardcode `Cmd+...` text without an `IS_MAC` ternary (`BlitzDialog`, `DatabaseBrowser`, two in `SearchReplaceBar`, two in `TranscriptSearchBar`).
- Five files that redefine `IS_MAC` locally with subtly different logic, worth consolidating into a shared util.

Both noted in #149.

## Related issue

Closes #149

## Testing

- New vitest suite at `packages/electron/src/shared/__tests__/KeyboardShortcuts.test.ts` covers Mac and non-Mac branches plus the three real `KeyboardShortcuts.*` constants this PR routes through the helper.
- I have not run the full repo test suite locally because `node_modules` is not installed in my fork checkout. Relying on CI to confirm.
- Manual UI verification on Windows 11 will need a packaged build with these changes; pre-fix the kbd chip in `SessionQuickOpen.tsx:528` reads `⌘⇧L`, post-fix it should read `Ctrl+Shift+L`. Same pattern for the other two sites.

## Notes for reviewers

- The default value for the new `isMac` parameter uses `typeof navigator !== 'undefined' && navigator.platform.startsWith('Mac')` so the helper is safe to call from a node-side test environment as well as the renderer.
- `KeyboardShortcutsDialog.tsx:189-231` and `ToolbarPlugin/index.tsx:889,900` already use `IS_MAC` / `IS_APPLE` ternaries with hardcoded glyphs - left alone since they are platform-correct as written. They could be migrated to the helper later but it would just be cleanup, not a fix.
- Electron menus in `packages/electron/src/main/menu/` use `accelerator: 'CmdOrCtrl+...'` which Electron handles per-platform automatically, so they are unaffected.

Signed-off-by: Andrew Demczuk <5212682+ademczuk@users.noreply.github.com>
