### PR TITLE
fix(file-tree): move all selected items on multi-file drag, not just one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Drag-and-drop on a multi-file selection now moves or copies every selected item, not just one. `handleDragStart` in `FlatFileTree.tsx` was setting `sourcePaths: [node.path]` regardless of the current `selectedPaths` set, and `handleDrop` was reading only `sourcePaths[0]`, so dragging a Ctrl-Click selection of N files always silently dropped N-1 of them. `handleDragStart` now uses the full selection when the dragged item is part of it (and falls back to single-item drag when the user grabs an unselected item, matching Finder/Explorer behavior). `handleDrop` iterates every dragged path, collects per-item failures, refreshes the tree if any succeeded, and surfaces a single summary `ErrorDialog` for partial failures (mirroring the multi-delete pattern from #216). The drag preview shows `N items` for multi-selection drags. Fixes #31.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/renderer/components/FlatFileTree.tsx
+++ b/packages/electron/src/renderer/components/FlatFileTree.tsx
@@ -468,19 +468,31 @@ export function FlatFileTree({
       return;
     }
 
+    // When the user drags an item that is part of the current multi-selection,
+    // include every selected path so the drop handler moves/copies them all
+    // in a single operation. When the dragged item is NOT in the selection
+    // (the user grabbed an unselected file/folder), drag only that item -
+    // matches the typical macOS Finder / Windows Explorer behaviour where
+    // dragging an unselected item ignores any prior selection. See #31.
+    const sourcePaths = selectedPaths.has(node.path) && selectedPaths.size > 1
+      ? Array.from(selectedPaths)
+      : [node.path];
+
     e.dataTransfer.effectAllowed = 'copyMove';
     e.dataTransfer.setData('text/plain', node.path);
     // Also set custom MIME type so AI input can accept this as an @-file mention
     e.dataTransfer.setData('application/x-nimbalyst-file-mention', node.path);
     setDragState({
-      sourcePaths: [node.path],
+      sourcePaths,
       dropTargetPath: null,
       isCopy: false,
     });
 
     // Custom drag image
     const dragImage = document.createElement('div');
-    dragImage.textContent = node.name;
+    dragImage.textContent = sourcePaths.length > 1
+      ? `${sourcePaths.length} items`
+      : node.name;
     dragImage.style.position = 'absolute';
     dragImage.style.top = '-1000px';
     dragImage.style.left = '-1000px';
@@ -607,30 +619,55 @@ export function FlatFileTree({
     }
 
     const isCopy = e.altKey || e.metaKey;
-    const sourcePath = dragState.sourcePaths[0];
-    if (!sourcePath || sourcePath === node.path) {
+    // Process every dragged path, not just the first. The previous code
+    // hardcoded `sourcePaths[0]` which silently dropped every other item
+    // in a multi-selection drag. See #31.
+    const sourcePaths = dragState.sourcePaths.filter(
+      (p) => p && p !== node.path
+    );
+    if (sourcePaths.length === 0) {
       setDragState(null);
       return;
     }
 
+    const action = isCopy ? 'copy' : 'move';
+    const failures: Array<{ path: string; error?: string }> = [];
+    let successCount = 0;
     try {
-      if (isCopy) {
-        const result = await window.electronAPI.copyFile(sourcePath, node.path);
-        if (!result.success) {
-          console.error('Failed to copy file:', result.error);
-        } else {
-          onRefreshFileTree?.();
-        }
-      } else {
-        const result = await window.electronAPI.moveFile(sourcePath, node.path);
-        if (!result.success) {
-          console.error('Failed to move file:', result.error);
-        } else {
-          onRefreshFileTree?.();
+      for (const sourcePath of sourcePaths) {
+        try {
+          const result = isCopy
+            ? await window.electronAPI.copyFile(sourcePath, node.path)
+            : await window.electronAPI.moveFile(sourcePath, node.path);
+          if (result.success) {
+            successCount++;
+          } else {
+            console.error(`Failed to ${action} file:`, sourcePath, result.error);
+            failures.push({ path: sourcePath, error: result.error });
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(`Error during ${action}:`, sourcePath, error);
+          failures.push({ path: sourcePath, error: message });
         }
       }
-    } catch (error) {
-      console.error('Error during drag and drop:', error);
+      if (successCount > 0) {
+        onRefreshFileTree?.();
+      }
+      if (failures.length > 0) {
+        // Same single-summary-dialog pattern as handleDeleteMultiple (#216)
+        // so users do not get one error dialog per failed file.
+        const failureSummary = failures
+          .map((f) => `- ${f.path.split(/[/\\]/).pop() || f.path}: ${f.error || 'unknown error'}`)
+          .join('\n');
+        const verb = isCopy ? 'copied' : 'moved';
+        const verbCap = isCopy ? 'Copy' : 'Move';
+        dialogRef.current?.open(DIALOG_IDS.ERROR, {
+          title: failures.length === sourcePaths.length ? `${verbCap} failed` : `Some files could not be ${verb}`,
+          message: `${failures.length} of ${sourcePaths.length} item${sourcePaths.length === 1 ? '' : 's'} could not be ${verb} into ${node.name}.`,
+          details: failureSummary,
+        });
+      }
     } finally {
       setDragState(null);
     }


### PR DESCRIPTION
## Summary

Fixes #31. Reporter selects N files via Ctrl-Click in the workspace tree, drags them to a target folder, and only the file they actually grabbed moves. The other N-1 files stay in place.

## Root cause

Two bugs in series in `FlatFileTree.tsx`:

**1. `handleDragStart` ignored the multi-selection.** Line 476 hardcoded `sourcePaths: [node.path]`. Even when the user had Ctrl-Click selected 5 files and dragged one of them, the drag state only carried that one path.

**2. `handleDrop` only read the first path.** Line 610 had `const sourcePath = dragState.sourcePaths[0]`. So even if I fixed `handleDragStart` to populate the array, drop only ever moved `[0]` and dropped the rest on the floor.

Either bug alone would have produced "only one file moves". Both together made the bug fully invisible to single-bug-fix attempts.

## Fix

**`handleDragStart`**:

```ts
const sourcePaths = selectedPaths.has(node.path) && selectedPaths.size > 1
  ? Array.from(selectedPaths)
  : [node.path];
```

When the dragged item is part of the multi-selection: drag the whole selection. When the user grabs an unselected item (clicked once, then dragged): drag only that item. This matches macOS Finder and Windows Explorer behavior. The drag-preview text shows `N items` instead of the filename when N > 1.

**`handleDrop`**:

Iterates `sourcePaths`, copies/moves each, collects per-item failures, refreshes the tree once if any succeeded, and surfaces a single summary `ErrorDialog` for partial failures. Mirrors the pattern `handleDeleteMultiple` already uses (shipped in #216, with the matching reasoning that one error dialog per failed file is hostile UX).

```ts
const sourcePaths = dragState.sourcePaths.filter((p) => p && p !== node.path);
// ...iterate, collect failures, single summary dialog
```

The dialog title flips between `Move failed` (all failed), `Some files could not be moved` (partial), and the verb swaps to `copied` when Alt/Cmd is held during drop. Same per-item failure-summary format `handleDeleteMultiple` uses.

## What stays the same

- Single-item drag (the user grabs an unselected file) is unchanged.
- `handleDragOver` / `handleDragEnter` / `handleDragLeave` are unchanged. The existing child-folder-of-source guard at `dragState.sourcePaths.some(src => ...)` already iterates the array, so it was already correct for the multi-source case.
- External drag from Finder (the `e.dataTransfer.types.includes('Files')` branch) is unchanged.
- Copy-on-Alt/Cmd modifier is unchanged.
- Tree refresh on success is unchanged.

## Class-of-bug check

`grep -n "sourcePaths\[" packages/electron/src/renderer/components/FlatFileTree.tsx` finds zero remaining hardcoded-index reads. Other consumers of `dragState.sourcePaths` already use `.some()` / `.includes()` (the over-folder validation), so they were already array-correct. Only the drag-start setter and the drop reader were buggy.

## Test plan

- [x] `npm run typecheck --workspace=packages/electron` passes
- [ ] Manual: select 3 files via Ctrl-Click, drag one of them into a folder, all 3 move
- [ ] Manual: select 3 files, hold Alt while dragging, all 3 copy (originals remain)
- [ ] Manual: drag an unselected file (no Ctrl-Click prior), only that file moves
- [ ] Manual: drag a multi-selection that includes the destination folder, the destination is filtered out (existing single-item behavior preserved for that edge case)
- [ ] Manual: induce a failure on one file mid-batch (e.g. permission denied on one of the selected files), the others still move and a single summary dialog lists the failure

## Closes

Fixes #31.
