### PR TITLE
feat(transcript): human-readable widget for upstream Claude API service errors

### DIFF
--- a/packages/runtime/src/ui/AgentTranscript/components/ApiServiceErrorWidget.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/ApiServiceErrorWidget.tsx
@@ -1,0 +1,238 @@
+import React, { useEffect, useState } from 'react';
+
+// Inject api-service-error widget styles once. Color treatment matches
+// the rate-limit widget's "warning" variant (not "blocked") because these
+// errors are transient and clear when the upstream incident resolves.
+const injectApiServiceErrorStyles = () => {
+  const styleId = 'api-service-error-widget-styles';
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(styleId)) return;
+
+  const style = document.createElement('style');
+  style.id = styleId;
+  style.textContent = `
+    .api-service-error-widget {
+      background-color: color-mix(in srgb, var(--nim-warning) 8%, transparent);
+      border: 1px solid color-mix(in srgb, var(--nim-warning) 25%, transparent);
+    }
+    .api-service-error-widget code.req-id {
+      background-color: var(--nim-bg-tertiary);
+      color: var(--nim-text);
+      padding: 0.1rem 0.35rem;
+      border-radius: 0.2rem;
+      font-size: 0.8em;
+      font-family: var(--font-mono, monospace);
+      user-select: all;
+    }
+    .api-service-error-widget details > summary {
+      cursor: pointer;
+      user-select: none;
+      color: var(--nim-text-muted);
+      font-size: 0.75rem;
+    }
+    .api-service-error-widget details[open] > summary {
+      margin-bottom: 0.4rem;
+    }
+    .api-service-error-widget details pre {
+      background-color: var(--nim-bg-tertiary);
+      color: var(--nim-text-muted);
+      padding: 0.5rem;
+      border-radius: 0.3rem;
+      font-size: 0.72rem;
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 8rem;
+      overflow-y: auto;
+    }
+  `;
+  document.head.appendChild(style);
+};
+
+interface ApiServiceErrorInfo {
+  /** The HTTP status the upstream API returned (500, 529, etc.). */
+  status: number | null;
+  /** The 'error.type' value from the API response if present. */
+  errorType: string | null;
+  /** The 'error.message' value from the API response if present. */
+  errorMessage: string | null;
+  /** The 'request_id' from the API response. The only handle Anthropic
+   *  support has to look up the server-side trace. */
+  requestId: string | null;
+  /** The full text we were given, kept available behind a "Show details"
+   *  disclosure for users escalating to support. */
+  raw: string;
+}
+
+/**
+ * Parse a terminal-style upstream API error of the shape:
+ *
+ *   API Error: 500 {"type":"error","error":{"type":"api_error",
+ *   "message":"Internal server error"},"request_id":"req_..."}
+ *   Claude may be experiencing issues. Check https://status.anthropic.com
+ *
+ * Tolerates the response being JSON-only, line-wrapped, or wrapped in
+ * extra Claude-Code style framing. Returns null fields when a piece is
+ * absent rather than throwing - downstream rendering handles each case.
+ */
+export function parseApiServiceError(content: string): ApiServiceErrorInfo {
+  const statusMatch = content.match(/\b(?:API\s+Error:\s*)?(\d{3})\b/);
+  const status = statusMatch && /^5\d\d$/.test(statusMatch[1])
+    ? parseInt(statusMatch[1], 10)
+    : null;
+
+  // Try to find an embedded JSON object first; fall back to loose regex.
+  let errorType: string | null = null;
+  let errorMessage: string | null = null;
+  let requestId: string | null = null;
+
+  const jsonMatch = content.match(/\{[\s\S]*"error"[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      const obj = JSON.parse(jsonMatch[0]);
+      const errObj = obj && obj.error ? obj.error : obj;
+      if (errObj) {
+        errorType = typeof errObj.type === 'string' ? errObj.type : null;
+        errorMessage = typeof errObj.message === 'string' ? errObj.message : null;
+      }
+      if (typeof obj.request_id === 'string') requestId = obj.request_id;
+    } catch {
+      // ignore parse errors, fall through to regex
+    }
+  }
+  if (errorType == null) {
+    const typeMatch = content.match(/"type"\s*:\s*"([a-z_]+)"/);
+    if (typeMatch && typeMatch[1] !== 'error') errorType = typeMatch[1];
+  }
+  if (errorMessage == null) {
+    const msgMatch = content.match(/"message"\s*:\s*"([^"]+)"/);
+    if (msgMatch) errorMessage = msgMatch[1];
+  }
+  if (requestId == null) {
+    const ridMatch = content.match(/req_[A-Za-z0-9]{8,}/);
+    if (ridMatch) requestId = ridMatch[0];
+  }
+
+  return { status, errorType, errorMessage, requestId, raw: content };
+}
+
+/**
+ * Returns true if `content` looks like an upstream API service error from
+ * Claude (api_error, overloaded_error) where the right user action is
+ * "retry / check status page / escalate with request_id", not "file a
+ * Nimbalyst bug". Conservative on purpose - we'd rather miss a borderline
+ * case and render the raw error than mis-classify a real client bug as
+ * "just a service hiccup".
+ */
+export function isApiServiceError(content: string): boolean {
+  if (!content) return false;
+  // Signal 1: explicit Anthropic error type token.
+  if (/"type"\s*:\s*"(api_error|overloaded_error)"/.test(content)) return true;
+  // Signal 2: 5xx status with a request_id, which is Anthropic's correlation
+  // id format. Together these distinguish upstream errors from generic
+  // 500 strings that might appear elsewhere in transcript text.
+  if (/\b5\d\d\b/.test(content) && /req_[A-Za-z0-9]{8,}/.test(content)) return true;
+  // Signal 3: the Claude-Code framing string, which the CLI prints after
+  // the JSON and which agents commonly echo back into the transcript.
+  if (/status\.(anthropic|claude)\.com/.test(content) && /\b5\d\d\b/.test(content)) return true;
+  return false;
+}
+
+interface ApiServiceErrorWidgetProps {
+  content: string;
+}
+
+/**
+ * Human-readable surface for upstream Claude API service errors that the
+ * CLI / SDK forwards verbatim into the transcript. Explains what the error
+ * means, points the user at the status page, surfaces the request_id for
+ * support escalation, and keeps the raw payload available behind a
+ * disclosure so it can still be copy-pasted into a bug report when one is
+ * genuinely warranted. See the related anthropics/claude-code issue
+ * cluster (40+ duplicate reports) for the user-confusion shape this
+ * widget is intended to neutralise.
+ */
+export const ApiServiceErrorWidget: React.FC<ApiServiceErrorWidgetProps> = ({ content }) => {
+  useEffect(() => { injectApiServiceErrorStyles(); }, []);
+  const [copied, setCopied] = useState(false);
+  const info = parseApiServiceError(content);
+
+  const isOverloaded = info.errorType === 'overloaded_error';
+  const title = isOverloaded
+    ? 'The Claude API is temporarily overloaded'
+    : 'The Claude API returned a temporary error';
+
+  const copyRequestId = async () => {
+    if (!info.requestId) return;
+    try {
+      await navigator.clipboard.writeText(info.requestId);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard can be denied in iframes / sandboxed contexts; the
+      // request id is also selectable on the inline code element.
+    }
+  };
+
+  return (
+    <div className="api-service-error-widget my-3 p-3 rounded-lg flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <span
+          className="flex items-center justify-center w-5 h-5 rounded-full text-white text-xs font-bold"
+          style={{ backgroundColor: 'var(--nim-warning)' }}
+        >
+          !
+        </span>
+        <span className="text-sm font-semibold" style={{ color: 'var(--nim-warning)' }}>
+          {title}
+        </span>
+        {info.status != null && (
+          <span className="text-[0.7rem] text-[var(--nim-text-faint)]">
+            HTTP {info.status}{info.errorType ? ` · ${info.errorType}` : ''}
+          </span>
+        )}
+      </div>
+
+      <div className="text-[var(--nim-text-muted)] text-[0.85rem] leading-relaxed">
+        {isOverloaded
+          ? 'This is an upstream capacity error on the API side, not a bug in Nimbalyst. The API will accept new requests once load eases. Retrying in a minute usually works; switching to a less-loaded model also helps.'
+          : 'This is a transient upstream error on the API side, not a bug in Nimbalyst. Most cases clear within a few minutes.'}
+      </div>
+
+      <ul className="text-[var(--nim-text-muted)] text-[0.8rem] leading-relaxed list-disc pl-5 m-0">
+        <li>
+          Check the status page at{' '}
+          <a
+            href="https://status.claude.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--nim-primary)] hover:underline"
+          >
+            status.claude.com
+          </a>{' '}
+          for an active incident on your model.
+        </li>
+        <li>Retry the request. Transient {info.errorType || 'api_error'} responses usually clear on the next attempt.</li>
+        <li>If your model is listed as degraded, try a different one from Settings until the incident resolves.</li>
+        {info.requestId && (
+          <li>
+            If the error keeps firing for more than a few minutes on the same prompt and model,
+            include the request id when contacting support:{' '}
+            <code className="req-id">{info.requestId}</code>{' '}
+            <button
+              type="button"
+              onClick={copyRequestId}
+              className="ml-1 text-[0.7rem] text-[var(--nim-text-faint)] hover:text-[var(--nim-text-muted)] underline-offset-2 hover:underline"
+            >
+              {copied ? 'copied' : 'copy'}
+            </button>
+          </li>
+        )}
+      </ul>
+
+      <details>
+        <summary>Show raw error payload</summary>
+        <pre>{info.raw}</pre>
+      </details>
+    </div>
+  );
+};

--- a/packages/runtime/src/ui/AgentTranscript/components/MessageSegment.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/MessageSegment.tsx
@@ -7,6 +7,7 @@ import { LoginRequiredWidget } from './LoginRequiredWidget';
 import { OpenAIAuthWidget } from './OpenAIAuthWidget';
 import { ContextLimitWidget } from './ContextLimitWidget';
 import { RateLimitWidget } from './RateLimitWidget';
+import { ApiServiceErrorWidget, isApiServiceError } from './ApiServiceErrorWidget';
 import { FullscreenModal } from './FullscreenModal';
 import { MaterialSymbol } from '../../icons/MaterialSymbol';
 import { formatToolDisplayName } from '../utils/toolNameFormatter';
@@ -181,6 +182,15 @@ export const MessageSegment: React.FC<MessageSegmentProps> = ({
     // Check if this is a rate limit event embedded in text content
     if (!isUser && isRateLimitContent(message.text ?? '')) {
       return <RateLimitWidget content={message.text ?? ''} />;
+    }
+
+    // Upstream Claude API service errors (api_error 5xx, overloaded_error)
+    // that the CLI / SDK forwards verbatim. Surface as a human-readable
+    // explanation with the request_id, status page link, and a "show raw
+    // payload" disclosure for support tickets. Conservative detection -
+    // see isApiServiceError for the signal definition.
+    if (!isUser && isApiServiceError(message.text ?? '')) {
+      return <ApiServiceErrorWidget content={message.text ?? ''} />;
     }
 
     // Check if this is an OpenAI auth error in the message content
@@ -358,6 +368,13 @@ export const MessageSegment: React.FC<MessageSegmentProps> = ({
     // Check if this is a rate limit event
     if (isRateLimitContent(errorMessage)) {
       return <RateLimitWidget content={errorMessage} />;
+    }
+
+    // Upstream API service error (api_error 5xx, overloaded_error) -
+    // same detection as the text-content path, applied here too so an
+    // error-flagged message also gets the human-readable surface.
+    if (isApiServiceError(errorMessage)) {
+      return <ApiServiceErrorWidget content={errorMessage} />;
     }
 
     // Otherwise, render the generic error UI


### PR DESCRIPTION
## Problem

When the upstream Claude API returns a 5xx with `api_error` or `overloaded_error`, the SDK forwards the raw JSON to the renderer and the transcript surfaces it as a wall of JSON:

```
API Error: 500 {"type":"error","error":{"type":"api_error","message":"Internal server error"},"request_id":"req_..."}
Claude may be experiencing issues. Check https://status.anthropic.com
```

Users see that and reasonably conclude Nimbalyst has crashed. The error is actually transient on the API side - the `request_id` is server-side, the status page tracks the incident, the right user action is "retry / check status / escalate with the request_id".

I went and looked at how the same payload lands in other clients to size the problem. On `anthropics/claude-code` the same JSON is producing **40+ open duplicate issues** over the last two months (Apr 13 wave: ~22 issues, Apr 15 wave: ~14 issues, smaller earlier waves), each filed by a user who saw the JSON and thought it was a client bug. Status-page incidents on those exact days correlate one-to-one. Nimbalyst doesn't have an open issue with this shape yet, but the same upstream surface is going to land here on the next API incident, and the bigger Nimbalyst gets the bigger the duplicate-filing rate.

## What this changes

Adds a Nimbalyst-side intercept. When the transcript sees a message that matches the upstream-API-error signature, it renders a new `ApiServiceErrorWidget` instead of the raw JSON.

The widget surfaces:

- The error class (transient upstream, not a client bug) plus the HTTP status and `error.type` if parseable
- A bulleted action list keyed off the error type
  - `status.claude.com` check
  - retry (transient `api_error` usually clears on next attempt)
  - try a different model if the current one is listed degraded
  - include the `request_id` if contacting support
- The `request_id` rendered as a copy-friendly inline code span with a one-click copy button. This is the only handle Anthropic support can use to look up the server-side trace, so it has to be prominent and copy-clean.
- A collapsed `Show raw error payload` disclosure containing the original JSON, so anyone genuinely filing a bug or asking on Discord still has the verbatim payload available.

Implementation lives next to the existing error widgets (`RateLimitWidget`, `ContextLimitWidget`, `LoginRequiredWidget`, `OpenAIAuthWidget`) and is wired into `MessageSegment` at the same two hook points as `RateLimitWidget` (text-content path + error path). Same shape, same module-injected styles, same `color-mix` warning treatment.

## Detection signals

`isApiServiceError(content)` returns true when any of these hold. All three are deliberately narrow to avoid swallowing real client bugs that happen to mention "500":

1. **Explicit Anthropic error type token**: `"type":"api_error"` or `"type":"overloaded_error"` in the body. The Anthropic SDK always emits these for the corresponding response classes; no other code path in Nimbalyst produces them.
2. **5xx status + Anthropic correlation id**: a `5\d\d` somewhere in the text AND a `req_[A-Za-z0-9]{8,}` correlation id. That combination is distinctive - Anthropic's `req_` ids only appear when the response came from their API.
3. **Status-page domain + 5xx**: `status.(anthropic|claude).com` near a 5xx, which catches the CLI's framing string when echoed back verbatim through tool calls.

All three signals are in a single helper so additional error categories (e.g. new server-side classes) can be added in one place.

## Parser shape

`parseApiServiceError(content)` extracts `status`, `errorType`, `errorMessage`, `requestId` from JSON-only, line-wrapped, and CLI-framed inputs. Falls back to loose regex when the JSON is malformed (it sometimes is, since the wrapping line breaks can interrupt the JSON span). Returns null fields when a piece is absent rather than throwing; the widget renders each piece conditionally.

## What this does NOT change

- The generic error UI for everything else. Non-matching messages still render untouched.
- Any error handling in the AI provider layer. The intercept is purely renderer-side.
- The underlying error surface to logs / telemetry. The raw JSON is still in `message.text` and still available via the widget's disclosure.

## Verify locally

Easiest path is to trigger a fake error via the dev console while a transcript is open:

```js
// Simulate the message landing in transcript text content
const fake = `API Error: 500 {"type":"error","error":{"type":"api_error","message":"Internal server error"},"request_id":"req_011Cb11ftJkM3kkU3hMTeNBA"}\nClaude may be experiencing issues. Check https://status.anthropic.com for service status.`
console.log(fake);
```

Or wait for the next Anthropic API incident window (status.claude.com tracks them - there have been several in the May 8-13 range).

## Follow-ups

I also opened anthropics/claude-code#58789 as a small docs PR adding a Troubleshooting section to that README that walks users through the same triage flow at the source. Independent change; this PR doesn't depend on that one merging.
