### PR TITLE
feat(tracker): allow tracker_update to change the primary type of an item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-<!-- New features go here -->
+- Allow `mcp__nimbalyst-tracker__tracker_update` to change the primary type of a tracker item. `tracker_update` previously only accepted `typeTags` as a secondary-tag list - the primary `type` (the thing that determines whether an item shows in the `task` / `idea` / `plan` / `bug` view) was set at creation time and immutable, so the only workaround for a `task` that turned out to be a `bug` was to archive it and recreate, losing comments, attachments, and session links. Adds a `primaryType` parameter that (a) validates against the tracker registry via `globalRegistry.has(newType)`, (b) updates `tracker_items.type` in a separate UPDATE before the existing data write, (c) re-validates the item's data against the new type's schema, (d) appends a `type_changed` activity-log entry, (e) rebuilds `type_tags` so the new primary type is at the front and the old primary type is removed (preserving any other secondary tags). When the user passes both `primaryType` and `typeTags` the explicit `typeTags` array wins. Fixes #79.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/main/mcp/tools/trackerToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/trackerToolHandlers.ts
@@ -669,6 +669,11 @@ export const trackerToolSchemas = [
           items: { type: "string" },
           description: "Set type tags (replaces existing type tags). Primary type is always included.",
         },
+        primaryType: {
+          type: "string",
+          description:
+            "Replace the item's primary type (e.g. change a 'task' into a 'bug', or an 'idea' into a 'plan'). Must be a registered tracker type. Item history (comments, attachments, session links) is preserved. The primary type is also auto-merged into type_tags so it remains the canonical primary tag.",
+        },
         fields: {
           type: "object",
           description: "Generic field bag for updating any schema-defined field. Values here override fixed arguments above.",
@@ -1726,6 +1731,31 @@ export async function handleTrackerUpdate(
       }
     }
 
+    // Apply primary-type change before validation so the new type's schema
+    // is what we validate against. Tracker items often start as one type
+    // (idea) and naturally evolve into another (task / bug / plan); the only
+    // existing workaround was archive-and-recreate which loses comments,
+    // attachments, and session links. See #79.
+    const oldType = row.type;
+    let primaryTypeChanged = false;
+    if (typeof args.primaryType === 'string' && args.primaryType !== row.type) {
+      const newType = args.primaryType;
+      if (!globalRegistry.has(newType)) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: unknown tracker type "${newType}". Use tracker_list to see registered types.`,
+            },
+          ],
+        };
+      }
+      changes.type = { from: oldType, to: newType };
+      row.type = newType;
+      primaryTypeChanged = true;
+    }
+
     const validationResult = globalRegistry.validate(row.type, data);
     if (!validationResult.valid) {
       return buildTrackerSchemaValidationError('tracker_update', row.type, validationResult.errors);
@@ -1736,6 +1766,7 @@ export async function handleTrackerUpdate(
     for (const [field, change] of Object.entries(changes)) {
       const action = field === 'status' ? 'status_changed'
         : field === 'archived' ? 'archived'
+        : field === 'type' ? 'type_changed'
         : 'updated';
       appendActivity(data, modifierIdentity, action, {
         field,
@@ -1744,13 +1775,40 @@ export async function handleTrackerUpdate(
       });
     }
 
-    // Update type_tags if provided
+    // Persist the primary-type change. Done before the type_tags / data
+    // updates so subsequent code (and the type_tags rebuild below) sees the
+    // new row.type.
+    if (primaryTypeChanged) {
+      await db.query(
+        `UPDATE tracker_items SET type = $1 WHERE id = $2`,
+        [row.type, row.id]
+      );
+    }
+
+    // Update type_tags if explicitly provided OR if primaryType changed and
+    // the existing type_tags still contain the OLD primary type (which would
+    // leak it as a secondary tag). The rebuild keeps secondary tags intact
+    // and ensures the new primary type is at the front.
     if (args.typeTags !== undefined) {
       // Ensure primary type is always in the array
       const newTypeTags: string[] = [row.type];
       for (const tag of args.typeTags) {
         if (!newTypeTags.includes(tag)) newTypeTags.push(tag);
       }
+      await db.query(
+        `UPDATE tracker_items SET type_tags = $1 WHERE id = $2`,
+        [newTypeTags, row.id]
+      );
+    } else if (primaryTypeChanged) {
+      // Migrate existing type_tags: remove the old primary type, prepend the
+      // new one, preserve any other secondary tags in the order they were.
+      const existingTags: string[] = Array.isArray((row as any).type_tags)
+        ? ((row as any).type_tags as string[])
+        : [oldType];
+      const preservedSecondary = existingTags.filter(
+        (t) => t !== oldType && t !== row.type
+      );
+      const newTypeTags = [row.type, ...preservedSecondary];
       await db.query(
         `UPDATE tracker_items SET type_tags = $1 WHERE id = $2`,
         [newTypeTags, row.id]


### PR DESCRIPTION
## Summary

Fixes #79. Tracker items often start as one type (idea) and evolve into another (task / bug / plan). `tracker_update` previously only accepted `typeTags` as a secondary-tag list. The primary `type` column was set at creation and immutable. The only workaround was archive-and-recreate, which loses comments, attachments, and session links.

## Fix

Adds a `primaryType` string parameter to the `tracker_update` MCP tool:

```ts
mcp__nimbalyst-tracker__tracker_update({
  id: "...",
  primaryType: "bug"
})
```

The handler:

1. **Validates** the new type against `globalRegistry.has(newType)`. Same registry that `tracker_create` validates against. Unknown types return a clear error.
2. **Persists** `tracker_items.type` via its own UPDATE before the existing data write, so the in-memory `row.type` and subsequent code (typeTags rebuild, activity log, sync) see the new value.
3. **Re-validates** `data` against the new type's schema. If the new type has a required field the old item lacks, the error surfaces as a normal validation error rather than silently writing a half-typed item.
4. **Logs activity** with action `type_changed` so the change appears in the item's history.
5. **Rebuilds `type_tags`**: the new primary type goes at the front, the old primary type is removed (it was leaking as a secondary tag with the previous code path), other secondary tags are preserved in order.
6. **Respects explicit typeTags**: if the user passes both `primaryType` and `typeTags`, the explicit `typeTags` array wins, consistent with the existing "replace the array" semantic.

## What stays the same

- `tracker_create`, validation rules, sync flow, activity-log shape - unchanged
- Item ID, comments, attachments, session links - all preserved (only the `type` column changes)
- `typeTags` semantics when `primaryType` is not provided - unchanged
- All 21 existing `trackerToolHandlers.test.ts` tests pass

## What is intentionally NOT in this PR

The reporter asks for the same UI surface ("a type selector on the item that allows changing"). That requires UI design - where the selector lives in the tracker detail panel, whether it confirms before changing, etc. - and is a separate ticket. This PR closes the MCP-side half so an agent (or a power user with MCP access) can flip the type today without losing history. Happy to follow up on the UI surface in a separate PR once @ghinkle picks the placement.

## Test plan

- [x] `npm run typecheck --workspace=packages/electron` passes
- [x] `npx vitest run packages/electron/src/main/mcp/tools/__tests__/trackerToolHandlers.test.ts` - 21/21 pass
- [ ] Manual via MCP: `tracker_update({ id: X, primaryType: "bug" })` on an existing `task`. The item now shows in `bug` view, history is intact, activity log records the change.
- [ ] Manual: pass an unknown type, get a clean error rather than a 500.
- [ ] Manual: pass a new type whose required fields the existing data lacks, get a normal validation error.
- [ ] Manual: pass both `primaryType: "bug"` and `typeTags: ["regression"]`, the resulting `type_tags` is `["bug", "regression"]` (explicit `typeTags` wins, primary type at the front).

## Note about CI

The Unit Tests workflow currently fails on main (since `5c0cf068` for #207, `WorkspaceEventBus-nested-gitignore.test.ts` has 3 isolation failures and one assertion mismatch). My PR will inherit that failure. The TypeScript Check passes cleanly. Verified locally that this PR does not introduce any additional test failures - the 21 tracker tests still pass.

## Closes

Fixes #79.
