### PR TITLE
fix(commit-widget): sort files and subdirectories alphabetically in renderDirectoryNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Commit proposal widget: sort files alphabetically by basename and subdirectories by displayPath within each directory node. Files inside a directory used to render in the order the model emitted them in `filesToStage`, which made it hard to scan a commit with many files in one folder. Folders-before-files convention is preserved. Fixes #233.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/GitCommitConfirmationWidget.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/GitCommitConfirmationWidget.tsx
@@ -726,14 +726,24 @@ export const GitCommitConfirmationWidget: React.FC<CustomToolWidgetProps> = ({
     const allSelected = selectedCount === filesInDir.length;
     const someSelected = selectedCount > 0 && !allSelected;
 
+    // Sort subdirectories by displayPath and files by basename so the
+    // tree renders deterministically rather than in the order the model
+    // emitted paths in filesToStage. Folders-before-files convention is
+    // preserved by rendering subdirectories before files at each site.
+    const sortedSubdirectories = Array.from(node.subdirectories.values())
+      .sort((a, b) => a.displayPath.localeCompare(b.displayPath));
+    const sortedFiles = [...node.files].sort((a, b) => {
+      const aBase = a.substring(a.lastIndexOf('/') + 1);
+      const bBase = b.substring(b.lastIndexOf('/') + 1);
+      return aBase.localeCompare(bBase);
+    });
+
     // Root node - just render children
     if (!node.displayPath) {
       return (
         <>
-          {Array.from(node.subdirectories.values()).map(subdir =>
-            renderDirectoryNode(subdir)
-          )}
-          {node.files.map(file => renderFile(file))}
+          {sortedSubdirectories.map(subdir => renderDirectoryNode(subdir))}
+          {sortedFiles.map(file => renderFile(file))}
         </>
       );
     }
@@ -785,10 +795,8 @@ export const GitCommitConfirmationWidget: React.FC<CustomToolWidgetProps> = ({
 
         {isExpanded && hasContent && (
           <div className="git-commit-widget__directory-children mt-0.5 pl-4">
-            {Array.from(node.subdirectories.values()).map(subdir =>
-              renderDirectoryNode(subdir)
-            )}
-            {node.files.map(file => renderFile(file, true))}
+            {sortedSubdirectories.map(subdir => renderDirectoryNode(subdir))}
+            {sortedFiles.map(file => renderFile(file, true))}
           </div>
         )}
       </div>

--- a/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/GitCommitConfirmationWidget.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/GitCommitConfirmationWidget.tsx
@@ -64,12 +64,32 @@ function getFilePath(file: FileInput): string {
 // Directory Tree Types and Helpers
 // ============================================================
 
-interface DirectoryNode {
+export interface DirectoryNode {
   path: string;
   displayPath: string;
   files: string[];
   subdirectories: Map<string, DirectoryNode>;
   fileCount: number;
+}
+
+/**
+ * Comparator: sort DirectoryNodes alphabetically by displayPath.
+ * Used by renderDirectoryNode for deterministic tree rendering.
+ */
+export function compareSubdirectoriesByDisplayPath(a: DirectoryNode, b: DirectoryNode): number {
+  return a.displayPath.localeCompare(b.displayPath);
+}
+
+/**
+ * Comparator: sort file path strings alphabetically by basename.
+ * Used by renderDirectoryNode so files within a directory render in
+ * alphabetical order regardless of how the model ordered them in
+ * `filesToStage`.
+ */
+export function compareFilesByBasename(a: string, b: string): number {
+  const aBase = a.substring(a.lastIndexOf('/') + 1);
+  const bBase = b.substring(b.lastIndexOf('/') + 1);
+  return aBase.localeCompare(bBase);
 }
 
 /**
@@ -731,12 +751,8 @@ export const GitCommitConfirmationWidget: React.FC<CustomToolWidgetProps> = ({
     // emitted paths in filesToStage. Folders-before-files convention is
     // preserved by rendering subdirectories before files at each site.
     const sortedSubdirectories = Array.from(node.subdirectories.values())
-      .sort((a, b) => a.displayPath.localeCompare(b.displayPath));
-    const sortedFiles = [...node.files].sort((a, b) => {
-      const aBase = a.substring(a.lastIndexOf('/') + 1);
-      const bBase = b.substring(b.lastIndexOf('/') + 1);
-      return aBase.localeCompare(bBase);
-    });
+      .sort(compareSubdirectoriesByDisplayPath);
+    const sortedFiles = [...node.files].sort(compareFilesByBasename);
 
     // Root node - just render children
     if (!node.displayPath) {

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/GitCommitConfirmationWidget.helpers.test.ts
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/GitCommitConfirmationWidget.helpers.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compareFilesByBasename,
+  compareSubdirectoriesByDisplayPath,
+  type DirectoryNode,
+} from '../CustomToolWidgets/GitCommitConfirmationWidget';
+
+function makeNode(displayPath: string): DirectoryNode {
+  return {
+    path: displayPath,
+    displayPath,
+    files: [],
+    subdirectories: new Map(),
+    fileCount: 0,
+  };
+}
+
+describe('compareFilesByBasename', () => {
+  it('sorts paths alphabetically by their basename (issue #233 example)', () => {
+    const modelOrder = [
+      '.claude/commands/analyze-code.md',
+      '.claude/commands/roadmap.md',
+      '.claude/commands/bug-report.md',
+      '.claude/commands/design.md',
+      '.claude/commands/posthog-analysis.md',
+    ];
+    expect(modelOrder.slice().sort(compareFilesByBasename)).toEqual([
+      '.claude/commands/analyze-code.md',
+      '.claude/commands/bug-report.md',
+      '.claude/commands/design.md',
+      '.claude/commands/posthog-analysis.md',
+      '.claude/commands/roadmap.md',
+    ]);
+  });
+
+  it('sorts by basename only, not by full path', () => {
+    const files = [
+      'deep/nested/path/zebra.ts',
+      'shallow/apple.ts',
+    ];
+    expect(files.slice().sort(compareFilesByBasename)).toEqual([
+      'shallow/apple.ts',
+      'deep/nested/path/zebra.ts',
+    ]);
+  });
+
+  it('handles paths without directory separators', () => {
+    const files = ['z.md', 'a.md', 'm.md'];
+    expect(files.slice().sort(compareFilesByBasename)).toEqual(['a.md', 'm.md', 'z.md']);
+  });
+
+  it('is stable across already-sorted input', () => {
+    const files = ['a.md', 'b.md', 'c.md'];
+    expect(files.slice().sort(compareFilesByBasename)).toEqual(['a.md', 'b.md', 'c.md']);
+  });
+});
+
+describe('compareSubdirectoriesByDisplayPath', () => {
+  it('sorts nodes alphabetically by displayPath', () => {
+    const nodes = [makeNode('utils'), makeNode('api'), makeNode('components')];
+    expect(
+      nodes
+        .slice()
+        .sort(compareSubdirectoriesByDisplayPath)
+        .map((n) => n.displayPath),
+    ).toEqual(['api', 'components', 'utils']);
+  });
+
+  it('handles collapsed compound displayPaths', () => {
+    const nodes = [
+      makeNode('packages/runtime/src'),
+      makeNode('packages/electron/src/components'),
+      makeNode('docs'),
+    ];
+    expect(
+      nodes
+        .slice()
+        .sort(compareSubdirectoriesByDisplayPath)
+        .map((n) => n.displayPath),
+    ).toEqual([
+      'docs',
+      'packages/electron/src/components',
+      'packages/runtime/src',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #233. Files inside the commit proposal widget rendered in the order the model emitted them in `filesToStage` rather than alphabetically. Sort subdirectories by `displayPath` and files by basename inside `renderDirectoryNode`. Folders-before-files convention is preserved by the existing render order.

## Changes

`packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/GitCommitConfirmationWidget.tsx`:
- Add two named, exported comparators at module scope: `compareSubdirectoriesByDisplayPath` and `compareFilesByBasename`.
- Inside `renderDirectoryNode`, compute `sortedSubdirectories` and `sortedFiles` once via the comparators and use them at both render sites (root node + expanded subdirectory).
- Export the `DirectoryNode` interface so tests can build fixture nodes without re-declaring the shape.

`packages/runtime/src/ui/AgentTranscript/components/__tests__/GitCommitConfirmationWidget.helpers.test.ts` (new):
- Covers the issue #233 example (`.claude/commands/` reordering to alphabetical).
- Covers basename-vs-full-path semantics (a path deep under `deep/nested/...` with basename `zebra.ts` should sort after a shallow path with basename `apple.ts`).
- Covers paths without directory separators and already-sorted input.
- Covers collapsed compound displayPath sorting on subdirectory nodes.
- 6 tests, all pass locally (`npm run test:unit -- --run packages/runtime/src/ui/AgentTranscript/components/__tests__/GitCommitConfirmationWidget.helpers.test.ts`).

`CHANGELOG.md` (+1): entry under `### Fixed` referencing #233.

## Test plan

- [x] New helper test file passes locally.
- [ ] Trigger a Smart Commit on a session with files spread across multiple directories.
- [ ] Verify each directory renders its files alphabetically by basename.
- [ ] Verify subdirectories within a parent render alphabetically by name.
- [ ] Verify folders still render before files at every level.

Issue example to reproduce: `.claude/commands/` should render `analyze-code.md, bug-report.md, design.md, posthog-analysis.md, roadmap.md` (alphabetical) rather than the model's emission order.

Single-concern PR. No new dependencies.
