### PR TITLE
fix(editor): scroll to in-document headings for #anchor links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
+- Markdown anchor links now scroll to in-document headings in the Lexical editor. A new `HeadingAnchorPlugin` walks `HeadingNode` mutations and assigns each rendered heading element a GitHub-style slug id (`# Hero` becomes `id="hero"`), with duplicate-suffix handling for repeat slugs. The global link-click handler in `App.tsx` was also extended to detect `href="#..."` links, find the matching id inside the active editor scroll container (so multiple open files do not interfere), and scroll to it; it falls back to default behaviour if no match is found. (#248)
 <!-- Bug fixes go here -->
 
 ### Removed

--- a/packages/electron/src/renderer/App.tsx
+++ b/packages/electron/src/renderer/App.tsx
@@ -1877,6 +1877,32 @@ export default function App() {
             });
             return;
           }
+
+          // In-document anchor link: scroll to the matching id inside the
+          // active editor scroll container, NOT the whole document. Multiple
+          // files can be open; we want the heading inside the same editor.
+          if (href && href.startsWith('#') && href.length > 1) {
+            let targetId: string;
+            try {
+              targetId = decodeURIComponent(href.slice(1));
+            } catch {
+              targetId = href.slice(1);
+            }
+            const scrollContainer = anchor.closest('.editor-scroller');
+            const scope: ParentNode = scrollContainer ?? document;
+            const escapedId = (
+              typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+                ? CSS.escape(targetId)
+                : targetId.replace(/(["\\\]\[\(\)\.:;'#])/g, '\\$1')
+            );
+            const targetElement = scope.querySelector(`#${escapedId}`);
+            if (targetElement) {
+              event.preventDefault();
+              event.stopPropagation();
+              targetElement.scrollIntoView({block: 'start', behavior: 'smooth'});
+              return;
+            }
+          }
           break;
         }
         target = target.parentElement;

--- a/packages/runtime/src/editor/Editor.tsx
+++ b/packages/runtime/src/editor/Editor.tsx
@@ -46,6 +46,7 @@ import FloatingLinkEditorPlugin from './plugins/FloatingLinkEditorPlugin';
 import FloatingTextFormatToolbarPlugin from './plugins/FloatingTextFormatToolbarPlugin';
 import ImagesPlugin from './plugins/ImagesPlugin';
 import { LayoutPlugin } from './plugins/LayoutPlugin/LayoutPlugin';
+import {HeadingAnchorPlugin} from './plugins/HeadingAnchorPlugin';
 import LinkPlugin from './plugins/LinkPlugin';
 import MarkdownShortcutPlugin from './plugins/MarkdownShortcutPlugin';
 import MarkdownPastePlugin from './plugins/MarkdownPastePlugin';
@@ -335,6 +336,7 @@ export default function Editor({config = DEFAULT_EDITOR_CONFIG}: EditorProps): J
               }
               ErrorBoundary={LexicalErrorBoundary}
             />
+            <HeadingAnchorPlugin />
             <MarkdownShortcutPlugin />
             <MarkdownPastePlugin transformers={markdownTransformers} />
             <MarkdownCopyPlugin transformers={markdownTransformers} />

--- a/packages/runtime/src/editor/plugins/HeadingAnchorPlugin/index.tsx
+++ b/packages/runtime/src/editor/plugins/HeadingAnchorPlugin/index.tsx
@@ -1,0 +1,54 @@
+import {useEffect} from 'react';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import type {LexicalEditor} from 'lexical';
+import {HeadingNode} from '@lexical/rich-text';
+
+import {slugify} from '../../utils/headingSlug';
+
+function recomputeHeadingIds(editor: LexicalEditor): void {
+  const root = editor.getRootElement();
+  if (!root) {
+    return;
+  }
+  const headings = root.querySelectorAll('h1, h2, h3, h4, h5, h6');
+  const taken = new Map<string, number>();
+  headings.forEach((element) => {
+    const text = element.textContent ?? '';
+    const slug = slugify(text);
+    if (!slug) {
+      if (element.id) {
+        element.removeAttribute('id');
+      }
+      return;
+    }
+    let candidate = slug;
+    const count = taken.get(slug);
+    if (count !== undefined) {
+      const next = count + 1;
+      candidate = `${slug}-${next}`;
+      taken.set(slug, next);
+    } else {
+      taken.set(slug, 0);
+    }
+    if (element.id !== candidate) {
+      element.id = candidate;
+    }
+  });
+}
+
+export function HeadingAnchorPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    recomputeHeadingIds(editor);
+    return editor.registerMutationListener(
+      HeadingNode,
+      () => {
+        recomputeHeadingIds(editor);
+      },
+      {skipInitialization: false},
+    );
+  }, [editor]);
+
+  return null;
+}

--- a/packages/runtime/src/editor/utils/__tests__/headingSlug.test.ts
+++ b/packages/runtime/src/editor/utils/__tests__/headingSlug.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { slugify } from '../headingSlug';
+
+describe('slugify', () => {
+  it('lowercases text', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  it('replaces spaces with hyphens', () => {
+    expect(slugify('foo bar baz')).toBe('foo-bar-baz');
+  });
+
+  it('collapses multiple spaces into one hyphen', () => {
+    expect(slugify('a  b   c')).toBe('a-b-c');
+  });
+
+  it('removes punctuation that is not a hyphen', () => {
+    expect(slugify('Hello, World!')).toBe('hello-world');
+  });
+
+  it('keeps existing hyphens', () => {
+    expect(slugify('step-by-step guide')).toBe('step-by-step-guide');
+  });
+
+  it('collapses consecutive hyphens', () => {
+    expect(slugify('foo--bar')).toBe('foo-bar');
+  });
+
+  it('trims leading and trailing whitespace before slugifying', () => {
+    expect(slugify('  hello  ')).toBe('hello');
+  });
+
+  it('handles typical markdown heading text', () => {
+    expect(slugify('1. Hero Multi-Editor Workspace')).toBe('1-hero-multi-editor-workspace');
+  });
+
+  it('handles heading with parentheses and colons', () => {
+    // parens and & are stripped; spaces collapse to single hyphens
+    expect(slugify('Getting Started (Setup & Config)')).toBe('getting-started-setup-config');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(slugify('')).toBe('');
+  });
+
+  it('handles numbers in headings', () => {
+    expect(slugify('Chapter 2: The Basics')).toBe('chapter-2-the-basics');
+  });
+
+  it('handles unicode letters', () => {
+    expect(slugify('Cafe au lait')).toBe('cafe-au-lait');
+  });
+});

--- a/packages/runtime/src/editor/utils/headingSlug.ts
+++ b/packages/runtime/src/editor/utils/headingSlug.ts
@@ -1,0 +1,17 @@
+/**
+ * GitHub-style heading slug generation for in-document anchor navigation.
+ *
+ * Rules match GitHub's algorithm:
+ * 1. Lowercase the text
+ * 2. Remove anything that is not a letter, number, space, or hyphen
+ * 3. Replace spaces (and runs of spaces) with a single hyphen
+ * 4. Collapse consecutive hyphens
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-{2,}/g, '-');
+}


### PR DESCRIPTION
## Summary

Fixes #248. Clicking a markdown anchor link like `[Section](#section)` inside the WYSIWYG Lexical editor now scrolls to the matching heading in the same document. Previously the click fell through to the browser's default which set `location.hash` in the Electron renderer, and that navigation surfaced as "appears to open a new project."

## What's in the diff

Two-part fix, as flagged in the issue diagnostic:

**Part 1: link-click handler in `App.tsx`.** The global link interceptor already handled `http://` / `https://` (forwards to `openExternal`). It now also handles `href="#..."`: resolves the id inside the active editor scroll container (`.editor-scroller` closest to the anchor, not the whole document, so multiple open files do not interfere), `scrollIntoView({ block: 'start' })` on it, `preventDefault` so the renderer URL is not touched. Falls back to default behaviour if no match is found in scope. `decodeURIComponent` is try/catch'd; `CSS.escape` is feature-detected with a regex fallback for safety.

**Part 2: heading-id assignment via `HeadingAnchorPlugin`.** Lexical's stock `@lexical/rich-text` `HeadingNode.createDOM()` emits `<h1>` ... `<h6>` with no id, so even if Part 1 worked there was nothing to target. The new plugin uses `editor.registerMutationListener(HeadingNode, ...)` to recompute heading ids whenever headings are created, updated, or destroyed. It runs after the DOM is committed, scopes to `editor.getRootElement()` so each open editor manages its own headings, and uses GitHub's slug algorithm (lowercase, strip non-letter / non-number punctuation, collapse whitespace and hyphens) with duplicate-suffix handling (`heading`, `heading-1`, `heading-2`).

The slug helper is a tiny pure function; a 12-case vitest covers the common heading shapes including punctuation, numbers, and unicode letters.

## Files

- `packages/runtime/src/editor/utils/headingSlug.ts` (new): pure slug helper.
- `packages/runtime/src/editor/utils/__tests__/headingSlug.test.ts` (new): unit tests.
- `packages/runtime/src/editor/plugins/HeadingAnchorPlugin/index.tsx` (new): mutation-listener plugin.
- `packages/runtime/src/editor/Editor.tsx`: register the plugin alongside `MarkdownShortcutPlugin`.
- `packages/electron/src/renderer/App.tsx`: extend the click handler with the `#fragment` branch.
- `CHANGELOG.md`: entry under Unreleased > Fixed.

## Test plan

- [x] `npm run test:unit -- --run packages/runtime/src/editor/utils/__tests__/headingSlug.test.ts` (12 passed)
- [x] Verified existing typecheck failures in `RequestUserInputWidget.tsx` are pre-existing missing `@dnd-kit/*` deps unrelated to this PR.
- [ ] Manual repro (maintainer): open a `.md` file with a TOC of `[Section](#section-slug)` links above `## Section Slug` headings; click each link; viewport scrolls to the matching heading inside the same document.

## Notes

- Plugin runs per editor instance via `useLexicalComposerContext`, so multi-editor / multi-window setups stay isolated.
- Mutation listener is the right hook (not `registerNodeTransform`) because the DOM element is needed AFTER Lexical commits.
- Duplicate-id handling matches GitHub's behaviour (`-1`, `-2` suffixes).