### PR TITLE
feat(tracker): visual creator, folders, free-form reorder, and item drag-and-drop

### DIFF
--- a/packages/electron/src/main/services/ElectronDocumentService.ts
+++ b/packages/electron/src/main/services/ElectronDocumentService.ts
@@ -1096,12 +1096,21 @@ export class ElectronDocumentService implements DocumentService {
 
     // Handle typeTags separately -- stored in SQL column, not JSONB
     if (updates.typeTags !== undefined) {
-      const newTypeTags: string[] = Array.isArray(updates.typeTags) ? updates.typeTags : [row.type];
-      // Ensure primary type is always included
-      if (!newTypeTags.includes(row.type)) newTypeTags.unshift(row.type);
+      const newTypeTags: string[] = Array.isArray(updates.typeTags) && updates.typeTags.length > 0
+        ? updates.typeTags
+        : [row.type];
+      const newPrimary = newTypeTags[0];
       await database.query(
-        `UPDATE tracker_items SET type_tags = $1 WHERE id = $2`,
-        [newTypeTags, itemId]
+        `UPDATE tracker_items SET type_tags = $1, type = $2 WHERE id = $3`,
+        [newTypeTags, newPrimary, itemId]
+      );
+    }
+
+    // Handle issueKey separately -- stored in SQL column issue_key, not JSONB
+    if (updates.issueKey !== undefined) {
+      await database.query(
+        `UPDATE tracker_items SET issue_key = $1 WHERE id = $2`,
+        [updates.issueKey, itemId]
       );
     }
 
@@ -1113,9 +1122,10 @@ export class ElectronDocumentService implements DocumentService {
     const fieldTimestamps: Record<string, number> = data._fieldUpdatedAt || {};
     const now = Date.now();
 
-    // Merge remaining updates into data (skip typeTags since it's a column)
+    // Merge remaining updates into data (skip typeTags and issueKey since they are columns)
     for (const [key, value] of Object.entries(updates)) {
       if (key === 'typeTags') continue;
+      if (key === 'issueKey') continue;
       data[key] = value;
       fieldTimestamps[key] = now;
     }

--- a/packages/electron/src/main/utils/store.ts
+++ b/packages/electron/src/main/utils/store.ts
@@ -392,6 +392,14 @@ export interface WorkspaceState {
     updatedAt: number;
   }>;
   trackerSyncPolicies?: Record<string, TrackerSyncModeSetting | TrackerSyncPolicySetting>;
+  trackerFolders?: Array<{ name: string; collapsed?: boolean; order: number }>;
+  trackerFolderOverrides?: Record<string, string | null>;
+  trackerSidebarLayout?: {
+    entries: Array<
+      | { kind: 'folder'; name: string; collapsed?: boolean; types: string[] }
+      | { kind: 'type'; typeId: string }
+    >;
+  };
   // Issue key prefix for tracker items (e.g., "NIM", "APP"). Used for local-only trackers.
   // For synced trackers, the prefix is stored server-side in TrackerRoom metadata.
   issueKeyPrefix?: string;

--- a/packages/electron/src/renderer/components/Settings/panels/TrackerConfigPanel.tsx
+++ b/packages/electron/src/renderer/components/Settings/panels/TrackerConfigPanel.tsx
@@ -9,6 +9,20 @@ import {
 } from '@nimbalyst/runtime';
 import { trackerItemCountByTypeAtom } from '@nimbalyst/runtime/plugins/TrackerPlugin';
 import { AlphaBadge } from '../../common/AlphaBadge';
+import { TrackerTypeCreator } from './TrackerTypeCreator';
+import {
+  loadLayout,
+  saveLayout,
+  loadLegacyState,
+  buildLayoutFromLegacy,
+  reconcileLayout,
+  addFolder,
+  renameFolder,
+  deleteFolder,
+  assignTypeToFolder,
+  moveEntry,
+  type TrackerSidebarLayout,
+} from '../../../services/TrackerSidebarLayout';
 
 // ============================================================================
 // Types
@@ -260,14 +274,272 @@ function IssueKeyPrefixInput({ value, onChange }: {
 }
 
 // ============================================================================
+// Folder Manager
+// ============================================================================
+
+function FolderManager({
+  trackers,
+  workspacePath,
+  onRefresh,
+}: {
+  trackers: TrackerDataModel[];
+  workspacePath?: string;
+  onRefresh?: () => void;
+}) {
+  const [layout, setLayout] = useState<TrackerSidebarLayout>({ entries: [] });
+  const [newFolderError, setNewFolderError] = useState('');
+
+  const reload = useCallback(async () => {
+    if (!workspacePath) return;
+    let saved = await loadLayout(workspacePath);
+    if (saved.entries.length === 0) {
+      const legacy = await loadLegacyState(workspacePath);
+      saved = buildLayoutFromLegacy(trackers, legacy.folders, legacy.overrides);
+    }
+    const reconciled = reconcileLayout(saved, trackers);
+    setLayout(reconciled);
+  }, [workspacePath, trackers]);
+
+  useEffect(() => {
+    reload();
+    const unsubscribe = globalRegistry.onChange(reload);
+    return () => { unsubscribe(); };
+  }, [reload]);
+
+  const persist = useCallback(async (next: TrackerSidebarLayout) => {
+    if (!workspacePath) return;
+    setLayout(next);
+    await saveLayout(workspacePath, next);
+    onRefresh?.();
+  }, [workspacePath, onRefresh]);
+
+  const handleAddFolder = useCallback(async () => {
+    const name = 'New Folder';
+    if (layout.entries.some((e) => e.kind === 'folder' && e.name === name)) {
+      setNewFolderError('A folder named "New Folder" already exists. Rename it first.');
+      return;
+    }
+    setNewFolderError('');
+    await persist(addFolder(layout, name));
+  }, [layout, persist]);
+
+  const handleRenameFolder = useCallback(async (oldName: string, newName: string) => {
+    const trimmed = newName.trim();
+    if (!trimmed || trimmed === oldName) return;
+    await persist(renameFolder(layout, oldName, trimmed));
+  }, [layout, persist]);
+
+  const handleDeleteFolder = useCallback(async (folderName: string) => {
+    await persist(deleteFolder(layout, folderName));
+  }, [layout, persist]);
+
+  const handleReorder = useCallback(async (folderName: string, direction: 'up' | 'down') => {
+    const folderIndices = layout.entries
+      .map((e, i) => (e.kind === 'folder' ? i : -1))
+      .filter((i) => i >= 0);
+    const folderEntryIdx = layout.entries.findIndex(
+      (e) => e.kind === 'folder' && e.name === folderName
+    );
+    if (folderEntryIdx < 0) return;
+    const posInFolders = folderIndices.indexOf(folderEntryIdx);
+    const swapPos = direction === 'up' ? posInFolders - 1 : posInFolders + 1;
+    if (swapPos < 0 || swapPos >= folderIndices.length) return;
+    const swapEntryIdx = folderIndices[swapPos];
+    const drop: import('../../../services/TrackerSidebarLayout').DropLocation = {
+      position: direction === 'up' ? 'before' : 'after',
+      target: [swapEntryIdx],
+    };
+    const drag: import('../../../services/TrackerSidebarLayout').DragLocation = {
+      kind: 'folder',
+      id: folderName,
+    };
+    await persist(moveEntry(layout, drag, drop));
+  }, [layout, persist]);
+
+  const handleAssignFolder = useCallback(async (typeId: string, folderName: string | null) => {
+    await persist(assignTypeToFolder(layout, typeId, folderName));
+  }, [layout, persist]);
+
+  const folderEntries = layout.entries.filter(
+    (e): e is Extract<typeof e, { kind: 'folder' }> => e.kind === 'folder'
+  );
+  const folderNames = folderEntries.map((f) => f.name);
+
+  const getEffectiveFolder = (model: TrackerDataModel): string | null => {
+    for (const entry of layout.entries) {
+      if (entry.kind === 'folder' && entry.types.includes(model.type)) {
+        return entry.name;
+      }
+    }
+    return null;
+  };
+
+  return (
+    <div className="provider-panel-section py-4 mb-4 border-b border-[var(--nim-border)] last:border-b-0 last:mb-0 last:pb-0">
+      <h4 className="provider-panel-section-title text-[15px] font-semibold mb-2 text-[var(--nim-text)]">
+        Tracker Folders
+      </h4>
+      <p className="text-[13px] leading-relaxed text-[var(--nim-text-muted)] mb-3">
+        Group tracker types into collapsible folders in the sidebar. Folders are per-workspace and do not affect your data.
+      </p>
+
+      {/* Folder list */}
+      {folderEntries.length > 0 && (
+        <div className="bg-[var(--nim-bg-secondary)] rounded-lg overflow-hidden mb-3">
+          {folderEntries.map((folder, idx) => (
+            <FolderRow
+              key={folder.name}
+              folderName={folder.name}
+              isFirst={idx === 0}
+              isLast={idx === folderEntries.length - 1}
+              onRename={(newName) => handleRenameFolder(folder.name, newName)}
+              onDelete={() => handleDeleteFolder(folder.name)}
+              onMoveUp={() => handleReorder(folder.name, 'up')}
+              onMoveDown={() => handleReorder(folder.name, 'down')}
+            />
+          ))}
+        </div>
+      )}
+
+      <button
+        onClick={handleAddFolder}
+        className="inline-flex items-center gap-1 px-2.5 py-1 bg-transparent border border-[var(--nim-border)] rounded text-[var(--nim-text-muted)] text-[11px] cursor-pointer hover:bg-[var(--nim-bg-hover)] mb-3"
+      >
+        <MaterialSymbol icon="create_new_folder" size={12} />
+        Add Folder
+      </button>
+      {newFolderError && (
+        <p className="text-[11px] text-[#ef4444] mb-3">{newFolderError}</p>
+      )}
+
+      {/* Per-type folder assignment */}
+      {trackers.length > 0 && (
+        <>
+          <h5 className="text-[12px] font-semibold text-[var(--nim-text-muted)] uppercase tracking-wide mb-2">
+            Assign Types to Folders
+          </h5>
+          <div className="bg-[var(--nim-bg-secondary)] rounded-lg overflow-hidden">
+            {trackers.map((model) => {
+              const currentFolder = getEffectiveFolder(model);
+              return (
+                <div
+                  key={model.type}
+                  className="flex items-center gap-2.5 px-3.5 py-2 border-b border-[var(--nim-bg)] last:border-b-0"
+                >
+                  <TrackerIcon color={model.color} icon={model.icon} />
+                  <span className="flex-1 text-[13px] text-[var(--nim-text)] truncate">
+                    {model.displayNamePlural}
+                  </span>
+                  <select
+                    value={currentFolder ?? ''}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      handleAssignFolder(model.type, val === '' ? null : val);
+                    }}
+                    className="px-2 py-1 text-[12px] bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] cursor-pointer"
+                  >
+                    <option value="">(no folder)</option>
+                    {folderNames.map((name) => (
+                      <option key={name} value={name}>{name}</option>
+                    ))}
+                  </select>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function FolderRow({
+  folderName,
+  isFirst,
+  isLast,
+  onRename,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+}: {
+  folderName: string;
+  isFirst: boolean;
+  isLast: boolean;
+  onRename: (name: string) => void;
+  onDelete: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}) {
+  const [draft, setDraft] = useState(folderName);
+
+  useEffect(() => {
+    setDraft(folderName);
+  }, [folderName]);
+
+  const handleBlur = () => {
+    onRename(draft);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+    if (e.key === 'Escape') {
+      setDraft(folderName);
+      (e.target as HTMLInputElement).blur();
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2 px-3.5 py-2 border-b border-[var(--nim-bg)] last:border-b-0">
+      <MaterialSymbol icon="folder" size={14} className="text-[var(--nim-text-faint)] shrink-0" />
+      <input
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        className="flex-1 px-1.5 py-0.5 text-[13px] bg-[var(--nim-bg)] border border-transparent rounded focus:border-[var(--nim-border)] text-[var(--nim-text)] outline-none transition-colors"
+      />
+      <div className="flex items-center gap-0.5 shrink-0">
+        <button
+          onClick={onMoveUp}
+          disabled={isFirst}
+          title="Move up"
+          className="p-1 rounded text-[var(--nim-text-faint)] hover:text-[var(--nim-text-muted)] hover:bg-[var(--nim-bg-tertiary)] cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        >
+          <MaterialSymbol icon="arrow_upward" size={12} />
+        </button>
+        <button
+          onClick={onMoveDown}
+          disabled={isLast}
+          title="Move down"
+          className="p-1 rounded text-[var(--nim-text-faint)] hover:text-[var(--nim-text-muted)] hover:bg-[var(--nim-bg-tertiary)] cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        >
+          <MaterialSymbol icon="arrow_downward" size={12} />
+        </button>
+        <button
+          onClick={onDelete}
+          title="Delete folder"
+          className="p-1 rounded text-[var(--nim-text-faint)] hover:text-[#ef4444] hover:bg-[var(--nim-bg-tertiary)] cursor-pointer transition-colors"
+        >
+          <MaterialSymbol icon="delete" size={12} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
 // Admin View
 // ============================================================================
 
-function AdminView({ trackers, onSyncModeChange, workspacePath }: {
+function AdminView({ trackers, onSyncModeChange, workspacePath, onAddCustomTracker }: {
   trackers: TrackerTypeConfig[];
   onSyncModeChange: (type: string, mode: TrackerSyncMode) => void;
   workspacePath?: string;
+  onAddCustomTracker: () => void;
 }) {
+  const models = trackers.map((t) => t.model);
+
   return (
     <>
       {/* Team Sync Policy Section */}
@@ -323,6 +595,16 @@ function AdminView({ trackers, onSyncModeChange, workspacePath }: {
             </div>
           ))}
         </div>
+
+        <div className="mt-3">
+          <button
+            onClick={onAddCustomTracker}
+            className="inline-flex items-center gap-1 px-2.5 py-1 bg-transparent border border-[var(--nim-border)] rounded text-[var(--nim-text-muted)] text-[11px] cursor-pointer hover:bg-[var(--nim-bg-hover)]"
+          >
+            <MaterialSymbol icon="add" size={12} />
+            Add Custom Tracker
+          </button>
+        </div>
       </div>
 
       {/* Inline Note */}
@@ -336,7 +618,7 @@ function AdminView({ trackers, onSyncModeChange, workspacePath }: {
       </div>
 
       {/* Promote Banner */}
-      <div className="provider-panel-section py-4">
+      <div className="provider-panel-section py-4 mb-4 border-b border-[var(--nim-border)] last:border-b-0 last:mb-0 last:pb-0">
         <div className="flex items-center gap-2 p-3 bg-[rgba(167,139,250,0.08)] border border-[rgba(167,139,250,0.15)] rounded-lg">
           <MaterialSymbol icon="arrow_upward" size={16} className="text-[#a78bfa] shrink-0" />
           <div className="flex-1 text-[12px] text-[var(--nim-text-muted)] leading-snug">
@@ -344,6 +626,8 @@ function AdminView({ trackers, onSyncModeChange, workspacePath }: {
           </div>
         </div>
       </div>
+
+      <FolderManager trackers={models} workspacePath={workspacePath} />
     </>
   );
 }
@@ -352,9 +636,10 @@ function AdminView({ trackers, onSyncModeChange, workspacePath }: {
 // Member View
 // ============================================================================
 
-function MemberView({ trackers, workspacePath }: { trackers: TrackerTypeConfig[]; workspacePath?: string }) {
+function MemberView({ trackers, workspacePath, onAddCustomTracker }: { trackers: TrackerTypeConfig[]; workspacePath?: string; onAddCustomTracker: () => void }) {
   const sharedTrackers = trackers.filter((t) => t.syncMode !== 'local');
   const localTrackers = trackers.filter((t) => t.syncMode === 'local');
+  const models = trackers.map((t) => t.model);
 
   return (
     <>
@@ -392,16 +677,16 @@ function MemberView({ trackers, workspacePath }: { trackers: TrackerTypeConfig[]
       </div>
 
       {/* Local Trackers */}
-      {localTrackers.length > 0 && (
-        <div className="provider-panel-section py-4 mb-4 border-b border-[var(--nim-border)] last:border-b-0 last:mb-0 last:pb-0">
-          <h4 className="provider-panel-section-title text-[15px] font-semibold mb-2 text-[var(--nim-text)] flex items-center gap-2">
-            Your Local Trackers
-            <span className="text-[11px] font-normal text-[var(--nim-text-faint)]">Only on this machine</span>
-          </h4>
-          <p className="text-[13px] leading-relaxed text-[var(--nim-text-muted)] mb-3">
-            These tracker types are local to your workspace. They never sync and are not visible to your team.
-          </p>
+      <div className="provider-panel-section py-4 mb-4 border-b border-[var(--nim-border)] last:border-b-0 last:mb-0 last:pb-0">
+        <h4 className="provider-panel-section-title text-[15px] font-semibold mb-2 text-[var(--nim-text)] flex items-center gap-2">
+          Your Local Trackers
+          <span className="text-[11px] font-normal text-[var(--nim-text-faint)]">Only on this machine</span>
+        </h4>
+        <p className="text-[13px] leading-relaxed text-[var(--nim-text-muted)] mb-3">
+          These tracker types are local to your workspace. They never sync and are not visible to your team.
+        </p>
 
+        {localTrackers.length > 0 ? (
           <div className="bg-[var(--nim-bg-secondary)] rounded-lg overflow-hidden">
             {localTrackers.map((tracker) => (
               <div
@@ -426,18 +711,25 @@ function MemberView({ trackers, workspacePath }: { trackers: TrackerTypeConfig[]
               </div>
             ))}
           </div>
-
-          <div className="mt-3">
-            <button className="inline-flex items-center gap-1 px-2.5 py-1 bg-transparent border border-[var(--nim-border)] rounded text-[var(--nim-text-muted)] text-[11px] cursor-pointer hover:bg-[var(--nim-bg-hover)]">
-              <MaterialSymbol icon="add" size={12} />
-              Add Custom Tracker
-            </button>
+        ) : (
+          <div className="bg-[var(--nim-bg-secondary)] rounded-lg px-3.5 py-3 text-[12px] text-[var(--nim-text-faint)] italic">
+            No local tracker types yet.
           </div>
+        )}
+
+        <div className="mt-3">
+          <button
+            onClick={onAddCustomTracker}
+            className="inline-flex items-center gap-1 px-2.5 py-1 bg-transparent border border-[var(--nim-border)] rounded text-[var(--nim-text-muted)] text-[11px] cursor-pointer hover:bg-[var(--nim-bg-hover)]"
+          >
+            <MaterialSymbol icon="add" size={12} />
+            Add Custom Tracker
+          </button>
         </div>
-      )}
+      </div>
 
       {/* Inline Note */}
-      <div className="provider-panel-section py-4">
+      <div className="provider-panel-section py-4 mb-4 border-b border-[var(--nim-border)] last:border-b-0 last:mb-0 last:pb-0">
         <div className="flex items-start gap-1.5 p-2.5 bg-[var(--nim-bg-secondary)] rounded-md text-[11px] text-[var(--nim-text-faint)] leading-relaxed">
           <MaterialSymbol icon="info" size={14} className="shrink-0 mt-0.5" />
           <span>
@@ -445,6 +737,8 @@ function MemberView({ trackers, workspacePath }: { trackers: TrackerTypeConfig[]
           </span>
         </div>
       </div>
+
+      <FolderManager trackers={models} workspacePath={workspacePath} />
     </>
   );
 }
@@ -458,6 +752,7 @@ export function TrackerConfigPanel({ workspacePath }: TrackerConfigPanelProps) {
   const [isAdmin, setIsAdmin] = useState(true);
   const [issueKeyPrefix, setIssueKeyPrefix] = useState('NIM');
   const [isSyncConnected, setIsSyncConnected] = useState(false);
+  const [showCreator, setShowCreator] = useState(false);
 
   useEffect(() => {
     // Load saved sync policies from workspace state, then merge with registry
@@ -587,9 +882,22 @@ export function TrackerConfigPanel({ workspacePath }: TrackerConfigPanelProps) {
           trackers={trackers}
           onSyncModeChange={handleSyncModeChange}
           workspacePath={workspacePath}
+          onAddCustomTracker={() => setShowCreator(true)}
         />
       ) : (
-        <MemberView trackers={trackers} workspacePath={workspacePath} />
+        <MemberView
+          trackers={trackers}
+          workspacePath={workspacePath}
+          onAddCustomTracker={() => setShowCreator(true)}
+        />
+      )}
+
+      {showCreator && workspacePath && (
+        <TrackerTypeCreator
+          workspacePath={workspacePath}
+          onClose={() => setShowCreator(false)}
+          onCreated={() => setShowCreator(false)}
+        />
       )}
     </div>
   );

--- a/packages/electron/src/renderer/components/Settings/panels/TrackerTypeCreator.tsx
+++ b/packages/electron/src/renderer/components/Settings/panels/TrackerTypeCreator.tsx
@@ -1,0 +1,835 @@
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  MaterialSymbol,
+  globalRegistry,
+  serializeTrackerYAML,
+  type TrackerDataModel,
+  type FieldDefinition,
+  type FieldType,
+} from '@nimbalyst/runtime';
+import {
+  loadLayout,
+  saveLayout,
+  loadLegacyState,
+  buildLayoutFromLegacy,
+  reconcileLayout,
+  addFolder,
+  assignTypeToFolder,
+  type TrackerSidebarLayout,
+} from '../../../services/TrackerSidebarLayout';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface TrackerTypeCreatorProps {
+  workspacePath: string;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+interface FieldRow {
+  id: string;
+  name: string;
+  type: FieldType;
+  required: boolean;
+  options: string;
+  isLocked: boolean;
+}
+
+interface FormErrors {
+  displayName?: string;
+  typeId?: string;
+  idPrefix?: string;
+  fields?: string;
+  submit?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const ICON_OPTIONS = [
+  'task_alt',
+  'bug_report',
+  'lightbulb',
+  'code',
+  'package',
+  'description',
+  'people',
+  'groups',
+  'campaign',
+  'science',
+  'flag',
+  'build',
+  'star',
+  'bookmark',
+  'label',
+  'folder',
+  'inbox',
+  'event',
+  'checklist',
+  'inventory_2',
+  'engineering',
+  'psychology',
+  'track_changes',
+  'article',
+  'menu_book',
+];
+
+const COLOR_PRESETS = [
+  '#3b82f6',
+  '#ef4444',
+  '#22c55e',
+  '#f59e0b',
+  '#8b5cf6',
+  '#ec4899',
+  '#06b6d4',
+  '#f97316',
+  '#6b7280',
+  '#14b8a6',
+];
+
+const FIELD_TYPES: { value: FieldType; label: string }[] = [
+  { value: 'string', label: 'Text (short)' },
+  { value: 'text', label: 'Text (long)' },
+  { value: 'select', label: 'Select' },
+  { value: 'number', label: 'Number' },
+  { value: 'date', label: 'Date' },
+  { value: 'boolean', label: 'Boolean' },
+  { value: 'multiselect', label: 'Multi-select' },
+  { value: 'datetime', label: 'Date & Time' },
+  { value: 'user', label: 'User' },
+  { value: 'reference', label: 'Reference' },
+];
+
+const TYPE_ID_REGEX = /^[a-z][a-z0-9-_]*$/;
+const ID_PREFIX_REGEX = /^[a-z][a-z0-9]{2,3}$/;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function toKebabCase(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-_]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-/, '');
+}
+
+function deriveIdPrefix(displayName: string): string {
+  const letters = displayName
+    .toLowerCase()
+    .replace(/[^a-z]/g, '');
+  return letters.slice(0, 4);
+}
+
+function generateId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function buildDefaultFields(): FieldRow[] {
+  return [
+    {
+      id: generateId(),
+      name: 'title',
+      type: 'string',
+      required: true,
+      options: '',
+      isLocked: true,
+    },
+    {
+      id: generateId(),
+      name: 'status',
+      type: 'select',
+      required: false,
+      options: 'Todo, In Progress, Done',
+      isLocked: false,
+    },
+  ];
+}
+
+function parseOptions(raw: string): Array<{ value: string; label: string }> {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((label) => ({
+      value: label.toLowerCase().replace(/\s+/g, '-'),
+      label,
+    }));
+}
+
+function buildFieldDefinition(row: FieldRow): FieldDefinition {
+  const def: FieldDefinition = {
+    name: row.name.trim(),
+    type: row.type,
+    required: row.required,
+  };
+  if ((row.type === 'select' || row.type === 'multiselect') && row.options.trim()) {
+    def.options = parseOptions(row.options);
+  }
+  return def;
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+function FormLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <label className="block text-[12px] font-semibold text-[var(--nim-text-muted)] uppercase tracking-wide mb-1.5">
+      {children}
+    </label>
+  );
+}
+
+function FormInput({
+  value,
+  onChange,
+  placeholder,
+  maxLength,
+  className = '',
+  mono = false,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  maxLength?: number;
+  className?: string;
+  mono?: boolean;
+}) {
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      maxLength={maxLength}
+      className={`w-full px-2.5 py-1.5 text-[13px] bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded-md text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] transition-colors placeholder:text-[var(--nim-text-faint)] ${mono ? 'font-mono' : ''} ${className}`}
+    />
+  );
+}
+
+function InlineError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <p className="text-[11px] text-[#ef4444] mt-1">{message}</p>;
+}
+
+function FieldRowEditor({
+  row,
+  onUpdate,
+  onRemove,
+}: {
+  row: FieldRow;
+  onUpdate: (updated: FieldRow) => void;
+  onRemove: () => void;
+}) {
+  const showOptions = row.type === 'select' || row.type === 'multiselect';
+
+  return (
+    <div className="flex flex-col gap-1.5 px-3 py-2.5 bg-[var(--nim-bg)] rounded-md border border-[var(--nim-border)]">
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={row.name}
+          onChange={(e) => onUpdate({ ...row, name: e.target.value })}
+          placeholder="field_name"
+          disabled={row.isLocked}
+          className={`flex-1 px-2 py-1 text-[12px] font-mono bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] rounded text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] transition-colors placeholder:text-[var(--nim-text-faint)] ${row.isLocked ? 'opacity-60 cursor-not-allowed' : ''}`}
+        />
+        <select
+          value={row.type}
+          onChange={(e) => onUpdate({ ...row, type: e.target.value as FieldType })}
+          className="px-2 py-1 text-[12px] bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] rounded text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] cursor-pointer"
+        >
+          {FIELD_TYPES.map((ft) => (
+            <option key={ft.value} value={ft.value}>
+              {ft.label}
+            </option>
+          ))}
+        </select>
+        <label className="flex items-center gap-1 text-[11px] text-[var(--nim-text-muted)] cursor-pointer select-none whitespace-nowrap">
+          <input
+            type="checkbox"
+            checked={row.required}
+            onChange={(e) => onUpdate({ ...row, required: e.target.checked })}
+            className="cursor-pointer"
+          />
+          Required
+        </label>
+        {row.isLocked ? (
+          <div className="w-5 h-5 shrink-0 flex items-center justify-center">
+            <MaterialSymbol icon="lock" size={12} className="text-[var(--nim-text-faint)]" />
+          </div>
+        ) : (
+          <button
+            onClick={onRemove}
+            className="w-5 h-5 shrink-0 flex items-center justify-center rounded text-[var(--nim-text-faint)] hover:text-[#ef4444] hover:bg-[var(--nim-bg-tertiary)] cursor-pointer transition-colors"
+            title="Remove field"
+          >
+            <MaterialSymbol icon="close" size={12} />
+          </button>
+        )}
+      </div>
+      {showOptions && (
+        <div className="pl-1">
+          <input
+            type="text"
+            value={row.options}
+            onChange={(e) => onUpdate({ ...row, options: e.target.value })}
+            placeholder="Option 1, Option 2, Option 3"
+            className="w-full px-2 py-1 text-[11px] bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] rounded text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] transition-colors placeholder:text-[var(--nim-text-faint)]"
+          />
+          <p className="text-[10px] text-[var(--nim-text-faint)] mt-1">Comma-separated option labels</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// TrackerTypeCreator
+// ============================================================================
+
+export function TrackerTypeCreator({ workspacePath, onClose, onCreated }: TrackerTypeCreatorProps) {
+  const [displayName, setDisplayName] = useState('');
+  const [displayNamePlural, setDisplayNamePlural] = useState('');
+  const [typeId, setTypeId] = useState('');
+  const [typeIdManuallyEdited, setTypeIdManuallyEdited] = useState(false);
+  const [idPrefix, setIdPrefix] = useState('');
+  const [idPrefixManuallyEdited, setIdPrefixManuallyEdited] = useState(false);
+  const [icon, setIcon] = useState('task_alt');
+  const [color, setColor] = useState('#3b82f6');
+  const [colorInput, setColorInput] = useState('#3b82f6');
+  const [inlineMode, setInlineMode] = useState(true);
+  const [fullDocMode, setFullDocMode] = useState(false);
+  const [fields, setFields] = useState<FieldRow[]>(buildDefaultFields);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Folder state
+  const [sidebarLayout, setSidebarLayout] = useState<TrackerSidebarLayout>({ entries: [] });
+  const [selectedFolder, setSelectedFolder] = useState<string>('');
+  const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState('');
+
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    (async () => {
+      let saved = await loadLayout(workspacePath);
+      if (saved.entries.length === 0) {
+        const legacy = await loadLegacyState(workspacePath);
+        const models = globalRegistry.getAll();
+        saved = buildLayoutFromLegacy(models, legacy.folders, legacy.overrides);
+      }
+      setSidebarLayout(saved);
+    })();
+  }, [workspacePath]);
+
+  // Sync color input with color state when swatch is clicked
+  useEffect(() => {
+    setColorInput(color);
+  }, [color]);
+
+  // Auto-derive typeId from displayName when not manually edited
+  useEffect(() => {
+    if (!typeIdManuallyEdited) {
+      setTypeId(toKebabCase(displayName));
+    }
+  }, [displayName, typeIdManuallyEdited]);
+
+  // Auto-derive idPrefix from displayName when not manually edited
+  useEffect(() => {
+    if (!idPrefixManuallyEdited) {
+      setIdPrefix(deriveIdPrefix(displayName));
+    }
+  }, [displayName, idPrefixManuallyEdited]);
+
+  const handleOverlayClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === overlayRef.current) {
+      onClose();
+    }
+  }, [onClose]);
+
+  const handleDisplayNameChange = useCallback((val: string) => {
+    setDisplayName(val);
+    if (!typeIdManuallyEdited) {
+      setTypeId(toKebabCase(val));
+    }
+    if (!idPrefixManuallyEdited) {
+      setIdPrefix(deriveIdPrefix(val));
+    }
+    setErrors((prev) => ({ ...prev, displayName: undefined }));
+  }, [typeIdManuallyEdited, idPrefixManuallyEdited]);
+
+  const handleTypeIdChange = useCallback((val: string) => {
+    const normalized = val.toLowerCase();
+    setTypeId(normalized);
+    setTypeIdManuallyEdited(true);
+    setErrors((prev) => ({ ...prev, typeId: undefined }));
+  }, []);
+
+  const handleIdPrefixChange = useCallback((val: string) => {
+    const normalized = val.toLowerCase().replace(/[^a-z0-9]/g, '');
+    setIdPrefix(normalized);
+    setIdPrefixManuallyEdited(true);
+    setErrors((prev) => ({ ...prev, idPrefix: undefined }));
+  }, []);
+
+  const handleColorInputChange = useCallback((val: string) => {
+    setColorInput(val);
+    if (/^#[0-9a-fA-F]{6}$/.test(val)) {
+      setColor(val);
+    }
+  }, []);
+
+  const handleColorInputBlur = useCallback(() => {
+    if (/^#[0-9a-fA-F]{6}$/.test(colorInput)) {
+      setColor(colorInput);
+    } else {
+      setColorInput(color);
+    }
+  }, [colorInput, color]);
+
+  const addField = useCallback(() => {
+    setFields((prev) => [
+      ...prev,
+      {
+        id: generateId(),
+        name: '',
+        type: 'string',
+        required: false,
+        options: '',
+        isLocked: false,
+      },
+    ]);
+    setErrors((prev) => ({ ...prev, fields: undefined }));
+  }, []);
+
+  const updateField = useCallback((id: string, updated: FieldRow) => {
+    setFields((prev) => prev.map((f) => (f.id === id ? updated : f)));
+  }, []);
+
+  const removeField = useCallback((id: string) => {
+    setFields((prev) => prev.filter((f) => f.id !== id));
+  }, []);
+
+  const validate = useCallback((): FormErrors => {
+    const errs: FormErrors = {};
+
+    if (!displayName.trim()) {
+      errs.displayName = 'Display name is required.';
+    }
+
+    if (!typeId) {
+      errs.typeId = 'Type ID is required.';
+    } else if (!TYPE_ID_REGEX.test(typeId)) {
+      errs.typeId = 'Must start with a letter and contain only lowercase letters, digits, hyphens, or underscores.';
+    } else {
+      const existing = globalRegistry.getAll().map((m) => m.type);
+      if (existing.includes(typeId)) {
+        errs.typeId = `A tracker type with ID "${typeId}" already exists.`;
+      }
+    }
+
+    if (!idPrefix) {
+      errs.idPrefix = 'ID prefix is required.';
+    } else if (!ID_PREFIX_REGEX.test(idPrefix)) {
+      errs.idPrefix = 'Must be 3-4 lowercase alphanumeric characters with no leading digit.';
+    }
+
+    const validFields = fields.filter((f) => f.name.trim());
+    if (validFields.length === 0) {
+      errs.fields = 'At least one field with a name is required.';
+    }
+
+    return errs;
+  }, [displayName, typeId, idPrefix, fields]);
+
+  const handleCreate = useCallback(async () => {
+    const errs = validate();
+    if (Object.keys(errs).length > 0) {
+      setErrors(errs);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrors({});
+
+    try {
+      const resolvedGroup: string | undefined = isCreatingFolder && newFolderName.trim()
+        ? newFolderName.trim()
+        : selectedFolder || undefined;
+
+      const fieldDefs: FieldDefinition[] = fields
+        .filter((f) => f.name.trim())
+        .map(buildFieldDefinition);
+
+      const model: TrackerDataModel = {
+        type: typeId,
+        displayName: displayName.trim(),
+        displayNamePlural: (displayNamePlural.trim() || `${displayName.trim()}s`),
+        icon,
+        color,
+        modes: {
+          inline: inlineMode,
+          fullDocument: fullDocMode,
+        },
+        idPrefix,
+        idFormat: 'ulid',
+        fields: fieldDefs,
+        ...(resolvedGroup ? { group: resolvedGroup } : {}),
+      };
+
+      const yamlContent = serializeTrackerYAML(model);
+      const filePath = `${workspacePath}/.nimbalyst/trackers/${model.type}.yaml`;
+
+      const result = await (window as any).electronAPI.createFile(filePath, yamlContent);
+      if (result && result.success === false) {
+        setErrors({ submit: result.error ?? 'Failed to create tracker file.' });
+        setIsSubmitting(false);
+        return;
+      }
+
+      globalRegistry.register(model);
+
+      // Update layout: ensure folder exists (if new), then move type into it
+      if (resolvedGroup) {
+        let currentLayout = await loadLayout(workspacePath);
+        if (currentLayout.entries.length === 0) {
+          const legacy = await loadLegacyState(workspacePath);
+          currentLayout = buildLayoutFromLegacy(
+            globalRegistry.getAll(),
+            legacy.folders,
+            legacy.overrides
+          );
+        }
+        const withFolder = isCreatingFolder
+          ? addFolder(currentLayout, resolvedGroup)
+          : currentLayout;
+        const reconciled = reconcileLayout(withFolder, globalRegistry.getAll());
+        const withAssignment = assignTypeToFolder(reconciled, typeId, resolvedGroup);
+        await saveLayout(workspacePath, withAssignment);
+      }
+
+      onCreated();
+      onClose();
+    } catch (err) {
+      setErrors({ submit: err instanceof Error ? err.message : 'An unexpected error occurred.' });
+      setIsSubmitting(false);
+    }
+  }, [
+    validate,
+    fields,
+    typeId,
+    displayName,
+    displayNamePlural,
+    icon,
+    color,
+    inlineMode,
+    fullDocMode,
+    idPrefix,
+    workspacePath,
+    onCreated,
+    onClose,
+    selectedFolder,
+    isCreatingFolder,
+    newFolderName,
+  ]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onClose();
+    }
+  }, [onClose]);
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      onKeyDown={handleKeyDown}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      tabIndex={-1}
+    >
+      <div
+        className="relative flex flex-col bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded-xl shadow-2xl w-full max-w-[560px] max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--nim-border)] shrink-0">
+          <div>
+            <h2 className="text-[15px] font-semibold text-[var(--nim-text)]">Create Custom Tracker Type</h2>
+            <p className="text-[12px] text-[var(--nim-text-muted)] mt-0.5">Define a new tracker type for your workspace.</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 flex items-center justify-center rounded-md text-[var(--nim-text-muted)] hover:text-[var(--nim-text)] hover:bg-[var(--nim-bg-secondary)] cursor-pointer transition-colors"
+          >
+            <MaterialSymbol icon="close" size={16} />
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+
+          {/* Display Name + Type ID */}
+          <div>
+            <FormLabel>Display Name</FormLabel>
+            <FormInput
+              value={displayName}
+              onChange={handleDisplayNameChange}
+              placeholder="e.g. Bug Report"
+            />
+            <InlineError message={errors.displayName} />
+            {typeId && (
+              <p className="text-[11px] text-[var(--nim-text-faint)] mt-1">
+                Type ID: <span className="font-mono">{typeId}</span>
+              </p>
+            )}
+          </div>
+
+          {/* Display Name Plural */}
+          <div>
+            <FormLabel>Display Name (Plural)</FormLabel>
+            <FormInput
+              value={displayNamePlural}
+              onChange={setDisplayNamePlural}
+              placeholder={displayName ? `e.g. ${displayName}s` : 'e.g. Bug Reports'}
+            />
+          </div>
+
+          {/* Type ID */}
+          <div>
+            <FormLabel>Type ID</FormLabel>
+            <FormInput
+              value={typeId}
+              onChange={handleTypeIdChange}
+              placeholder="e.g. bug-report"
+              mono
+            />
+            <InlineError message={errors.typeId} />
+            <p className="text-[10px] text-[var(--nim-text-faint)] mt-1">
+              Lowercase letters, digits, hyphens, underscores. Cannot be changed later.
+            </p>
+          </div>
+
+          {/* ID Prefix */}
+          <div>
+            <FormLabel>ID Prefix</FormLabel>
+            <div className="flex items-center gap-2">
+              <div className="w-28">
+                <FormInput
+                  value={idPrefix}
+                  onChange={handleIdPrefixChange}
+                  placeholder="e.g. bugr"
+                  maxLength={4}
+                  mono
+                />
+              </div>
+              <span className="text-[13px] text-[var(--nim-text-faint)] font-mono">-01J...</span>
+            </div>
+            <InlineError message={errors.idPrefix} />
+            <p className="text-[10px] text-[var(--nim-text-faint)] mt-1">
+              3-4 lowercase alphanumeric characters, no leading digit.
+            </p>
+          </div>
+
+          {/* Icon */}
+          <div>
+            <FormLabel>Icon</FormLabel>
+            <div className="flex items-center gap-2 mb-2">
+              <div
+                className="w-8 h-8 rounded-md flex items-center justify-center shrink-0"
+                style={{ background: `${color}20` }}
+              >
+                <MaterialSymbol icon={icon} size={18} style={{ color }} fill />
+              </div>
+              <FormInput
+                value={icon}
+                onChange={setIcon}
+                placeholder="Material Symbol name"
+              />
+            </div>
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(32px,1fr))] gap-1">
+              {ICON_OPTIONS.map((ic) => (
+                <button
+                  key={ic}
+                  onClick={() => setIcon(ic)}
+                  title={ic}
+                  className={`w-8 h-8 flex items-center justify-center rounded-md cursor-pointer transition-colors ${
+                    icon === ic
+                      ? 'bg-[var(--nim-primary)] text-white'
+                      : 'bg-[var(--nim-bg-secondary)] text-[var(--nim-text-muted)] hover:bg-[var(--nim-bg-tertiary)] hover:text-[var(--nim-text)]'
+                  }`}
+                >
+                  <MaterialSymbol icon={ic} size={16} />
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Color */}
+          <div>
+            <FormLabel>Color</FormLabel>
+            <div className="flex items-center gap-2 mb-2">
+              <div
+                className="w-7 h-7 rounded-md border border-[var(--nim-border)] shrink-0"
+                style={{ background: color }}
+              />
+              <input
+                type="text"
+                value={colorInput}
+                onChange={(e) => handleColorInputChange(e.target.value)}
+                onBlur={handleColorInputBlur}
+                placeholder="#3b82f6"
+                maxLength={7}
+                className="w-28 px-2.5 py-1.5 text-[13px] font-mono bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded-md text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] transition-colors placeholder:text-[var(--nim-text-faint)]"
+              />
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {COLOR_PRESETS.map((preset) => (
+                <button
+                  key={preset}
+                  onClick={() => setColor(preset)}
+                  title={preset}
+                  className={`w-6 h-6 rounded-full cursor-pointer transition-transform hover:scale-110 ${
+                    color === preset ? 'ring-2 ring-offset-1 ring-[var(--nim-primary)] ring-offset-[var(--nim-bg)]' : ''
+                  }`}
+                  style={{ background: preset }}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Modes */}
+          <div>
+            <FormLabel>Modes</FormLabel>
+            <div className="flex flex-col gap-2">
+              <label className="flex items-start gap-2.5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={inlineMode}
+                  onChange={(e) => setInlineMode(e.target.checked)}
+                  className="mt-0.5 cursor-pointer"
+                />
+                <div>
+                  <div className="text-[13px] text-[var(--nim-text)]">Inline mode</div>
+                  <div className="text-[11px] text-[var(--nim-text-faint)]">Use in markdown documents (e.g. <code className="text-[10px] bg-[var(--nim-bg-secondary)] px-1 rounded">#type[...]</code>)</div>
+                </div>
+              </label>
+              <label className="flex items-start gap-2.5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={fullDocMode}
+                  onChange={(e) => setFullDocMode(e.target.checked)}
+                  className="mt-0.5 cursor-pointer"
+                />
+                <div>
+                  <div className="text-[13px] text-[var(--nim-text)]">Full document mode</div>
+                  <div className="text-[11px] text-[var(--nim-text-faint)]">Items get their own dedicated pages</div>
+                </div>
+              </label>
+            </div>
+          </div>
+
+          {/* Folder */}
+          <div>
+            <FormLabel>Folder</FormLabel>
+            <select
+              value={isCreatingFolder ? '__new__' : selectedFolder}
+              onChange={(e) => {
+                if (e.target.value === '__new__') {
+                  setIsCreatingFolder(true);
+                  setSelectedFolder('');
+                } else {
+                  setIsCreatingFolder(false);
+                  setSelectedFolder(e.target.value);
+                }
+              }}
+              className="w-full px-2.5 py-1.5 text-[13px] bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded-md text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] cursor-pointer transition-colors"
+            >
+              <option value="">(no folder)</option>
+              {sidebarLayout.entries
+                .filter((e): e is Extract<typeof e, { kind: 'folder' }> => e.kind === 'folder')
+                .map((f) => (
+                  <option key={f.name} value={f.name}>{f.name}</option>
+                ))}
+              <option value="__new__">Create new folder…</option>
+            </select>
+            {isCreatingFolder && (
+              <div className="mt-2">
+                <input
+                  type="text"
+                  value={newFolderName}
+                  onChange={(e) => setNewFolderName(e.target.value)}
+                  placeholder="New folder name"
+                  autoFocus
+                  className="w-full px-2.5 py-1.5 text-[13px] bg-[var(--nim-bg)] border border-[var(--nim-primary)] rounded-md text-[var(--nim-text)] outline-none transition-colors placeholder:text-[var(--nim-text-faint)]"
+                />
+                <p className="text-[10px] text-[var(--nim-text-faint)] mt-1">
+                  The folder will be created when you click "Create Tracker".
+                </p>
+              </div>
+            )}
+          </div>
+
+          {/* Fields */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <FormLabel>Fields</FormLabel>
+              <button
+                onClick={addField}
+                className="inline-flex items-center gap-1 px-2 py-0.5 text-[11px] text-[var(--nim-text-muted)] hover:text-[var(--nim-text)] bg-[var(--nim-bg-secondary)] hover:bg-[var(--nim-bg-tertiary)] border border-[var(--nim-border)] rounded cursor-pointer transition-colors"
+              >
+                <MaterialSymbol icon="add" size={12} />
+                Add field
+              </button>
+            </div>
+            <div className="flex flex-col gap-2">
+              {fields.map((row) => (
+                <FieldRowEditor
+                  key={row.id}
+                  row={row}
+                  onUpdate={(updated) => updateField(row.id, updated)}
+                  onRemove={() => removeField(row.id)}
+                />
+              ))}
+            </div>
+            <InlineError message={errors.fields} />
+          </div>
+
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-5 py-3.5 border-t border-[var(--nim-border)] shrink-0 bg-[var(--nim-bg)]">
+          <div className="flex-1">
+            {errors.submit && (
+              <p className="text-[11px] text-[#ef4444]">{errors.submit}</p>
+            )}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="px-3.5 py-1.5 text-[13px] font-medium text-[var(--nim-text-muted)] hover:text-[var(--nim-text)] bg-transparent hover:bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] rounded-md cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={isSubmitting}
+              className="px-3.5 py-1.5 text-[13px] font-medium text-white bg-[var(--nim-primary)] hover:opacity-90 rounded-md cursor-pointer transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? 'Creating…' : 'Create Tracker'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/components/TrackerMode/AddFolderModal.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/AddFolderModal.tsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { MaterialSymbol } from '@nimbalyst/runtime';
+
+interface AddFolderModalProps {
+  existingFolderNames: string[];
+  onCancel: () => void;
+  onConfirm: (name: string) => void;
+}
+
+export function AddFolderModal({ existingFolderNames, onCancel, onConfirm }: AddFolderModalProps) {
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | undefined>();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError('Folder name is required.');
+      return;
+    }
+    if (existingFolderNames.some((n) => n.toLowerCase() === trimmed.toLowerCase())) {
+      setError(`A folder named "${trimmed}" already exists.`);
+      return;
+    }
+    onConfirm(trimmed);
+  }, [name, existingFolderNames, onConfirm]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel();
+      } else if (e.key === 'Enter') {
+        handleSubmit();
+      }
+    },
+    [onCancel, handleSubmit]
+  );
+
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === overlayRef.current) {
+        onCancel();
+      }
+    },
+    [onCancel]
+  );
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      onKeyDown={handleKeyDown}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      tabIndex={-1}
+    >
+      <div
+        className="relative flex flex-col bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded-xl shadow-2xl w-full max-w-[400px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--nim-border)] shrink-0">
+          <h2 className="text-[15px] font-semibold text-[var(--nim-text)]">Add Folder</h2>
+          <button
+            onClick={onCancel}
+            className="w-7 h-7 flex items-center justify-center rounded-md text-[var(--nim-text-muted)] hover:text-[var(--nim-text)] hover:bg-[var(--nim-bg-secondary)] cursor-pointer transition-colors"
+          >
+            <MaterialSymbol icon="close" size={16} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4">
+          <label className="block text-[12px] font-semibold text-[var(--nim-text-muted)] uppercase tracking-wide mb-1.5">
+            Folder name
+          </label>
+          <input
+            ref={inputRef}
+            type="text"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              setError(undefined);
+            }}
+            placeholder="Folder name"
+            className="w-full px-2.5 py-1.5 text-[13px] bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded-md text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] transition-colors placeholder:text-[var(--nim-text-faint)]"
+          />
+          {error && <p className="text-[11px] text-[#ef4444] mt-1">{error}</p>}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-5 py-3.5 border-t border-[var(--nim-border)] shrink-0">
+          <button
+            onClick={onCancel}
+            className="px-3.5 py-1.5 text-[13px] font-medium text-[var(--nim-text-muted)] hover:text-[var(--nim-text)] bg-transparent hover:bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] rounded-md cursor-pointer transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            className="px-3.5 py-1.5 text-[13px] font-medium text-white bg-[var(--nim-primary)] hover:opacity-90 rounded-md cursor-pointer transition-opacity"
+          >
+            Add Folder
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/components/TrackerMode/KanbanBoard.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/KanbanBoard.tsx
@@ -7,6 +7,7 @@ import { globalRegistry, getRoleField } from '@nimbalyst/runtime/plugins/Tracker
 import { getRecordTitle, getRecordStatus, getRecordPriority, getRecordSortOrder, getStatusOptions, getFieldByRole } from '@nimbalyst/runtime/plugins/TrackerPlugin/trackerRecordAccessors';
 import { generateKeyBetween } from '@nimbalyst/runtime/utils/fractionalIndex';
 import { UserAvatar } from '@nimbalyst/runtime/plugins/TrackerPlugin/components/UserAvatar';
+import { setDragPayload } from './trackerItemDnd';
 
 // ── Module-level drag-and-drop handler ──────────────────────────────────
 // Registered once on `document`, survives HMR. The component sets the
@@ -233,6 +234,14 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
     dragItemRef.current = item;
     e.dataTransfer.effectAllowed = 'move';
     e.dataTransfer.setData('text/plain', item.id);
+    setDragPayload(e, {
+      itemId: item.id,
+      primaryType: item.primaryType,
+      typeTags: item.typeTags,
+      currentDataKeys: Object.keys((item.fields as Record<string, any>) ?? {}),
+      data: (item.fields as Record<string, any>) ?? {},
+      key: item.issueKey ?? '',
+    });
   }, []);
 
   const handleDragOver = useCallback((e: React.DragEvent, columnValue: string) => {

--- a/packages/electron/src/renderer/components/TrackerMode/TrackerItemMoveConfirm.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/TrackerItemMoveConfirm.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useRef } from 'react';
+import { MaterialSymbol, globalRegistry } from '@nimbalyst/runtime';
+
+interface TrackerItemMoveConfirmProps {
+  itemKey: string;
+  sourceTypeId: string;
+  targetTypeId: string;
+  lostFields: string[];
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export const TrackerItemMoveConfirm: React.FC<TrackerItemMoveConfirmProps> = ({
+  itemKey,
+  sourceTypeId,
+  targetTypeId,
+  lostFields,
+  onCancel,
+  onConfirm,
+}) => {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const sourceModel = globalRegistry.get(sourceTypeId);
+  const targetModel = globalRegistry.get(targetTypeId);
+  const sourceDisplayName = sourceModel?.displayName ?? sourceTypeId;
+  const targetDisplayName = targetModel?.displayName ?? targetTypeId;
+  const targetColor = targetModel?.color ?? 'var(--nim-primary)';
+  const targetIcon = targetModel?.icon ?? 'label';
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) onConfirm();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onCancel, onConfirm]);
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === overlayRef.current) onCancel();
+  };
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <div
+        className="relative flex flex-col bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded-xl shadow-2xl w-full max-w-[480px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--nim-border)]">
+          <div className="flex items-center gap-2">
+            <span style={{ color: targetColor }}>
+              <MaterialSymbol icon={targetIcon} size={18} />
+            </span>
+            <h2 className="text-[15px] font-semibold text-[var(--nim-text)]">
+              Move item to {targetDisplayName}?
+            </h2>
+          </div>
+          <button
+            onClick={onCancel}
+            className="w-7 h-7 flex items-center justify-center rounded-md text-[var(--nim-text-muted)] hover:text-[var(--nim-text)] hover:bg-[var(--nim-bg-secondary)] cursor-pointer transition-colors"
+          >
+            <MaterialSymbol icon="close" size={16} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-4">
+          {/* Item summary */}
+          <div className="flex items-center gap-3 p-3 bg-[var(--nim-bg-secondary)] rounded-lg">
+            <span className="text-[11px] font-mono font-medium uppercase tracking-[0.08em] text-[var(--nim-text-faint)] shrink-0">
+              {itemKey}
+            </span>
+            <MaterialSymbol icon="arrow_forward" size={14} className="text-[var(--nim-text-faint)] shrink-0" />
+            <span className="text-[13px] text-[var(--nim-text-muted)]">
+              <span className="font-medium text-[var(--nim-text)]">{sourceDisplayName}</span>
+              {' '}→{' '}
+              <span className="font-medium" style={{ color: targetColor }}>{targetDisplayName}</span>
+            </span>
+          </div>
+
+          {/* Field loss warning or no-loss confirmation */}
+          {lostFields.length > 0 ? (
+            <div className="p-3 bg-[#ef444415] border border-[#ef444430] rounded-lg space-y-2">
+              <div className="flex items-center gap-1.5 text-[#ef4444]">
+                <MaterialSymbol icon="warning" size={15} />
+                <span className="text-[12px] font-semibold">These fields will be removed:</span>
+              </div>
+              <div className="flex flex-wrap gap-1.5 mt-1">
+                {lostFields.map((field) => (
+                  <span
+                    key={field}
+                    className="text-[11px] font-mono px-2 py-0.5 rounded bg-[#ef444420] text-[#ef4444] border border-[#ef444430]"
+                  >
+                    {field}
+                  </span>
+                ))}
+              </div>
+              <p className="text-[11px] text-[#ef4444]/70 mt-1">
+                These fields are not defined on {targetDisplayName} and will be deleted.
+              </p>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1.5 p-3 bg-[#22c55e15] border border-[#22c55e30] rounded-lg">
+              <MaterialSymbol icon="check_circle" size={15} className="text-[#22c55e]" />
+              <span className="text-[12px] text-[#22c55e]">No data will be lost.</span>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-[var(--nim-border)]">
+          <button
+            onClick={onCancel}
+            className="px-4 py-1.5 rounded-lg text-[13px] font-medium text-[var(--nim-text-muted)] hover:bg-[var(--nim-bg-secondary)] hover:text-[var(--nim-text)] transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-1.5 rounded-lg text-[13px] font-medium text-white transition-opacity hover:opacity-90 cursor-pointer"
+            style={{ backgroundColor: targetColor }}
+          >
+            Move Item
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/electron/src/renderer/components/TrackerMode/TrackerMainView.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/TrackerMainView.tsx
@@ -3,6 +3,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { MaterialSymbol } from '@nimbalyst/runtime';
 import type { TrackerIdentity } from '@nimbalyst/runtime';
 import type { TrackerRecord } from '@nimbalyst/runtime/core/TrackerRecord';
+import { setDragPayload } from './trackerItemDnd';
 import { getRecordTitle, getRecordPriority, getRecordStatus, getRecordFieldStr, getFieldByRole, isMyRecord } from '@nimbalyst/runtime/plugins/TrackerPlugin/trackerRecordAccessors';
 import {
   TrackerTable,
@@ -303,6 +304,17 @@ export const TrackerMainView: React.FC<TrackerMainViewProps> = ({
     }
   }, []);
 
+  const handleRowDragStart = useCallback((e: React.DragEvent, item: TrackerRecord) => {
+    setDragPayload(e, {
+      itemId: item.id,
+      primaryType: item.primaryType,
+      typeTags: item.typeTags,
+      currentDataKeys: Object.keys((item.fields as Record<string, any>) ?? {}),
+      data: (item.fields as Record<string, any>) ?? {},
+      key: item.issueKey ?? '',
+    });
+  }, []);
+
   const handleNewItem = useCallback((type: string) => {
     setQuickAddType(type);
   }, []);
@@ -529,6 +541,7 @@ export const TrackerMainView: React.FC<TrackerMainViewProps> = ({
               searchQuery={searchQuery}
               columnConfig={columnConfig}
               onColumnConfigChange={handleColumnConfigChange}
+              onRowDragStart={handleRowDragStart}
             />
           ) : (
             <KanbanBoard

--- a/packages/electron/src/renderer/components/TrackerMode/TrackerMode.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/TrackerMode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useCallback } from 'react';
+import React, { useEffect, useMemo, useCallback, useState } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { globalRegistry, loadBuiltinTrackers } from '@nimbalyst/runtime/plugins/TrackerPlugin/models';
 import { TrackerSidebar } from './TrackerSidebar';
@@ -10,6 +10,14 @@ import {
   setTrackerModeLayoutAtom,
   type TrackerFilterChip,
 } from '../../store/atoms/trackers';
+import {
+  computeFieldLoss,
+  buildNewTypeTags,
+  regenerateKey,
+  migrateData,
+  type DraggedTrackerItem,
+} from './trackerItemDnd';
+import { TrackerItemMoveConfirm } from './TrackerItemMoveConfirm';
 
 // Ensure built-in trackers are loaded
 loadBuiltinTrackers();
@@ -73,6 +81,47 @@ export const TrackerMode: React.FC<TrackerModeProps> = ({
 
   const filterType = selectedType as TrackerItemType | 'all';
 
+  // ── Cross-type drag-and-drop move ──────────────────────────────────────────
+  const [moveConfirm, setMoveConfirm] = useState<{
+    payload: DraggedTrackerItem;
+    targetType: string;
+    lostFields: string[];
+  } | null>(null);
+
+  const handleItemMove = useCallback((payload: DraggedTrackerItem, targetType: string) => {
+    if (payload.primaryType === targetType) return;
+    const { lostFields } = computeFieldLoss(payload.currentDataKeys, targetType);
+    setMoveConfirm({ payload, targetType, lostFields });
+  }, []);
+
+  const performMove = useCallback(async () => {
+    if (!moveConfirm) return;
+    const { payload, targetType } = moveConfirm;
+    const targetModel = globalRegistry.get(targetType);
+    if (!targetModel) {
+      setMoveConfirm(null);
+      return;
+    }
+    const newTypeTags = buildNewTypeTags(payload.typeTags, payload.primaryType, targetType);
+    const newKey = payload.key ? regenerateKey(payload.key, targetModel.idPrefix) : undefined;
+    const newData = migrateData(payload.data, targetType);
+    try {
+      const updates: Record<string, any> = { typeTags: newTypeTags, ...newData };
+      for (const lostKey of moveConfirm.lostFields) {
+        updates[lostKey] = null;
+      }
+      if (newKey) updates.issueKey = newKey;
+      await (window as any).electronAPI.documentService.updateTrackerItem({
+        itemId: payload.itemId,
+        updates,
+        syncMode: undefined,
+      });
+    } catch (err) {
+      console.error('[TrackerMode] move failed', err);
+    }
+    setMoveConfirm(null);
+  }, [moveConfirm]);
+
   const sidebarContent = (
     <TrackerSidebar
       workspacePath={workspacePath || undefined}
@@ -84,6 +133,7 @@ export const TrackerMode: React.FC<TrackerModeProps> = ({
       onSelectType={handleSelectType}
       onToggleFilter={handleToggleFilter}
       onViewModeChange={handleViewModeChange}
+      onItemMove={handleItemMove}
     />
   );
 
@@ -109,6 +159,16 @@ export const TrackerMode: React.FC<TrackerModeProps> = ({
         maxWidth={350}
         onWidthChange={handleSidebarWidthChange}
       />
+      {moveConfirm && (
+        <TrackerItemMoveConfirm
+          itemKey={moveConfirm.payload.key}
+          sourceTypeId={moveConfirm.payload.primaryType}
+          targetTypeId={moveConfirm.targetType}
+          lostFields={moveConfirm.lostFields}
+          onCancel={() => setMoveConfirm(null)}
+          onConfirm={performMove}
+        />
+      )}
     </div>
   );
 };

--- a/packages/electron/src/renderer/components/TrackerMode/TrackerSidebar.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/TrackerSidebar.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useAtomValue } from 'jotai';
-import { MaterialSymbol } from '@nimbalyst/runtime';
+import { MaterialSymbol, globalRegistry } from '@nimbalyst/runtime';
 import type { TrackerItemType } from '@nimbalyst/runtime';
 import { trackerItemCountByTypeAtom } from '@nimbalyst/runtime/plugins/TrackerPlugin';
 import type { TrackerDataModel } from '@nimbalyst/runtime/plugins/TrackerPlugin/models';
@@ -8,6 +8,24 @@ import type { TrackerFilterChip } from '../../store/atoms/trackers';
 import type { ViewMode } from './TrackerMainView';
 import { WorkspaceSummaryHeader } from '../WorkspaceSummaryHeader';
 import { AlphaBadge } from '../common/AlphaBadge';
+import {
+  loadLayout,
+  saveLayout,
+  loadLegacyState,
+  buildLayoutFromLegacy,
+  reconcileLayout,
+  moveEntry,
+  setFolderCollapsed,
+  EMPTY_LAYOUT,
+  type TrackerSidebarLayout,
+  type SidebarEntry,
+  type DragLocation,
+  type DropLocation,
+} from '../../services/TrackerSidebarLayout';
+import { readDragPayload, TRACKER_ITEM_DND_MIME, type DraggedTrackerItem } from './trackerItemDnd';
+
+const FOLDER_REORDER_MIME = 'application/x-nimbalyst-tracker-folder-reorder';
+const TYPE_REORDER_MIME = 'application/x-nimbalyst-tracker-type-reorder';
 
 interface TrackerSidebarProps {
   workspacePath?: string;
@@ -19,6 +37,7 @@ interface TrackerSidebarProps {
   onSelectType: (type: string | 'all') => void;
   onToggleFilter: (filter: TrackerFilterChip) => void;
   onViewModeChange: (mode: ViewMode) => void;
+  onItemMove?: (payload: DraggedTrackerItem, targetType: string) => void;
 }
 
 const FILTER_CHIPS: { id: TrackerFilterChip; label: string; icon: string }[] = [
@@ -29,11 +48,132 @@ const FILTER_CHIPS: { id: TrackerFilterChip; label: string; icon: string }[] = [
   { id: 'archived', label: 'Archived', icon: 'archive' },
 ];
 
-/** Small component so each sidebar row subscribes to its own atom */
 function SidebarTypeCount({ type }: { type: TrackerItemType }) {
   const count = useAtomValue(trackerItemCountByTypeAtom(type));
   return <>{count}</>;
 }
+
+// ============================================================================
+// Drop indicator state
+// ============================================================================
+
+interface DropIndicator {
+  position: 'before' | 'after' | 'inside';
+  target: number[];
+}
+
+// ============================================================================
+// TrackerTypeButton (with both item-drop and reorder-drop support)
+// ============================================================================
+
+function TrackerTypeButton({
+  tracker,
+  selectedType,
+  onSelect,
+  onItemDrop,
+  draggable,
+  onDragStart,
+  dropIndicator,
+  onReorderDragOver,
+  onReorderDrop,
+  onDragLeave,
+}: {
+  tracker: TrackerDataModel;
+  selectedType: string | 'all';
+  onSelect: (type: string | 'all') => void;
+  onItemDrop?: (payload: DraggedTrackerItem, targetType: string) => void;
+  draggable?: boolean;
+  onDragStart?: (e: React.DragEvent) => void;
+  dropIndicator?: DropIndicator | null;
+  onReorderDragOver?: (e: React.DragEvent) => void;
+  onReorderDrop?: (e: React.DragEvent) => void;
+  onDragLeave?: (e: React.DragEvent) => void;
+}) {
+  const [isItemDropHover, setIsItemDropHover] = useState(false);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes(TRACKER_ITEM_DND_MIME)) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      setIsItemDropHover(true);
+    } else if (
+      e.dataTransfer.types.includes(FOLDER_REORDER_MIME) ||
+      e.dataTransfer.types.includes(TYPE_REORDER_MIME)
+    ) {
+      onReorderDragOver?.(e);
+    }
+  };
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes(TRACKER_ITEM_DND_MIME)) {
+      e.preventDefault();
+      setIsItemDropHover(true);
+    }
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsItemDropHover(false);
+    }
+    onDragLeave?.(e);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes(TRACKER_ITEM_DND_MIME)) {
+      e.preventDefault();
+      setIsItemDropHover(false);
+      const payload = readDragPayload(e);
+      if (!payload) return;
+      if (payload.primaryType === tracker.type) return;
+      onItemDrop?.(payload, tracker.type);
+    } else {
+      onReorderDrop?.(e);
+    }
+  };
+
+  const showBefore = dropIndicator?.position === 'before';
+  const showAfter = dropIndicator?.position === 'after';
+
+  return (
+    <div className="relative">
+      {showBefore && (
+        <div className="absolute top-0 left-0 right-0 h-[2px] bg-[var(--nim-primary)] z-10 pointer-events-none" />
+      )}
+      <button
+        key={tracker.type}
+        data-testid="tracker-type-button"
+        data-tracker-type={tracker.type}
+        draggable={draggable}
+        onDragStart={onDragStart}
+        className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors cursor-grab active:cursor-grabbing ${
+          selectedType === tracker.type
+            ? 'bg-nim-active text-nim'
+            : 'text-nim-muted hover:bg-nim-tertiary hover:text-nim'
+        } ${isItemDropHover ? 'ring-2 ring-[var(--nim-primary)] bg-[var(--nim-bg-tertiary)]' : ''}`}
+        onClick={() => onSelect(tracker.type)}
+        onDragOver={handleDragOver}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        <span style={{ color: tracker.color }}>
+          <MaterialSymbol icon={tracker.icon} size={16} />
+        </span>
+        <span className="flex-1 text-left truncate">{tracker.displayNamePlural}</span>
+        <span className="text-[10px] font-semibold text-nim-faint min-w-[20px] text-right">
+          <SidebarTypeCount type={tracker.type as TrackerItemType} />
+        </span>
+      </button>
+      {showAfter && (
+        <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-[var(--nim-primary)] z-10 pointer-events-none" />
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Main sidebar
+// ============================================================================
 
 export const TrackerSidebar: React.FC<TrackerSidebarProps> = ({
   workspacePath,
@@ -45,9 +185,248 @@ export const TrackerSidebar: React.FC<TrackerSidebarProps> = ({
   onSelectType,
   onToggleFilter,
   onViewModeChange,
+  onItemMove,
 }) => {
+  const [layout, setLayout] = useState<TrackerSidebarLayout>(EMPTY_LAYOUT);
+  const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null);
+  const layoutRef = useRef<TrackerSidebarLayout>(EMPTY_LAYOUT);
+
+  const updateLayout = useCallback((next: TrackerSidebarLayout) => {
+    layoutRef.current = next;
+    setLayout(next);
+  }, []);
+
+  const loadAndReconcile = useCallback(async (models: TrackerDataModel[]) => {
+    if (!workspacePath) return;
+    let saved = await loadLayout(workspacePath);
+    if (saved.entries.length === 0) {
+      const legacy = await loadLegacyState(workspacePath);
+      saved = buildLayoutFromLegacy(models, legacy.folders, legacy.overrides);
+    }
+    const reconciled = reconcileLayout(saved, models);
+    updateLayout(reconciled);
+    const hasChanges =
+      JSON.stringify(reconciled.entries) !== JSON.stringify(saved.entries);
+    if (hasChanges) {
+      await saveLayout(workspacePath, reconciled);
+    }
+  }, [workspacePath, updateLayout]);
+
+  useEffect(() => {
+    if (!workspacePath) return;
+    loadAndReconcile(trackerTypes);
+
+    const unsubscribe = globalRegistry.onChange(() => {
+      loadAndReconcile(globalRegistry.getAll());
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [workspacePath, loadAndReconcile, trackerTypes]);
+
+  // ============================================================================
+  // Drag/drop helpers
+  // ============================================================================
+
+  const computeDropPosition = (
+    e: React.DragEvent,
+    isFolder: boolean
+  ): 'before' | 'after' | 'inside' => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const relY = e.clientY - rect.top;
+    const third = rect.height / 3;
+    if (relY < third) return 'before';
+    if (relY > third * 2 && isFolder) return 'inside';
+    return 'after';
+  };
+
+  const handleFolderToggle = useCallback(async (folderName: string, currentCollapsed: boolean) => {
+    if (!workspacePath) return;
+    const next = setFolderCollapsed(layoutRef.current, folderName, !currentCollapsed);
+    updateLayout(next);
+    await saveLayout(workspacePath, next);
+  }, [workspacePath, updateLayout]);
+
+  // ============================================================================
+  // Reorder drag handlers — top-level entries
+  // ============================================================================
+
+  const handleTopLevelDragStart = (
+    e: React.DragEvent,
+    entry: SidebarEntry,
+    entryIdx: number
+  ) => {
+    if (entry.kind === 'folder') {
+      e.dataTransfer.setData(FOLDER_REORDER_MIME, JSON.stringify({ name: entry.name }));
+    } else {
+      e.dataTransfer.setData(
+        TYPE_REORDER_MIME,
+        JSON.stringify({ typeId: entry.typeId, fromFolder: null })
+      );
+    }
+    e.dataTransfer.effectAllowed = 'move';
+    // Store origin index for computing drop target after removal
+    e.dataTransfer.setData('text/plain', String(entryIdx));
+  };
+
+  const handleTopLevelDragOver = (
+    e: React.DragEvent,
+    entryIdx: number,
+    isFolder: boolean
+  ) => {
+    const isReorder =
+      e.dataTransfer.types.includes(FOLDER_REORDER_MIME) ||
+      e.dataTransfer.types.includes(TYPE_REORDER_MIME);
+    if (!isReorder) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    const pos = computeDropPosition(e, isFolder);
+    setDropIndicator({ position: pos, target: [entryIdx] });
+  };
+
+  const handleTopLevelDrop = useCallback(async (e: React.DragEvent, entryIdx: number) => {
+    e.preventDefault();
+    const isFolder = e.dataTransfer.types.includes(FOLDER_REORDER_MIME);
+    const isType = e.dataTransfer.types.includes(TYPE_REORDER_MIME);
+    if (!isFolder && !isType) return;
+
+    const pos = computeDropPosition(e, !isType);
+    const drop: DropLocation = { position: pos, target: [entryIdx] };
+    let drag: DragLocation;
+
+    if (isFolder) {
+      const data = JSON.parse(e.dataTransfer.getData(FOLDER_REORDER_MIME));
+      drag = { kind: 'folder', id: data.name };
+    } else {
+      const data = JSON.parse(e.dataTransfer.getData(TYPE_REORDER_MIME));
+      drag = { kind: 'type', id: data.typeId, fromFolder: data.fromFolder };
+    }
+
+    const next = moveEntry(layoutRef.current, drag, drop);
+    updateLayout(next);
+    setDropIndicator(null);
+    if (workspacePath) await saveLayout(workspacePath, next);
+  }, [workspacePath, updateLayout]);
+
+  // ============================================================================
+  // Reorder drag handlers — types inside a folder
+  // ============================================================================
+
+  const handleInFolderTypeDragStart = (
+    e: React.DragEvent,
+    typeId: string,
+    folderName: string
+  ) => {
+    e.stopPropagation();
+    e.dataTransfer.setData(
+      TYPE_REORDER_MIME,
+      JSON.stringify({ typeId, fromFolder: folderName })
+    );
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleInFolderTypeDragOver = (
+    e: React.DragEvent,
+    folderIdx: number,
+    typeIdx: number
+  ) => {
+    const isReorder =
+      e.dataTransfer.types.includes(FOLDER_REORDER_MIME) ||
+      e.dataTransfer.types.includes(TYPE_REORDER_MIME);
+    if (!isReorder) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'move';
+    const pos = computeDropPosition(e, false);
+    setDropIndicator({ position: pos, target: [folderIdx, typeIdx] });
+  };
+
+  const handleInFolderTypeDrop = useCallback(async (
+    e: React.DragEvent,
+    folderIdx: number,
+    typeIdx: number
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const isFolder = e.dataTransfer.types.includes(FOLDER_REORDER_MIME);
+    const isType = e.dataTransfer.types.includes(TYPE_REORDER_MIME);
+    if (!isFolder && !isType) return;
+
+    const pos = computeDropPosition(e, false);
+    const drop: DropLocation = { position: pos, target: [folderIdx, typeIdx] };
+    let drag: DragLocation;
+
+    if (isFolder) {
+      const data = JSON.parse(e.dataTransfer.getData(FOLDER_REORDER_MIME));
+      drag = { kind: 'folder', id: data.name };
+    } else {
+      const data = JSON.parse(e.dataTransfer.getData(TYPE_REORDER_MIME));
+      drag = { kind: 'type', id: data.typeId, fromFolder: data.fromFolder };
+    }
+
+    const next = moveEntry(layoutRef.current, drag, drop);
+    updateLayout(next);
+    setDropIndicator(null);
+    if (workspacePath) await saveLayout(workspacePath, next);
+  }, [workspacePath, updateLayout]);
+
+  const handleFolderHeaderDragOver = (
+    e: React.DragEvent,
+    folderIdx: number
+  ) => {
+    const isReorder =
+      e.dataTransfer.types.includes(FOLDER_REORDER_MIME) ||
+      e.dataTransfer.types.includes(TYPE_REORDER_MIME);
+    if (!isReorder) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    const pos = computeDropPosition(e, true);
+    setDropIndicator({ position: pos, target: [folderIdx] });
+  };
+
+  const handleFolderHeaderDrop = useCallback(async (
+    e: React.DragEvent,
+    folderIdx: number
+  ) => {
+    e.preventDefault();
+    const isFolder = e.dataTransfer.types.includes(FOLDER_REORDER_MIME);
+    const isType = e.dataTransfer.types.includes(TYPE_REORDER_MIME);
+    if (!isFolder && !isType) return;
+
+    const pos = computeDropPosition(e, true);
+    const drop: DropLocation = { position: pos, target: [folderIdx] };
+    let drag: DragLocation;
+
+    if (isFolder) {
+      const data = JSON.parse(e.dataTransfer.getData(FOLDER_REORDER_MIME));
+      drag = { kind: 'folder', id: data.name };
+    } else {
+      const data = JSON.parse(e.dataTransfer.getData(TYPE_REORDER_MIME));
+      drag = { kind: 'type', id: data.typeId, fromFolder: data.fromFolder };
+    }
+
+    const next = moveEntry(layoutRef.current, drag, drop);
+    updateLayout(next);
+    setDropIndicator(null);
+    if (workspacePath) await saveLayout(workspacePath, next);
+  }, [workspacePath, updateLayout]);
+
+  const handleDragEnd = () => {
+    setDropIndicator(null);
+  };
+
+  // ============================================================================
+  // Render
+  // ============================================================================
+
+  const modelMap = new Map(trackerTypes.map((m) => [m.type, m]));
+
   return (
-    <div className="tracker-sidebar w-full h-full flex flex-col bg-nim-secondary overflow-hidden" data-testid="tracker-sidebar">
+    <div
+      className="tracker-sidebar w-full h-full flex flex-col bg-nim-secondary overflow-hidden"
+      data-testid="tracker-sidebar"
+    >
       {workspacePath && (
         <WorkspaceSummaryHeader
           workspacePath={workspacePath}
@@ -55,40 +434,41 @@ export const TrackerSidebar: React.FC<TrackerSidebarProps> = ({
           actions={
             <>
               <div className="flex items-center rounded border border-nim overflow-hidden">
-                  <button
-                    className={`flex items-center justify-center w-7 h-6 transition-colors ${
-                      viewMode === 'table'
-                        ? 'bg-nim-active text-nim'
-                        : 'bg-nim-secondary text-nim-muted hover:text-nim'
-                    }`}
-                    onClick={() => onViewModeChange('table')}
-                    title="Table view"
-                  >
-                    <MaterialSymbol icon="table_rows" size={16} />
-                  </button>
-                  <button
-                    className={`relative flex items-center justify-center w-7 h-6 border-l border-nim transition-colors ${
-                      viewMode === 'kanban'
-                        ? 'bg-nim-active text-nim'
-                        : 'bg-nim-secondary text-nim-muted hover:text-nim'
-                    }`}
-                    onClick={() => onViewModeChange('kanban')}
-                    title="Kanban view (alpha)"
-                  >
-                    <MaterialSymbol icon="view_kanban" size={16} />
-                    <AlphaBadge size="dot" className="absolute -top-1 -right-1 pointer-events-none" />
-                  </button>
-                </div>
+                <button
+                  className={`flex items-center justify-center w-7 h-6 transition-colors ${
+                    viewMode === 'table'
+                      ? 'bg-nim-active text-nim'
+                      : 'bg-nim-secondary text-nim-muted hover:text-nim'
+                  }`}
+                  onClick={() => onViewModeChange('table')}
+                  title="Table view"
+                >
+                  <MaterialSymbol icon="table_rows" size={16} />
+                </button>
+                <button
+                  className={`relative flex items-center justify-center w-7 h-6 border-l border-nim transition-colors ${
+                    viewMode === 'kanban'
+                      ? 'bg-nim-active text-nim'
+                      : 'bg-nim-secondary text-nim-muted hover:text-nim'
+                  }`}
+                  onClick={() => onViewModeChange('kanban')}
+                  title="Kanban view (alpha)"
+                >
+                  <MaterialSymbol icon="view_kanban" size={16} />
+                  <AlphaBadge size="dot" className="absolute -top-1 -right-1 pointer-events-none" />
+                </button>
+              </div>
             </>
           }
         />
       )}
+
       <div className="px-3 py-1.5 border-b border-nim text-[11px] font-semibold text-nim-muted uppercase tracking-wider">
         Trackers
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        {/* Filter chips (multi-select) */}
+        {/* Filter chips */}
         <div className="px-2 pt-2 pb-1">
           <div className="text-[10px] font-semibold text-nim-faint uppercase tracking-wider px-1 mb-1.5">
             Filters
@@ -116,7 +496,7 @@ export const TrackerSidebar: React.FC<TrackerSidebarProps> = ({
           {activeFilters.length > 0 && (
             <button
               className="mt-1 px-1 text-[10px] text-nim-faint hover:text-nim-muted transition-colors"
-              onClick={() => activeFilters.forEach(f => onToggleFilter(f))}
+              onClick={() => activeFilters.forEach((f) => onToggleFilter(f))}
             >
               Clear filters
             </button>
@@ -142,28 +522,133 @@ export const TrackerSidebar: React.FC<TrackerSidebarProps> = ({
             <span className="flex-1 text-left truncate">All</span>
           </button>
 
-          {/* Individual types */}
-          {trackerTypes.map((tracker) => (
-            <button
-              key={tracker.type}
-              data-testid="tracker-type-button"
-              data-tracker-type={tracker.type}
-              className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors ${
-                selectedType === tracker.type
-                  ? 'bg-nim-active text-nim'
-                  : 'text-nim-muted hover:bg-nim-tertiary hover:text-nim'
-              }`}
-              onClick={() => onSelectType(tracker.type)}
-            >
-              <span style={{ color: tracker.color }}>
-                <MaterialSymbol icon={tracker.icon} size={16} />
-              </span>
-              <span className="flex-1 text-left truncate">{tracker.displayNamePlural}</span>
-              <span className="text-[10px] font-semibold text-nim-faint min-w-[20px] text-right">
-                <SidebarTypeCount type={tracker.type as TrackerItemType} />
-              </span>
-            </button>
-          ))}
+          {/* Layout-based entries */}
+          {layout.entries.map((entry, entryIdx) => {
+            if (entry.kind === 'type') {
+              const tracker = modelMap.get(entry.typeId);
+              if (!tracker) return null;
+
+              const indicator =
+                dropIndicator?.target.length === 1 &&
+                dropIndicator.target[0] === entryIdx
+                  ? dropIndicator
+                  : null;
+
+              return (
+                <TrackerTypeButton
+                  key={tracker.type}
+                  tracker={tracker}
+                  selectedType={selectedType}
+                  onSelect={onSelectType}
+                  onItemDrop={onItemMove}
+                  draggable
+                  onDragStart={(e) => handleTopLevelDragStart(e, entry, entryIdx)}
+                  dropIndicator={indicator}
+                  onReorderDragOver={(e) => handleTopLevelDragOver(e, entryIdx, false)}
+                  onReorderDrop={(e) => handleTopLevelDrop(e, entryIdx)}
+                  onDragLeave={() => setDropIndicator(null)}
+                />
+              );
+            }
+
+            // Folder entry
+            const isCollapsed = entry.collapsed === true;
+            const folderTypes = entry.types
+              .map((t) => modelMap.get(t))
+              .filter((m): m is TrackerDataModel => m != null);
+
+            const isInsideTarget =
+              dropIndicator?.position === 'inside' &&
+              dropIndicator.target.length === 1 &&
+              dropIndicator.target[0] === entryIdx;
+
+            const folderHeaderIndicator =
+              dropIndicator?.target.length === 1 &&
+              dropIndicator.target[0] === entryIdx &&
+              dropIndicator.position !== 'inside'
+                ? dropIndicator
+                : null;
+
+            return (
+              <div
+                key={entry.name}
+                className="flex flex-col"
+                onDragEnd={handleDragEnd}
+              >
+                {/* Folder header */}
+                <div className="relative">
+                  {folderHeaderIndicator?.position === 'before' && (
+                    <div className="absolute top-0 left-0 right-0 h-[2px] bg-[var(--nim-primary)] z-10 pointer-events-none" />
+                  )}
+                  <div
+                    draggable
+                    onDragStart={(e) => handleTopLevelDragStart(e, entry, entryIdx)}
+                    onDragOver={(e) => handleFolderHeaderDragOver(e, entryIdx)}
+                    onDrop={(e) => handleFolderHeaderDrop(e, entryIdx)}
+                    onDragLeave={(e) => {
+                      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                        setDropIndicator(null);
+                      }
+                    }}
+                    className={`cursor-grab active:cursor-grabbing ${
+                      isInsideTarget ? 'ring-2 ring-[var(--nim-primary)] rounded-md' : ''
+                    }`}
+                  >
+                    <button
+                      onClick={() => handleFolderToggle(entry.name, isCollapsed)}
+                      className="w-full flex items-center gap-1 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-nim-faint hover:text-nim-muted transition-colors"
+                    >
+                      <MaterialSymbol
+                        icon={isCollapsed ? 'chevron_right' : 'expand_more'}
+                        size={14}
+                      />
+                      <span className="flex-1 text-left truncate">{entry.name}</span>
+                      <span className="text-[10px] text-nim-faint">{folderTypes.length}</span>
+                    </button>
+                  </div>
+                  {folderHeaderIndicator?.position === 'after' && (
+                    <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-[var(--nim-primary)] z-10 pointer-events-none" />
+                  )}
+                </div>
+
+                {/* Folder contents */}
+                {!isCollapsed && (
+                  <div className="flex flex-col pl-2.5">
+                    {folderTypes.map((tracker, typeIdx) => {
+                      const indicator =
+                        dropIndicator?.target.length === 2 &&
+                        dropIndicator.target[0] === entryIdx &&
+                        dropIndicator.target[1] === typeIdx
+                          ? dropIndicator
+                          : null;
+
+                      return (
+                        <TrackerTypeButton
+                          key={tracker.type}
+                          tracker={tracker}
+                          selectedType={selectedType}
+                          onSelect={onSelectType}
+                          onItemDrop={onItemMove}
+                          draggable
+                          onDragStart={(e) =>
+                            handleInFolderTypeDragStart(e, tracker.type, entry.name)
+                          }
+                          dropIndicator={indicator}
+                          onReorderDragOver={(e) =>
+                            handleInFolderTypeDragOver(e, entryIdx, typeIdx)
+                          }
+                          onReorderDrop={(e) =>
+                            handleInFolderTypeDrop(e, entryIdx, typeIdx)
+                          }
+                          onDragLeave={() => setDropIndicator(null)}
+                        />
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/packages/electron/src/renderer/components/TrackerMode/TrackerSidebar.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/TrackerSidebar.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { AddFolderModal } from './AddFolderModal';
+import { TrackerTypeCreator } from '../Settings/panels/TrackerTypeCreator';
 import { useAtomValue } from 'jotai';
 import { MaterialSymbol, globalRegistry } from '@nimbalyst/runtime';
 import type { TrackerItemType } from '@nimbalyst/runtime';
@@ -16,6 +18,7 @@ import {
   reconcileLayout,
   moveEntry,
   setFolderCollapsed,
+  addFolder,
   EMPTY_LAYOUT,
   type TrackerSidebarLayout,
   type SidebarEntry,
@@ -190,6 +193,10 @@ export const TrackerSidebar: React.FC<TrackerSidebarProps> = ({
   const [layout, setLayout] = useState<TrackerSidebarLayout>(EMPTY_LAYOUT);
   const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null);
   const layoutRef = useRef<TrackerSidebarLayout>(EMPTY_LAYOUT);
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
+  const [addFolderOpen, setAddFolderOpen] = useState(false);
+  const [addTypeOpen, setAddTypeOpen] = useState(false);
+  const addMenuRef = useRef<HTMLDivElement>(null);
 
   const updateLayout = useCallback((next: TrackerSidebarLayout) => {
     layoutRef.current = next;
@@ -224,6 +231,19 @@ export const TrackerSidebar: React.FC<TrackerSidebarProps> = ({
       unsubscribe();
     };
   }, [workspacePath, loadAndReconcile, trackerTypes]);
+
+  useEffect(() => {
+    if (!addMenuOpen) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
+        setAddMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [addMenuOpen]);
 
   // ============================================================================
   // Drag/drop helpers
@@ -463,8 +483,38 @@ export const TrackerSidebar: React.FC<TrackerSidebarProps> = ({
         />
       )}
 
-      <div className="px-3 py-1.5 border-b border-nim text-[11px] font-semibold text-nim-muted uppercase tracking-wider">
-        Trackers
+      <div className="px-3 py-1.5 border-b border-nim flex items-center justify-between">
+        <span className="text-[11px] font-semibold text-nim-muted uppercase tracking-wider">
+          Trackers
+        </span>
+        <div className="relative" ref={addMenuRef}>
+          <button
+            onClick={() => setAddMenuOpen((v) => !v)}
+            className="w-5 h-5 flex items-center justify-center rounded text-nim-muted hover:text-nim hover:bg-nim-tertiary cursor-pointer transition-colors"
+            title="Add tracker type or folder"
+            data-testid="tracker-sidebar-add"
+          >
+            <MaterialSymbol icon="add" size={14} />
+          </button>
+          {addMenuOpen && (
+            <div className="absolute right-0 top-full mt-1 z-20 bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded-md shadow-lg py-1 min-w-[160px]">
+              <button
+                onClick={() => { setAddMenuOpen(false); setAddFolderOpen(true); }}
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-nim hover:bg-nim-tertiary cursor-pointer text-left"
+              >
+                <MaterialSymbol icon="folder" size={14} />
+                Add Folder
+              </button>
+              <button
+                onClick={() => { setAddMenuOpen(false); setAddTypeOpen(true); }}
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-nim hover:bg-nim-tertiary cursor-pointer text-left"
+              >
+                <MaterialSymbol icon="add_circle" size={14} />
+                Add Tracker Type
+              </button>
+            </div>
+          )}
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto">
@@ -651,6 +701,28 @@ export const TrackerSidebar: React.FC<TrackerSidebarProps> = ({
           })}
         </div>
       </div>
+
+      {addFolderOpen && (
+        <AddFolderModal
+          existingFolderNames={layout.entries
+            .filter((e): e is Extract<SidebarEntry, { kind: 'folder' }> => e.kind === 'folder')
+            .map((e) => e.name)}
+          onCancel={() => setAddFolderOpen(false)}
+          onConfirm={async (name) => {
+            const next = addFolder(layout, name);
+            updateLayout(next);
+            if (workspacePath) await saveLayout(workspacePath, next);
+            setAddFolderOpen(false);
+          }}
+        />
+      )}
+      {addTypeOpen && workspacePath && (
+        <TrackerTypeCreator
+          workspacePath={workspacePath}
+          onClose={() => setAddTypeOpen(false)}
+          onCreated={() => setAddTypeOpen(false)}
+        />
+      )}
     </div>
   );
 };

--- a/packages/electron/src/renderer/components/TrackerMode/trackerItemDnd.ts
+++ b/packages/electron/src/renderer/components/TrackerMode/trackerItemDnd.ts
@@ -1,0 +1,70 @@
+import type { DragEvent } from 'react';
+import { globalRegistry } from '@nimbalyst/runtime/plugins/TrackerPlugin/models';
+import type { TrackerDataModel } from '@nimbalyst/runtime/plugins/TrackerPlugin/models';
+
+export const TRACKER_ITEM_DND_MIME = 'application/x-nimbalyst-tracker-item';
+
+export interface DraggedTrackerItem {
+  itemId: string;
+  primaryType: string;
+  typeTags: string[];
+  currentDataKeys: string[];
+  data: Record<string, any>;
+  key: string;
+}
+
+export function setDragPayload(e: DragEvent, payload: DraggedTrackerItem): void {
+  e.dataTransfer.effectAllowed = 'move';
+  e.dataTransfer.setData(TRACKER_ITEM_DND_MIME, JSON.stringify(payload));
+}
+
+export function readDragPayload(e: DragEvent): DraggedTrackerItem | null {
+  const raw = e.dataTransfer.getData(TRACKER_ITEM_DND_MIME);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as DraggedTrackerItem;
+  } catch {
+    return null;
+  }
+}
+
+export function computeFieldLoss(
+  currentDataKeys: string[],
+  targetType: string
+): { lostFields: string[]; targetModel: TrackerDataModel | null } {
+  const targetModel = globalRegistry.get(targetType) ?? null;
+  if (!targetModel) return { lostFields: [], targetModel: null };
+  const targetFieldNames = new Set(targetModel.fields.map((f) => f.name));
+  const lostFields = currentDataKeys.filter((k) => !targetFieldNames.has(k));
+  return { lostFields, targetModel };
+}
+
+export function buildNewTypeTags(
+  currentTags: string[],
+  currentPrimary: string,
+  targetType: string
+): string[] {
+  const filtered = currentTags.filter((t) => t !== currentPrimary && t !== targetType);
+  return [targetType, ...filtered];
+}
+
+export function regenerateKey(currentKey: string, targetIdPrefix: string): string {
+  const dashIdx = currentKey.lastIndexOf('-');
+  if (dashIdx < 0) return `${targetIdPrefix.toUpperCase()}-${currentKey}`;
+  const suffix = currentKey.slice(dashIdx + 1);
+  return `${targetIdPrefix.toUpperCase()}-${suffix}`;
+}
+
+export function migrateData(
+  currentData: Record<string, any>,
+  targetType: string
+): Record<string, any> {
+  const targetModel = globalRegistry.get(targetType);
+  if (!targetModel) return currentData;
+  const targetFieldNames = new Set(targetModel.fields.map((f) => f.name));
+  const next: Record<string, any> = {};
+  for (const key of Object.keys(currentData)) {
+    if (targetFieldNames.has(key)) next[key] = currentData[key];
+  }
+  return next;
+}

--- a/packages/electron/src/renderer/services/TrackerSidebarLayout.ts
+++ b/packages/electron/src/renderer/services/TrackerSidebarLayout.ts
@@ -1,0 +1,303 @@
+import type { TrackerDataModel } from '@nimbalyst/runtime';
+
+export type SidebarEntry =
+  | { kind: 'folder'; name: string; collapsed?: boolean; types: string[] }
+  | { kind: 'type'; typeId: string };
+
+export interface TrackerSidebarLayout {
+  entries: SidebarEntry[];
+}
+
+export const EMPTY_LAYOUT: TrackerSidebarLayout = { entries: [] };
+
+export function reconcileLayout(
+  layout: TrackerSidebarLayout,
+  models: TrackerDataModel[]
+): TrackerSidebarLayout {
+  const known = new Set<string>();
+  const knownFolders = new Set<string>();
+  const next: SidebarEntry[] = [];
+
+  for (const entry of layout.entries) {
+    if (entry.kind === 'folder') {
+      const types = entry.types.filter((t) => models.some((m) => m.type === t));
+      for (const t of types) known.add(t);
+      knownFolders.add(entry.name);
+      next.push({ ...entry, types });
+    } else {
+      if (models.some((m) => m.type === entry.typeId)) {
+        known.add(entry.typeId);
+        next.push(entry);
+      }
+    }
+  }
+
+  for (const model of models) {
+    if (known.has(model.type)) continue;
+    if (model.group && knownFolders.has(model.group)) {
+      const folder = next.find(
+        (e) => e.kind === 'folder' && e.name === model.group
+      ) as Extract<SidebarEntry, { kind: 'folder' }> | undefined;
+      if (folder) {
+        folder.types.push(model.type);
+        continue;
+      }
+    }
+    next.push({ kind: 'type', typeId: model.type });
+  }
+
+  return { entries: next };
+}
+
+export function buildLayoutFromLegacy(
+  models: TrackerDataModel[],
+  oldFolders: Array<{ name: string; collapsed?: boolean; order: number }>,
+  oldOverrides: Record<string, string | null>
+): TrackerSidebarLayout {
+  const sortedFolders = [...oldFolders].sort((a, b) => a.order - b.order);
+  const folderMap = new Map<string, Extract<SidebarEntry, { kind: 'folder' }>>();
+  const entries: SidebarEntry[] = [];
+
+  for (const folder of sortedFolders) {
+    const entry: Extract<SidebarEntry, { kind: 'folder' }> = {
+      kind: 'folder',
+      name: folder.name,
+      collapsed: folder.collapsed,
+      types: [],
+    };
+    folderMap.set(folder.name, entry);
+    entries.push(entry);
+  }
+
+  for (const model of models) {
+    let folderName: string | null;
+    if (model.type in oldOverrides) {
+      folderName = oldOverrides[model.type];
+    } else {
+      folderName = model.group ?? null;
+    }
+    if (folderName && folderMap.has(folderName)) {
+      folderMap.get(folderName)!.types.push(model.type);
+    } else {
+      entries.push({ kind: 'type', typeId: model.type });
+    }
+  }
+
+  return { entries };
+}
+
+export async function loadLayout(workspacePath: string): Promise<TrackerSidebarLayout> {
+  try {
+    const state = await (window as any).electronAPI.invoke('workspace:get-state', workspacePath);
+    if (state?.trackerSidebarLayout?.entries) {
+      return state.trackerSidebarLayout as TrackerSidebarLayout;
+    }
+    return EMPTY_LAYOUT;
+  } catch {
+    return EMPTY_LAYOUT;
+  }
+}
+
+export async function saveLayout(
+  workspacePath: string,
+  layout: TrackerSidebarLayout
+): Promise<void> {
+  await (window as any).electronAPI.invoke('workspace:update-state', workspacePath, {
+    trackerSidebarLayout: layout,
+  });
+}
+
+export async function loadLegacyState(workspacePath: string): Promise<{
+  folders: Array<{ name: string; collapsed?: boolean; order: number }>;
+  overrides: Record<string, string | null>;
+}> {
+  try {
+    const state = await (window as any).electronAPI.invoke('workspace:get-state', workspacePath);
+    return {
+      folders: Array.isArray(state?.trackerFolders) ? state.trackerFolders : [],
+      overrides: state?.trackerFolderOverrides ?? {},
+    };
+  } catch {
+    return { folders: [], overrides: {} };
+  }
+}
+
+// ============================================================================
+// Layout mutation operations (immutable — return new layout)
+// ============================================================================
+
+export interface DragLocation {
+  kind: 'folder' | 'type';
+  id: string;
+  fromFolder?: string | null;
+}
+
+export interface DropLocation {
+  position: 'before' | 'after' | 'inside';
+  target: number[];
+}
+
+export function moveEntry(
+  layout: TrackerSidebarLayout,
+  drag: DragLocation,
+  drop: DropLocation
+): TrackerSidebarLayout {
+  const entries: SidebarEntry[] = layout.entries.map((e) =>
+    e.kind === 'folder' ? { ...e, types: [...e.types] } : { ...e }
+  );
+
+  let dragged: SidebarEntry | null = null;
+  if (drag.kind === 'folder') {
+    const idx = entries.findIndex((e) => e.kind === 'folder' && e.name === drag.id);
+    if (idx >= 0) {
+      dragged = entries[idx];
+      entries.splice(idx, 1);
+    }
+  } else {
+    if (drag.fromFolder == null) {
+      const idx = entries.findIndex((e) => e.kind === 'type' && e.typeId === drag.id);
+      if (idx >= 0) {
+        dragged = entries[idx];
+        entries.splice(idx, 1);
+      }
+    } else {
+      const folder = entries.find(
+        (e) => e.kind === 'folder' && e.name === drag.fromFolder
+      ) as Extract<SidebarEntry, { kind: 'folder' }> | undefined;
+      if (folder) {
+        const idx = folder.types.indexOf(drag.id);
+        if (idx >= 0) {
+          folder.types.splice(idx, 1);
+          dragged = { kind: 'type', typeId: drag.id };
+        }
+      }
+    }
+  }
+  if (dragged == null) return layout;
+
+  if (drop.position === 'inside') {
+    const folderIdx = drop.target[0];
+    const folder = entries[folderIdx];
+    if (folder?.kind === 'folder' && dragged.kind === 'type') {
+      folder.types.push(dragged.typeId);
+    } else if (folder?.kind === 'folder' && dragged.kind === 'folder') {
+      return layout;
+    }
+    return { entries };
+  }
+
+  if (drop.target.length === 1) {
+    const idx = drop.target[0];
+    const insertAt = drop.position === 'before' ? idx : idx + 1;
+    entries.splice(insertAt, 0, dragged);
+    return { entries };
+  }
+
+  if (drop.target.length === 2 && dragged.kind === 'type') {
+    const folderIdx = drop.target[0];
+    const folder = entries[folderIdx];
+    if (folder?.kind === 'folder') {
+      const typeIdx = drop.target[1];
+      const insertAt = drop.position === 'before' ? typeIdx : typeIdx + 1;
+      folder.types.splice(insertAt, 0, dragged.typeId);
+    }
+    return { entries };
+  }
+
+  return layout;
+}
+
+export function setFolderCollapsed(
+  layout: TrackerSidebarLayout,
+  folderName: string,
+  collapsed: boolean
+): TrackerSidebarLayout {
+  const entries = layout.entries.map((e) => {
+    if (e.kind === 'folder' && e.name === folderName) {
+      return { ...e, collapsed };
+    }
+    return e;
+  });
+  return { entries };
+}
+
+export function addFolder(
+  layout: TrackerSidebarLayout,
+  name: string
+): TrackerSidebarLayout {
+  if (layout.entries.some((e) => e.kind === 'folder' && e.name === name)) {
+    return layout;
+  }
+  return {
+    entries: [...layout.entries, { kind: 'folder', name, collapsed: false, types: [] }],
+  };
+}
+
+export function renameFolder(
+  layout: TrackerSidebarLayout,
+  oldName: string,
+  newName: string
+): TrackerSidebarLayout {
+  if (oldName === newName) return layout;
+  if (layout.entries.some((e) => e.kind === 'folder' && e.name === newName)) return layout;
+  return {
+    entries: layout.entries.map((e) =>
+      e.kind === 'folder' && e.name === oldName ? { ...e, name: newName } : e
+    ),
+  };
+}
+
+export function deleteFolder(
+  layout: TrackerSidebarLayout,
+  folderName: string
+): TrackerSidebarLayout {
+  const entries: SidebarEntry[] = [];
+  for (const e of layout.entries) {
+    if (e.kind === 'folder' && e.name === folderName) {
+      for (const t of e.types) entries.push({ kind: 'type', typeId: t });
+    } else {
+      entries.push(e);
+    }
+  }
+  return { entries };
+}
+
+export function assignTypeToFolder(
+  layout: TrackerSidebarLayout,
+  typeId: string,
+  targetFolder: string | null
+): TrackerSidebarLayout {
+  const entries: SidebarEntry[] = layout.entries.map((e) =>
+    e.kind === 'folder' ? { ...e, types: [...e.types] } : { ...e }
+  );
+
+  // Remove from current location
+  for (const entry of entries) {
+    if (entry.kind === 'folder') {
+      const idx = entry.types.indexOf(typeId);
+      if (idx >= 0) {
+        entry.types.splice(idx, 1);
+      }
+    }
+  }
+  const topLevelIdx = entries.findIndex((e) => e.kind === 'type' && e.typeId === typeId);
+  if (topLevelIdx >= 0) {
+    entries.splice(topLevelIdx, 1);
+  }
+
+  // Insert into target location
+  if (targetFolder != null) {
+    const folder = entries.find(
+      (e) => e.kind === 'folder' && e.name === targetFolder
+    ) as Extract<SidebarEntry, { kind: 'folder' }> | undefined;
+    if (folder) {
+      folder.types.push(typeId);
+    } else {
+      entries.push({ kind: 'type', typeId });
+    }
+  } else {
+    entries.push({ kind: 'type', typeId });
+  }
+
+  return { entries };
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -58,6 +58,7 @@ export {
   ModelLoader,
   globalRegistry,
   parseTrackerYAML,
+  serializeTrackerYAML,
   // Tracker data atoms (cross-platform reactive state)
   trackerItemsMapAtom,
   trackerDataLoadedAtom,
@@ -79,6 +80,7 @@ export type {
   TrackerSyncMode,
   TrackerSchemaRole,
   FieldDefinition,
+  FieldType,
   DocumentHeaderProvider,
   DocumentHeaderComponentProps,
 } from './plugins/TrackerPlugin';

--- a/packages/runtime/src/plugins/TrackerPlugin/components/TrackerTable.tsx
+++ b/packages/runtime/src/plugins/TrackerPlugin/components/TrackerTable.tsx
@@ -57,6 +57,8 @@ interface TrackerTableProps {
   columnConfig?: import('./trackerColumns').TypeColumnConfig;
   /** Callback when column config changes (from display options panel) */
   onColumnConfigChange?: (config: import('./trackerColumns').TypeColumnConfig) => void;
+  /** Callback when user starts dragging a row (for cross-type DnD) */
+  onRowDragStart?: (e: React.DragEvent, item: TrackerRecord) => void;
 }
 
 /**
@@ -641,6 +643,7 @@ export function TrackerTable({
   searchQuery: externalSearchQuery,
   columnConfig: externalColumnConfig,
   onColumnConfigChange,
+  onRowDragStart,
 }: TrackerTableProps): JSX.Element {
   // Type filter: use prop filterType when hideTypeTabs is true, otherwise use internal state
   const [internalTypeFilter, setInternalTypeFilter] = useState<TrackerItemType | 'all'>('all');
@@ -1473,6 +1476,7 @@ export function TrackerTable({
             return (
               <div
                 key={item.id || index}
+                draggable={!!onRowDragStart}
                 className={`tracker-table-row flex items-center gap-3 px-3 py-[7px] border-b border-[var(--nim-border)] cursor-pointer transition-colors duration-100 hover:bg-[var(--nim-bg-secondary)] select-none ${
                   selectedIds.has(item.id) ? 'bg-[var(--nim-bg-secondary)]' : ''
                 } ${
@@ -1486,6 +1490,7 @@ export function TrackerTable({
                 onClick={(e) => handleRowClick(item, index, e)}
                 onDoubleClick={() => { if (item.system.documentPath) openItemInEditor(item); }}
                 onContextMenu={(e) => handleContextMenu(e, item, index)}
+                onDragStart={onRowDragStart ? (e) => onRowDragStart(e, item) : undefined}
               >
                 {/* Type icon - fixed width for alignment */}
                 <span className="shrink-0 w-5 flex items-center justify-center" style={{ color: getTypeColor(item.primaryType), opacity: 0.7 }}>

--- a/packages/runtime/src/plugins/TrackerPlugin/index.tsx
+++ b/packages/runtime/src/plugins/TrackerPlugin/index.tsx
@@ -957,8 +957,8 @@ export { TrackerDocumentHeader, shouldRenderTrackerHeader } from './documentHead
 
 // Export data models
 export { ModelLoader, loadBuiltinTrackers } from './models/ModelLoader';
-export type { TrackerDataModel, FieldDefinition, TrackerSyncPolicy, TrackerSyncMode, TrackerSchemaRole } from './models/TrackerDataModel';
-export { parseTrackerYAML } from './models/YAMLParser';
+export type { TrackerDataModel, FieldDefinition, FieldType, TrackerSyncPolicy, TrackerSyncMode, TrackerSchemaRole } from './models/TrackerDataModel';
+export { parseTrackerYAML, serializeTrackerYAML } from './models/YAMLParser';
 export { globalRegistry, getRoleField, getFieldByRole } from './models/TrackerDataModel';
 
 // Export components

--- a/packages/runtime/src/plugins/TrackerPlugin/models/TrackerDataModel.ts
+++ b/packages/runtime/src/plugins/TrackerPlugin/models/TrackerDataModel.ts
@@ -127,6 +127,8 @@ export interface TrackerDataModel {
    * without hardcoding field names like "status".
    */
   roles?: Partial<Record<TrackerSchemaRole, string>>;
+  /** Default sidebar folder for this tracker type (stored in workspace state as override). */
+  group?: string;
 }
 
 /**

--- a/packages/runtime/src/plugins/TrackerPlugin/models/YAMLParser.ts
+++ b/packages/runtime/src/plugins/TrackerPlugin/models/YAMLParser.ts
@@ -131,6 +131,8 @@ export function parseTrackerYAML(yamlString: string): TrackerDataModel {
     }
   }
 
+  if (typeof data.group === 'string') model.group = data.group;
+
   // Parse sync policy
   if (data.sync) {
     const validModes: TrackerSyncMode[] = ['local', 'shared', 'hybrid'];


### PR DESCRIPTION
## Summary

This PR adds four related improvements to tracker types:

1. **Visual creator UI** for custom tracker types — no more hand-editing YAML in `.nimbalyst/trackers/`.
2. **Folders** for organizing tracker types in the sidebar.
3. **Free-form drag-and-drop reordering** — folders and tracker types can be reordered as peers.
4. **Drag items between tracker types** — drop a tracker item onto another type in the sidebar to change its primary type.

## Changes by commit

- `feat(tracker): export serializeTrackerYAML and FieldType from runtime` — exports `serializeTrackerYAML` (needed by the creator UI) and `FieldType` (was defined but not publicly re-exported) through the runtime public surface.
- `feat(tracker): visual creator UI for custom tracker types` — new modal accessible from Settings → Trackers. Supports icon selection, color picker, field editor, mode toggles, id prefix, and folder assignment on creation.
- `feat(tracker): folders and free-form sidebar reordering` — adds `trackerSidebarLayout` to workspace state, migrating from prior folder-only state if present. Reordering uses native HTML5 DnD with separate MIME types so it doesn't conflict with item DnD.
- `feat(tracker): drag items between tracker types` — confirmation modal previews field loss and the regenerated issue key. Includes a fix to `ElectronDocumentService.updateTrackerItem` so the SQL `type` column tracks the primary type (previously only `type_tags` was updated, leaving the item stuck under its old type). Also fixes `issueKey` not being persisted to its SQL column when supplied via updates.

## Test plan

- [ ] Settings → Trackers → "Add Custom Tracker" creates a YAML in `.nimbalyst/trackers/` and registers the type live.
- [ ] Drag a folder header in the main sidebar → drops at a new position and persists across reload.
- [ ] Drag a tracker type out of a folder to the top level (and back) → persists.
- [ ] Drag a tracker item card onto a different type in the sidebar → confirmation modal shows lost fields → after confirm, item appears under the new type and is removed from the source list.
- [ ] Existing workspaces with prior `trackerFolders`/`trackerFolderOverrides` migrate cleanly into the new `trackerSidebarLayout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)