### PR TITLE
fix(agent-view): initialize unified workstream state on drag-drop conversion

### DIFF
--- a/packages/electron/src/renderer/store/atoms/__tests__/workstreamState.convertToWorkstream.test.ts
+++ b/packages/electron/src/renderer/store/atoms/__tests__/workstreamState.convertToWorkstream.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createStore } from 'jotai';
+import {
+  convertToWorkstreamAtom,
+  initWorkstreamState,
+  workstreamStateAtom,
+} from '../workstreamState';
+
+/**
+ * Unit tests for convertToWorkstreamAtom covering both:
+ *   - the sibling-creation path (existing behavior)
+ *   - the drag-drop path (new: siblingId omitted)
+ *
+ * The drag-drop path was previously gated out at the call site in sessions.ts,
+ * so workstreamStateAtom(parentId) was never initialized. This test pins the
+ * fully-initialized behavior so future refactors can't silently regress it.
+ */
+
+describe('convertToWorkstreamAtom', () => {
+  let store: ReturnType<typeof createStore>;
+  const sessionId = 'session-original';
+  const parentId = 'parent-workstream';
+  const siblingId = 'session-sibling';
+
+  beforeEach(() => {
+    store = createStore();
+    // Required by workstreamStateAtom's writer (schedulePersist asserts a workspace path is set).
+    initWorkstreamState('/test-workspace');
+  });
+
+  describe('with siblingId (normal conversion)', () => {
+    it('initializes parent state with both children and sibling as active', () => {
+      store.set(convertToWorkstreamAtom, { sessionId, parentId, siblingId });
+
+      const parent = store.get(workstreamStateAtom(parentId));
+      expect(parent.type).toBe('workstream');
+      expect(parent.childSessionIds).toEqual([sessionId, siblingId]);
+      expect(parent.activeChildId).toBe(siblingId);
+    });
+
+    it('clears the original session state to type=single', () => {
+      store.set(convertToWorkstreamAtom, { sessionId, parentId, siblingId });
+
+      const original = store.get(workstreamStateAtom(sessionId));
+      expect(original.type).toBe('single');
+      expect(original.childSessionIds).toEqual([]);
+      expect(original.activeChildId).toBeNull();
+    });
+
+    it('initializes sibling state to defaults', () => {
+      store.set(convertToWorkstreamAtom, { sessionId, parentId, siblingId });
+
+      const sibling = store.get(workstreamStateAtom(siblingId));
+      expect(sibling.type).toBe('single');
+      expect(sibling.childSessionIds).toEqual([]);
+    });
+
+    it('inherits UI settings from the original session onto the parent', () => {
+      // Pre-set non-default UI state on the original session
+      store.set(workstreamStateAtom(sessionId), {
+        layoutMode: 'editor',
+        splitRatio: 0.7,
+        filesSidebarVisible: false,
+      });
+
+      store.set(convertToWorkstreamAtom, { sessionId, parentId, siblingId });
+
+      const parent = store.get(workstreamStateAtom(parentId));
+      expect(parent.layoutMode).toBe('editor');
+      expect(parent.splitRatio).toBe(0.7);
+      expect(parent.filesSidebarVisible).toBe(false);
+    });
+  });
+
+  describe('without siblingId (drag-drop conversion)', () => {
+    it('initializes parent with the original session as the only child', () => {
+      store.set(convertToWorkstreamAtom, { sessionId, parentId });
+
+      const parent = store.get(workstreamStateAtom(parentId));
+      expect(parent.type).toBe('workstream');
+      expect(parent.childSessionIds).toEqual([sessionId]);
+      expect(parent.activeChildId).toBe(sessionId);
+    });
+
+    it('still clears the original session state to type=single', () => {
+      store.set(convertToWorkstreamAtom, { sessionId, parentId });
+
+      const original = store.get(workstreamStateAtom(sessionId));
+      expect(original.type).toBe('single');
+      expect(original.childSessionIds).toEqual([]);
+      expect(original.activeChildId).toBeNull();
+    });
+
+    it('inherits UI settings from the original session', () => {
+      store.set(workstreamStateAtom(sessionId), {
+        layoutMode: 'split',
+        splitRatio: 0.3,
+        filesSidebarVisible: true,
+      });
+
+      store.set(convertToWorkstreamAtom, { sessionId, parentId });
+
+      const parent = store.get(workstreamStateAtom(parentId));
+      expect(parent.layoutMode).toBe('split');
+      expect(parent.splitRatio).toBe(0.3);
+      expect(parent.filesSidebarVisible).toBe(true);
+    });
+  });
+});

--- a/packages/electron/src/renderer/store/atoms/sessions.ts
+++ b/packages/electron/src/renderer/store/atoms/sessions.ts
@@ -1417,15 +1417,18 @@ export const convertToWorkstreamAtom = atom(
         set(setWorkstreamActiveChildAtom, { workstreamId: parentSessionId, childId: sessionId });
       }
 
-      // Update unified workstream state (only when sibling was created)
-      if (siblingResult.success && siblingResult.sessionId) {
-        const { convertToWorkstreamAtom: convertToWorkstreamStateAtom } = await import('./workstreamState');
-        set(convertToWorkstreamStateAtom, {
-          sessionId,
-          parentId: parentSessionId,
-          siblingId: siblingResult.sessionId,
-        });
-      }
+      // Update unified workstream state. Always runs so drag-drop conversions
+      // (skipSiblingCreation=true) initialize childSessionIds; otherwise subsequent
+      // reparentSession calls operate on uninitialized state and the workstream's
+      // child list never reflects further drops.
+      const { convertToWorkstreamAtom: convertToWorkstreamStateAtom } = await import('./workstreamState');
+      set(convertToWorkstreamStateAtom, {
+        sessionId,
+        parentId: parentSessionId,
+        ...(siblingResult.success && siblingResult.sessionId
+          ? { siblingId: siblingResult.sessionId }
+          : {}),
+      });
 
       // Add the new parent session to the session list so it appears in the sidebar
       // If original was pinned, transfer pin to the parent workstream

--- a/packages/electron/src/renderer/store/atoms/workstreamState.ts
+++ b/packages/electron/src/renderer/store/atoms/workstreamState.ts
@@ -599,17 +599,21 @@ export const convertToWorkstreamAtom = atom(
       sessionId,
       parentId,
       siblingId,
-    }: { sessionId: string; parentId: string; siblingId: string }
+    }: { sessionId: string; parentId: string; siblingId?: string }
   ) => {
     // Get the current session's state to preserve UI settings
     const currentState = get(workstreamStateAtom(sessionId));
 
-    // Create parent workstream state, inheriting UI settings from the original session
+    // Create parent workstream state, inheriting UI settings from the original session.
+    // When siblingId is omitted (drag-drop conversion) the original session is the only
+    // child and becomes the active child.
+    const childSessionIds = siblingId ? [sessionId, siblingId] : [sessionId];
+    const activeChildId = siblingId ?? sessionId;
     set(workstreamStateAtom(parentId), {
       id: parentId,
       type: 'workstream',
-      childSessionIds: [sessionId, siblingId],
-      activeChildId: siblingId,
+      childSessionIds,
+      activeChildId,
       worktreeId: null,
       worktreePath: null,
       // Inherit UI state from original session
@@ -645,8 +649,10 @@ export const convertToWorkstreamAtom = atom(
       fileScopeMode: 'all-changes',
     });
 
-    // Initialize sibling state
-    set(workstreamStateAtom(siblingId), createDefaultState(siblingId));
+    // Initialize sibling state (only when a sibling was created)
+    if (siblingId) {
+      set(workstreamStateAtom(siblingId), createDefaultState(siblingId));
+    }
   }
 );
 


### PR DESCRIPTION
> Replaces #210 (closed — same diff, refiled from a different fork).

## Summary

When a user drag-drops one session onto another to create a workstream, the unified workstream state for the new parent is not initialized. This produces inconsistent UI when more sessions are subsequently dragged into the workstream and the parent does not inherit the dragged session's UI settings (layout mode, split ratio, files sidebar visibility) the way the sibling-creation path does.

## Repro

1. In the agent-view sidebar, drag one session row onto another. A new workstream parent is created with the dropped session as its first child.
2. Drag a second session into the same workstream.
3. Inconsistent rendering of the parent workstream: layout, sidebar visibility, etc. fall back to defaults instead of the dragged session's settings; subsequent reparent operations on the parent operate against uninitialized fields.

## Root cause

In `packages/electron/src/renderer/store/atoms/sessions.ts:1420-1428`, the call to `convertToWorkstreamAtom` (in `workstreamState.ts`) was gated:

```ts
// Update unified workstream state (only when sibling was created)
if (siblingResult.success && siblingResult.sessionId) {
  const { convertToWorkstreamAtom } = await import('./workstreamState');
  set(convertToWorkstreamAtom, { sessionId, parentId: parentSessionId, siblingId: siblingResult.sessionId });
}
```

Drag-drop sets `skipSiblingCreation: true`, so `siblingResult.sessionId` is never produced and the `if` block was skipped. As a result `workstreamStateAtom(parentSessionId)` was never written — only `setWorkstreamActiveChildAtom` ran (which only patches `activeChildId`). The new parent ended up with default values for everything else, including:
- `childSessionIds: []` (default), so the type auto-detect on read stayed `'single'` until a later reparent populated children indirectly.
- All UI settings (`layoutMode`, `splitRatio`, `filesSidebarVisible`, etc.) at defaults instead of inherited from the dragged session.

The signature of `convertToWorkstreamAtom` in `workstreamState.ts` required `siblingId: string`, which is why the call site couldn't simply be moved out of the conditional.

## Fix

**`packages/electron/src/renderer/store/atoms/workstreamState.ts`**
- Make `siblingId` optional in the action's input type.
- Derive `childSessionIds`: `[sessionId, siblingId]` when a sibling exists, otherwise `[sessionId]`.
- Derive `activeChildId`: `siblingId ?? sessionId`.
- Skip the `set(workstreamStateAtom(siblingId), createDefaultState(siblingId))` call when `siblingId` is omitted (nothing to initialize).

The original-session-cleared block and the parent-state UI-inheritance block are unchanged so the existing sibling-creation path is preserved exactly.

**`packages/electron/src/renderer/store/atoms/sessions.ts`**
- Remove the `if (siblingResult.success && siblingResult.sessionId)` gate around the `convertToWorkstreamAtom` call so it runs in both paths.
- Spread `siblingId` into the action input only when present, so the no-sibling case stays clean.

`markSessionReadAtom` is intentionally left gated on sibling existence — there's no need to mark the original session as read since it already was.

**Tests** (new file: `packages/electron/src/renderer/store/atoms/__tests__/workstreamState.convertToWorkstream.test.ts`)
- Pins the with-sibling behavior (parent state + cleared original + sibling defaults + UI inheritance).
- Pins the new no-sibling drag-drop behavior (parent has only the original as a child, original session is the active child, original session state cleared, UI settings inherited).
- Follows the existing standalone-Jotai-store pattern from `fileTree.visibleNodes.test.ts`.

All 7 cases pass: `npx vitest run packages/electron/src/renderer/store/atoms/__tests__/workstreamState.convertToWorkstream.test.ts`.

## Test plan

- [x] `electron-vite build` succeeds.
- [x] New unit tests pass (7/7).
- [x] Manual test: drag-create a workstream from a session → drag more sessions into it → child list visually consistent.
- [x] Existing sibling-creation conversion path unchanged.

## Related

Companion to the rename live-update / workstream-rename-menu PR. PRs are independent and can be merged in either order.
