### PR TITLE
Fix Copilot ACP integration losing context between turns

### DIFF
--- a/packages/runtime/src/ai/server/protocols/CopilotACPProtocol.ts
+++ b/packages/runtime/src/ai/server/protocols/CopilotACPProtocol.ts
@@ -244,6 +244,22 @@ export class CopilotACPProtocol implements AgentProtocol {
         raw: { result },
       };
     } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+
+      // The Copilot ACP server keeps sessions live in-process. When the session
+      // was created earlier in this same process, `session/load` fails with
+      // "Session <id> is already loaded". That is not a real failure -- the
+      // session is ready for `session/prompt`. Falling back to createSession
+      // here would discard all conversation context, breaking multi-turn chat.
+      if (/already loaded/i.test(msg)) {
+        console.log('[COPILOT-ACP] Session already loaded, reusing:', sessionId);
+        return {
+          id: sessionId,
+          platform: this.platform,
+          raw: { alreadyLoaded: true },
+        };
+      }
+
       console.warn('[COPILOT-ACP] Resume failed, creating new session:', error);
       return this.createSession(options);
     }


### PR DESCRIPTION
Fixes #251

## Problem
The GitHub Copilot integration loses conversation context between turns -- every follow-up message is treated as a brand-new chat.

## Root cause
`CopilotACPProtocol.resumeSession` calls `session/load` for the previously captured session id. The Copilot CLI keeps sessions live in-process after `session/new`, so the load request fails with:

```
Error: Session <id> is already loaded
```

The catch block treats any error as "resume failed" and silently calls `createSession`, producing a fresh session and discarding all prior turns. From the logs:

```
[COPILOT-ACP] Session created: 8012d4c4-...
[COPILOT-ACP] Resume failed, creating new session: Error: Session 8012d4c4-... is already loaded
[COPILOT-ACP] Session created: 3a19bda4-...
[COPILOT-ACP] Resume failed, creating new session: Error: Session 3a19bda4-... is already loaded
```

## Fix
Treat the "already loaded" error as success in `resumeSession` -- the session is in fact ready for `session/prompt`. Only fall back to `createSession` for genuine load failures (e.g. fresh process after a Nimbalyst restart where the session id is no longer in the CLI's memory and was never persisted).

## Verification
- Built locally and reproduced the bug before the fix (each turn produced a new `session/new` and the assistant had no memory of prior turns).
- After the fix, follow-up turns reuse the existing session id and the assistant correctly references earlier messages.

## Notes
- No new tests added: there is currently no test scaffolding for `CopilotACPProtocol` (it spawns a real child process), and adding one would require introducing a new mock layer that is out of scope for this targeted fix. Happy to add one in a follow-up if desired.
