### PR TITLE
fix(git-watcher): skip empty repos cleanly instead of logging a stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Open a workspace whose `.git` repo has zero commits yet without spamming a multi-line stack trace into `main.log`. `GitRefWatcher.start` was letting the "fatal: your current branch X does not have any commits yet" error from `simple-git`'s `log()` call escape into the outer catch as `[GitRefWatcher] Failed to start watching: ...`. The pre-flight branch + HEAD lookup is now wrapped in a narrow try/catch that pattern-matches that exact error, logs a one-line info message, and returns cleanly. All other errors still surface to the outer catch unchanged. Mirrors the existing detached-HEAD short-circuit. Adds unit tests for the empty-repo, unrelated-error, and detached-HEAD paths.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/file/GitRefWatcher.ts
+++ b/packages/electron/src/main/file/GitRefWatcher.ts
@@ -148,18 +148,37 @@ export class GitRefWatcher {
 
       const git: SimpleGit = simpleGit(workspacePath);
 
-      // Get current branch
-      const status = await git.status();
-      const currentBranch = status.current;
-      if (!currentBranch) {
-        // Not on a branch (detached HEAD) - skip watching
-        logger.main.info('[GitRefWatcher] Skipping detached HEAD workspace:', workspacePath);
-        return;
-      }
+      // Pre-flight: get current branch + HEAD hash. Both can fail on a
+      // fresh-init repo with zero commits ("fatal: your current branch X
+      // does not have any commits yet"). Treat that as a known no-op rather
+      // than logging the full stack trace, mirroring the detached-HEAD
+      // short-circuit below.
+      let currentBranch: string;
+      let lastCommitHash: string;
+      try {
+        const status = await git.status();
+        if (!status.current) {
+          // Not on a branch (detached HEAD) - skip watching
+          logger.main.info('[GitRefWatcher] Skipping detached HEAD workspace:', workspacePath);
+          return;
+        }
+        currentBranch = status.current;
 
-      // Get current commit hash as baseline
-      const log = await git.log({ maxCount: 1 });
-      const lastCommitHash = log.latest?.hash || '';
+        const log = await git.log({ maxCount: 1 });
+        lastCommitHash = log.latest?.hash || '';
+      } catch (preflightError) {
+        const msg = preflightError instanceof Error
+          ? preflightError.message
+          : String(preflightError);
+        if (/does not have any commits yet/i.test(msg)) {
+          logger.main.info(
+            '[GitRefWatcher] Skipping workspace with no commits yet:',
+            path.basename(workspacePath),
+          );
+          return;
+        }
+        throw preflightError;
+      }
 
       // Watch refs/heads/<current-branch> for commit detection
       // Use commonDir for refs (in worktrees, refs are in the shared parent .git dir)

--- a/packages/electron/src/main/file/__tests__/GitRefWatcher.test.ts
+++ b/packages/electron/src/main/file/__tests__/GitRefWatcher.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Hoisted mocks: simple-git fakes that individual tests can wire per scenario,
+// plus logger fakes that the vi.mock factory below references. Hoisting is
+// required because vi.mock factories run before any non-hoisted top-level
+// statements.
+const {
+  mockStatus,
+  mockLog,
+  loggerInfo,
+  loggerError,
+  loggerWarn,
+  loggerDebug,
+} = vi.hoisted(() => ({
+  mockStatus: vi.fn(),
+  mockLog: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerError: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerDebug: vi.fn(),
+}));
+
+vi.mock('simple-git', () => ({
+  default: () => ({
+    status: mockStatus,
+    log: mockLog,
+  }),
+}));
+
+// chokidar.watch is invoked at .start() once preflight passes. We never want
+// real file watchers in tests, so return a no-op that satisfies the FSWatcher
+// interface enough for our assertions.
+vi.mock('chokidar', () => ({
+  default: {
+    watch: vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      close: vi.fn().mockResolvedValue(undefined),
+    })),
+  },
+}));
+
+// Pretend `<workspace>/.git` is a regular directory.
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      stat: vi.fn().mockResolvedValue({
+        isDirectory: () => true,
+        isFile: () => false,
+      }),
+      readFile: vi.fn(),
+    },
+  };
+});
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    main: {
+      info: loggerInfo,
+      error: loggerError,
+      warn: loggerWarn,
+      debug: loggerDebug,
+    },
+  },
+}));
+
+vi.mock('../../ipc/GitStatusHandlers', () => ({
+  clearGitStatusCache: vi.fn(),
+}));
+
+import { GitRefWatcher } from '../GitRefWatcher';
+
+describe('GitRefWatcher.start - empty repo handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips cleanly when git.log throws "does not have any commits yet"', async () => {
+    mockStatus.mockResolvedValue({ current: 'master' });
+    mockLog.mockRejectedValue(
+      new Error("fatal: your current branch 'master' does not have any commits yet"),
+    );
+
+    const watcher = new GitRefWatcher();
+    await expect(watcher.start('/fake/workspace')).resolves.toBeUndefined();
+
+    expect(loggerInfo).toHaveBeenCalledWith(
+      '[GitRefWatcher] Skipping workspace with no commits yet:',
+      'workspace',
+    );
+    // The fresh-init path must NOT log via logger.error -- that was the
+    // original symptom (multi-line stack trace in main.log).
+    expect(loggerError).not.toHaveBeenCalled();
+
+    expect(watcher.getStats().activeWatchers).toBe(0);
+  });
+
+  it('still logs error and skips when git.log throws an unrelated message', async () => {
+    mockStatus.mockResolvedValue({ current: 'master' });
+    mockLog.mockRejectedValue(new Error('unexpected git failure'));
+
+    const watcher = new GitRefWatcher();
+    await watcher.start('/fake/workspace');
+
+    // The outer catch in start() handles all other errors and logs them.
+    expect(loggerError).toHaveBeenCalledWith(
+      '[GitRefWatcher] Failed to start watching:',
+      expect.any(Error),
+    );
+    expect(watcher.getStats().activeWatchers).toBe(0);
+  });
+
+  it('skips detached HEAD workspaces (existing behavior preserved)', async () => {
+    mockStatus.mockResolvedValue({ current: undefined });
+
+    const watcher = new GitRefWatcher();
+    await watcher.start('/fake/workspace');
+
+    expect(loggerInfo).toHaveBeenCalledWith(
+      '[GitRefWatcher] Skipping detached HEAD workspace:',
+      '/fake/workspace',
+    );
+    expect(watcher.getStats().activeWatchers).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Open a workspace whose `.git` exists but has zero commits without spamming a multi-line `[GitRefWatcher] Failed to start watching: ...` stack trace into `main.log`.

Hit reliably on freshly-init'd workspaces (the user runs `git init` inside a folder, opens it as a workspace before making any commits). `GitRefWatcher.start` was letting the `simple-git` "fatal: your current branch X does not have any commits yet" exception flow into the outer catch as a full error log.

## What changed

- `GitRefWatcher.ts`: pre-flight branch + HEAD lookup is now wrapped in a narrow try/catch that pattern-matches `/does not have any commits yet/i`. On match, logs a one-line `info` message and returns cleanly. Mirrors the existing detached-HEAD short-circuit.
- All other errors still flow to the outer catch unchanged. The fix is intentionally narrow.
- Tests cover three pre-flight paths: empty repo (info, no error), unrelated git error (still hits outer error log), detached HEAD (existing behavior preserved).

## Testing

- `npx vitest run packages/electron/src/main/file/__tests__/GitRefWatcher.test.ts` -> 3/3 pass
- `npm run typecheck --prefix packages/electron` -> clean
- `git merge-tree --write-tree upstream/main HEAD` -> exit 0 (no conflicts)
- Manual repro: `git init` a fresh folder, open it in Nimbalyst, before vs after the patch:
  - Before: 8-line `[GitRefWatcher] Failed to start watching: Error: fatal: ...` stack trace in main.log
  - After: `[GitRefWatcher] Skipping workspace with no commits yet: <basename>`

## Notes for reviewers

- The pattern-match is on the message text rather than an error type because `simple-git` doesn't expose typed errors for this case. The string `"does not have any commits yet"` is git's own canonical wording (`die_if_no_commits` in git's source) and is locale-stable for English locales. If you'd prefer a different detection mechanism (e.g. swallow all errors from log() and rely on the empty `lastCommitHash` fallback already at the call site), happy to switch.
- Once the user makes their first commit, they currently need to reopen the workspace for the watcher to attach. Adding a periodic re-check or a parent-directory watch to auto-attach on first commit is a follow-up; this PR's scope is just the noisy-log fix.
- The CHANGELOG entry is in `[Unreleased] -> Fixed` directly above the `[0.58.21]` block. If PR #166 (open) lands first, there will be a one-line CHANGELOG conflict that's mechanical to resolve.

Signed-off-by: Andrew Demczuk <5212682+ademczuk@users.noreply.github.com>