### PR TITLE
fix(walkthrough): use 420px width in clamp math when step.wide is true

### DIFF
--- a/packages/electron/src/renderer/walkthroughs/WalkthroughService.ts
+++ b/packages/electron/src/renderer/walkthroughs/WalkthroughService.ts
@@ -218,6 +218,13 @@ export interface CalloutPosition {
 }
 
 const CALLOUT_WIDTH = 320;
+/**
+ * Width of the wide variant. Must match the `w-[420px]` Tailwind class applied
+ * in `WalkthroughCallout.tsx` when `step.wide` is true. If you change one, change
+ * both. Otherwise viewport-clamp arithmetic here disagrees with the rendered
+ * width and the callout will overflow the viewport edge on wide steps.
+ */
+const CALLOUT_WIDE_WIDTH = 420;
 const CALLOUT_HEIGHT_ESTIMATE = 200; // Will vary based on content
 const ARROW_SIZE = 12;
 const VIEWPORT_MARGIN = 16;
@@ -226,8 +233,10 @@ const ARROW_MAX_OFFSET_FROM_EDGE = 24; // Maximum distance arrow can be from cal
 
 export function calculateCalloutPosition(
   target: HTMLElement,
-  preferredPlacement: WalkthroughStep['placement']
+  preferredPlacement: WalkthroughStep['placement'],
+  wide: boolean = false,
 ): CalloutPosition {
+  const calloutWidth = wide ? CALLOUT_WIDE_WIDTH : CALLOUT_WIDTH;
   const rect = target.getBoundingClientRect();
   const viewportWidth = window.innerWidth;
   const viewportHeight = window.innerHeight;
@@ -246,8 +255,8 @@ export function calculateCalloutPosition(
   let placement = preferredPlacement;
 
   // Check if preferred placement actually fits, otherwise find the best alternative
-  const fitsRight = spaceRight >= CALLOUT_WIDTH + ARROW_SIZE + VIEWPORT_MARGIN;
-  const fitsLeft = spaceLeft >= CALLOUT_WIDTH + ARROW_SIZE + VIEWPORT_MARGIN;
+  const fitsRight = spaceRight >= calloutWidth + ARROW_SIZE + VIEWPORT_MARGIN;
+  const fitsLeft = spaceLeft >= calloutWidth + ARROW_SIZE + VIEWPORT_MARGIN;
   const fitsBelow = spaceBelow >= CALLOUT_HEIGHT_ESTIMATE + ARROW_SIZE + VIEWPORT_MARGIN;
   const fitsAbove = spaceAbove >= CALLOUT_HEIGHT_ESTIMATE + ARROW_SIZE + VIEWPORT_MARGIN;
 
@@ -286,17 +295,17 @@ export function calculateCalloutPosition(
   switch (placement) {
     case 'top':
       top = rect.top - CALLOUT_HEIGHT_ESTIMATE - ARROW_SIZE;
-      left = targetCenterX - CALLOUT_WIDTH / 2;
+      left = targetCenterX - calloutWidth / 2;
       arrowPosition = 'bottom';
       break;
     case 'bottom':
       top = rect.bottom + ARROW_SIZE;
-      left = targetCenterX - CALLOUT_WIDTH / 2;
+      left = targetCenterX - calloutWidth / 2;
       arrowPosition = 'top';
       break;
     case 'left':
       top = targetCenterY - CALLOUT_HEIGHT_ESTIMATE / 2;
-      left = rect.left - CALLOUT_WIDTH - ARROW_SIZE;
+      left = rect.left - calloutWidth - ARROW_SIZE;
       arrowPosition = 'right';
       break;
     case 'right':
@@ -307,12 +316,12 @@ export function calculateCalloutPosition(
     default:
       // Fallback to bottom
       top = rect.bottom + ARROW_SIZE;
-      left = targetCenterX - CALLOUT_WIDTH / 2;
+      left = targetCenterX - calloutWidth / 2;
       arrowPosition = 'top';
   }
 
   // Clamp to viewport bounds
-  left = Math.max(VIEWPORT_MARGIN, Math.min(left, viewportWidth - CALLOUT_WIDTH - VIEWPORT_MARGIN));
+  left = Math.max(VIEWPORT_MARGIN, Math.min(left, viewportWidth - calloutWidth - VIEWPORT_MARGIN));
   top = Math.max(VIEWPORT_MARGIN, Math.min(top, viewportHeight - CALLOUT_HEIGHT_ESTIMATE - VIEWPORT_MARGIN));
 
   // Calculate arrow offset - where the arrow should point to hit the target
@@ -327,7 +336,7 @@ export function calculateCalloutPosition(
     // Arrow should point at target center horizontally
     arrowOffset = targetCenterX - left;
     // Clamp arrow to stay within callout bounds with padding
-    arrowOffset = Math.max(ARROW_MIN_OFFSET, Math.min(arrowOffset, CALLOUT_WIDTH - ARROW_MIN_OFFSET));
+    arrowOffset = Math.max(ARROW_MIN_OFFSET, Math.min(arrowOffset, calloutWidth - ARROW_MIN_OFFSET));
   }
 
   return { top, left, arrowPosition, arrowOffset };

--- a/packages/electron/src/renderer/walkthroughs/__tests__/WalkthroughService.test.ts
+++ b/packages/electron/src/renderer/walkthroughs/__tests__/WalkthroughService.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { calculateCalloutPosition } from '../WalkthroughService';
+
+/**
+ * Build a fake target element whose `getBoundingClientRect()` returns the given rect.
+ * Tests don't actually need a real DOM-mounted element since the callout-position
+ * code only reads bounding-rect geometry plus `window.innerWidth`/`innerHeight`.
+ */
+function fakeTarget(rect: { top: number; left: number; width: number; height: number }): HTMLElement {
+  const el = document.createElement('div');
+  el.getBoundingClientRect = () => ({
+    x: rect.left,
+    y: rect.top,
+    top: rect.top,
+    left: rect.left,
+    bottom: rect.top + rect.height,
+    right: rect.left + rect.width,
+    width: rect.width,
+    height: rect.height,
+    toJSON: () => ({}),
+  });
+  return el;
+}
+
+describe('calculateCalloutPosition', () => {
+  const originalInnerWidth = window.innerWidth;
+  const originalInnerHeight = window.innerHeight;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: 1280, writable: true, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 800, writable: true, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: originalInnerWidth, writable: true, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: originalInnerHeight, writable: true, configurable: true });
+  });
+
+  describe('default (non-wide) callout', () => {
+    it('clamps left to viewport when target is near the right edge', () => {
+      // Target hugs the right edge of a 1280px-wide viewport (rect.right = 1280, spaceRight = 0).
+      // 320px callout + 12px arrow + 16px margin = 348px needed on the right, none available.
+      // Should fall back to a placement that fits, with left clamped inside the viewport.
+      const target = fakeTarget({ top: 400, left: 1200, width: 80, height: 30 });
+      const pos = calculateCalloutPosition(target, 'right');
+      expect(pos.left).toBeGreaterThanOrEqual(16); // VIEWPORT_MARGIN
+      expect(pos.left + 320).toBeLessThanOrEqual(1280 - 16);
+    });
+
+    it('places callout to the right when there is room', () => {
+      const target = fakeTarget({ top: 400, left: 100, width: 50, height: 30 });
+      const pos = calculateCalloutPosition(target, 'right');
+      // 100 + 50 + 12 = 162 (rect.right + ARROW_SIZE)
+      expect(pos.left).toBe(162);
+      expect(pos.arrowPosition).toBe('left');
+    });
+  });
+
+  describe('wide callout', () => {
+    it('uses 420 (not 320) when computing fitsRight', () => {
+      // Viewport = 1280. Target.right = 800. spaceRight = 480.
+      // For default (320): 480 >= 320+12+16 = 348 -> fitsRight = true.
+      // For wide (420):    480 >= 420+12+16 = 448 -> fitsRight = true.
+      // Make a tighter case where wide=false fits but wide=true does not.
+      // Target at left=400, width=50 -> right=450, spaceRight=830.
+      // Both fit. Use a tighter case: target.right = 900, spaceRight = 380.
+      // Default: 380 >= 348 -> fits.  Wide: 380 < 448 -> does NOT fit.
+      const target = fakeTarget({ top: 400, left: 850, width: 50, height: 30 });
+      const widePos = calculateCalloutPosition(target, 'right', true);
+      // Wide should NOT place to the right because 380 < 448. Should fall back to 'bottom' (fits).
+      expect(widePos.arrowPosition).not.toBe('left');
+    });
+
+    it('clamps left for wide callouts using 420 width', () => {
+      // Place target near the right edge.
+      // For wide=true, viewport-clamp uses 420: max-left = 1280 - 420 - 16 = 844.
+      // For wide=false, viewport-clamp uses 320: max-left = 1280 - 320 - 16 = 944.
+      // Pick a target whose unclamped left would exceed 844 but stay below 944.
+      // bottom placement: left = targetCenterX - calloutWidth/2.
+      // targetCenterX = 1100, wide left = 1100 - 210 = 890; clamped to 844.
+      // wide=false left = 1100 - 160 = 940; clamped to 940 (under 944, no clamp).
+      const target = fakeTarget({ top: 100, left: 1080, width: 40, height: 30 });
+      const narrow = calculateCalloutPosition(target, 'bottom', false);
+      const wide = calculateCalloutPosition(target, 'bottom', true);
+      expect(narrow.left).toBe(940);
+      expect(wide.left).toBe(844);
+      expect(wide.left + 420).toBeLessThanOrEqual(1280 - 16);
+    });
+
+    it('arrow offset uses calloutWidth bound for wide callouts', () => {
+      // For bottom placement with wide=true, arrowOffset is clamped to <= calloutWidth - ARROW_MIN_OFFSET = 420 - 24 = 396.
+      // Default would clamp to 320 - 24 = 296.
+      // Build a case where targetCenter is far right of the clamped left so the arrow would be near the right edge.
+      const target = fakeTarget({ top: 100, left: 1000, width: 100, height: 30 });
+      const wide = calculateCalloutPosition(target, 'bottom', true);
+      expect(wide.arrowPosition).toBe('top');
+      // arrowOffset must be within the wide callout (>= 24, <= 420 - 24).
+      expect(wide.arrowOffset).toBeGreaterThanOrEqual(24);
+      expect(wide.arrowOffset).toBeLessThanOrEqual(420 - 24);
+    });
+  });
+
+  describe('default parameter behavior', () => {
+    it('omitting wide is equivalent to wide=false', () => {
+      const target = fakeTarget({ top: 400, left: 100, width: 50, height: 30 });
+      const omitted = calculateCalloutPosition(target, 'right');
+      const explicit = calculateCalloutPosition(target, 'right', false);
+      expect(omitted).toEqual(explicit);
+    });
+  });
+});

--- a/packages/electron/src/renderer/walkthroughs/components/WalkthroughCallout.tsx
+++ b/packages/electron/src/renderer/walkthroughs/components/WalkthroughCallout.tsx
@@ -114,7 +114,7 @@ export function WalkthroughCallout({
           return;
         }
         setTargetElement(target);
-        const pos = calculateCalloutPosition(target, step.placement);
+        const pos = calculateCalloutPosition(target, step.placement, step.wide ?? false);
         setPosition(pos);
       } else {
         setTargetElement(null);


### PR DESCRIPTION
## Summary

`calculateCalloutPosition()` in `WalkthroughService.ts` hardcoded `CALLOUT_WIDTH = 320` for fit checks, viewport clamping, and arrow-offset bounds. But `WalkthroughCallout.tsx:230` renders the wide variant at 420px (`w-[420px]` Tailwind class, gated on `step.wide`). On wide steps the math used 320 while the DOM was 420, so the clamp arithmetic disagreed with the rendered width. Result: wide callouts could overflow the viewport edge or the arrow could point past the target.

The fix:

1. Add `CALLOUT_WIDE_WIDTH = 420` constant in `WalkthroughService.ts`, with a doc comment that ties it to the `w-[420px]` Tailwind class so the next person editing one knows to update the other.
2. Add a `wide: boolean = false` parameter to `calculateCalloutPosition`. The default keeps existing call-site behavior unchanged for any caller that omits it.
3. Pass `step.wide ?? false` from `WalkthroughCallout.tsx:117` so the function uses the right constant.
4. New unit tests at `packages/electron/src/renderer/walkthroughs/__tests__/WalkthroughService.test.ts` cover both branches plus the default-parameter contract. Tests use jsdom (the repo's vitest default) and stub `getBoundingClientRect` per element rather than mounting real DOM.

Out of scope, kept for later (mentioned in #148):

- Migrating to `@floating-ui/react` per `.claude/rules/floating-ui.md`. The codebase already has `useFloatingMenu` (`hooks/useFloatingMenu.ts`) wrapping `useFloating` with standard middleware, so the migration is feasible. It is just larger than this hotfix.
- Replacing `setInterval(findTarget, 500)` in `WalkthroughCallout.tsx:129` with a `ResizeObserver`.

## Related issue

Refs #148

## Testing

- New vitest suite covers wide vs default at three points: fit checks, viewport clamping, and arrow-offset bounds. Plus a contract test that omitting the parameter equals passing `false`.
- I have not run the full repo test suite locally because `node_modules` is not installed in the fork checkout. Relying on CI.
- Manual verification will need the repo's existing wide walkthrough (`session-quick-open-intro` is `wide: true`). Pre-fix, on a viewport where `spaceRight` is between 348 and 448, the wide callout would think it fits to the right but render past the viewport edge. Post-fix, the function falls back to a placement that actually fits the 420px width.

## Notes for reviewers

- The default parameter value (`wide: boolean = false`) is the only behavioral change for existing callers. I grepped the monorepo for `calculateCalloutPosition`: the only runtime caller is `WalkthroughCallout.tsx`, and there is one re-export in `walkthroughs/index.ts`. Nothing else.
- The legacy `CALLOUT_WIDTH` constant is preserved as the default-width source of truth, so the diff is additive rather than a rename.
- I left `ARROW_MAX_OFFSET_FROM_EDGE` alone even though it is unused. Cleanup is out of scope.
- The doc comment on `CALLOUT_WIDE_WIDTH` calls out the duplicate-source-of-truth between this constant and the Tailwind class, since the existing pattern keeps these decoupled.

Signed-off-by: Andrew Demczuk <5212682+ademczuk@users.noreply.github.com>
