### PR TITLE
fix: read User-scope customClaudeCodePath from ai-settings store

### DIFF
--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -64,7 +64,6 @@ import {
     updateWorkspaceState,
     runMigrations,
     getAppSetting,
-    store
 } from './utils/store';
 import { getAIProviderOverridesWithWorktreeFallback } from './utils/aiSettingsMerge';
 import { registerMCPConfigHandlers } from './ipc/MCPConfigHandlers';
@@ -1726,6 +1725,16 @@ app.whenReady().then(async () => {
     // worktree-to-parent inheritance. Only fall through to the global setting when no
     // project-level override exists at all (which is the intended fallback, not a routing
     // failure). A missing workspacePath here would mean an upstream wiring bug, so throw.
+    //
+    // The global value is read via aiService.getCustomClaudeCodePath() so it comes from the
+    // ai-settings electron-store -- the same store ai:saveSettings writes to. Reading from
+    // the app-settings store (`store.get('customClaudeCodePath', ...)`) silently returned ''
+    // because the key is never written there, which made the User-scope custom path appear
+    // ignored on every launch (issue #165).
+    const aiSvcForClaudePath = aiService;
+    if (!aiSvcForClaudePath) {
+      throw new Error('[ClaudeCodeProvider] AIService must be initialized before the customClaudeCodePath loader');
+    }
     ClaudeCodeProvider.setCustomClaudeCodePathLoader((workspacePath: string) => {
       if (!workspacePath) {
         throw new Error('[ClaudeCodeProvider] customClaudeCodePathLoader called without a workspacePath');
@@ -1736,7 +1745,7 @@ app.whenReady().then(async () => {
         return projectOverride;
       }
 
-      return (store.get('customClaudeCodePath', '') as string) || '';
+      return aiSvcForClaudePath.getCustomClaudeCodePath();
     });
     logger.main.info('[ClaudeCodeProvider] Initialized customClaudeCodePath loader (workspace-aware)');
 

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -414,6 +414,21 @@ export class AIService {
   }
 
   /**
+   * Returns the User-scope custom Claude Code executable path from the
+   * ai-settings store (the same store ai:saveSettings writes to).
+   *
+   * Exposed so the main process loader in index.ts can read this value from
+   * the correct store. Reading directly from the app-settings store via
+   * `store.get('customClaudeCodePath', ...)` always returns '' because the
+   * key is never written there, which silently dropped the User-scope path
+   * and caused the SDK to fall back to the bundled native binary instead of
+   * the user's wrapper script (issue #165).
+   */
+  public getCustomClaudeCodePath(): string {
+    return (this.getSettingsStore().get('customClaudeCodePath', '') as string) || '';
+  }
+
+  /**
    * Get API key for a provider, considering project-level overrides.
    * Project-specific API keys take precedence over global keys.
    */


### PR DESCRIPTION
Fixes #165.

## Summary

The User-scope **Custom Claude Installation** path was being silently dropped on every launch, causing the SDK to fall back to the bundled native `claude` binary instead of the user's wrapper script. For users with corporate-SSO wrappers (the original use case for the setting), this meant `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` and the rest of the wrapper's env setup never ran, and traffic hit the default Anthropic endpoint.

## Root cause

The path is **written** to `ai-settings.json` (via `AIService.saveSettings` -> `getSettingsStore()`, name `ai-settings`).

The path was **read** from `app-settings.json` in the loader registered in `packages/electron/src/main/index.ts`:

```ts
return (store.get('customClaudeCodePath', '') as string) || '';
```

…where `store` is the app-settings electron-store (`name: 'app-settings'`). The key is never written to that file, so the global fallback always resolved to `''`.

Project-scope overrides happened to work because they read from `workspace-settings.json` via `getAIProviderOverridesWithWorktreeFallback`, which masked the bug for workspaces that had a project-level override and made the symptom look intermittent.

The "uncheck Use Claude Agent + re-paste the path" workaround that worked around 0.56–0.57 relied on an in-memory cache (`ClaudeCodeProvider.setCustomClaudeCodePath`) that was repopulated on save. That cache write was removed in `28c71a19` ("hot-reload customClaudeCodePath without app restart") when the loader was switched to read fresh from disk on each query, which is why the workaround stopped working — matching the reporter's experience.

The bug predates #128 and the worktree-fallback follow-up commit. It goes back to the original `feat: allow custom Claude executable path for corporate SSO wrappers` change, where the commit message stated the value persists via the ai-settings store but the runtime read used the app-settings store.

## Fix

- Expose `AIService.getCustomClaudeCodePath(): string` that reads from `getSettingsStore()` (the ai-settings store the renderer writes to).
- The loader in `index.ts` calls that accessor for the global fallback instead of `store.get('customClaudeCodePath', ...)`.
- Removed the now-unused `store` import from `index.ts`.
- Added an explicit guard at loader-registration time so a future reordering that registers the loader before `AIService` is instantiated fails loudly instead of silently falling back to the bundled binary again.

The loader still re-reads on every query, so hot-reload of the setting without an app restart is preserved.

Project-scope overrides and worktree-to-project inheritance are unchanged.

## Test plan

- [x] `tsc --noEmit` clean in `packages/electron`
- [x] `tsc --noEmit` clean in `packages/runtime`
- [x] `npm run test:unit` exits 0
- [x] Manual: User scope sets a wrapper script path; starting a Claude Agent session logs `[CLAUDE-CODE] Binary path: custom=<wrapper-path>` and the wrapper's env vars (e.g. `ANTHROPIC_BASE_URL`) reach the spawned process.
- [x] Manual: Clearing the User-scope path falls back to the bundled native binary on the next session (no stale value).
- [x] Manual: Project-scope override still wins over the User-scope value, and clearing the override re-inherits the User-scope value.
- [x] Manual: Worktree without its own override inherits the parent project's override (worktree-fallback behaviour from `e44fa2de` preserved).