### PR TITLE
fix(commit-widget): render error state for real failures, not cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
+- Commit-widget failure path now renders the error state instead of the cancelled state. The renderer's `gitCommit` host was collapsing every `result.success === false` outcome (including hook rejection, no-staged-changes errors, and IPC throws) into `action: 'cancelled'`, which the widget's reader at `GitCommitConfirmationWidget.tsx:452` short-circuits to the cancelled state before reaching the error check. Real failures are now sent as `action: 'error'` with the underlying error string, and the widget gains an `error`/`failed` action handler so the user sees the actual failure reason. `'cancelled'` stays reserved for the explicit user-cancel path. (Partial fix for #202.)
 <!-- Bug fixes go here -->
 
 ### Removed

--- a/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
@@ -737,7 +737,7 @@ export async function handleGitCommitProposal(
     let pollTimer: ReturnType<typeof setInterval> | null = null;
 
     type CommitResult = {
-      action: "committed" | "cancelled";
+      action: "committed" | "cancelled" | "error";
       commitHash?: string;
       commitDate?: string;
       error?: string;

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -1311,13 +1311,17 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
             files
           ) as { success: boolean; commitHash?: string; commitDate?: string; error?: string };
 
-          // Send response via unified IPC channel for the durable prompt
+          // Send response via unified IPC channel for the durable prompt.
+          // A real failure (success=false with an error) maps to action='error',
+          // not 'cancelled'. 'cancelled' is reserved for the explicit user-cancel
+          // path; collapsing failures into 'cancelled' makes the widget render
+          // the cancelled state instead of surfacing the error to the user.
           await window.electronAPI.invoke('messages:respond-to-prompt', {
             sessionId,
             promptId: proposalId,
             promptType: 'git_commit_proposal_request' as const,
             response: {
-              action: result.success ? 'committed' : 'cancelled',
+              action: result.success ? 'committed' : 'error',
               commitHash: result.commitHash,
               commitDate: result.commitDate,
               error: result.error,
@@ -1334,13 +1338,14 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
             error: error instanceof Error ? error.message : String(error),
           };
 
-          // Send error result back via unified IPC
+          // IPC threw outright. Surface as action='error' for the same reason
+          // as above: the user needs to see the failure, not a cancelled state.
           await window.electronAPI.invoke('messages:respond-to-prompt', {
             sessionId,
             promptId: proposalId,
             promptType: 'git_commit_proposal_request' as const,
             response: {
-              action: 'cancelled',
+              action: 'error',
               error: errorResult.error,
             },
             respondedBy: 'desktop' as const,

--- a/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/GitCommitConfirmationWidget.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/GitCommitConfirmationWidget.tsx
@@ -461,6 +461,12 @@ export const GitCommitConfirmationWidget: React.FC<CustomToolWidgetProps> = ({
       if (action === 'cancelled' || action === 'canceled') {
         return { type: 'cancelled' as const };
       }
+      if (action === 'error' || action === 'failed') {
+        return {
+          type: 'error' as const,
+          error: structuredResult.error || toolResult || 'Commit failed',
+        };
+      }
     }
 
     if (structuredResult?.error) {


### PR DESCRIPTION
## Summary

Renderer-side partial fix from the three-site scope discussed in #202. The commit widget was rendering the cancelled state for real commit failures (hook rejection, no-staged-changes errors, IPC throws), hiding the error reason from the user. Now real failures render the error state with the underlying error string, and `action='cancelled'` is reserved for the explicit user-cancel path.

## What's wrong

In `SessionTranscript.tsx`, the `gitCommit` host was sending:

```ts
response: {
  action: result.success ? 'committed' : 'cancelled',
  ...
  error: result.error,
}
```

The widget's `completedState` reader at `GitCommitConfirmationWidget.tsx:452` checks `structuredResult.action` BEFORE it checks `structuredResult.error`, so `action='cancelled'` short-circuits the error path. Users saw the cancelled UI even though `error` was populated.

## What changed

- **`SessionTranscript.tsx`**: send `action: 'error'` (with the underlying error string) when `result.success === false` or the IPC throws. `'cancelled'` stays reserved for the explicit user-cancel path.
- **`GitCommitConfirmationWidget.tsx`**: add a handler for `action === 'error'` / `action === 'failed'` so the widget renders the error state and surfaces the error message.
- **`interactiveToolHandlers.ts`**: widen the `CommitResult` action type from `\"committed\" | \"cancelled\"` to also include `\"error\"`. The existing `else` branch in `settle()` already handles non-committed outcomes correctly; this is just type-narrowing alignment.

## Scope split rationale

#202 surfaced three fixable sites in the same overall failure mode (TaiwanTammy's diagnosis + my code-read follow-up):

1. **This PR**: renderer hardcoding 'cancelled' on failure.
2. **Holding**: auto-commit outer catch in `interactiveToolHandlers.ts:707-709` swallowing simple-git throws without writing a proposal_response.
3. **Holding**: switching auto-commit from `simple-git` to direct `child_process.spawn` with exit-code-as-success-signal.

(1) is a clean, defensible one-file-equivalent change. (2) and (3) are architectural and benefit from explicit maintainer signal before shipping. Splitting them avoids waiting indefinitely for the bigger scope while still fixing the UX bug that surfaces today.

## Test plan

- [x] `npm run test:unit -- --run packages/runtime/src/ui/AgentTranscript/components/__tests__/GitCommitConfirmationWidget.helpers.test.ts` (6 passed)
- [x] Verified typecheck does not regress (existing `@dnd-kit/*` deps errors are pre-existing on local install).
- [ ] Manual repro (maintainer): set up a pre-commit hook that exits 1, ask Claude to smart-commit, confirm the widget now shows the error state with the hook's error message instead of green-cancelled.

## Notes

- The widget reader keeps the existing `structuredResult?.error` and `structuredResult?.success === false` fallbacks below the action check, so any provider that sets `error`/`success` without `action` still works.
- The `interactiveToolHandlers.ts` settle path at line 808 already resolves to `isError: true` for non-committed actions, so the MCP tool result correctly reports failure to the agent.