### PR TITLE
fix(transcript): add chatShowToolCalls user setting to honour issue #118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-<!-- New features go here -->
+- Honour a new user-facing `chatShowToolCalls` setting in `ai-settings.json` (default `true`) so the AI chat view can hide tool-call rows entirely instead of just collapsing them. The original `showToolCalls` field stays a developer-mode-only toggle (default `false`, gated behind `isDevelopment` in `AgentFeaturesPanel`), so production users get a discoverable "Show Tool Calls in Chat" toggle in Agent Features that defaults to on. The renderer's tool-row guards in `RichTranscriptView` (orphan-tool path and `toolMessagesBefore` path) consume the new value flowing through `initialSettings.showToolCalls`. Interactive tool widgets (`ToolPermission`, `ExitPlanMode`, `AskUserQuestion`, `GitCommitProposal`) always render so the user can still act on prompts even when tool rows are hidden. Default `true` preserves UX for everyone who has not manually set the value. Fixes #118.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -429,6 +429,10 @@ export class AIService {
             type: 'boolean',
             default: false  // Hidden by default, developer mode only
           },
+          chatShowToolCalls: {
+            type: 'boolean',
+            default: true  // User-facing chat toggle; defaults true to preserve current UX
+          },
           aiDebugLogging: {
             type: 'boolean',
             default: false  // Hidden by default, developer mode only
@@ -2570,6 +2574,7 @@ export class AIService {
       const apiKeys = this.getSettingsStore().get('apiKeys', {}) as Record<string, string>;
       const providerSettings = this.getNormalizedProviderSettings();
       const showToolCalls = this.getSettingsStore().get('showToolCalls', false) as boolean;
+      const chatShowToolCalls = this.getSettingsStore().get('chatShowToolCalls', true) as boolean;
       const aiDebugLogging = this.getSettingsStore().get('aiDebugLogging', false) as boolean;
       const showPromptAdditions = this.getSettingsStore().get('showPromptAdditions', false) as boolean;
       const showUsageIndicator = this.getSettingsStore().get('showUsageIndicator', true) as boolean;
@@ -2592,6 +2597,7 @@ export class AIService {
         apiKeys: this.maskApiKeys(apiKeys),
         providerSettings,
         showToolCalls,
+        chatShowToolCalls,
         aiDebugLogging,
         showPromptAdditions,
         showUsageIndicator,
@@ -2689,6 +2695,10 @@ export class AIService {
 
       if (settings.showToolCalls !== undefined) {
         this.getSettingsStore().set('showToolCalls', settings.showToolCalls);
+      }
+
+      if (settings.chatShowToolCalls !== undefined) {
+        this.getSettingsStore().set('chatShowToolCalls', settings.chatShowToolCalls);
       }
 
       if (settings.aiDebugLogging !== undefined) {
@@ -3221,6 +3231,7 @@ export class AIService {
       const apiKeys = this.getSettingsStore().get('apiKeys', {}) as Record<string, string>;
       const providerSettings = this.getSettingsStore().get('providerSettings', {}) as any;
       const showToolCalls = this.getSettingsStore().get('showToolCalls', false) as boolean;
+      const chatShowToolCalls = this.getSettingsStore().get('chatShowToolCalls', true) as boolean;
       const aiDebugLogging = this.getSettingsStore().get('aiDebugLogging', false) as boolean;
       const showPromptAdditions = this.getSettingsStore().get('showPromptAdditions', false) as boolean;
       const defaultProvider = this.getSettingsStore().get('defaultProvider', 'claude-code') as string;
@@ -3230,6 +3241,7 @@ export class AIService {
         apiKeys: this.maskApiKeys(apiKeys),
         providerSettings,
         showToolCalls,
+        chatShowToolCalls,
         aiDebugLogging,
         showPromptAdditions,
       };

--- a/packages/electron/src/renderer/components/Settings/AgentFeaturesPanel.tsx
+++ b/packages/electron/src/renderer/components/Settings/AgentFeaturesPanel.tsx
@@ -42,7 +42,7 @@ export function AgentFeaturesPanel() {
 
   const [aiDebugSettings] = useAtom(aiDebugSettingsAtom);
   const [, updateAIDebugSettings] = useAtom(setAIDebugSettingsAtom);
-  const { showToolCalls, aiDebugLogging, showPromptAdditions } = aiDebugSettings;
+  const { showToolCalls, chatShowToolCalls, aiDebugLogging, showPromptAdditions } = aiDebugSettings;
   const [workflowSettingsLoading, setWorkflowSettingsLoading] = useState(false);
   const [preferredAgentLanguage, setPreferredAgentLanguage] = useState<string>('');
   const [workflowSourceSettings, setWorkflowSourceSettings] = useState<WorkflowSourceSettings>({
@@ -265,6 +265,13 @@ export function AgentFeaturesPanel() {
             description={feature.description}
           />
         ))}
+
+        <SettingsToggle
+          checked={chatShowToolCalls}
+          onChange={(checked) => updateAIDebugSettings({ chatShowToolCalls: checked })}
+          name="Show Tool Calls in Chat"
+          description="Display tool call rows in the AI chat view. Turn off to hide tool activity and see only the conversational messages."
+        />
       </div>
 
       {isDevelopment && (

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -74,7 +74,7 @@ import { convertToWorkstreamAtom, sessionPromptAdditionsAtom, sessionLastSubmitA
 import { clearAIInputHistoryAtom } from '../../store/atoms/aiInputUndo';
 import { scrollToTeammateAtom, scrollToMessageAtom, requestOpenSessionAtom } from '../../store/atoms/agentMode';
 import { usePostHog } from 'posthog-js/react';
-import { setAgentModeSettingsAtom, showPromptAdditionsAtom, hasExternalEditorAtom, externalEditorNameAtom, openInExternalEditorAtom, defaultAgentModelAtom, defaultEffortLevelAtom } from '../../store/atoms/appSettings';
+import { setAgentModeSettingsAtom, showPromptAdditionsAtom, hasExternalEditorAtom, externalEditorNameAtom, openInExternalEditorAtom, defaultAgentModelAtom, defaultEffortLevelAtom, chatShowToolCallsAtom } from '../../store/atoms/appSettings';
 import { supportsEffortLevel, parseEffortLevel, type EffortLevel } from '../../utils/modelUtils';
 import { buildPlanImplementationPrompt, resolvePlanFilePath } from '../../utils/pathUtils';
 import { autoCommitEnabledAtom, setAutoCommitEnabledAtom } from '../../store/atoms/autoCommitAtoms';
@@ -312,6 +312,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
   const provider = useAtomValue(sessionProviderAtom(sessionId));
   const tokenUsage = useAtomValue(sessionTokenUsageAtom(sessionId));
   const isDataLoading = useAtomValue(sessionLoadingAtom(sessionId));
+  const chatShowToolCalls = useAtomValue(chatShowToolCallsAtom);
   const [aiMode, setAiMode] = useAtom(sessionModeAtom(sessionId));
   const [currentModel, setCurrentModel] = useAtom(sessionModelAtom(sessionId));
   const [isArchived, setIsArchived] = useAtom(sessionArchivedAtom(sessionId));
@@ -1647,7 +1648,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
             showFloatingActions={mode === 'agent'}
             workspacePath={workspacePath}
             initialSettings={{
-              showToolCalls: true,
+              showToolCalls: chatShowToolCalls,
               compactMode: false,
               collapseTools: false,
               showThinking: true,

--- a/packages/electron/src/renderer/store/atoms/appSettings.ts
+++ b/packages/electron/src/renderer/store/atoms/appSettings.ts
@@ -827,6 +827,7 @@ export async function initSyncConfig(): Promise<SyncConfig> {
 
 export interface AIDebugSettings {
   showToolCalls: boolean;
+  chatShowToolCalls: boolean;
   aiDebugLogging: boolean;
   showPromptAdditions: boolean;
 }
@@ -836,6 +837,7 @@ export interface AIDebugSettings {
  */
 const defaultAIDebugSettings: AIDebugSettings = {
   showToolCalls: false,
+  chatShowToolCalls: true,
   aiDebugLogging: false,
   showPromptAdditions: false,
 };
@@ -868,6 +870,7 @@ function scheduleAIDebugPersist(settings: AIDebugSettings): void {
       try {
         await window.electronAPI.aiSaveSettings({
           showToolCalls: settings.showToolCalls,
+          chatShowToolCalls: settings.chatShowToolCalls,
           aiDebugLogging: settings.aiDebugLogging,
           showPromptAdditions: settings.showPromptAdditions,
         });
@@ -881,9 +884,17 @@ function scheduleAIDebugPersist(settings: AIDebugSettings): void {
 // === Derived read-only atoms (slices) ===
 
 /**
- * Show tool calls setting.
+ * Show tool calls setting (developer-mode only - the existing dev toggle).
  */
 export const showToolCallsAtom = atom((get) => get(aiDebugSettingsAtom).showToolCalls);
+
+/**
+ * User-facing chat-view tool-call visibility (default true).
+ * Independent of the dev-only `showToolCallsAtom` above. Reporter on #118
+ * who manually sets `chatShowToolCalls: false` in ai-settings.json sees
+ * tool rows hidden; default-true preserves UX for everyone else.
+ */
+export const chatShowToolCallsAtom = atom((get) => get(aiDebugSettingsAtom).chatShowToolCalls);
 
 /**
  * AI debug logging setting.
@@ -924,6 +935,7 @@ export async function initAIDebugSettings(): Promise<AIDebugSettings> {
     const settings = await window.electronAPI.aiGetSettings();
     return {
       showToolCalls: settings?.showToolCalls ?? false,
+      chatShowToolCalls: settings?.chatShowToolCalls ?? true,
       aiDebugLogging: settings?.aiDebugLogging ?? false,
       showPromptAdditions: settings?.showPromptAdditions ?? false,
     };

--- a/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
@@ -481,6 +481,13 @@ const isEditToolName = (name?: string): boolean => {
 
 const WRITE_TOOL_NAMES = new Set(['write', 'notebookedit']);
 
+/**
+ * Interactive tool widgets that require the user to act. These render even when
+ * `settings.showToolCalls` is false, so the user can still respond to prompts
+ * (permission grants, plan-mode exits, AskUserQuestion answers, commit proposals).
+ */
+const INTERACTIVE_WIDGET_TOOLS = new Set(['ToolPermission', 'ExitPlanMode', 'AskUserQuestion', 'GitCommitProposal']);
+
 const isFileModifyingTool = (name?: string): boolean => {
   if (!name) return false;
   const normalized = name.toLowerCase();
@@ -1845,15 +1852,14 @@ export const RichTranscriptView = React.forwardRef<
                     // NEVER hide interactive tool widgets (ToolPermission, ExitPlanMode, etc.) that require user action.
                     // Also never hide assistant messages that would carry interactive widgets in toolMessagesBefore.
                     if (message.type === 'assistant_message' || isToolLikeMessage(message)) {
-                      const INTERACTIVE_WIDGETS = ['ToolPermission', 'ExitPlanMode', 'AskUserQuestion', 'GitCommitProposal'];
                       const isInteractiveWidget = isToolLikeMessage(message) && message.toolCall?.toolName &&
-                        INTERACTIVE_WIDGETS.includes(message.toolCall.toolName);
+                        INTERACTIVE_WIDGET_TOOLS.has(message.toolCall.toolName);
                       // For assistant messages, check if preceding tool messages contain interactive widgets
                       let hasInteractiveToolsBefore = false;
                       if (message.type === 'assistant_message') {
                         let checkPrev = index - 1;
                         while (checkPrev >= 0 && isToolLikeMessage(messages[checkPrev])) {
-                          if (messages[checkPrev].toolCall?.toolName && INTERACTIVE_WIDGETS.includes(messages[checkPrev].toolCall!.toolName)) {
+                          if (messages[checkPrev].toolCall?.toolName && INTERACTIVE_WIDGET_TOOLS.has(messages[checkPrev].toolCall!.toolName!)) {
                             hasInteractiveToolsBefore = true;
                             break;
                           }
@@ -1908,8 +1914,17 @@ export const RichTranscriptView = React.forwardRef<
                     }
                     const isNewGroup = !effectivePrevMessage || effectivePrevMessage.type !== message.type;
 
-                    // Render orphaned tool calls
+                    // Render orphaned tool calls.
+                    // When settings.showToolCalls is false, hide non-interactive tool
+                    // rows from the chat view but always render interactive widgets
+                    // (ToolPermission / ExitPlanMode / AskUserQuestion /
+                    // GitCommitProposal) so the user can still act on prompts.
                     if (isTool && message.toolCall) {
+                      const toolName = message.toolCall.toolName;
+                      const isInteractiveWidget = toolName ? INTERACTIVE_WIDGET_TOOLS.has(toolName) : false;
+                      if (!settings.showToolCalls && !isInteractiveWidget) {
+                        return null;
+                      }
                       return (
                         <div key={`${sessionId}-${index}`} className="rich-transcript-tool-container orphan ml-6 mb-2">
                           {renderToolCard(message, index, 0)}
@@ -2033,13 +2048,24 @@ export const RichTranscriptView = React.forwardRef<
                           </div>
                         )}
 
-                        {toolMessagesBefore.length > 0 && (
-                          <div className={`rich-transcript-tool-messages flex flex-col gap-2 mb-1.5 ${isNewGroup ? 'indented ml-6' : ''}`}>
-                            {toolMessagesBefore.map(({ message: toolMsg, index: toolIndex }) =>
-                              renderToolCard(toolMsg, toolIndex, 0)
-                            )}
-                          </div>
-                        )}
+                        {toolMessagesBefore.length > 0 && (() => {
+                          // Filter out non-interactive tool messages when settings.showToolCalls
+                          // is off; always keep interactive widgets so the user can act on prompts.
+                          const visibleToolMessages = settings.showToolCalls
+                            ? toolMessagesBefore
+                            : toolMessagesBefore.filter(
+                                ({ message: toolMsg }) =>
+                                  !!toolMsg.toolCall?.toolName && INTERACTIVE_WIDGET_TOOLS.has(toolMsg.toolCall.toolName)
+                              );
+                          if (visibleToolMessages.length === 0) return null;
+                          return (
+                            <div className={`rich-transcript-tool-messages flex flex-col gap-2 mb-1.5 ${isNewGroup ? 'indented ml-6' : ''}`}>
+                              {visibleToolMessages.map(({ message: toolMsg, index: toolIndex }) =>
+                                renderToolCard(toolMsg, toolIndex, 0)
+                              )}
+                            </div>
+                          );
+                        })()}
 
                         <div className={`rich-transcript-message-content relative ${isNewGroup ? 'ml-6' : 'no-indent ml-0'}`}>
                           {/* Copy button - shows on hover */}


### PR DESCRIPTION
## Summary

Fixes #118. Reporter on the issue set `showToolCalls: false` in `ai-settings.json` expecting tool-call rows to disappear from the chat view, but they kept rendering as collapsed bars.

## Why the original approach (single-flag) was wrong

The existing `showToolCalls` field is **dev-mode-only**:
- Default `false` in the electron-store schema (with comment "Hidden by default, developer mode only").
- The UI toggle in `AgentFeaturesPanel` is gated behind an `{isDevelopment && ...}` block.

Naively making the chat view honour `showToolCalls` from the atom (as the original draft of this PR did) would silently hide tool rows for **every** production user after upgrade, since their stored value is the default `false`. The reporter who manually set `false` is a power user; the rest of the user base never sees the toggle.

I caught this on a second-pass review, moved the PR back to draft, and reworked.

## What this PR does (approach A)

Adds a separate user-facing `chatShowToolCalls: boolean` (default `true`) that the chat transcript routes through. The dev-only `showToolCalls` field is untouched.

**Main-process schema and IPC** (`packages/electron/src/main/services/ai/AIService.ts`):
- New `chatShowToolCalls` boolean in the electron-store schema with `default: true`.
- Parallel reads in `ai:getSettings` and `ai:getEffectiveSettings`, parallel write block in `ai:saveSettings`.

**Renderer atom** (`packages/electron/src/renderer/store/atoms/appSettings.ts`):
- `AIDebugSettings` interface gains `chatShowToolCalls: boolean`.
- Default `true` in `defaultAIDebugSettings` and `initAIDebugSettings`.
- Persisted via the existing debounced `scheduleAIDebugPersist`.
- New `chatShowToolCallsAtom` slice export, peer to `showToolCallsAtom`.

**UI toggle** (`packages/electron/src/renderer/components/Settings/AgentFeaturesPanel.tsx`):
- "Show Tool Calls in Chat" toggle placed in the always-visible Agent Features section (NOT in the `isDevelopment` block).
- The existing dev-only "Show All Tool Calls" toggle is unchanged and stays in `Developer Options`.

**Chat transcript routing** (`packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx`):
- Reads `chatShowToolCallsAtom` and passes it into `initialSettings.showToolCalls` (replaces the hardcoded `true`).

**Renderer guards** (`packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx`):
- Two render paths previously called `renderToolCard` unconditionally:
  1. Orphan tool cards (tool ran but no following assistant message yet).
  2. `toolMessagesBefore` cards rendered alongside the next assistant turn.
- Both now check `settings.showToolCalls` and skip non-interactive tools when off.
- Interactive widgets (`ToolPermission`, `ExitPlanMode`, `AskUserQuestion`, `GitCommitProposal`) always render so the user can act on prompts even when tool rows are hidden.
- `INTERACTIVE_WIDGET_TOOLS` is lifted from an inline array (line 1848 on main) to a module-scope `Set`, reused at all three guard sites.

## Behaviour table

| User state | Before | After |
|---|---|---|
| Hasn't touched setting (default) | sees tool rows | sees tool rows (default `true`) |
| Manually set `chatShowToolCalls: false` in `ai-settings.json` (reporter on #118) | sees tool rows | tool rows hidden, interactive widgets still shown |
| Has dev mode on + toggles dev-only `showToolCalls` | unchanged | unchanged |

## Test plan

- [x] `tsc --noEmit` clean across `packages/runtime` + `packages/electron` (3 pre-existing `@dnd-kit/*` module-resolution errors are unrelated to this PR; same on `upstream/main`).
- [x] `npm run test:unit -- --run packages/runtime/src/ui/AgentTranscript/components/__tests__/TranscriptWidgets.test.tsx`: 57/57 pass.
- [ ] Manual: fresh install, agent session with tool calls visible by default.
- [ ] Manual: toggle off in Agent Features, agent session shows no tool rows but `ToolPermission`/`ExitPlanMode`/`AskUserQuestion`/`GitCommitProposal` widgets still render and accept input.
- [ ] Manual: set `chatShowToolCalls: false` directly in `~/.claude/ai-settings.json`, confirm matches the in-app toggle off.

## Notes

- Default `true` preserves UX for every existing user who hasn't touched the setting. The migration safety pattern (`?? true` in `initAIDebugSettings`) handles users whose stored settings predate this field.
- The original draft's "honour the existing dev-only field" approach was wrong. Walked back, reworked. Greg, I commented this rationale on the original draft (Sat 09:18Z) and proposed approach A; absent a different opinion this is what shipped.

Closes #118.
