### PR TITLE
fix(transcript): open /abs/path/ markdown links on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Commit proposal widget: sort files alphabetically by basename and subdirectories by displayPath within each directory node. Files inside a directory used to render in the order the model emitted them in `filesToStage`, which made it hard to scan a commit with many files in one folder. Folders-before-files convention is preserved. Fixes #233.
+- Open file links of the form `/abs/path/<real absolute path>` on Windows. Claude Code emits markdown file references with this prefix (e.g. `/abs/path/C:/Users/foo/file.ts:42`); the literal path does not exist on disk so the workspace file opener never fires. `resolveTranscriptFilePathFromHref` in `packages/runtime/src/ui/AgentTranscript/components/MarkdownRenderer.tsx` now strips the `/abs/path/` prefix just before the absolute-path check, after the existing scheme detection and line/column-suffix stripping, so the path that flows into `workspace:open-file` is the real on-disk path. Works for both Windows (`/abs/path/C:/...`) and macOS (`/abs/path//Users/...`) shapes. Adds 6 unit tests covering both platforms, with and without `:line:col` suffixes, and a non-absolute-remainder regression check. Fixes #240.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/runtime/src/ui/AgentTranscript/components/MarkdownRenderer.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/MarkdownRenderer.tsx
@@ -259,9 +259,20 @@ export function resolveTranscriptFilePathFromHref(href?: string): string | null 
     candidate = safeDecodeURIComponent(stripQueryAndHash(trimmedHref));
   }
 
-  const cleanedPath = stripLineAndColumnSuffix(candidate);
+  let cleanedPath = stripLineAndColumnSuffix(candidate);
   if (!cleanedPath) {
     return null;
+  }
+
+  // Claude Code emits markdown links of the form
+  // `/abs/path/<real absolute path>` (e.g.
+  // `/abs/path/C:/Users/foo/file.ts:42` on Windows or
+  // `/abs/path//Users/foo/file.ts:42` on macOS). The `/abs/path/`
+  // prefix is a Claude Code marker, not a real filesystem segment;
+  // strip it so the rest of the renderer routes the link through
+  // `workspace:open-file` with the actual on-disk path. Fixes #240.
+  if (cleanedPath.startsWith('/abs/path/')) {
+    cleanedPath = cleanedPath.slice('/abs/path/'.length);
   }
 
   return isAbsoluteFilePath(cleanedPath) ? cleanedPath : null;

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/MarkdownRenderer.test.ts
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/MarkdownRenderer.test.ts
@@ -27,4 +27,49 @@ describe('resolveTranscriptFilePathFromHref', () => {
   it('returns null for non-absolute local paths', () => {
     expect(resolveTranscriptFilePathFromHref('src/ai/prompt.ts')).toBeNull();
   });
+
+  // Claude Code emits markdown links with an `/abs/path/` prefix on
+  // top of the real filesystem path. The reporter on #240 confirmed
+  // these links failed to open on Windows because the literal path
+  // does not exist. Strip the prefix before the absolute-path check
+  // so the IPC handler receives the real on-disk path.
+  it('strips /abs/path/ prefix on Windows-style paths', () => {
+    expect(
+      resolveTranscriptFilePathFromHref('/abs/path/C:/Users/test/project/src/file.ts')
+    ).toBe('C:/Users/test/project/src/file.ts');
+  });
+
+  it('strips /abs/path/ prefix and line:column suffix on Windows-style paths', () => {
+    expect(
+      resolveTranscriptFilePathFromHref('/abs/path/C:/Users/test/project/src/file.ts:236')
+    ).toBe('C:/Users/test/project/src/file.ts');
+  });
+
+  it('strips /abs/path/ prefix on macOS-style paths', () => {
+    expect(
+      resolveTranscriptFilePathFromHref('/abs/path//Users/test/project/src/file.ts')
+    ).toBe('/Users/test/project/src/file.ts');
+  });
+
+  it('strips /abs/path/ prefix with line:column on macOS-style paths', () => {
+    expect(
+      resolveTranscriptFilePathFromHref('/abs/path//Users/test/project/src/file.ts:42:7')
+    ).toBe('/Users/test/project/src/file.ts');
+  });
+
+  it('returns null when /abs/path/ wraps a non-absolute remainder', () => {
+    // After stripping the prefix we have `relative/file.ts` which is not
+    // an absolute filesystem path, so the renderer should leave it for
+    // the default link handler rather than route it through workspace
+    // file-open.
+    expect(
+      resolveTranscriptFilePathFromHref('/abs/path/relative/file.ts')
+    ).toBeNull();
+  });
+
+  it('leaves non-/abs/path/ absolute paths untouched', () => {
+    expect(
+      resolveTranscriptFilePathFromHref('/Users/test/normal/file.ts')
+    ).toBe('/Users/test/normal/file.ts');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #240. Markdown file links of the form `/abs/path/<real absolute path>` (emitted by Claude Code, e.g. `/abs/path/C:/Users/foo/file.ts:42`) failed to open the target file on Windows. The literal path does not exist on disk, so the `workspace:open-file` IPC handler treated the click as a no-op.

The reporter on #240 confirmed via a local hotpatch that stripping the `/abs/path/` prefix before routing to `workspace:open-file` resolves the issue. This PR upstreams that fix.

## Changes

`packages/runtime/src/ui/AgentTranscript/components/MarkdownRenderer.tsx`:
- In `resolveTranscriptFilePathFromHref`, strip the `/abs/path/` prefix just before the `isAbsoluteFilePath` check, after the existing scheme detection and line/column-suffix stripping. Both Windows (`/abs/path/C:/...`) and macOS (`/abs/path//Users/...`) shapes flow through cleanly to the real on-disk path. Non-prefixed absolute paths are unchanged.

`packages/runtime/src/ui/AgentTranscript/components/__tests__/MarkdownRenderer.test.ts`:
- 6 new unit tests:
  1. Windows path with prefix only
  2. Windows path with prefix and `:line` suffix
  3. macOS path with prefix only
  4. macOS path with prefix and `:line:col` suffix
  5. Prefix wrapping a non-absolute remainder returns null (won't route a bogus path through IPC)
  6. Non-prefixed absolute path unchanged (regression check on the existing happy path)

`CHANGELOG.md`: entry under `[Unreleased]` `### Fixed` referencing #240.

## Test plan

- [x] `npm run test:unit -- --run packages/runtime/src/ui/AgentTranscript/components/__tests__/MarkdownRenderer.test.ts`: 11/11 pass (5 pre-existing + 6 new).
- [ ] Manual on Windows: trigger a Claude Code session that produces a `/abs/path/C:/...:line` link in chat; click it; confirm the workspace file editor opens to the file.
- [ ] Manual on macOS: same trigger with `/abs/path//Users/...` link; confirm it opens.
- [ ] Negative check: an external `https://...` link in the same transcript still opens in the browser, not as a file.

## Notes

- Reporter mentioned a follow-up opportunity to support `:line:col` navigation inside the opened file. That's out of scope here; this PR restores the "file opens at all" baseline.
- Single-concern PR. No new dependencies. The strip happens AFTER the existing `stripQueryAndHash` + `safeDecodeURIComponent` + `stripLineAndColumnSuffix` chain so the only behaviour change is the new prefix-strip step itself.

Closes #240.
