### PR TITLE
fix(settings): read SDK version from both candidate node_modules locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Settings → Claude Agent SDK panel no longer reads `Version: unknown` on builds where npm workspace dedup hoists `@anthropic-ai/claude-agent-sdk` to the repo-root `node_modules/`. The build-time version read in `electron.vite.config.ts` was hardcoded to `packages/electron/node_modules/...` and silently fell through to `'unknown'` on hoisted installs; it now tries both the local and workspace-root candidates. Closes #60.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/electron.vite.config.ts
+++ b/packages/electron/electron.vite.config.ts
@@ -87,14 +87,28 @@ const isOfficialBuild = process.env.OFFICIAL_BUILD === 'true';
 // IS_DEV_MODE is true only when running `npm run dev`, not for any packaged builds
 const isDevMode = isDev;
 
-// Read Claude Agent SDK version at build time for display in settings
+// Read Claude Agent SDK version at build time for display in settings.
+//
+// The bundled SDK may live in packages/electron/node_modules/ (when not
+// hoisted) OR in the workspace-root node_modules/ (when npm workspace dedup
+// hoists it). Hardcoding the local path to the package was silently falling
+// through to 'unknown' on builds where the install hoisted, so the Settings
+// panel always read 'Version: unknown' on those builds. Try the local path
+// first, then the workspace-root fallback. Closes #60.
 const claudeAgentSdkVersion = (() => {
-  try {
-    const pkgPath = resolve(__dirname, 'node_modules/@anthropic-ai/claude-agent-sdk/package.json');
-    return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
-  } catch {
-    return 'unknown';
+  const candidates = [
+    resolve(__dirname, 'node_modules/@anthropic-ai/claude-agent-sdk/package.json'),
+    resolve(__dirname, '../../node_modules/@anthropic-ai/claude-agent-sdk/package.json'),
+  ];
+  for (const pkgPath of candidates) {
+    try {
+      const version = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
+      if (version) return version;
+    } catch {
+      // try next candidate
+    }
   }
+  return 'unknown';
 })();
 const runtimeSrcDir = resolve(__dirname, '../runtime/src');
 const runtimeDistDir = resolve(__dirname, '../runtime/dist');


### PR DESCRIPTION
## Summary

This PR hopefully fixes the `Settings > Claude Agent SDK` panel reading `Version: unknown` on builds where npm workspace dedup hoists `@anthropic-ai/claude-agent-sdk` to the repo-root `node_modules/` instead of leaving it under `packages/electron/node_modules/`.

The build-time read in `electron.vite.config.ts` was hardcoded to `resolve(__dirname, 'node_modules/...')`, with a silent `catch { return 'unknown' }` that swallowed the ENOENT on hoisted installs. The literal string `"unknown"` then got baked into the renderer bundle (`__CLAUDE_AGENT_SDK_VERSION__` define), and the macOS panel had no runtime fallback.

## Related issue

Closes #60.

## What changed

`packages/electron/electron.vite.config.ts`: the IIFE that computes `claudeAgentSdkVersion` now tries the local path first (preserves prior behavior on non-hoisted installs), then the workspace-root candidate. Same `fs.readFileSync` + `JSON.parse` logic; only difference is trying a second location before giving up.

## Testing

- `npm run typecheck --prefix packages/electron` clean.
- Verified locally: on this checkout the SDK is at `packages/electron/node_modules/@anthropic-ai/claude-agent-sdk` and resolves to `0.2.126`; the second candidate is correctly skipped (path doesn't exist). On a hoisted install, the second candidate would resolve and the Settings panel would show the real version instead of `'unknown'`.

## Notes for reviewers

- **Cosmetic fix only** - no behavior change beyond the displayed string. Reporter at #60 confirmed the literal `"unknown"` is the only definition + only usage in the renderer bundle, no IPC.
- **Why try-paths instead of `require.resolve`?** Vite config files have inconsistent ESM/CJS resolution semantics across electron-vite versions and `createRequire(import.meta.url)` adds a small but non-zero risk of breaking on a config that compiles to a target without `import.meta`. The two-candidate try is sufficient because npm workspace hoisting only ever lands the package in those two places.
- **Alternative considered**: replace the build-time define with an IPC + runtime lookup (the existing `getClaudeCodeVersion` in `ClaudeUsageService.ts:69` already does this for User-Agent purposes). Bigger surface than this issue warrants - the literal-define approach is correct in principle, just had a path-resolution gap.

Signed-off-by: Andrew Demczuk <5212682+ademczuk@users.noreply.github.com>
