### PR TITLE
fix(claude-provider): omit temperature for Opus 4.7+ to unbreak Test Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Claude Chat no longer fails Test Connection (and real chat sends) against the default `claude-opus-4-7` model. Anthropic deprecated `temperature` for Opus 4.7 and the provider was sending it unconditionally, so every fresh install hit `400 "temperature is deprecated for this model"` on the first API call and reported a misleading "Test Connection: Failed" against valid keys. `ClaudeProvider` now omits `temperature` for Opus 4.7+ via a new `ClaudeProvider.supportsTemperature(modelId)` denylist (matches `claude-opus-4-N` for N >= 7, while keeping Opus 4 / 4.1 / 4.5 / 4.6, every Sonnet variant, every Haiku variant, and legacy Claude 3 models on the existing temperature path). Mirrors the pattern `OpenAIProvider` already uses for `o1` / `gpt-5` / `gpt-4.5`. Adds 18 unit tests covering the Opus version boundary, the 8-digit date suffix on Opus 4.0 (`claude-opus-4-20250514`), case-insensitive matching, and malformed input. Fixes #199.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/runtime/src/ai/server/providers/ClaudeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeProvider.ts
@@ -284,11 +284,21 @@ export class ClaudeProvider extends BaseAIProvider {
       const apiRequest: any = {
         model: modelId,
         max_tokens: this.config.maxTokens || 4000,
-        temperature: this.config.temperature || 0,
         system: systemPrompt,
         messages: apiMessages,
         ...(tools.length > 0 ? { tools } : {}),
       };
+
+      // Anthropic deprecated `temperature` for `claude-opus-4-7` and is
+      // expected to do so on future reasoning Opus releases. Sending it
+      // returns HTTP 400 `"temperature is deprecated for this model"`,
+      // which surfaces in Nimbalyst as a misleading "Test Connection:
+      // Failed" against valid API keys -- users blame their key. The
+      // default model on a fresh install is Opus 4.7, so every new user
+      // hits this until they switch to Sonnet. See nimbalyst#199.
+      if (ClaudeProvider.supportsTemperature(modelId)) {
+        apiRequest.temperature = this.config.temperature || 0;
+      }
 
       // Apply response format if specified (extension chat completions)
       if (this.config.responseFormat && this.config.responseFormat.type !== 'text') {
@@ -305,7 +315,7 @@ export class ClaudeProvider extends BaseAIProvider {
       console.group('🚀 [ClaudeProvider] Final API Request');
       console.log('Model:', apiRequest.model);
       console.log('Max tokens:', apiRequest.max_tokens);
-      console.log('Temperature:', apiRequest.temperature);
+      console.log('Temperature:', 'temperature' in apiRequest ? apiRequest.temperature : '(omitted - not supported by model)');
       console.log('Has tools:', !!apiRequest.tools);
       console.log('Number of tools:', apiRequest.tools?.length || 0);
       console.log('System prompt length:', apiRequest.system.length);
@@ -912,5 +922,48 @@ export class ClaudeProvider extends BaseAIProvider {
   static isModelAllowed(modelId: string): boolean {
     const cleanId = modelId.replace('claude:', '');
     return CLAUDE_MODELS.some(m => m.id === cleanId);
+  }
+
+  /**
+   * Whether the given Claude model accepts the `temperature` parameter.
+   *
+   * Anthropic deprecated `temperature` starting with `claude-opus-4-7` --
+   * any non-default value (including the explicit `0` we send today) returns
+   * HTTP 400 `"temperature is deprecated for this model"`. The expectation
+   * is that future reasoning Opus releases (4.8, 4.9, ...) will follow the
+   * same pattern.
+   *
+   * Strategy: denylist of known-rejecting prefixes. Today that is
+   * `claude-opus-4-N` for N >= 7. Everything else -- all Sonnet variants
+   * (3.x and 4.x), all Haiku variants, Opus 4 / 4.1 / 4.5 / 4.6, and any
+   * `claude-3-*` Opus model -- still accepts `temperature`.
+   *
+   * The denylist is intentionally narrow. The fail-open default preserves
+   * user-configured `temperature` for new Claude models; if Anthropic
+   * deprecates it on a future model the denylist is updated in a follow-up
+   * PR (the failure mode is a loud HTTP 400 with a clear message, not
+   * silent loss of a sampling parameter). See nimbalyst#199.
+   *
+   * Static + exported for unit testing without instantiating the provider.
+   *
+   * @param modelId - The Anthropic model ID (without the `claude:` prefix)
+   * @returns true if `temperature` should be sent, false if it must be omitted
+   */
+  static supportsTemperature(modelId: string | undefined): boolean {
+    if (!modelId || typeof modelId !== 'string') return true;
+    const id = modelId.trim().toLowerCase();
+    if (!id) return true;
+
+    // Match `claude-opus-4-N` where N is a one or two-digit minor version.
+    // The trailing `(?:-|$)` anchor avoids matching the 8-digit date suffix
+    // on Opus 4.0 (`claude-opus-4-20250514`) -- without the anchor, the
+    // regex would capture `2` from the date and misclassify Opus 4.0.
+    const opusMinor = id.match(/^claude-opus-4-(\d{1,2})(?:-|$)/);
+    if (opusMinor) {
+      const minor = parseInt(opusMinor[1], 10);
+      return minor < 7;
+    }
+
+    return true;
   }
 }

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeProvider.temperature.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeProvider.temperature.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { ClaudeProvider } from '../ClaudeProvider';
+
+// Regression coverage for nimbalyst#199. Anthropic deprecated `temperature`
+// for `claude-opus-4-7`; sending it returns HTTP 400. The default model on
+// a fresh install is Opus 4.7, so every new user hit a misleading "Test
+// Connection: Failed" until they switched to Sonnet.
+
+describe('ClaudeProvider.supportsTemperature', () => {
+  describe('rejects temperature for Opus 4.7+', () => {
+    it('returns false for claude-opus-4-7', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-7')).toBe(false);
+    });
+
+    it('returns false for hypothetical future opus-4-8 / 4-9', () => {
+      // Document the forward-compatibility intent: when Anthropic ships
+      // claude-opus-4-8 / 4-9, the deprecation pattern is expected to hold.
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-8')).toBe(false);
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-9')).toBe(false);
+    });
+
+    it('returns false for two-digit Opus minor (4-10, 4-25)', () => {
+      // Without the `\d{1,2}` cap, naive regexes either miss two-digit
+      // minors or match the 8-digit date suffix on Opus 4.0.
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-10')).toBe(false);
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-25')).toBe(false);
+    });
+
+    it('matches case-insensitively', () => {
+      expect(ClaudeProvider.supportsTemperature('CLAUDE-OPUS-4-7')).toBe(false);
+      expect(ClaudeProvider.supportsTemperature('Claude-Opus-4-7')).toBe(false);
+    });
+  });
+
+  describe('accepts temperature for older Opus 4.x', () => {
+    it('returns true for Opus 4 (no minor / claude-opus-4-20250514)', () => {
+      // The 8-digit date suffix on Opus 4.0 must NOT be parsed as a minor
+      // version. A naive regex would capture `2` from `20250514` and treat
+      // Opus 4.0 as Opus 4.2, which would still be < 7 and so happen to
+      // return true here, but breaks for hypothetical claude-opus-4-99999999.
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-20250514')).toBe(true);
+    });
+
+    it('returns true for Opus 4.1', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-1-20250805')).toBe(true);
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-1')).toBe(true);
+    });
+
+    it('returns true for Opus 4.5', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-5-20251101')).toBe(true);
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-5')).toBe(true);
+    });
+
+    it('returns true for Opus 4.6', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-6')).toBe(true);
+    });
+  });
+
+  describe('accepts temperature for all Sonnet variants', () => {
+    it('returns true for Sonnet 4.6', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-sonnet-4-6')).toBe(true);
+    });
+
+    it('returns true for Sonnet 4.5', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-sonnet-4-5-20250929')).toBe(true);
+    });
+
+    it('returns true for Sonnet 4', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-sonnet-4-20250514')).toBe(true);
+    });
+
+    it('returns true for Sonnet 3.7', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-3-7-sonnet-20250219')).toBe(true);
+    });
+
+    it('does NOT classify Sonnet 4.7 as Opus 4.7 (different family)', () => {
+      // If Anthropic ever ships claude-sonnet-4-7 the regex must NOT match
+      // the opus-only pattern. Sonnet has not been reported as deprecating
+      // temperature at any version, so this stays true.
+      expect(ClaudeProvider.supportsTemperature('claude-sonnet-4-7')).toBe(true);
+      expect(ClaudeProvider.supportsTemperature('claude-sonnet-4-99')).toBe(true);
+    });
+  });
+
+  describe('accepts temperature for Haiku and legacy models', () => {
+    it('returns true for Haiku variants', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-haiku-4-5')).toBe(true);
+      expect(ClaudeProvider.supportsTemperature('claude-3-5-haiku-20241022')).toBe(true);
+    });
+
+    it('returns true for legacy Claude 3 Opus', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-3-opus-20240229')).toBe(true);
+    });
+  });
+
+  describe('handles malformed input safely', () => {
+    it('treats undefined / null / empty as supporting temperature (no-op)', () => {
+      // We cannot strip `temperature` from a request that has no model id;
+      // returning true is the conservative choice (preserves existing
+      // behaviour for missing-model corner cases). Cast through unknown
+      // so the test still exercises the type guard at runtime.
+      expect(ClaudeProvider.supportsTemperature(undefined)).toBe(true);
+      expect(ClaudeProvider.supportsTemperature(null as unknown as string)).toBe(true);
+      expect(ClaudeProvider.supportsTemperature('')).toBe(true);
+      expect(ClaudeProvider.supportsTemperature('   ')).toBe(true);
+    });
+
+    it('returns true for unrecognised non-Claude ids', () => {
+      // Conservative default: include `temperature` for anything we do not
+      // explicitly know rejects it. The denylist is the active list; the
+      // failure mode of including on a rejecting model is loud (HTTP 400),
+      // the failure mode of stripping on a supporting model is silent.
+      expect(ClaudeProvider.supportsTemperature('gpt-5')).toBe(true);
+      expect(ClaudeProvider.supportsTemperature('not-a-model')).toBe(true);
+    });
+
+    it('trims whitespace around the model id before matching', () => {
+      expect(ClaudeProvider.supportsTemperature('  claude-opus-4-7  ')).toBe(false);
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-7 ')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #199. Anthropic deprecated `temperature` for `claude-opus-4-7`; sending it returns HTTP 400 `"temperature is deprecated for this model"`. The default Claude Chat model on a fresh install is Opus 4.7, so every new user hit a misleading "Test Connection: Failed" against valid Anthropic API keys and blamed their key. Real chat sends failed the same way.

`ClaudeProvider` now omits `temperature` for Opus 4.7+ via a new `ClaudeProvider.supportsTemperature(modelId)` denylist. Older Opus (4 / 4.1 / 4.5 / 4.6), every Sonnet variant, every Haiku variant, and legacy Claude 3 models stay on the existing temperature path, mirroring the pattern `OpenAIProvider` already uses for `o1` / `gpt-5` / `gpt-4.5` (`OpenAIProvider.ts:262-269`).

## Root cause

`packages/runtime/src/ai/server/providers/ClaudeProvider.ts:287` was building the request unconditionally:

```ts
const apiRequest: any = {
  model: modelId,
  max_tokens: this.config.maxTokens || 4000,
  temperature: this.config.temperature || 0,  // <-- always sent
  system: systemPrompt,
  messages: apiMessages,
  ...(tools.length > 0 ? { tools } : {}),
};
```

The `|| 0` fallback meant `temperature` was always present in the API request, so the moment Anthropic flipped `claude-opus-4-7` to reject it the Test Connection button broke for every fresh install.

## Fix

```ts
// Build request without `temperature`...
const apiRequest: any = {
  model: modelId,
  max_tokens: this.config.maxTokens || 4000,
  system: systemPrompt,
  messages: apiMessages,
  ...(tools.length > 0 ? { tools } : {}),
};

// ...then add it back only when the model accepts it.
if (ClaudeProvider.supportsTemperature(modelId)) {
  apiRequest.temperature = this.config.temperature || 0;
}
```

The classifier is a small static method:

```ts
static supportsTemperature(modelId: string | undefined): boolean {
  if (!modelId || typeof modelId !== 'string') return true;
  const id = modelId.trim().toLowerCase();
  if (!id) return true;

  const opusMinor = id.match(/^claude-opus-4-(\d{1,2})(?:-|$)/);
  if (opusMinor) {
    const minor = parseInt(opusMinor[1], 10);
    return minor < 7;
  }

  return true;
}
```

The regex is anchored on `(?:-|$)` to avoid mis-parsing the 8-digit date suffix on Opus 4.0 (`claude-opus-4-20250514`) as a minor version. The `\d{1,2}` cap keeps two-digit minors (`claude-opus-4-10`) classified correctly without colliding with the date.

## Design choice: denylist over allowlist

Took both options to a multi-model consensus check. The trade-off is:

- **Denylist** (chosen): omit `temperature` for known-rejecting models, default to including for new models. If Anthropic deprecates `temperature` on a future model the denylist needs a follow-up PR, but the failure mode is a loud HTTP 400 with a clear message.
- **Allowlist**: include `temperature` only for known-good models, default to omitting for new models. Every new Claude release silently strips `temperature` from API calls until the allowlist is updated, regressing user-set values without any visible signal.

Picked denylist because the silent regression mode of an allowlist is the worse failure for users who set temperature deliberately, and because `OpenAIProvider` already uses the same pattern in this codebase.

## Tests

`packages/runtime/src/ai/server/providers/__tests__/ClaudeProvider.temperature.test.ts` adds 18 unit tests:

- Opus 4.7 / hypothetical 4.8 / 4.9 rejected
- Two-digit minors (4-10, 4-25) rejected
- Opus 4.0 (`claude-opus-4-20250514`) accepted - the 8-digit date suffix must not be parsed as a minor
- Opus 4.1 / 4.5 / 4.6 accepted (with and without date suffix)
- All Sonnet variants (3.7, 4, 4.5, 4.6) accepted
- Hypothetical `claude-sonnet-4-7` accepted (denylist scoped to Opus only)
- All Haiku variants accepted
- Legacy `claude-3-opus-20240229` accepted
- Case-insensitive matching
- Whitespace-trimmed input
- Malformed input (undefined, null, empty string) safely returns `true`

```
Test Files  1 passed (1)
     Tests  18 passed (18)
```

`npm run typecheck` passes. The two pre-existing test failures on Windows (`ClaudeCodeProvider.bashParser.test.ts`, `claudeCodeEnvironment.test.ts`) reproduce on `upstream/main` and are unrelated.

## Files

- `packages/runtime/src/ai/server/providers/ClaudeProvider.ts` - omit `temperature` for Opus 4.7+, add `supportsTemperature` static method, update the diagnostic `console.log` to render `(omitted - not supported by model)` instead of `undefined`
- `packages/runtime/src/ai/server/providers/__tests__/ClaudeProvider.temperature.test.ts` - 18 new tests
- `CHANGELOG.md` - entry under `[Unreleased] > Fixed`

## Related

- Reproducible by setting Claude Chat to Opus 4.7 (the default) and clicking Test in Settings, or by sending any chat message
- Workaround currently in use: switch the Claude Chat default model to a Sonnet variant
- The Claude Code panel's Test button hits the same provider path and was broken the same way; this fix covers it too
