### PR TITLE
fix: read customClaudeCodePath from ai-settings store in path loader

### DIFF
--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -1720,25 +1720,8 @@ app.whenReady().then(async () => {
     const sessionRestored = shouldSkipSessionRestore ? false : await restoreSessionState();
     markEnd('session-restore');
 
-    // Set up a loader that reads customClaudeCodePath fresh from the store on each query,
-    // so changes in the UI take effect without restarting the app. The workspace path is
-    // required: getAIProviderOverridesWithWorktreeFallback handles direct overrides plus
-    // worktree-to-parent inheritance. Only fall through to the global setting when no
-    // project-level override exists at all (which is the intended fallback, not a routing
-    // failure). A missing workspacePath here would mean an upstream wiring bug, so throw.
-    ClaudeCodeProvider.setCustomClaudeCodePathLoader((workspacePath: string) => {
-      if (!workspacePath) {
-        throw new Error('[ClaudeCodeProvider] customClaudeCodePathLoader called without a workspacePath');
-      }
-
-      const projectOverride = getAIProviderOverridesWithWorktreeFallback(workspacePath)?.customClaudeCodePath;
-      if (projectOverride !== undefined) {
-        return projectOverride;
-      }
-
-      return (store.get('customClaudeCodePath', '') as string) || '';
-    });
-    logger.main.info('[ClaudeCodeProvider] Initialized customClaudeCodePath loader (workspace-aware)');
+    // Note: customClaudeCodePathLoader is now set up in AIService constructor,
+    // where it has direct access to the ai-settings store that owns this value.
 
     // Close splash screen now that initialization is done and a real window is about to show.
     // The last restored window activates the app via its own ready-to-show handler.

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -55,7 +55,7 @@ import {
   shouldShowCommunityPopup,
   wasCommunityPopupShownThisLaunch
 } from '../../utils/store';
-import { mergeAISettings } from '../../utils/aiSettingsMerge';
+import { mergeAISettings, getAIProviderOverridesWithWorktreeFallback } from '../../utils/aiSettingsMerge';
 import { DocumentContextService, type RawDocumentContext, type PreparedDocumentContext } from '@nimbalyst/runtime';
 import { getMessageSyncHandler, getSyncProvider, isDesktopTrulyAway } from '../SyncManager';
 import { normalizeCodexProviderConfig, omitModelsField, stripTransientProviderFields } from '@nimbalyst/runtime/ai/server/utils/modelConfigUtils';
@@ -164,6 +164,22 @@ export class AIService {
     for (const tool of BUILT_IN_TOOLS) {
       toolRegistry.register(tool);
     }
+
+    // Wire up the custom binary path loader so each query reads the current
+    // value fresh from the ai-settings store. This must live here (not in
+    // index.ts) because only AIService owns the ai-settings store; the
+    // store reference in index.ts points to app-settings and would always
+    // return empty string.
+    ClaudeCodeProvider.setCustomClaudeCodePathLoader((workspacePath: string) => {
+      if (!workspacePath) {
+        throw new Error('[ClaudeCodeProvider] customClaudeCodePathLoader called without a workspacePath');
+      }
+      const projectOverride = getAIProviderOverridesWithWorktreeFallback(workspacePath)?.customClaudeCodePath;
+      if (projectOverride !== undefined) {
+        return projectOverride;
+      }
+      return (this.getSettingsStore().get('customClaudeCodePath', '') as string) || '';
+    });
 
     // API keys must be explicitly set by the user in settings.
     // NEVER auto-import keys from process.env. A user's .env file with


### PR DESCRIPTION
## Summary

Move `ClaudeCodeProvider.setCustomClaudeCodePathLoader(...)` from `index.ts` into the `AIService` constructor so it reads from the correct electron-store instance (`ai-settings.json`) where the UI persists the custom path. Previously the loader in `index.ts` called `store.get('customClaudeCodePath')` which reads from `app-settings.json`, a separate store that never receives this value, so the custom binary path was always ignored.

## Related issue

Closes #58

## Testing

Manually tested with a corporate SSO wrapper binary (`/usr/local/bin/<path_to_custom_claude>`) set as the custom Claude Code path. Before this fix the app showed "Login Required" despite the path being configured. After the fix, the `[CLAUDE-CODE] Binary path:` log confirms `custom=<path>` rather than `(none)`, and the wrapper is correctly invoked.

## Notes for reviewers

`ClaudeCodeProvider.setCustomClaudeCodePathLoader` is last-write-wins. The stale registration in `index.ts` would always overwrite the correct one set by `AIService` (since `app.whenReady()` fires after the constructor). 
