### PR TITLE
fix(marketplace): surface error when GitHub repo lacks built dist/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
+- Marketplace install from a GitHub URL no longer reports success and then silently fails to load when the repo does not include a built `dist/` directory. The install handler now returns a clear error explaining that the repo must be built before installing (or noting if the repo lacks a `package.json` entirely) and cleans up the partially-installed extension directory so the user can retry from a fresh state. (#247)
 <!-- Bug fixes go here -->
 
 ### Removed

--- a/packages/electron/src/main/ipc/ExtensionMarketplaceHandlers.ts
+++ b/packages/electron/src/main/ipc/ExtensionMarketplaceHandlers.ts
@@ -367,21 +367,36 @@ async function installFromGitHub(githubUrl: string): Promise<InstallResult> {
     // Copy to extensions directory (excluding .git and node_modules)
     await copyDirectory(sourceDir, installPath);
 
-    // Check if there's a dist/ directory; if not, check if there's a package.json and build
+    // Check if there's a dist/ directory; if not, surface the error to the
+    // user rather than silently registering an extension that cannot load.
+    // Auto-building is intentionally deferred (slow, error-prone, runs
+    // arbitrary npm scripts), so we ask the user to build locally first.
     const distPath = path.join(installPath, 'dist');
     try {
       await fs.access(distPath);
     } catch {
-      // No dist directory - check if there's a package.json to build
       const pkgJsonPath = path.join(installPath, 'package.json');
+      let hasPkgJson = false;
       try {
         await fs.access(pkgJsonPath);
-        logger.main.info(`[ExtMarketplace] Extension needs building - run 'npm install && npm run build' in ${installPath}`);
-        // We don't auto-build here because it could be slow and error-prone.
-        // The user can use the extension dev tools to build it.
+        hasPkgJson = true;
       } catch {
-        // No package.json either - extension might be pre-built or not need building
+        // No package.json either - extension might be pre-built or malformed
       }
+
+      // Clean up the partially-installed extension directory so the user
+      // can retry from a fresh state.
+      try {
+        await fs.rm(installPath, { recursive: true, force: true });
+      } catch (cleanupErr) {
+        logger.main.warn(`[ExtMarketplace] Failed to clean up ${installPath} after dist/ check:`, cleanupErr);
+      }
+
+      const message = hasPkgJson
+        ? `Extension repository does not include a built dist/ directory. Clone the repo locally, run "npm install && npm run build", and install from the local folder.`
+        : `Extension repository does not include a dist/ directory or a package.json. The repo may be malformed or built artifacts may not be committed.`;
+      logger.main.info(`[ExtMarketplace] Aborting install of ${extensionId} from GitHub: ${message}`);
+      return { success: false, error: message };
     }
 
     // Track the install


### PR DESCRIPTION
## Summary

Fixes #247. Installing an extension from a GitHub URL no longer reports success when the repo does not include a built `dist/` directory. The handler now returns a clear error and cleans up the partially-installed extension directory so the user can retry.

## What's wrong

`ExtensionMarketplaceHandlers.ts:370-385` checks for `dist/`, and if absent it logs an info-level message and falls through to register the install + fire `extension:dev-reload` anyway. The renderer reads `result.success === true` and shows "Extension installed from GitHub". The extension loader then fails silently when it tries to dynamically import `manifest.main` (typically `dist/index.js`), because the file does not exist.

Reporter (#247) saw the success toast and only realized something was wrong when the extension never showed up.

## What changed

Returns `{ success: false, error }` when `dist/` is absent, with a message that distinguishes the two cases:

- `package.json` present: "Extension repository does not include a built `dist/` directory. Clone the repo locally, run `npm install && npm run build`, and install from the local folder."
- No `package.json` either: "Extension repository does not include a `dist/` directory or a `package.json`. The repo may be malformed or built artifacts may not be committed."

Also cleans up the partially-installed extension directory via `fs.rm(installPath, { recursive: true, force: true })` so the user can retry from a fresh state without manually deleting the half-installed folder.

## Out of scope (deferred)

Auto-building on install (running `npm install && npm run build` inside the cloned repo) is intentionally deferred per the original handler's comment at line 380. The trade-offs are real: slow, error-prone, runs arbitrary npm scripts, needs progress IPC, needs `npm` on `PATH`, needs a sandbox decision. That's a follow-up once direction is confirmed by a maintainer.

## Test plan

- [x] `npm run typecheck --workspace=@nimbalyst/electron` shows no new errors from this change (pre-existing `@dnd-kit/*` deps errors are unrelated).
- [ ] Manual repro (maintainer): pick any GitHub extension repo without a committed `dist/` folder, install via the marketplace URL field, confirm the install reports failure with the helpful message and the partial install directory is cleaned up.

## Notes

- The cleanup `fs.rm` is wrapped in try/catch so a cleanup failure does not mask the original error; it warns to the log instead.
- The error message uses straight double-quotes around the npm command for clarity in toasts.