### PR TITLE
fix(test): add embedded-file to editorNodeSnapshot expected list

### DIFF
--- a/packages/runtime/src/editor/extensions/__tests__/editorNodeSnapshot.test.ts
+++ b/packages/runtime/src/editor/extensions/__tests__/editorNodeSnapshot.test.ts
@@ -34,6 +34,7 @@ const EXPECTED_NODE_TYPES = [
   'collapsible-container',
   'collapsible-content',
   'collapsible-title',
+  'embedded-file',
   'emoji',
   'hashtag',
   'heading',


### PR DESCRIPTION
One-line test fixture fix. Unblocks main CI and every open PR.

## What's broken

`b85bc2f4 feat: inline embeds for extension-edited files in markdown` registered a new `embedded-file` node via the EmbedExtension but did not update `editorNodeSnapshot.test.ts`'s `EXPECTED_NODE_TYPES`. Main CI has been failing on Unit Tests since that commit landed:

```
AssertionError: expected [ 'artificial', 'autolink', ...(35) ] to deeply equal [ ..., ...(34) ]
+ "embedded-file"
```

The test fires twice (once in standalone mode, once in collaboration mode), so the failure shows as 2 failed assertions in one file. Both have the same root cause and the same fix.

## What this fixes

Add `'embedded-file'` to `EXPECTED_NODE_TYPES`, preserving alphabetical order (between `collapsible-title` and `emoji`).

## Why this is the right action

The snapshot test exists specifically to catch unintended node-set drift. When the drift is intended (as it is here - EmbedPlugin is a shipping feature) the right response is to update the expected list. The file's own header comment says so:

```
* out or a new one is added, update `EXPECTED_NODE_TYPES`; do not delete
```

## Effect

- Unblocks main CI (last 3 main CI runs all failed on this).
- Unblocks every open PR that has rebased through `b85bc2f4`. At time of writing that includes #243, #275, #277.

Single file, single line added, no other changes.
