### PR TITLE
fix(tracker): launch session uses default provider, not hardcoded claude-code

### DIFF
--- a/packages/electron/src/renderer/components/TrackerMode/TrackerMainView.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/TrackerMainView.tsx
@@ -28,6 +28,8 @@ import { setSelectedWorkstreamAtom, sessionRegistryAtom, refreshSessionListAtom,
 import { trackerItemsMapAtom } from '@nimbalyst/runtime/plugins/TrackerPlugin/trackerDataAtoms';
 import { workstreamStateAtom } from '../../store/atoms/workstreamState';
 import { setWindowModeAtom } from '../../store/atoms/windowMode';
+import { defaultAgentModelAtom } from '../../store/atoms/appSettings';
+import { ModelIdentifier } from '@nimbalyst/runtime/ai/server/types';
 import { store } from '../../store';
 
 export type ViewMode = 'table' | 'kanban';
@@ -55,6 +57,12 @@ export const TrackerMainView: React.FC<TrackerMainViewProps> = ({
   const [sortDirection, setSortDirection] = useState<TrackerSortDirection>('desc');
   const [searchQuery, setSearchQuery] = useState('');
   const [quickAddType, setQuickAddType] = useState<string | null>(null);
+
+  // User's selected default model. Used by handleLaunchSession so the new
+  // session uses the workspace's configured provider rather than always
+  // falling back to claude-code (which fails for Codex-only installs).
+  // See nimbalyst#176.
+  const defaultModel = useAtomValue(defaultAgentModelAtom);
 
   useEffect(() => {
     if (!workspacePath) return;
@@ -135,8 +143,23 @@ export const TrackerMainView: React.FC<TrackerMainViewProps> = ({
   /** Launch a new AI session linked to a tracker item */
   const handleLaunchSession = useCallback(async (trackerItemId: string) => {
     try {
-      const result = await window.electronAPI.aiCreateSession('claude-code', undefined, workspacePath);
-      if (result?.id) {
+      // Derive provider from the user's default model rather than hardcoding
+      // 'claude-code'. Mirrors AgentMode.createNewSession so a Codex-only
+      // workspace launches a Codex session, not a failed claude-code one.
+      // See nimbalyst#176.
+      const sessionId = crypto.randomUUID();
+      const parsedModel = defaultModel ? ModelIdentifier.tryParse(defaultModel) : null;
+      const provider = parsedModel?.provider || 'claude-code';
+      const result = await window.electronAPI.invoke('sessions:create', {
+        session: {
+          id: sessionId,
+          provider,
+          model: defaultModel,
+          title: 'New Session',
+        },
+        workspaceId: workspacePath,
+      });
+      if (result?.success && result?.id) {
         // Look up the tracker item to build a context-aware draft prompt
         const itemsMap = store.get(trackerItemsMapAtom);
         const trackerItem = itemsMap.get(trackerItemId);
@@ -203,7 +226,7 @@ export const TrackerMainView: React.FC<TrackerMainViewProps> = ({
     } catch (err) {
       console.error('[TrackerMainView] Failed to launch session:', err);
     }
-  }, [workspacePath, refreshSessionList, setSelectedWorkstream, setWindowMode]);
+  }, [workspacePath, refreshSessionList, setSelectedWorkstream, setWindowMode, defaultModel]);
 
   // Base item sets from atoms
   const activeItems = useAtomValue(trackerItemsByTypeAtom(filterType));


### PR DESCRIPTION
## Summary

Fixes #176. Reporter @sjdevchoi (Codex-only install, no Claude) found that clicking "+ Launch Session" on a tracker task fails with:

```
Provider claude-code is not enabled for this workspace
```

Codex itself works in their workspace. Only the tracker launch path is broken because it hardcodes the provider.

## Root cause

`TrackerMainView.handleLaunchSession` calls the legacy IPC with provider hardcoded:

```ts
const result = await window.electronAPI.aiCreateSession('claude-code', undefined, workspacePath);
```

`AgentMode.createNewSession` (the "+ New Session" button) does it the right way at `AgentMode.tsx:293-306`:

```ts
const parsedModel = defaultModel ? ModelIdentifier.tryParse(defaultModel) : null;
const provider = parsedModel?.provider || 'claude-code';
const result = await window.electronAPI.invoke('sessions:create', {
  session: { id: sessionId, provider, model: defaultModel, title: 'New Session' },
  workspaceId: workspacePath,
});
```

The tracker path was missing the `defaultAgentModelAtom` read.

## Fix

Replace the legacy `aiCreateSession` call with the modern `sessions:create` IPC, deriving provider from `defaultAgentModelAtom` exactly like `AgentMode.createNewSession` does. Falls back to `'claude-code'` only when no default model is configured (fresh install with no model selected).

Diff is 1 file, +26/-3 lines. No new tests; the existing AgentMode coverage already exercises the same `sessions:create` path with the same provider derivation.

## Verification path

1. Disable Claude in Settings -> AI Models
2. Enable Codex with a model selected
3. Open Tracker, create a task, click "+ Launch Session"

Before: `Provider claude-code is not enabled for this workspace` toast/log, no session created.
After: a Codex session opens with the tracker item's context pre-filled in the draft.

## Test plan

- [x] Local typecheck passes (`npm run typecheck`)
- [ ] Manual repro on Codex-only workspace (Greg has the tools to verify on macOS faster than I can on Windows)
- [ ] CI green

## CHANGELOG

Skipped on purpose. Main currently has unresolved conflict markers in `[Unreleased] > Fixed` (filed as PR #203, also pending). Once #203 lands I can add the entry in a one-line follow-up, or you can drop one in during squash-merge if it's easier.
