### PR TITLE
fix(tool-errors): annotate Stream closed tool errors with audit-log guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Surface a clearer error than `Stream closed` on Claude Code tool-call failures. The native binary's bare error string left operators chasing permission-mode or token issues, but the failure correlates with PGLite write-lock contention on the audit-log tables (`ai_agent_messages`, `ai_tool_call_file_edits`) under sustained tool-call traffic in `permissionMode: bypass-all`. `ClaudeCodeProvider` now passes tool-result content through a new `annotateStreamClosedToolResult` helper that prepends a diagnostic message identifying the audit-log-contention pattern and pointing at #163 for the full hypothesis and ranked deeper fixes. The original error text is preserved verbatim at the end. Existing `STREAM_CLOSED_DIAGNOSTIC` console logging is untouched (it reads the raw chunk content, not the toolCall result). References #163.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -63,6 +63,7 @@ import {
   prepareClaudeCodeAttachments,
 } from './claudeCode/messagePreparation';
 import {
+  annotateStreamClosedToolResult,
   applyToolResultToToolCall,
   isSearchableAssistantChunk,
 } from './claudeCode/toolChunkUtils';
@@ -940,7 +941,11 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
               case 'tool_result': {
                 const toolCall = toolCallsById.get(item.toolUseId);
                 if (toolCall) {
-                  const { isDuplicate } = applyToolResultToToolCall(toolCall, item.content, item.isError);
+                  // Swap "Stream closed" for an operator-actionable message before
+                  // it reaches the UI. The original `item.content` is left untouched
+                  // so the diagnostic logging below still inspects the raw signal.
+                  const annotatedContent = annotateStreamClosedToolResult(item.content, item.isError);
+                  const { isDuplicate } = applyToolResultToToolCall(toolCall, annotatedContent, item.isError);
                   if (isDuplicate) break;
 
                   // Diagnostic: detect "Stream closed" errors from the native binary

--- a/packages/runtime/src/ai/server/providers/claudeCode/__tests__/toolChunkUtils.test.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/__tests__/toolChunkUtils.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  annotateStreamClosedToolResult,
+  applyToolResultToToolCall,
+} from '../toolChunkUtils';
+
+describe('annotateStreamClosedToolResult', () => {
+  it('rewrites string tool_result containing "Stream closed" when isError=true', () => {
+    const annotated = annotateStreamClosedToolResult(
+      'Tool permission request failed: Error: Stream closed',
+      true,
+    );
+    expect(typeof annotated).toBe('string');
+    expect(annotated).toContain('PGLite write-lock contention');
+    expect(annotated).toContain('nimbalyst/nimbalyst#163');
+    // Original text is preserved verbatim at the end
+    expect(annotated).toContain('Tool permission request failed: Error: Stream closed');
+  });
+
+  it('returns input unchanged when isError=false', () => {
+    const passthrough = annotateStreamClosedToolResult(
+      'echo Stream closed (this is just normal output)',
+      false,
+    );
+    expect(passthrough).toBe('echo Stream closed (this is just normal output)');
+  });
+
+  it('returns input unchanged when string does not include "Stream closed"', () => {
+    const passthrough = annotateStreamClosedToolResult(
+      'Tool call failed: ECONNREFUSED',
+      true,
+    );
+    expect(passthrough).toBe('Tool call failed: ECONNREFUSED');
+  });
+
+  it('returns input unchanged when toolResult is not a string', () => {
+    const arr = [{ type: 'text', text: 'Stream closed' }];
+    expect(annotateStreamClosedToolResult(arr, true)).toBe(arr);
+    expect(annotateStreamClosedToolResult(undefined, true)).toBe(undefined);
+    expect(annotateStreamClosedToolResult(null, true)).toBe(null);
+  });
+});
+
+describe('applyToolResultToToolCall integration with annotated content', () => {
+  it('writes the annotated string to toolCall.result without duplicating', () => {
+    const toolCall: any = { name: 'Bash', arguments: { command: 'sleep 60 && echo done' } };
+    const annotated = annotateStreamClosedToolResult('Stream closed', true);
+
+    const { isDuplicate } = applyToolResultToToolCall(toolCall, annotated, true);
+    expect(isDuplicate).toBe(false);
+    expect(typeof toolCall.result).toBe('string');
+    expect(toolCall.result).toContain('audit-log tables');
+    expect(toolCall.isError).toBe(true);
+  });
+
+  it('does not corrupt Edit-tool result-shape preservation', () => {
+    // For Edit tools without an error, the existing logic builds a structured
+    // result. annotateStreamClosedToolResult must not interfere on the success
+    // path because isError=false short-circuits the helper.
+    const toolCall: any = {
+      name: 'Edit',
+      arguments: { file_path: '/x.txt', old_string: 'a', new_string: 'b' },
+    };
+    const successText = 'File edited.';
+    const passthrough = annotateStreamClosedToolResult(successText, false);
+    expect(passthrough).toBe(successText);
+
+    applyToolResultToToolCall(toolCall, passthrough, false);
+    expect(toolCall.result).toEqual({
+      message: successText,
+      file_path: '/x.txt',
+      old_string: 'a',
+      new_string: 'b',
+    });
+  });
+});

--- a/packages/runtime/src/ai/server/providers/claudeCode/toolChunkUtils.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/toolChunkUtils.ts
@@ -46,6 +46,47 @@ export function buildToolResultMessage(
 }
 
 /**
+ * The Claude Code native binary surfaces "Stream closed" as the tool_result
+ * content when the SDK's stdin closes mid-tool-call. ClaudeCodeProvider already
+ * mitigates one trigger of this (premature stdin close on `type: 'result'`)
+ * with the AsyncIterable prompt + grace-period timer. A second trigger remains
+ * in `permissionMode: bypass-all`: sustained tool-call traffic queues
+ * audit-log writes (ai_agent_messages, ai_tool_call_file_edits) behind PGLite's
+ * single-writer lock, the IPC-side timeout fires before the audit write
+ * completes, and the same "Stream closed" string surfaces. The bare error
+ * leaves operators chasing permission-mode or token issues that aren't there.
+ *
+ * When the pattern matches, replace the bare text with a diagnostic message
+ * pointing at audit-log contention and the tracking issue. The original error
+ * is preserved verbatim at the end so nothing is lost. Any non-string, non-
+ * matching, or non-error input passes through unchanged.
+ *
+ * Tracking: see #163 for the full hypothesis + ranked deeper fixes.
+ */
+export function annotateStreamClosedToolResult(
+  toolResult: unknown,
+  isError: boolean,
+): unknown {
+  if (!isError) return toolResult;
+  if (typeof toolResult !== 'string') return toolResult;
+  if (!toolResult.includes('Stream closed')) return toolResult;
+  return (
+    'Tool call failed in Nimbalyst.\n' +
+    '\n' +
+    'The native binary returned "Stream closed". The most common cause in ' +
+    'permissionMode: bypass-all is PGLite write-lock contention on the ' +
+    'audit-log tables (ai_agent_messages, ai_tool_call_file_edits) under ' +
+    'sustained tool-call traffic. Restarting Nimbalyst typically resets ' +
+    'the wall for ~2 more calls.\n' +
+    '\n' +
+    'See nimbalyst/nimbalyst#163 for the full hypothesis and ranked workarounds.\n' +
+    '\n' +
+    'Original tool_result content:\n' +
+    toolResult
+  );
+}
+
+/**
  * Mutates toolCall in place to keep existing call-site behavior.
  */
 export function applyToolResultToToolCall(


### PR DESCRIPTION
## Summary

Replace the cryptic `Stream closed` tool-result error with an operator-actionable diagnostic message that identifies the audit-log-contention pattern and points at the tracking issue. Original error text preserved verbatim. This is the cheapest of the 6 fixes ranked in #163.

## Related issue

References #163. This PR addresses suggestion #1 from the issue body (\"surface a clearer error than `Stream closed`\"). The deeper fixes (audit-write offloading, IPC timeout tuning, separate PGLite connection pool, etc.) remain open for follow-up.

## What changed

- New helper `annotateStreamClosedToolResult` in `claudeCode/toolChunkUtils.ts`. Pattern matches only when `isError=true` AND the string content includes `Stream closed`. Non-matching inputs pass through unchanged.
- `ClaudeCodeProvider` calls the helper once on the `tool_result` branch, immediately before `applyToolResultToToolCall`. The original `item.content` is left untouched so existing `STREAM_CLOSED_DIAGNOSTIC` console logging keeps inspecting the raw signal.
- New test file `__tests__/toolChunkUtils.test.ts` with 6 tests covering the four guard branches plus integration with `applyToolResultToToolCall` (including a regression check that the Edit tool's success-path result-shape preservation is unaffected).
- CHANGELOG entry under `[Unreleased] -> Fixed`.

## What it surfaces to operators

Before:
```
Tool permission request failed: Error: Stream closed
```

After (when the failure pattern matches):
```
Tool call failed in Nimbalyst.

The native binary returned \"Stream closed\". The most common cause in
permissionMode: bypass-all is PGLite write-lock contention on the
audit-log tables (ai_agent_messages, ai_tool_call_file_edits) under
sustained tool-call traffic. Restarting Nimbalyst typically resets
the wall for ~2 more calls.

See nimbalyst/nimbalyst#163 for the full hypothesis and ranked workarounds.

Original tool_result content:
Tool permission request failed: Error: Stream closed
```

## Testing

- `npx vitest run packages/runtime/src/ai/server/providers/claudeCode/__tests__/toolChunkUtils.test.ts` -> 6/6 pass
- `npm run typecheck --prefix packages/runtime` -> clean
- `git merge-tree --write-tree upstream/main HEAD` -> exit 0 (no conflicts)
- Verified locally: in a long bypass-all session that was reproducing the issue, the new wrapped message renders in the chat with the original error preserved at the end.

## Notes for reviewers

- The helper short-circuits on `isError=false`, so the Edit tool's success path that builds a structured `{ message, file_path, old_string, new_string }` result is unaffected. There is an explicit regression test for this.
- `processTeammateToolResult` and `task.summary` are left reading the original `item.content` rather than the annotated string. Single-concern principle: this PR only changes what reaches the chat UI. Happy to extend to those paths in a follow-up if you'd prefer.
- This does not fix the underlying PGLite write-lock contention. It just stops the error message from sending operators down the wrong debugging path. Suggestions 2-6 in #163 (offload audit writes, raise IPC timeout, separate connection pool, periodic VACUUM, coarser flush granularity) remain open and would each be a separate PR.
- The replacement string mentions `nimbalyst/nimbalyst#163` explicitly so the link survives if a user copies the error out of Nimbalyst into their own bug report.

Signed-off-by: Andrew Demczuk <5212682+ademczuk@users.noreply.github.com>