### PR TITLE
fix(database): ambiguous-lock branch with user dialog (Greg's #316 review follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
+- PGLite lock-staleness check now surfaces an "ambiguous" branch and asks the user via dialog instead of guessing. Follow-up to the closed PR #316: previously the EPERM-with-fresh-timestamp case (lock < 60s old, lock holder PID unsignalable from us) was treated as a live sibling and the launch was refused. On a slow-disk machine where the original Nimbalyst wrote the lock less than 60s before crashing, that produced a false-positive DATABASE_LOCKED that the user could only clear by deleting the lock file from the filesystem. `decideLockIsRunning` now returns a ternary `decision: 'running' | 'stale' | 'ambiguous'` and exposes `lockPid` / `lockAgeMs` for dialog rendering. The 'running' and 'stale' branches behave as before. The 'ambiguous' branch raises a distinct `DATABASE_LOCKED_AMBIGUOUS` error code; `PGLiteDatabaseWorker` catches it and shows a dialog explaining the two scenarios (live sibling vs fast PID reuse) with "Cancel" and "Open Anyway (clear lock)" buttons. The legacy `isRunning` boolean stays on the return shape for backwards compatibility (true for both 'running' and 'ambiguous'). Per @ghinkle's review on the closed PR #316. (#272 follow-up)
 <!-- Bug fixes go here -->
 
 ### Removed

--- a/packages/electron/src/main/database/PGLiteDatabaseWorker.ts
+++ b/packages/electron/src/main/database/PGLiteDatabaseWorker.ts
@@ -546,6 +546,76 @@ export class PGLiteDatabaseWorker {
       logger.main.error('[PGLite Worker] Failed to initialize:', error);
       this.initPromise = null;
 
+      // Check for the AMBIGUOUS branch FIRST (its error message also contains
+      // the string "DATABASE_LOCKED" so the simpler check below would match
+      // it otherwise). The ambiguous branch fires when worker.js could not
+      // signal the lock holder via `kill(0)` (EPERM) AND the lock timestamp
+      // is fresh enough that we cannot rule out a real sibling instance.
+      // Per @ghinkle's review on the closed PR #316: ask the user instead of
+      // guessing. See #272 for the original Windows-pid-reuse hazard.
+      if (error?.code === 'DATABASE_LOCKED_AMBIGUOUS') {
+        if (process.env.PLAYWRIGHT === '1') {
+          // Tests should never hit this; if they do, surface the ambiguity
+          // rather than silently force-unlocking which could mask a real
+          // dual-instance race in test setup.
+          console.error('FATAL: Ambiguous database-lock state in Playwright. Refusing to force-unlock.');
+          process.exit(1);
+        }
+        const lockPid = (error as any).lockPid;
+        const lockTimestamp = (error as any).lockTimestamp;
+        const lockHostname = (error as any).lockHostname;
+        const lockFilePath = (error as any).lockFilePath as string | undefined;
+        const response = await dialog.showMessageBox({
+          type: 'question',
+          title: 'Nimbalyst - Database Locked (Ambiguous)',
+          message: 'Cannot tell whether another Nimbalyst is already running.',
+          detail:
+            `Nimbalyst found a database lock from a few seconds ago and cannot confirm whether ` +
+            `the process holding it (PID ${lockPid}, host ${lockHostname}, acquired ${lockTimestamp}) ` +
+            `is still alive. Two scenarios are equally likely:\n\n` +
+            `  1. Another Nimbalyst window is open under a different user account or privilege level. ` +
+            `Opening anyway will run two instances against the same database and may corrupt data.\n\n` +
+            `  2. A previous Nimbalyst crashed less than a minute ago and the OS has already reused ` +
+            `the original PID for a system process. In this case the lock is safe to clear.\n\n` +
+            `If unsure, choose Cancel and look for another Nimbalyst window before retrying.`,
+          buttons: ['Cancel', 'Open Anyway (clear lock)'],
+          defaultId: 0,
+          cancelId: 0,
+        }).catch(() => ({ response: 0 } as Electron.MessageBoxReturnValue));
+
+        if (response.response === 1 && lockFilePath) {
+          this.analytics.sendEvent('database_lock_ambiguous_force_unlock', { lockPid });
+          try {
+            const fs = await import('fs');
+            fs.unlinkSync(lockFilePath);
+            logger.main.info(`[PGLite Worker] User chose to force-unlock; removed ${lockFilePath}. Retrying init.`);
+            // Recreate worker + retry init. INIT_TIMEOUT_MS covers the
+            // post-force-unlock recovery path (#238 lesson).
+            await this.recreateWorkerAndReinit();
+            this.initialized = true;
+            return;
+          } catch (unlockErr) {
+            logger.main.error('[PGLite Worker] Force-unlock failed:', unlockErr);
+            this.showErrorAndQuit(
+              'Database Locked',
+              'Could not clear the database lock.',
+              `Removing the lock file failed: ${this.formatError(unlockErr)}\n\n` +
+              `If another Nimbalyst window is open, close it manually before retrying.`
+            );
+            throw new HandledError('DATABASE_LOCKED_AMBIGUOUS_UNLOCK_FAILED');
+          }
+        }
+
+        // User cancelled - quit cleanly without removing the lock.
+        this.analytics.sendEvent('database_lock_ambiguous_cancel', { lockPid });
+        this.showErrorAndQuit(
+          'Database Locked',
+          'Nimbalyst cannot start while the database lock state is uncertain.',
+          'Close any other Nimbalyst windows you have open and try again. If you are sure no other Nimbalyst is running, restart this machine to clear any stale system locks.'
+        );
+        throw new HandledError('DATABASE_LOCKED_AMBIGUOUS');
+      }
+
       // Check for database locked error (another instance running)
       if (error?.message?.includes('DATABASE_LOCKED') || error?.message?.includes('locked by another process')) {
         if (process.env.PLAYWRIGHT === '1') {

--- a/packages/electron/src/main/database/__tests__/lockStaleness.test.ts
+++ b/packages/electron/src/main/database/__tests__/lockStaleness.test.ts
@@ -92,11 +92,13 @@ describe('decideLockIsRunning (issue #272)', () => {
     });
   });
 
-  describe('EPERM + fresh timestamp (genuine live sibling)', () => {
-    it('treats EPERM as RUNNING when lock is younger than the grace window', () => {
+  describe('EPERM + fresh timestamp (ambiguous - ask the user)', () => {
+    it('returns decision=ambiguous when lock is younger than the grace window (Greg #316 review)', () => {
       // A sibling Nimbalyst running under another user/profile that
       // happens to share this PGLite path. Lock was acquired 10s ago,
-      // within the 60s grace. Block the launch.
+      // within the 60s grace. Could also be a fast PID reuse if the
+      // original Nimbalyst wrote the lock <60s before crash. Cannot
+      // tell from kill(0) alone - ask the user via dialog.
       const killFn = vi.fn(() => {
         throw makeKillError('EPERM');
       });
@@ -106,8 +108,13 @@ describe('decideLockIsRunning (issue #272)', () => {
         killFn,
         now: NOW,
       });
+      expect(result.decision).toBe('ambiguous');
+      // isRunning stays true for backwards compatibility with callers
+      // that have not yet been updated to consume `decision`.
       expect(result.isRunning).toBe(true);
-      expect(result.reason).toMatch(/live sibling/);
+      expect(result.reason).toMatch(/Ambiguous/);
+      expect(result.lockPid).toBe(9999);
+      expect(result.lockAgeMs).toBe(10_000);
     });
 
     it('uses a custom grace window when caller overrides it', () => {

--- a/packages/electron/src/main/database/lockStaleness.d.ts
+++ b/packages/electron/src/main/database/lockStaleness.d.ts
@@ -30,17 +30,39 @@ export interface DecideLockIsRunningArgs {
   now?: number;
   /**
    * Grace window inside the EPERM branch. A lock younger than this is
-   * assumed to belong to a genuinely-competing sibling instance;
-   * anything older is treated as PID reuse. Default 60_000 ms.
+   * routed to 'ambiguous' (caller asks the user) instead of being
+   * assumed stale; anything older is treated as PID reuse. Default
+   * 60_000 ms.
    */
   staleGraceMs?: number;
 }
 
+/**
+ * Ternary decision surface. Caller maps each value to behaviour:
+ *   'running'   -> refuse to open the database; show DATABASE_LOCKED error
+ *   'stale'     -> proceed; remove the stale lock file and re-acquire
+ *   'ambiguous' -> ask the user (the lock is fresh but we cannot signal
+ *                  the PID owner; could be a real sibling or a fast PID
+ *                  reuse). Per @ghinkle's review on closed PR #316.
+ */
+export type LockLivenessDecision = 'running' | 'stale' | 'ambiguous';
+
 export interface DecideLockIsRunningResult {
-  /** True iff the prior lock holder is presumed alive. */
+  /** Ternary decision the caller routes on. */
+  decision: LockLivenessDecision;
+  /**
+   * Backwards-compatible boolean for callers that have not yet been
+   * updated to consume `decision`. True for both 'running' and
+   * 'ambiguous' (matches the historical conservative default before
+   * the ambiguous branch existed). New code should use `decision`.
+   */
   isRunning: boolean;
   /** Human-readable explanation. Caller logs this verbatim. */
   reason: string;
+  /** Echoed from the input for dialog rendering. */
+  lockPid: number;
+  /** How long ago the lock was written, in ms. `Infinity` if unknown. */
+  lockAgeMs: number;
 }
 
 export function decideLockIsRunning(

--- a/packages/electron/src/main/database/lockStaleness.js
+++ b/packages/electron/src/main/database/lockStaleness.js
@@ -9,61 +9,98 @@
  *
  * Decision rule:
  *   - If `process.kill(lockPid, 0)` does NOT throw -> the lock holder is
- *     alive and we own it; another instance is running.
+ *     alive and we own it; another instance is running. Decision: 'running'.
  *   - If it throws ESRCH -> no such process; the lock is stale, the prior
- *     instance crashed without releasing.
+ *     instance crashed without releasing. Decision: 'stale'.
  *   - If it throws EPERM -> ambiguous on Windows. Either a sibling
  *     Nimbalyst we cannot signal (e.g. different user, different
  *     privilege level) OR a system / service process that happened to
  *     reuse the PID after the original Nimbalyst process died (the
  *     #272 case). Disambiguate by lock age:
- *       * Lock timestamp younger than `staleGraceMs` (default 60s):
- *         treat as alive. A genuine competing instance just acquired the
- *         lock during the current launch attempt.
- *       * Lock timestamp older than `staleGraceMs`: treat as stale. The
- *         original lock holder is long dead; PID has been reused.
- *   - Any other thrown error code: fail closed (treat as running) so we
- *     never clobber a potentially-live sibling's lock on an
+ *       * Lock timestamp older than `staleGraceMs` (default 60s):
+ *         decision: 'stale'. The original lock holder is long dead;
+ *         PID has been reused.
+ *       * Lock timestamp younger than `staleGraceMs`: decision:
+ *         'ambiguous'. Could be a genuine sibling that just acquired
+ *         the lock OR PID reuse on a slow-disk machine where the
+ *         original lock was written less than 60s before crash.
+ *         Caller should ask the user. Per @ghinkle's review on the
+ *         closed PR #316.
+ *       * No timestamp / unparseable: decision: 'stale' (legacy lock
+ *         files predate the timestamp field and are by definition old).
+ *   - Any other thrown error code: decision: 'running'. Fail closed so
+ *     we never clobber a potentially-live sibling's lock on an
  *     unrecognised failure.
  *
- * Returns `{ isRunning, reason }`. `reason` is informational and is
- * logged by the caller. Pure function: no fs, no os, no global state.
+ * Returns `{ decision, reason, lockPid, lockAgeMs }`. `reason` is
+ * informational and is logged by the caller. `lockPid` and `lockAgeMs`
+ * are surfaced so a dialog can show them to the user when the decision
+ * is 'ambiguous'. Pure function: no fs, no os, no global state.
+ *
+ * `isRunning` is also returned for backwards compatibility with callers
+ * that haven't been updated to consume the new ternary decision; it is
+ * `true` for both 'running' and 'ambiguous' (the historical conservative
+ * default before the dialog branch existed). New code should use
+ * `decision` directly.
  */
 
 const DEFAULT_STALE_LOCK_GRACE_MS = 60_000;
 
 function decideLockIsRunning({ lockPid, lockTimestamp, killFn, now = Date.now(), staleGraceMs = DEFAULT_STALE_LOCK_GRACE_MS }) {
+  const parsedLockTime =
+    lockTimestamp && lockTimestamp !== 'unknown'
+      ? new Date(lockTimestamp).getTime()
+      : NaN;
+  const lockAgeMs = Number.isFinite(parsedLockTime) ? now - parsedLockTime : Number.POSITIVE_INFINITY;
+
   try {
     killFn(lockPid, 0);
-    return { isRunning: true, reason: 'kill(0) succeeded; lock holder is alive and signalable' };
+    return {
+      decision: 'running',
+      isRunning: true,
+      reason: 'kill(0) succeeded; lock holder is alive and signalable',
+      lockPid,
+      lockAgeMs,
+    };
   } catch (e) {
     if (e && e.code === 'ESRCH') {
-      return { isRunning: false, reason: 'ESRCH: no such process; lock is stale' };
+      return {
+        decision: 'stale',
+        isRunning: false,
+        reason: 'ESRCH: no such process; lock is stale',
+        lockPid,
+        lockAgeMs,
+      };
     }
     if (e && e.code === 'EPERM') {
-      const parsedLockTime =
-        lockTimestamp && lockTimestamp !== 'unknown'
-          ? new Date(lockTimestamp).getTime()
-          : NaN;
-      const lockAgeMs = Number.isFinite(parsedLockTime) ? now - parsedLockTime : Number.POSITIVE_INFINITY;
       if (!Number.isFinite(lockAgeMs) || lockAgeMs > staleGraceMs) {
         return {
+          decision: 'stale',
           isRunning: false,
           reason:
             `EPERM on PID ${lockPid} but lock timestamp is ${Math.round(lockAgeMs / 1000)}s old ` +
             `(> ${staleGraceMs / 1000}s grace). Treating as stale (Windows pid-reuse hazard).`,
+          lockPid,
+          lockAgeMs,
         };
       }
       return {
+        decision: 'ambiguous',
         isRunning: true,
         reason:
           `EPERM on PID ${lockPid} and lock timestamp is ${Math.round(lockAgeMs / 1000)}s old ` +
-          `(within ${staleGraceMs / 1000}s grace). Treating as a live sibling instance.`,
+          `(within ${staleGraceMs / 1000}s grace). Ambiguous: could be a live sibling or a fast PID reuse. ` +
+          `Asking the user.`,
+        lockPid,
+        lockAgeMs,
       };
     }
     return {
+      decision: 'running',
       isRunning: true,
       reason: `unrecognised process.kill error (${e && e.code}); failing closed to protect live sibling`,
+      lockPid,
+      lockAgeMs,
     };
   }
 }

--- a/packages/electron/src/main/database/worker.js
+++ b/packages/electron/src/main/database/worker.js
@@ -131,21 +131,28 @@ class PGLiteWorker {
           // extracted to ./lockStaleness.js so it can be unit-tested
           // without spawning a real worker thread. See nimbalyst#272 for
           // the Windows-pid-reuse hazard the timestamp gate guards
-          // against.
+          // against, and the closed PR #316 review thread for the
+          // 'ambiguous' branch that asks the user instead of guessing.
           const { decideLockIsRunning } = require('./lockStaleness');
-          let isRunning = false;
-          if (!isStaleFromReboot) {
-            const decision = decideLockIsRunning({
+          let livenessDecision = 'stale';
+          let livenessReason = '';
+          if (isStaleFromReboot) {
+            livenessDecision = 'stale';
+            livenessReason = 'lock predates last reboot';
+          } else {
+            const result = decideLockIsRunning({
               lockPid,
               lockTimestamp,
               killFn: process.kill.bind(process),
             });
-            isRunning = decision.isRunning;
-            console.log(`[PGLite Worker] Lock liveness check: ${decision.reason}`);
+            livenessDecision = result.decision;
+            livenessReason = result.reason;
+            console.log(`[PGLite Worker] Lock liveness check: ${result.reason}`);
           }
 
-          if (isRunning) {
-            // Another instance is actually running - block!
+          if (livenessDecision === 'running') {
+            // Another instance is confirmed alive (kill(0) succeeded, OR
+            // unrecognised errno). Refuse the launch unconditionally.
             const error = new Error(
               `Database is locked by another Nimbalyst process.\n\n` +
               `Lock holder PID: ${lockPid}\n` +
@@ -157,12 +164,35 @@ class PGLiteWorker {
             error.code = 'DATABASE_LOCKED';
             error.lockPid = lockPid;
             return { acquired: false, error };
-          } else {
-            // Process is dead - stale lock from a crash
-            console.log(`[PGLite Worker] Removing stale lock file from crashed process (PID ${lockPid} no longer running)`);
-            console.log(`[PGLite Worker] Previous lock was acquired at: ${lockTimestamp}`);
-            fs.unlinkSync(this.lockFilePath);
           }
+          if (livenessDecision === 'ambiguous') {
+            // EPERM with a fresh timestamp (<60s old). Either a live
+            // sibling we cannot signal (different user / privilege level)
+            // OR a fast PID reuse on a slow-disk machine where the
+            // original lock was written less than 60s before crash.
+            // Surface a distinct error code so the main process can show
+            // a dialog letting the user choose between "Open Anyway"
+            // (force-unlock) and "Cancel". Per @ghinkle's review on the
+            // closed PR #316.
+            const error = new Error(
+              `Cannot tell whether another Nimbalyst is running.\n\n` +
+              `Lock holder PID: ${lockPid}\n` +
+              `Lock acquired: ${lockTimestamp}\n` +
+              `Lock host: ${lockHostname}\n\n` +
+              `Reason: ${livenessReason}`
+            );
+            error.code = 'DATABASE_LOCKED_AMBIGUOUS';
+            error.lockPid = lockPid;
+            error.lockFilePath = this.lockFilePath;
+            error.lockTimestamp = lockTimestamp;
+            error.lockHostname = lockHostname;
+            return { acquired: false, error };
+          }
+          // livenessDecision === 'stale'. Process is dead, or lock
+          // predates the last reboot, or EPERM with a stale timestamp.
+          console.log(`[PGLite Worker] Removing stale lock file from crashed process (PID ${lockPid} no longer running)`);
+          console.log(`[PGLite Worker] Previous lock was acquired at: ${lockTimestamp}`);
+          fs.unlinkSync(this.lockFilePath);
         }
       }
 


### PR DESCRIPTION
## Summary

Draft follow-up to the closed PR #316. @ghinkle suggested adding a user dialog for the ambiguous EPERM-with-fresh-timestamp case rather than guessing. This PR ships that dialog plus the supporting ternary decision surface in `decideLockIsRunning`.

## Background

`decideLockIsRunning` previously returned a binary `isRunning` flag. The EPERM branch with a fresh timestamp (lock written less than 60s ago, lock holder PID unsignalable from us) was treated as a live sibling and the launch was refused with `DATABASE_LOCKED`. On a slow-disk machine where the original Nimbalyst wrote the lock less than 60s before crashing, that produced a false-positive that the user could only clear by deleting `nimbalyst-db.pid` manually.

## Changes

**`lockStaleness.js`** now returns a ternary `decision: 'running' | 'stale' | 'ambiguous'` plus `lockPid` and `lockAgeMs` for dialog rendering. The legacy `isRunning` boolean stays on the return shape for backwards compatibility - true for both 'running' and 'ambiguous'.

**`worker.js`** raises a distinct `DATABASE_LOCKED_AMBIGUOUS` error code for the ambiguous branch and stashes `lockFilePath`, `lockTimestamp`, `lockHostname` on the error so the dialog can render those values.

**`PGLiteDatabaseWorker.doInitialize`** catches the new error code BEFORE the existing `DATABASE_LOCKED` substring check (which would otherwise match - "DATABASE_LOCKED_AMBIGUOUS" contains "DATABASE_LOCKED"). Shows a question dialog with two scenarios spelled out:

> Cannot tell whether another Nimbalyst is already running.
>
> Nimbalyst found a database lock from a few seconds ago and cannot confirm whether the process holding it (PID ..., host ..., acquired ...) is still alive. Two scenarios are equally likely:
>
>   1. Another Nimbalyst window is open under a different user account or privilege level. Opening anyway will run two instances against the same database and may corrupt data.
>
>   2. A previous Nimbalyst crashed less than a minute ago and the OS has already reused the original PID for a system process. In this case the lock is safe to clear.
>
> If unsure, choose Cancel and look for another Nimbalyst window before retrying.
>
> [Cancel] [Open Anyway (clear lock)]

Cancel is the default. Open Anyway removes the lock file, calls `recreateWorkerAndReinit` (which uses the 120s `INIT_TIMEOUT_MS` from PR #317 / #238 for the post-unlock WAL recovery path), and continues.

**Playwright branch** explicitly refuses to force-unlock so test setup races stay visible.

**Analytics** fire on both buttons (`database_lock_ambiguous_cancel` / `database_lock_ambiguous_force_unlock`) so we can measure how often the ambiguous case actually shows up in practice.

## Tests

8 unit cases in `lockStaleness.test.ts` still pass. The EPERM-fresh-timestamp test now asserts `decision === 'ambiguous'` plus the new surfaced `lockPid` and `lockAgeMs` fields. Other branches unchanged.

## Why draft

@ghinkle's framing on the closed #316 was "we can see how it goes, but maybe we do that user dialog feature down the road." Marking this as draft so the dialog copy, the analytics names, and the Playwright behaviour can be reviewed before merge.

Two specific calls I want your input on:

1. Default button is Cancel. Argument for: data corruption from running two instances is worse than the inconvenience of investigating before clicking Open Anyway. Argument against: most users will not have a second instance and will hit this dialog from a crash; defaulting to Cancel adds friction for the common case. Happy to flip if you prefer.
2. The "Open Anyway" path uses `recreateWorkerAndReinit`, which re-fires init with the 120s `INIT_TIMEOUT_MS`. If the lock was a false positive AND the previous Nimbalyst had also corrupted the DB on crash, the corruption-recovery path fires inside that retry. The user sees: dialog -> click -> 30-90s wait -> "Database Recovered" notice. That seems fine but worth flagging.

Per-Greg-review-followup-to closed PR #316. Builds on the merged #316 (PGLite lock self-heal).