### PR TITLE
fix(editor): tracker item Enter on last line inserts new paragraph (closes #263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Pressing Enter at the end of a task/bug/idea/plan/decision/automation tracker-item line on the last line of a markdown file in the rich Lexical editor no longer silently swallows the keypress. `TrackerItemNode` was relying on the base `ElementNode.insertNewAfter` which returns null, so Lexical's RichText KEY_ENTER_COMMAND handler had nothing to insert and the user was stuck with no way to add content below the last tracker item. The node now mirrors HeadingNode/QuoteNode and inserts a new `ParagraphNode` below itself, preserving the direction (LTR/RTL). (#263)
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/runtime/src/plugins/TrackerPlugin/TrackerItemNode.tsx
+++ b/packages/runtime/src/plugins/TrackerPlugin/TrackerItemNode.tsx
@@ -1,9 +1,12 @@
 import {
   $applyNodeReplacement,
+  $createParagraphNode,
   $createTextNode,
   ElementNode,
   LexicalNode,
   NodeKey,
+  ParagraphNode,
+  RangeSelection,
   SerializedElementNode,
   Spread,
   $getNodeByKey,
@@ -330,6 +333,23 @@ export class TrackerItemNode extends ElementNode {
     return false;
   }
 
+  // Without this, pressing Enter on a tracker-item line at the end of the
+  // document is a no-op: Lexical's default RichText KEY_ENTER_COMMAND handler
+  // calls insertNewAfter on the parent ElementNode and bails when the result
+  // is null. The base ElementNode implementation returns null, so the cursor
+  // has nowhere to go and the keypress is silently swallowed. Mirror the
+  // HeadingNode/QuoteNode pattern from @lexical/rich-text: a new empty
+  // paragraph below the tracker item. Tested behavior for #263.
+  insertNewAfter(
+    _selection: RangeSelection | null,
+    restoreSelection = true,
+  ): ParagraphNode {
+    const newElement = $createParagraphNode();
+    const direction = this.getDirection();
+    newElement.setDirection(direction);
+    this.insertAfter(newElement, restoreSelection);
+    return newElement;
+  }
 
 }
 

--- a/packages/runtime/src/plugins/TrackerPlugin/__tests__/TrackerItemNode.insertNewAfter.test.ts
+++ b/packages/runtime/src/plugins/TrackerPlugin/__tests__/TrackerItemNode.insertNewAfter.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression test for issue #263.
+ *
+ * Pressing Enter at the end of a tracker-item line on the very last line of
+ * a markdown file used to silently swallow the keypress, because Lexical's
+ * default RichText KEY_ENTER_COMMAND handler delegates to the parent
+ * ElementNode's `insertNewAfter` and the base implementation returns null.
+ *
+ * Mirror of HeadingNode/QuoteNode's pattern from `@lexical/rich-text`:
+ * `insertNewAfter` should create and insert a new ParagraphNode below the
+ * current tracker item so the cursor can land on a fresh empty line.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createEditor,
+  $getRoot,
+  $createTextNode,
+  $isParagraphNode,
+} from 'lexical';
+
+import {
+  TrackerItemNode,
+  $createTrackerItemNode,
+  $isTrackerItemNode,
+  type TrackerItemData,
+} from '../TrackerItemNode';
+
+function makeEditor() {
+  // Headless Lexical editor with the tracker node registered.
+  return createEditor({
+    namespace: 'tracker-item-test',
+    nodes: [TrackerItemNode],
+    onError: (error: Error) => { throw error; },
+  });
+}
+
+function makeTrackerData(overrides: Partial<TrackerItemData> = {}): TrackerItemData {
+  return {
+    id: 'test-tracker-1',
+    type: 'task',
+    title: 'Sample task',
+    status: 'to-do',
+    ...overrides,
+  };
+}
+
+describe('TrackerItemNode.insertNewAfter (issue #263)', () => {
+  it('inserts a ParagraphNode immediately after the tracker item', () => {
+    const editor = makeEditor();
+    let inserted: ReturnType<TrackerItemNode['insertNewAfter']> | null = null;
+
+    editor.update(() => {
+      const root = $getRoot();
+      const tracker = $createTrackerItemNode(makeTrackerData());
+      tracker.append($createTextNode('Sample task'));
+      root.append(tracker);
+
+      inserted = tracker.insertNewAfter(null);
+    }, { discrete: true });
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      expect(children).toHaveLength(2);
+      expect($isTrackerItemNode(children[0])).toBe(true);
+      expect($isParagraphNode(children[1])).toBe(true);
+      expect(inserted).not.toBeNull();
+      expect($isParagraphNode(inserted as any)).toBe(true);
+    });
+  });
+
+  it('returns the inserted paragraph so the caller can re-anchor selection', () => {
+    const editor = makeEditor();
+    let insertedKey: string | null = null;
+
+    editor.update(() => {
+      const root = $getRoot();
+      const tracker = $createTrackerItemNode(makeTrackerData({ type: 'bug', title: 'Crash on Enter' }));
+      tracker.append($createTextNode('Crash on Enter'));
+      root.append(tracker);
+
+      const newPara = tracker.insertNewAfter(null);
+      insertedKey = newPara.getKey();
+    }, { discrete: true });
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      // The inserted paragraph must be the same instance, in position 1
+      expect(children[1].getKey()).toBe(insertedKey);
+    });
+  });
+
+  it('works for every tracker item type (task / bug / idea / plan / decision / automation)', () => {
+    const types = ['task', 'bug', 'idea', 'plan', 'decision', 'automation'] as const;
+
+    for (const type of types) {
+      const editor = makeEditor();
+      editor.update(() => {
+        const root = $getRoot();
+        const tracker = $createTrackerItemNode(makeTrackerData({ type, title: `Sample ${type}` }));
+        tracker.append($createTextNode(`Sample ${type}`));
+        root.append(tracker);
+
+        tracker.insertNewAfter(null);
+      }, { discrete: true });
+
+      editor.read(() => {
+        const children = $getRoot().getChildren();
+        expect(children).toHaveLength(2);
+        expect($isParagraphNode(children[1])).toBe(true);
+      });
+    }
+  });
+
+  it('preserves the direction (LTR/RTL) of the tracker item on the new paragraph', () => {
+    const editor = makeEditor();
+
+    editor.update(() => {
+      const root = $getRoot();
+      const tracker = $createTrackerItemNode(makeTrackerData());
+      tracker.append($createTextNode('rtl content'));
+      // Force RTL on the tracker item so the new paragraph should mirror it.
+      tracker.setDirection('rtl');
+      root.append(tracker);
+
+      tracker.insertNewAfter(null);
+    }, { discrete: true });
+
+    editor.read(() => {
+      const children = $getRoot().getChildren();
+      const para = children[1];
+      // ParagraphNode (an ElementNode) has getDirection on its prototype.
+      // Narrow the type so TS is happy without weakening the test.
+      if (!$isParagraphNode(para)) throw new Error('Expected a ParagraphNode below the tracker item');
+      expect(para.getDirection()).toBe('rtl');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #263.

## Symptom

In the rich Lexical editor, pressing Enter at the end of a `task` / `bug` / `idea` / `plan` / `decision` / `automation` tracker-item line on the very last line of a markdown file is a no-op. The user has no way to add content below the last tracker item unless a blank line already exists.

## Root cause

`TrackerItemNode` extends `ElementNode` but does not override `insertNewAfter`. Lexical's RichText KEY_ENTER_COMMAND handler at `packages/lexical-rich-text` (upstream) calls `parent.insertNewAfter(selection)` and bails when the return value is null. The base `ElementNode.insertNewAfter` returns null, so the keypress is silently swallowed for every tracker-item node.

`HeadingNode` and `QuoteNode` in `@lexical/rich-text` solve this with the same pattern: create a `ParagraphNode` below themselves, preserve direction, and return the new paragraph.

## Fix

`packages/runtime/src/plugins/TrackerPlugin/TrackerItemNode.tsx` now overrides `insertNewAfter` to:

1. Create a new `ParagraphNode`
2. Copy the tracker item's direction (LTR/RTL) onto it
3. Insert it after the tracker item with `restoreSelection` honored
4. Return the new paragraph so the RichText handler can place the cursor on it

The result matches Karl's "Expected behavior" in the issue: a new empty line is inserted below the current line, allowing the user to continue typing.

## Tests

Added `packages/runtime/src/plugins/TrackerPlugin/__tests__/TrackerItemNode.insertNewAfter.test.ts` with four cases:

- Paragraph is inserted at position 1, after the tracker item
- The returned paragraph is the same instance that ends up in the document (caller can re-anchor selection)
- All six tracker types (task / bug / idea / plan / decision / automation) get the same treatment
- RTL direction propagates from the tracker item to the new paragraph

All 4 tests pass via `npx vitest run packages/runtime/src/plugins/TrackerPlugin/__tests__/TrackerItemNode.insertNewAfter.test.ts`.

## Regression risk

Low. The change adds an override on a method that previously returned null (effectively dead behavior). No call site depended on the null return. The only observable behavior change is: pressing Enter on a tracker-item line now does the documented thing instead of nothing.

## Changelog

Added under `[Unreleased]` -> `### Fixed`.
