### PR TITLE
fix(agent-view): live-update sub-session renames and add Rename to workstream parent menu

### DIFF
--- a/packages/electron/src/renderer/components/AgentMode/AgentMode.tsx
+++ b/packages/electron/src/renderer/components/AgentMode/AgentMode.tsx
@@ -939,12 +939,17 @@ export const AgentMode = forwardRef<AgentModeRef, AgentModeProps>(function Agent
   }, [updateSessionStore, selectedWorkstream, workspacePath, setSelectedWorkstream]);
 
   // Rename a session
+  const [renamedSession, setRenamedSession] = useState<{ id: string; title: string } | null>(null);
   const handleSessionRename = useCallback(async (sessionId: string, newName: string) => {
     try {
       const result = await window.electronAPI.invoke('sessions:update-metadata', sessionId, { title: newName });
       if (result.success) {
         // Update in atom store (syncs both sessionStoreAtom and sessionRegistryAtom)
         updateSessionStore({ sessionId, updates: { title: newName, updatedAt: Date.now() } });
+        // Sub-sessions render from SessionHistory's workstreamChildrenCache, not from
+        // sessionRegistryAtom. The cache only patches when its `renamedSession` prop
+        // changes, so trigger that here.
+        setRenamedSession({ id: sessionId, title: newName });
       } else {
         console.error('[AgentMode] Failed to rename session:', result.error);
       }
@@ -1034,6 +1039,7 @@ export const AgentMode = forwardRef<AgentModeRef, AgentModeProps>(function Agent
       onSessionDelete={handleSessionDelete}
       onSessionArchive={handleSessionArchive}
       onSessionRename={handleSessionRename}
+      renamedSession={renamedSession}
       onSessionBranch={handleSessionBranch}
       onNewSession={createNewSession}
       onNewWorktreeSession={isWorktreesAvailable ? createNewWorktreeSession : undefined}

--- a/packages/electron/src/renderer/components/AgenticCoding/WorkstreamGroup.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/WorkstreamGroup.tsx
@@ -257,6 +257,11 @@ export const WorkstreamGroup: React.FC<WorkstreamGroupProps> = ({
   const [worktreeRenameValue, setWorktreeRenameValue] = useState('');
   const worktreeRenameInputRef = useRef<HTMLInputElement>(null);
 
+  // Workstream parent rename state
+  const [isRenamingWorkstream, setIsRenamingWorkstream] = useState(false);
+  const [workstreamRenameValue, setWorkstreamRenameValue] = useState('');
+  const workstreamRenameInputRef = useRef<HTMLInputElement>(null);
+
   // Sort sessions: pinned first, then by sortBy field (respecting parent sort preference)
   const sortedSessions = React.useMemo(() => {
     return [...sessions].sort((a, b) => {
@@ -343,8 +348,11 @@ export const WorkstreamGroup: React.FC<WorkstreamGroupProps> = ({
     if (type === 'worktree' && worktree) {
       setWorktreeRenameValue(worktree.displayName || worktree.name || '');
       setIsRenamingWorktree(true);
+    } else if (type === 'workstream') {
+      setWorkstreamRenameValue(title);
+      setIsRenamingWorkstream(true);
     }
-  }, [type, worktree]);
+  }, [type, worktree, title]);
 
   const handleWorktreeRenameSubmit = useCallback(() => {
     const trimmedValue = worktreeRenameValue.trim();
@@ -373,6 +381,33 @@ export const WorkstreamGroup: React.FC<WorkstreamGroupProps> = ({
       worktreeRenameInputRef.current.select();
     }
   }, [isRenamingWorktree]);
+
+  const handleWorkstreamRenameSubmit = useCallback(() => {
+    const trimmedValue = workstreamRenameValue.trim();
+    if (trimmedValue && trimmedValue !== title && onSessionRename) {
+      onSessionRename(id, trimmedValue);
+    }
+    setIsRenamingWorkstream(false);
+  }, [workstreamRenameValue, title, id, onSessionRename]);
+
+  const handleWorkstreamRenameKeyDown = useCallback((e: React.KeyboardEvent) => {
+    e.stopPropagation();
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleWorkstreamRenameSubmit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setIsRenamingWorkstream(false);
+    }
+  }, [handleWorkstreamRenameSubmit]);
+
+  // Focus and select input when entering workstream rename mode
+  useEffect(() => {
+    if (isRenamingWorkstream && workstreamRenameInputRef.current) {
+      workstreamRenameInputRef.current.focus();
+      workstreamRenameInputRef.current.select();
+    }
+  }, [isRenamingWorkstream]);
 
   const handleAddSuperLoop = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -599,6 +634,17 @@ export const WorkstreamGroup: React.FC<WorkstreamGroupProps> = ({
                   onBlur={handleWorktreeRenameSubmit}
                   onClick={(e) => e.stopPropagation()}
                 />
+              ) : isRenamingWorkstream && type === 'workstream' ? (
+                <input
+                  ref={workstreamRenameInputRef}
+                  type="text"
+                  className="workstream-group-rename-input flex-1 min-w-0 px-1 py-0 text-[0.8125rem] font-medium border border-[var(--nim-primary)] rounded bg-[var(--nim-bg)] text-[var(--nim-text)] outline-none"
+                  value={workstreamRenameValue}
+                  onChange={(e) => setWorkstreamRenameValue(e.target.value)}
+                  onKeyDown={handleWorkstreamRenameKeyDown}
+                  onBlur={handleWorkstreamRenameSubmit}
+                  onClick={(e) => e.stopPropagation()}
+                />
               ) : (
                 <span className="workstream-group-name font-medium text-[var(--nim-text)] whitespace-nowrap overflow-hidden text-ellipsis">{displayTitle}</span>
               )}
@@ -793,6 +839,15 @@ export const WorkstreamGroup: React.FC<WorkstreamGroupProps> = ({
           )}
 
           {/* Workstream menu items */}
+          {type === 'workstream' && onSessionRename && (
+            <button
+              className="workstream-group-context-menu-item flex items-center gap-2 w-full py-2 px-3 bg-transparent border-none cursor-pointer text-[0.8125rem] text-[var(--nim-text)] text-left rounded transition-colors duration-150 hover:bg-[var(--nim-bg-hover)]"
+              onClick={handleRenameClick}
+            >
+              <MaterialSymbol icon="edit" size={14} />
+              Rename
+            </button>
+          )}
           {type === 'workstream' && onWorkstreamPinToggle && (
             <button
               className="workstream-group-context-menu-item flex items-center gap-2 w-full py-2 px-3 bg-transparent border-none cursor-pointer text-[0.8125rem] text-[var(--nim-text)] text-left rounded transition-colors duration-150 hover:bg-[var(--nim-bg-hover)]"


### PR DESCRIPTION
> Replaces #208 (closed — same diff, refiled from a different fork).

## Summary

Two related fixes for renaming sessions in the agent view sidebar:

1. **Sub-session rename did not live-update.** Renaming a child session inside a workstream group via right-click would persist to disk but the displayed title only refreshed after restarting the app.
2. **Workstream parent rows had no Rename option.** The right-click menu had Pin / Branch / Copy / Share / Export / Archive / Delete but no rename, so users could not change a workstream's title from the UI.

## Repro

1. Open the agent view sidebar.
2. Expand a workstream group with one or more child sessions.
3. Right-click a child session → Rename → enter a new title → Enter.
   - **Before:** title in the sidebar shows the old name until app restart.
   - **After:** title updates immediately.
4. Right-click the workstream parent row.
   - **Before:** no Rename item in the menu.
   - **After:** Rename item appears at the top; clicking it shows an inline input that submits via Enter / Blur and cancels via Escape, mirroring the existing worktree rename pattern.

## Root cause

### Sub-session live-update

`AgentMode.handleSessionRename` calls `sessions:update-metadata` (which writes to DB and broadcasts `sessions:session-updated`) and `updateSessionStoreAtom` (which patches `sessionRegistryAtom`). Top-level rows in the sidebar do read titles from `sessionRegistryAtom`, so they update fine.

Sub-sessions are a different render path: `WorkstreamGroup` → `WorkstreamSessionItem` reads `session.title` from the `sessions` prop, which `SessionHistory` populates from a **local** `workstreamChildrenCache` Map (`SessionHistory.tsx:261`). That cache is only patched by an effect keyed on the `renamedSession` prop (`SessionHistory.tsx:574-606`). The cache-patch effect supports both `sessions` state and `workstreamChildrenCache` Map updates, with a custom memo comparator at `SessionHistory.tsx:3156-3158` set up to let the prop change through.

But nothing in the renderer ever passed the `renamedSession` prop. A grep for `renamedSession` only matched declarations and the consumer code inside `SessionHistory.tsx` itself — `AgentMode` (the actual parent at `SessionHistory.tsx:1029-1048`) never set it. The receiver was wired and the comparator was set up to handle the prop, but the producer side was missing, so the cache never got patched and the displayed title stayed stale.

### Workstream parent rename menu

`WorkstreamGroup`'s context menu only emitted a Rename button under `type === 'worktree'` (lines 728-736 in the file). The `type === 'workstream'` branch (lines 795+) had no rename UI even though `WorkstreamGroup` already received an `onSessionRename` prop (used for child sessions inside the group).

## Fix

**`packages/electron/src/renderer/components/AgentMode/AgentMode.tsx`** (+6 lines)
- Add a `renamedSession` `useState` and pass it as a prop to `<SessionHistory>`.
- In `handleSessionRename`, after the IPC succeeds and `updateSessionStoreAtom` patches the registry, set `renamedSession` so the existing cache-patch effect in `SessionHistory` actually fires.

**`packages/electron/src/renderer/components/AgenticCoding/WorkstreamGroup.tsx`** (+57 / -1)
- Add `isRenamingWorkstream` / `workstreamRenameValue` / `workstreamRenameInputRef` state, mirroring the existing worktree rename state.
- Extend `handleRenameClick` to handle `type === 'workstream'` (currently it only handled worktrees).
- Add `handleWorkstreamRenameSubmit`, `handleWorkstreamRenameKeyDown`, and a focus-on-enter `useEffect` — same shape as the worktree counterparts, routing to `onSessionRename(id, trimmedValue)`.
- Add an inline `<input>` JSX branch in the title row when renaming a workstream.
- Add a Rename button at the top of the workstream context menu items, gated on `onSessionRename` being provided.

The rename submit goes through the existing `onSessionRename` prop chain → `AgentMode.handleSessionRename` → `sessions:update-metadata` IPC + atom updates + the `setRenamedSession` trigger from fix 1, so the workstream parent's title update flows through the same code path that now correctly live-updates everything.

## Test plan

- [x] Right-click a sub-session inside a workstream → Rename → Enter. Title updates immediately, persists across reload.
- [x] Right-click a workstream parent row → confirm new Rename item is present.
- [x] Click Rename → inline input shows current title selected.
- [x] Type new title + Enter → updates immediately, persists across reload.
- [x] Type new title + click outside (blur) → submits.
- [x] Press Escape → cancels without changes.
- [x] Submit empty / unchanged value → no-op (matches worktree behavior).
- [x] Worktree rename still works unchanged.
- [x] Top-level standalone session rename still works unchanged.
- [x] `electron-vite build` succeeds.

## Companion PR

The drag-drop / workstream init bug noted under "Out of scope" in the previous filing is now its own PR: see the related drag-drop initialization PR.
