### PR TITLE
fix(transcript): Wrap toggle now persists across OverflowWrapper remounts (closes #274)

### DIFF
--- a/packages/runtime/src/ui/AgentTranscript/components/MarkdownRenderer.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/MarkdownRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
@@ -130,12 +130,63 @@ if (typeof document !== 'undefined') {
   injectMarkdownRendererStyles();
 }
 
+// Per-content wrap preference, persisted across remounts. The transcript
+// re-renders during streaming and react-markdown re-creates the children
+// tree on every content update; a code block's position can shift enough
+// to make React unmount and remount the OverflowWrapper, which loses local
+// state. Keying off the rendered content gives us a stable identity that
+// survives those remounts, so the Wrap checkbox stays sticky once toggled.
+// Bounded LRU so a long session can't grow the map without limit.
+const WRAP_PREFERENCE_CAP = 200;
+const wrapPreferenceByContent = new Map<string, boolean>();
+
+function setWrapPreference(key: string, value: boolean) {
+  if (!key) return;
+  if (wrapPreferenceByContent.has(key)) {
+    wrapPreferenceByContent.delete(key);
+  } else if (wrapPreferenceByContent.size >= WRAP_PREFERENCE_CAP) {
+    const firstKey = wrapPreferenceByContent.keys().next().value;
+    if (firstKey !== undefined) wrapPreferenceByContent.delete(firstKey);
+  }
+  wrapPreferenceByContent.set(key, value);
+}
+
+function extractTextContent(node: React.ReactNode): string {
+  if (node == null || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(extractTextContent).join('');
+  if (typeof node === 'object' && 'props' in node) {
+    return extractTextContent((node as React.ReactElement).props.children);
+  }
+  return '';
+}
+
+function computeWrapKey(node: React.ReactNode): string {
+  // Use the first 200 chars of the rendered text content as the wrap key.
+  // First line is enough to make code blocks distinguishable in practice,
+  // and 200 chars keeps the key stable once the code block has streamed
+  // past its preamble — subsequent appends during streaming no longer
+  // change the key, so a toggle made mid-stream survives later renders.
+  const text = extractTextContent(node).slice(0, 200);
+  return text ? `cb:${text.length}:${text}` : '';
+}
+
 // Wrapper for any element that might overflow horizontally.
 // Uses IntersectionObserver to defer scrollWidth measurement until visible,
 // and ResizeObserver to re-check on size changes - avoids forced reflow during
 // initial session load when many code blocks render off-screen.
 const OverflowWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [wordWrap, setWordWrap] = useState(false);
+  // Compute the key once per mount. Re-mounts get a fresh useMemo and pick
+  // up the persisted preference (if any) for the new key.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const wrapKey = useMemo(() => computeWrapKey(children), []);
+  const [wordWrap, setWordWrapState] = useState<boolean>(
+    () => wrapPreferenceByContent.get(wrapKey) ?? false
+  );
+  const setWordWrap = useCallback((next: boolean) => {
+    setWordWrapState(next);
+    setWrapPreference(wrapKey, next);
+  }, [wrapKey]);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
   const hasBeenVisible = useRef(false);

--- a/packages/runtime/src/ui/AgentTranscript/components/MarkdownRenderer.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/MarkdownRenderer.tsx
@@ -130,58 +130,61 @@ if (typeof document !== 'undefined') {
   injectMarkdownRendererStyles();
 }
 
-// Per-content wrap preference, persisted across remounts. The transcript
-// re-renders during streaming and react-markdown re-creates the children
-// tree on every content update; a code block's position can shift enough
-// to make React unmount and remount the OverflowWrapper, which loses local
-// state. Keying off the rendered content gives us a stable identity that
-// survives those remounts, so the Wrap checkbox stays sticky once toggled.
-// Bounded LRU so a long session can't grow the map without limit.
+// Wrap preference for transcript code blocks, persisted across remounts.
+// react-markdown re-renders on every streaming chunk and reconciles by
+// sibling index, not content, so a code block whose position shifts (a new
+// paragraph appears above it, a message appends, etc.) gets unmounted and
+// remounted with fresh local state. That's the "wrap deselects itself"
+// symptom.
+//
+// Identity is keyed by `${messageId}:${nodeOffset}`. The message id is
+// passed in from MessageSegment; node.position.start.offset comes from
+// react-markdown's override API and is the byte offset of the code fence
+// in the original markdown source. Together they're stable from first
+// render through end of stream, which closes the early-streaming hole
+// that a content-prefix key would leave open. Falls back to a counter
+// for callers that don't have a message id (NewFilePreview, tool result
+// renderers, etc.) so the cache still helps in those paths without
+// risking cross-message bleed (counter values are uniquely allocated
+// per mount, so the only carrier of state restoration in the fallback
+// path is the same-instance re-render case).
 const WRAP_PREFERENCE_CAP = 200;
-const wrapPreferenceByContent = new Map<string, boolean>();
+const wrapPreferenceByKey = new Map<string, boolean>();
 
 function setWrapPreference(key: string, value: boolean) {
   if (!key) return;
-  if (wrapPreferenceByContent.has(key)) {
-    wrapPreferenceByContent.delete(key);
-  } else if (wrapPreferenceByContent.size >= WRAP_PREFERENCE_CAP) {
-    const firstKey = wrapPreferenceByContent.keys().next().value;
-    if (firstKey !== undefined) wrapPreferenceByContent.delete(firstKey);
+  if (wrapPreferenceByKey.has(key)) {
+    wrapPreferenceByKey.delete(key);
+  } else if (wrapPreferenceByKey.size >= WRAP_PREFERENCE_CAP) {
+    const firstKey = wrapPreferenceByKey.keys().next().value;
+    if (firstKey !== undefined) wrapPreferenceByKey.delete(firstKey);
   }
-  wrapPreferenceByContent.set(key, value);
+  wrapPreferenceByKey.set(key, value);
 }
 
-function extractTextContent(node: React.ReactNode): string {
-  if (node == null || typeof node === 'boolean') return '';
-  if (typeof node === 'string' || typeof node === 'number') return String(node);
-  if (Array.isArray(node)) return node.map(extractTextContent).join('');
-  if (typeof node === 'object' && 'props' in node) {
-    return extractTextContent((node as React.ReactElement).props.children);
-  }
-  return '';
-}
-
-function computeWrapKey(node: React.ReactNode): string {
-  // Use the first 200 chars of the rendered text content as the wrap key.
-  // First line is enough to make code blocks distinguishable in practice,
-  // and 200 chars keeps the key stable once the code block has streamed
-  // past its preamble — subsequent appends during streaming no longer
-  // change the key, so a toggle made mid-stream survives later renders.
-  const text = extractTextContent(node).slice(0, 200);
-  return text ? `cb:${text.length}:${text}` : '';
+let _wrapFallbackCounter = 0;
+function nextFallbackKey(): string {
+  _wrapFallbackCounter += 1;
+  return `cb:fallback:${_wrapFallbackCounter}`;
 }
 
 // Wrapper for any element that might overflow horizontally.
 // Uses IntersectionObserver to defer scrollWidth measurement until visible,
 // and ResizeObserver to re-check on size changes - avoids forced reflow during
 // initial session load when many code blocks render off-screen.
-const OverflowWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  // Compute the key once per mount. Re-mounts get a fresh useMemo and pick
-  // up the persisted preference (if any) for the new key.
+const OverflowWrapper: React.FC<{
+  children: React.ReactNode;
+  /** Stable id for wrap-preference persistence across remounts. Compose
+   *  from messageId + AST node offset at the call site. */
+  persistKey?: string;
+}> = ({ children, persistKey }) => {
+  // Freeze the key once per mount so the same wrap-preference slot is used
+  // for the lifetime of this instance. Re-mounts re-evaluate useMemo and
+  // pick up the persisted preference (if any) for the resolved key.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const wrapKey = useMemo(() => computeWrapKey(children), []);
+  const wrapKey = useMemo(() => persistKey || nextFallbackKey(), []);
   const [wordWrap, setWordWrapState] = useState<boolean>(
-    () => wrapPreferenceByContent.get(wrapKey) ?? false
+    () => wrapPreferenceByKey.get(wrapKey) ?? false
   );
   const setWordWrap = useCallback((next: boolean) => {
     setWordWrapState(next);
@@ -258,6 +261,10 @@ interface MarkdownRendererProps {
   onOpenFile?: (filePath: string) => void;
   /** Optional: Navigate to a session by ID (for @@session reference links) */
   onOpenSession?: (sessionId: string) => void;
+  /** Optional: Stable identifier (typically the message id) used to scope
+   *  per-block UI preferences (e.g. the OverflowWrapper Wrap toggle) so
+   *  preferences survive react-markdown remounts during streaming. */
+  messageId?: string | number;
 }
 
 function safeDecodeURIComponent(value: string): string {
@@ -340,8 +347,21 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   isUser = false,
   isSystemMessage = false,
   onOpenFile,
-  onOpenSession
+  onOpenSession,
+  messageId
 }) => {
+  // Stable per-block key for the OverflowWrapper wrap-preference cache.
+  // Combines the message id (so different messages can never share a slot)
+  // with the source-position offset of the code-fence node in the parsed
+  // markdown AST (so different blocks within the same message also don't
+  // share). react-markdown 10 passes the AST node to each override.
+  const codeBlockPersistKey = useCallback((node: unknown): string | undefined => {
+    if (messageId == null) return undefined;
+    const offset = (node as { position?: { start?: { offset?: number } } } | null | undefined)
+      ?.position?.start?.offset;
+    if (typeof offset !== 'number') return undefined;
+    return `cb:${String(messageId)}:${offset}`;
+  }, [messageId]);
   return (
     <div
       className={`markdown-content text-[0.9375rem] leading-relaxed max-w-full overflow-x-hidden break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 ${isUser ? 'font-medium' : 'font-normal'} ${isSystemMessage ? 'opacity-85 font-mono text-[0.95em]' : ''}`}
@@ -410,7 +430,9 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
                 </SyntaxHighlighter>
               );
               // Only wrap multi-line blocks with OverflowWrapper
-              return isSingleLine ? syntaxBlock : <OverflowWrapper>{syntaxBlock}</OverflowWrapper>;
+              return isSingleLine
+                ? syntaxBlock
+                : <OverflowWrapper persistKey={codeBlockPersistKey(node)}>{syntaxBlock}</OverflowWrapper>;
             }
 
             // Code block without language
@@ -429,7 +451,9 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
               </code>
             );
             // Only wrap multi-line blocks with OverflowWrapper
-            return isSingleLine ? codeBlock : <OverflowWrapper>{codeBlock}</OverflowWrapper>;
+            return isSingleLine
+              ? codeBlock
+              : <OverflowWrapper persistKey={codeBlockPersistKey(node)}>{codeBlock}</OverflowWrapper>;
           },
           // Remove default pre wrapper - we handle styling in code component
           pre: ({ children }) => <>{children}</>,

--- a/packages/runtime/src/ui/AgentTranscript/components/MessageSegment.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/MessageSegment.tsx
@@ -229,6 +229,7 @@ export const MessageSegment: React.FC<MessageSegmentProps> = ({
           isSystemMessage={isSystemMessage}
           onOpenFile={onOpenFile}
           onOpenSession={onOpenSession}
+          messageId={message.id}
         />
         {isCollapsed && (
           <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-[var(--nim-bg-secondary)] to-transparent pointer-events-none" />


### PR DESCRIPTION
Closes #274.

## Symptom

@AnisminC reported that the Wrap checkbox in transcript code blocks deselects itself - sometimes immediately, sometimes after 30-60 seconds - without any user action.

## Root cause

`OverflowWrapper.wordWrap` is local component state. react-markdown 10 reconciles its children by sibling-index keys generated in `hast-util-to-jsx-runtime` (e.g. `pre-0`, `code-0`), not by content. During streaming, when a new paragraph appears above a code block or a new message appends to the transcript, the code block's position-key shifts and React unmounts the old `OverflowWrapper` instance and mounts a fresh one with `wordWrap = false`.

The "immediately" case is a fast re-render hitting just after the click. The "30-60 seconds" case matches the streaming cadence on slower turns.

## Fix

Persist wrap preference in a module-scoped Map (`wrapPreferenceByKey`), bounded LRU at 200 entries with FIFO eviction. Identity for each cache slot is `${messageId}:${node.position.start.offset}`.

- **`messageId`** is threaded from `MessageSegment` via a new optional prop on `MarkdownRenderer`. The other call sites (`RichTranscriptView`, `NewFilePreview`, tool-result renderers) don't yet have a message id - they hit the fallback path described below.
- **`node.position.start.offset`** is the byte offset of the code fence in the original markdown source. react-markdown 10 surfaces it via the override API as the `node` prop on each component override. It is a property of the parsed AST, not of the rendered string length, so it is stable from the first render through the end of the stream. That closes both holes a content-prefix key would have: cross-block/cross-message bleed AND the early-streaming miss.
- **Fallback**: when the key cannot be derived (no `messageId`, or AST `node` lacks position metadata), `OverflowWrapper` allocates a unique per-mount counter. Each instance still gets its own cache slot, so no cross-block bleed; persistence-across-remount degrades to "best effort" for those paths, which matches current behaviour, not a regression.

## What was reviewed and revised before merge

Codex review of the first cut (which keyed by content prefix `slice(0, 200)`) flagged two issues that landed me on the messageId + offset approach:

1. Content-prefix keys risk cross-block / cross-message state bleed when different blocks share the same first 200 chars (matching imports, identical shebangs).
2. There was an early-streaming hole: if a user toggled wrap before the first 200 chars were emitted and a remount happened later, the preference was lost.

Both are gone with the offset-keyed approach. The first commit on this branch is the content-prefix version; the second is the revision. Happy to squash on merge.

## Behavioural notes

- Rendering output is identical for the no-overflow case.
- The wrap-toggle label still only appears when `isOverflowing || wordWrap`. The opacity-on-hover CSS is unchanged.
- No tests added: the existing `MarkdownRenderer.test.ts` covers rendering output, which this change does not touch. The persistence behaviour is hard to unit-test without a mock for the streaming remount pattern; happy to add one if you want to specify the shape.

## Verify locally

1. Open a session whose transcript has multiple code blocks (any decent agent turn with code).
2. Hover one of the code blocks, click Wrap.
3. Wait through several streaming updates from the agent, or scroll up so the block leaves and re-enters the viewport, or let the agent append more messages above it.
4. Wrap stays checked across the remounts. On `main` it would flip back off within seconds.
