### PR TITLE
feat(mcp/sessions): add searchField=title to list_recent_sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-<!-- New features go here -->
+- Title-only mode for `mcp__nimbalyst-session-context__list_recent_sessions`. The existing `query` parameter goes through `AISessionsRepository.search`, which uses Postgres full-text search across both session titles and `ai_transcript_events.searchable_text`. That made it hard to find a session by name when the search term appeared frequently in conversations (e.g. searching `"Budget"` returned every session that mentioned budgets in passing, not just the session titled "Budget tracker setup"). Adds a `searchField` parameter accepting `'title'`, `'content'`, or `'both'` (default `'both'` keeps existing behavior). When `searchField: 'title'` is passed, the handler calls `AISessionsRepository.list` and filters in memory by case-insensitive substring match on `s.title`, bypassing the FTS path entirely. The result label and no-results message both show `in titles` when the title-only mode is active so the model can tell the modes apart. Fixes #83.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/main/mcp/sessionContextServer.ts
+++ b/packages/electron/src/main/mcp/sessionContextServer.ts
@@ -395,13 +395,26 @@ async function handleListRecentSessions(
   offset: number,
   workspaceId: string,
   currentSessionId: string,
-  includeArchived: boolean
+  includeArchived: boolean,
+  searchField: "title" | "content" | "both" = "both"
 ): Promise<string> {
   let sessions: SessionMeta[];
 
   const options = { includeArchived };
-  if (query && query.trim().length > 0) {
-    sessions = await AISessionsRepository.search(workspaceId, query.trim(), options);
+  const trimmedQuery = query?.trim() ?? "";
+  if (trimmedQuery.length > 0) {
+    if (searchField === "title") {
+      // Title-only: list everything in the workspace, then case-insensitive
+      // substring match on title. Avoids the FTS path which also matches
+      // conversation content. See #83.
+      const all = await AISessionsRepository.list(workspaceId, options);
+      const needle = trimmedQuery.toLowerCase();
+      sessions = all.filter((s) =>
+        (s.title ?? "").toLowerCase().includes(needle)
+      );
+    } else {
+      sessions = await AISessionsRepository.search(workspaceId, trimmedQuery, options);
+    }
   } else {
     sessions = await AISessionsRepository.list(workspaceId, options);
   }
@@ -412,9 +425,11 @@ async function handleListRecentSessions(
   const limited = leafSessions.slice(offset, offset + limit);
 
   if (limited.length === 0) {
-    return query
-      ? `No sessions found matching "${query}"`
-      : "No sessions found in this workspace.";
+    if (trimmedQuery.length > 0) {
+      const scope = searchField === "title" ? " in titles" : "";
+      return `No sessions found matching "${trimmedQuery}"${scope}`;
+    }
+    return "No sessions found in this workspace.";
   }
 
   const parentIds = new Set<string>();
@@ -459,7 +474,11 @@ async function handleListRecentSessions(
   }
 
   const lines: string[] = [];
-  const totalLabel = query ? `matching "${query}"` : "total";
+  const matchScope =
+    trimmedQuery.length > 0
+      ? `matching "${trimmedQuery}"${searchField === "title" ? " in titles" : ""}`
+      : "total";
+  const totalLabel = matchScope;
   const offsetLabel = offset > 0 ? `, offset ${offset}` : "";
   lines.push(
     `Recent sessions (showing ${limited.length} of ${leafSessions.length} ${totalLabel}${offsetLabel}):`
@@ -705,7 +724,7 @@ function createSessionContextMcpServer(
         {
           name: "list_recent_sessions",
           description:
-            "List recent AI sessions in the current workspace. Optionally search by title or content. Use this when the user references a previous session or asks about past work (e.g., 'implement the plan from our session about X'). By default, archived sessions are excluded -- pass includeArchived: true to search across archived sessions as well.",
+            "List recent AI sessions in the current workspace. Optionally search by title or content. Use this when the user references a previous session or asks about past work (e.g., 'implement the plan from our session about X'). By default, archived sessions are excluded -- pass includeArchived: true to search across archived sessions as well. To find a session by name when the search term appears frequently in conversations, pass searchField: 'title' to restrict matching to session titles only.",
           inputSchema: {
             type: "object",
             properties: {
@@ -713,6 +732,12 @@ function createSessionContextMcpServer(
                 type: "string",
                 description:
                   "Optional search string to filter sessions by title or content.",
+              },
+              searchField: {
+                type: "string",
+                enum: ["title", "content", "both"],
+                description:
+                  "Where to look for the query. 'title' matches only session titles (case-insensitive substring). 'content' and 'both' match titles and conversation content via full-text search. Defaults to 'both'. Ignored if query is empty.",
               },
               limit: {
                 type: "number",
@@ -857,13 +882,19 @@ function createSessionContextMcpServer(
           );
           const offset = Math.max((args?.offset as number) || 0, 0);
           const includeArchived = Boolean(args?.includeArchived);
+          const rawSearchField = args?.searchField as string | undefined;
+          const searchField: "title" | "content" | "both" =
+            rawSearchField === "title" || rawSearchField === "content"
+              ? rawSearchField
+              : "both";
           const result = await handleListRecentSessions(
             args?.query as string | undefined,
             limit,
             offset,
             workspaceId,
             aiSessionId,
-            includeArchived
+            includeArchived,
+            searchField
           );
           return {
             content: [{ type: "text", text: result }],


### PR DESCRIPTION
## Summary

Fixes #83. Reporter wants `mcp__nimbalyst-session-context__list_recent_sessions` to support a title-only search mode so models can find a session by name without getting drowned in content matches.

## Root cause

The current `query` parameter goes through `AISessionsRepository.search`, which in `PGLiteSessionStore` runs two FTS queries and unions the results: one against `s.title` and one against `ai_transcript_events.searchable_text`. So searching `"Budget"` returns:
- the session titled "Budget tracker setup" (good)
- every session that mentioned a budget anywhere in its conversation (noise)

There was no way to scope the query to titles only.

## Fix

Adds a `searchField` parameter to the tool schema with values `'title' | 'content' | 'both'`. Default is `'both'`, which preserves the existing behavior.

When `searchField: 'title'` is passed:

```ts
const all = await AISessionsRepository.list(workspaceId, options);
const needle = trimmedQuery.toLowerCase();
sessions = all.filter((s) =>
  (s.title ?? "").toLowerCase().includes(needle)
);
```

The handler calls `list()` (which is what the no-query path already calls) and filters by case-insensitive substring on `s.title`. The FTS path is bypassed entirely. Pagination via `slice(offset, offset + limit)` happens after the filter, same as before.

The result label and no-results message both append `in titles` when the title-only mode is active so the model can tell the modes apart in the output:

```
Recent sessions (showing 1 of 1 matching "Budget" in titles):
1. "Budget tracker setup" (uuid) - 2 hours ago
   Provider: claude-code
```

## Why a JS substring filter and not a SQL title-only branch

The store's existing title query at `PGLiteSessionStore.ts:644-678` uses `plainto_tsquery('english', ...)` which stems and tokenizes. For "find by name" the user wants substring fidelity, not stemming -- searching `"Budg"` should match `"Budget tracker setup"`. Adding a separate parametrized SQL path would mean either teaching the SessionStore interface a new flag or introducing an `ILIKE` branch that has different semantics from the main FTS path. Filtering in JS keeps the change scoped to the MCP handler, makes the semantics obvious, and matches how `SessionManager.test.ts:95-110` already mocks `search` for tests.

## Class-of-bug check

Grepped `AISessionsRepository.search` across the MCP package -- only `handleListRecentSessions` calls it. `VoiceModeService.ts:586` also calls it, but that's the voice-agent search-recent-sessions tool, which is a different surface and not what the reporter raised.

## Test plan

- [x] `npm run typecheck --workspace=packages/electron` passes
- [ ] Manual: `list_recent_sessions({ query: "Budget" })` -- existing FTS behavior, matches title and content
- [ ] Manual: `list_recent_sessions({ query: "Budget", searchField: "title" })` -- only sessions whose title contains "Budget"
- [ ] Manual: `list_recent_sessions({ searchField: "title" })` with no query -- behaves like list-all (the searchField is ignored when query is empty, per the description)
- [ ] Manual: invalid `searchField` value falls back to `'both'`

## Closes

Fixes #83.
