### PR TITLE
fix(file-watcher): make supportsRecursiveWatch lazy and use path.sep in boundary check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- `WorkspaceEventBus` now evaluates `supportsRecursiveWatch` lazily and uses `path.sep` (not a `process.platform`-derived separator) inside `findGitRootForPathCached`, so the `WorkspaceEventBus-nested-gitignore.test.ts` suite added with #207 passes regardless of which test file imports the module first or which OS runs the tests. Previously the module-level `const supportsRecursiveWatch = process.platform === 'darwin' || process.platform === 'win32'` froze the value at module load, so vitest workers that imported the bus before the test's `vi.hoisted` `process.platform = 'darwin'` override took effect locked the value to the real platform (false on Linux CI), routing `subscribe` through the chokidar path instead of the mocked `fs.watch` and producing `Error: No watcher callback registered`. Separately, the boundary check at line 320 used a `process.platform === 'win32' ? '\\' : '/'` separator that clashed with the actual OS-style separator returned by real `path.join` on Windows when `process.platform` was mocked to `darwin`, causing the nested-repo discovery to give up and treat `nested/rootfs/etc/foo.txt` as not-ignored. Both the `supportsRecursiveWatch` accessor and the separator are now resolved at call-time. Production code behaves identically because `process.platform` and `path.sep` agree there. Refs #207.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/file/WorkspaceEventBus.ts
+++ b/packages/electron/src/main/file/WorkspaceEventBus.ts
@@ -12,8 +12,18 @@ import { isPathInWorkspace } from '../utils/workspaceDetection';
  * macOS uses FSEvents (1 FD for the entire tree).
  * Windows uses ReadDirectoryChangesW (1 handle for the entire tree).
  * Linux does NOT support recursive: true and throws ERR_FEATURE_UNAVAILABLE_ON_PLATFORM.
+ *
+ * Implemented as a function (rather than a module-level const) so test
+ * setups that override `process.platform` via `vi.hoisted` (see
+ * `WorkspaceEventBus-nested-gitignore.test.ts`) pick up the override
+ * regardless of which test file imports this module first. A const would
+ * lock the value at module-load time, so any earlier test importing this
+ * module before the override ran would freeze the real platform value
+ * for every subsequent test in the same worker.
  */
-const supportsRecursiveWatch = process.platform === 'darwin' || process.platform === 'win32';
+function supportsRecursiveWatch(): boolean {
+  return process.platform === 'darwin' || process.platform === 'win32';
+}
 
 /**
  * .git is always ignored — it's an internal data structure, never user content.
@@ -317,7 +327,12 @@ function findGitRootForPathCached(
   workspaceAbs: string,
   cache: Map<string, string | null>,
 ): string | null {
-  const sep = process.platform === 'win32' ? '\\' : '/';
+  // Use `path.sep` rather than `process.platform`-derived separator: the
+  // test harness for this module overrides `process.platform`, so reading
+  // it directly produced the wrong separator when the actual filesystem
+  // paths from `path.join` / `mkdtempSync` continued to use the real OS
+  // separator. `path.sep` is locked to the actual OS at module load.
+  const sep = path.sep;
   const boundaryWithSep = workspaceAbs.endsWith(sep) ? workspaceAbs : workspaceAbs + sep;
   if (absolutePath !== workspaceAbs && !absolutePath.startsWith(boundaryWithSep)) {
     return null;
@@ -446,7 +461,7 @@ export async function subscribe(
 
   const ig = await loadGitignoreFilter(workspacePath);
 
-  if (supportsRecursiveWatch) {
+  if (supportsRecursiveWatch()) {
     startRecursiveWatch(key, workspacePath, subscriberId, listener, ig);
   } else {
     startChokidarWatch(key, workspacePath, subscriberId, listener, ig);
@@ -506,7 +521,7 @@ export function resetBus(): void {
  * No-op on macOS/Windows (recursive fs.watch covers the entire tree).
  */
 export function addWatchedPath(workspacePath: string, folderPath: string): void {
-  if (supportsRecursiveWatch) return;
+  if (supportsRecursiveWatch()) return;
 
   const key = path.resolve(workspacePath);
   const entry = busEntries.get(key);
@@ -542,7 +557,7 @@ export function addGitignoreBypass(workspacePath: string, absolutePath: string):
   entry.gitignoreBypassPaths.add(normalizedPath);
 
   // On Linux, ensure chokidar watches this specific path
-  if (!supportsRecursiveWatch && 'add' in entry.watcher) {
+  if (!supportsRecursiveWatch() && 'add' in entry.watcher) {
     (entry.watcher as ChokidarFSWatcher).add(absolutePath);
   }
 
@@ -599,7 +614,7 @@ export function clearGitignoreBypasses(workspacePath: string): void {
  * No-op on macOS/Windows.
  */
 export function removeWatchedPath(workspacePath: string, folderPath: string): void {
-  if (supportsRecursiveWatch) return;
+  if (supportsRecursiveWatch()) return;
 
   const key = path.resolve(workspacePath);
   const entry = busEntries.get(key);
@@ -617,7 +632,7 @@ export async function stopAll(): Promise<void> {
   const closePromises: Promise<void>[] = [];
   for (const [key, entry] of busEntries.entries()) {
     try {
-      if (supportsRecursiveWatch) {
+      if (supportsRecursiveWatch()) {
         (entry.watcher as fs.FSWatcher).close();
       } else {
         closePromises.push((entry.watcher as ChokidarFSWatcher).close());
@@ -656,7 +671,7 @@ export function getStats(): {
     });
   }
   return {
-    type: supportsRecursiveWatch
+    type: supportsRecursiveWatch()
       ? 'WorkspaceEventBus (fs.watch recursive)'
       : 'WorkspaceEventBus (chokidar)',
     activeWorkspaces: busEntries.size,
@@ -669,7 +684,7 @@ export function getStats(): {
 // ---------------------------------------------------------------------------
 
 function closeWatcher(watcher: fs.FSWatcher | ChokidarFSWatcher): void {
-  if (supportsRecursiveWatch) {
+  if (supportsRecursiveWatch()) {
     (watcher as fs.FSWatcher).close();
   } else {
     (watcher as ChokidarFSWatcher).close();


### PR DESCRIPTION
## Summary

Unblocks the broken Unit Tests CI on `main` since `5c0cf068` (the #207 fix). All four `WorkspaceEventBus-nested-gitignore.test.ts` cases now pass; production code behaves identically.

## Root cause

Two compounding platform-mocking bugs in `WorkspaceEventBus.ts`. Neither affects production runtime (`process.platform` doesn't lie there) but both break the test harness, and the test failure pattern depends on which platform CI runs on.

**1. `supportsRecursiveWatch` evaluated at module load**

```ts
const supportsRecursiveWatch = process.platform === 'darwin' || process.platform === 'win32';
```

The test forces `process.platform = 'darwin'` via `vi.hoisted` to exercise the recursive-watch code path. But the `const` is computed once when the module first loads. If any earlier test in the same vitest worker imports `WorkspaceEventBus` before the override takes effect, the value freezes to the real OS. On Linux CI this means `supportsRecursiveWatch` stays `false`, `subscribe` routes through chokidar instead of the mocked `fs.watch`, the test's `mockWatcherCallbacks` array stays empty, and `fireWatchEvent` throws `Error: No watcher callback registered`.

**2. Boundary check uses a `process.platform`-derived separator**

```ts
const sep = process.platform === 'win32' ? '\\' : '/';
const boundaryWithSep = workspaceAbs.endsWith(sep) ? workspaceAbs : workspaceAbs + sep;
if (absolutePath !== workspaceAbs && !absolutePath.startsWith(boundaryWithSep)) {
  return null;
}
```

When the test mocks `process.platform = 'darwin'` on a Windows host, this branch picks `sep = '/'`. Real `path.join` and `mkdtempSync` keep returning Windows-style paths with `\`. The boundary becomes `C:\...\Tkz1xE/`, the `absolutePath` is `C:\...\Tkz1xE\nested\...`, the `startsWith` fails, the function returns null, the nested-repo `.gitignore` never gets consulted, and the test's "drops content events for files inside a nested-repo gitignored dir" sees `onChange` fire when it shouldn't.

## Fix

Both are small. Both make the implementation more correct against any future platform mocking.

```ts
function supportsRecursiveWatch(): boolean {
  return process.platform === 'darwin' || process.platform === 'win32';
}
```

8 call sites updated to call the function. And inside `findGitRootForPathCached`:

```ts
const sep = path.sep;
```

`path.sep` is locked to the actual OS at module load via the path module variant (`path.win32` vs `path.posix`) and is independent of `process.platform` runtime mocking.

## What stays the same

- Every existing call site keeps its semantic meaning - `if (supportsRecursiveWatch)` -> `if (supportsRecursiveWatch())`. No control-flow change in production.
- `path.sep` and `process.platform` agree at runtime, so production behavior is byte-for-byte identical.
- No behavior change in the recursive-watch path, the chokidar path, the gitignore filter, the nested-repo discovery, or the event dispatcher.
- `loadGitignoreFilter`, `loadGitignoreFilterSync`, `isGitignoredScoped`, `getGitignoreAction`, and the chokidar `ignored` callback are all unchanged.

## Verification

Before this PR (on `main` at `e387c040`):
- `WorkspaceEventBus-nested-gitignore.test.ts`: 3 failed / 1 passed (Windows local), 4 failed / 0 passed (Linux CI per `CI #133` / `CI #135` for v0.59.3 release)
- Total file/ tests: 17 failed / 38 passed (Windows local)

After this PR:
- `WorkspaceEventBus-nested-gitignore.test.ts`: 4/4 pass
- Total file/ tests: 14 failed / 41 passed (3 net improvement, 0 regressions)

The remaining 14 failures (`FileSnapshotCache.test.ts` and `WorkspaceEventBus-gitignore-bypass.test.ts`) are pre-existing on `main` and unrelated to this PR.

## Test plan

- [x] `npm run typecheck --workspace=packages/electron` passes
- [x] `npx vitest run packages/electron/src/main/file/__tests__/WorkspaceEventBus-nested-gitignore.test.ts` - 4/4 pass
- [x] No new failures introduced in `packages/electron/src/main/file/` test suite
- [ ] CI Unit Tests on Linux turns green for this PR (and consequently for #226 and #227 once they rebase against the merged main)

## Note on context

@ghinkle, this is the test-architecture fix I offered on PR #226's CI-failure note. Happy for you to take it in a different direction if you have a preferred shape - e.g. you might want to keep the `const` and rework the test to use `vi.resetModules()` instead. The lazy-function form is the minimum-change approach that works on all three CI platforms (macOS, Windows, Linux) and against the existing test mocking strategy without touching the test file at all.

## Closes

Refs #207.
