### PR TITLE
fix(csv): wire formatCellValue into cellTemplate for currency/percent/number (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- CSV editor currency, percent, and number column formats now render. `formatCellValue` in `packages/extensions/csv-spreadsheet/src/utils/formatters.ts` existed but was dead code; `generateColumns` in `SpreadsheetEditor.tsx` now wires it into a RevoGrid `cellTemplate` for non-text formats so `0.123` with a percentage format renders `12.3%` and `1234.56` with a USD format renders `$1,234.56`. Edit mode is untouched because RevoGrid's editor reads `editCell.val` from the raw source via `getCellRaw`, not via `cellTemplate`; copy / cut / save-to-CSV also read source data, so the clipboard and on-disk file still carry the raw value. Scope deliberately covers all three non-text formats because the dead-code root cause is identical; the issue body called out currency and percent specifically. Fixes sub-bug 4 of #329; sub-bugs 2 (cell label drift), 3 (diff state), 5 (Cmd+B/U) remain follow-ups. 18 new tests in `formatters.test.ts`. (#329)
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/extensions/csv-spreadsheet/src/components/SpreadsheetEditor.tsx
+++ b/packages/extensions/csv-spreadsheet/src/components/SpreadsheetEditor.tsx
@@ -22,7 +22,7 @@ import { UndoRedoPlugin } from '../plugins/UndoRedoPlugin';
 import { columnIndexToLetter, columnLetterToIndex, generateColumnHeaders, parseCSV } from '../utils/csvParser';
 import { computeDiff, getCellDiffClass, getCellPreviousValue } from '../utils/diffCompute';
 import { isFormula } from '../utils/formulaEngine';
-import { getColumnTypeName } from '../utils/formatters';
+import { formatCellValue, getColumnTypeName } from '../utils/formatters';
 import { FormulaBar, type FormulaBarHandle } from './FormulaBar';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 import { ColumnFormatDialog } from './ColumnFormatDialog';
@@ -84,12 +84,26 @@ function generateColumns(
     const alignClass = getColumnAlignmentClass(format);
     const width = columnWidths[index] ?? DEFAULT_COLUMN_WIDTH;
 
+    const needsDisplayFormat =
+      format && (format.type === 'currency' || format.type === 'percentage' || format.type === 'number');
+
     return {
       prop: letter,
       name: letter,
       size: width,
       editor: 'sheets',
       ...(index < frozenColumnCount ? { pin: 'colPinStart' as const } : {}),
+      ...(needsDisplayFormat
+        ? {
+            // Format display only; edit mode reads the raw source value via editCell.val,
+            // so source data is unchanged and double-click editing shows the unformatted number.
+            cellTemplate: (h, props) => {
+              const raw = props.model?.[props.prop as string];
+              const value = typeof raw === 'string' || typeof raw === 'number' ? raw : null;
+              return h('span', {}, formatCellValue(value, format));
+            },
+          }
+        : {}),
       cellProperties: (cellData: { model: Record<string, unknown>; rowIndex: number }) => {
         const classes: Record<string, boolean> = {};
 

--- a/packages/extensions/csv-spreadsheet/src/utils/__tests__/formatters.test.ts
+++ b/packages/extensions/csv-spreadsheet/src/utils/__tests__/formatters.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { formatCellValue } from '../formatters';
+import type { ColumnFormat } from '../../types';
+
+describe('formatCellValue (cellTemplate wire path for #329 sub-bug 4)', () => {
+  describe('currency', () => {
+    const usd: ColumnFormat = { type: 'currency', currency: 'USD', decimals: 2, showThousandsSeparator: true };
+
+    it('formats a raw number as USD', () => {
+      expect(formatCellValue(1234.56, usd)).toBe('$1,234.56');
+    });
+
+    it('formats a numeric string as USD', () => {
+      expect(formatCellValue('1234.56', usd)).toBe('$1,234.56');
+    });
+
+    it('strips existing $ / commas before formatting', () => {
+      expect(formatCellValue('$1,234.56', usd)).toBe('$1,234.56');
+    });
+
+    it('handles negatives', () => {
+      expect(formatCellValue(-1234.5, usd)).toBe('-$1,234.50');
+    });
+
+    it('falls back to String(value) when not numeric', () => {
+      expect(formatCellValue('hello', usd)).toBe('hello');
+    });
+
+    it('handles EUR locale formatting', () => {
+      const eur: ColumnFormat = { type: 'currency', currency: 'EUR', decimals: 2, showThousandsSeparator: true };
+      // Intl en-DE / de-DE uses a non-breaking space and the symbol after the number;
+      // we only assert the symbol is present and the digits appear.
+      const out = formatCellValue(1234.5, eur);
+      expect(out).toMatch(/€/);
+      expect(out).toMatch(/1\.234|1,234/);
+    });
+  });
+
+  describe('percentage', () => {
+    const pct: ColumnFormat = { type: 'percentage', decimals: 1 };
+
+    it('formats a value 0..1 as a percent', () => {
+      expect(formatCellValue(0.123, pct)).toBe('12.3%');
+    });
+
+    it('treats a >1 value as already a percent', () => {
+      expect(formatCellValue(45.6, pct)).toBe('45.6%');
+    });
+
+    it('handles negative percentages', () => {
+      expect(formatCellValue(-0.5, pct)).toBe('-50.0%');
+    });
+
+    it('preserves zero', () => {
+      expect(formatCellValue(0, pct)).toBe('0.0%');
+    });
+
+    it('falls back to String(value) when not numeric', () => {
+      expect(formatCellValue('n/a', pct)).toBe('n/a');
+    });
+  });
+
+  describe('number', () => {
+    const numWithSep: ColumnFormat = { type: 'number', decimals: 2, showThousandsSeparator: true };
+    const numNoSep: ColumnFormat = { type: 'number', decimals: 2, showThousandsSeparator: false };
+
+    it('adds thousands separator when configured', () => {
+      expect(formatCellValue(1234567.89, numWithSep)).toBe('1,234,567.89');
+    });
+
+    it('omits thousands separator when configured', () => {
+      expect(formatCellValue(1234567.89, numNoSep)).toBe('1234567.89');
+    });
+
+    it('respects decimals=0', () => {
+      const zeroDec: ColumnFormat = { type: 'number', decimals: 0, showThousandsSeparator: true };
+      expect(formatCellValue(1234.7, zeroDec)).toBe('1,235');
+    });
+  });
+
+  describe('null / empty edge cases', () => {
+    const usd: ColumnFormat = { type: 'currency', currency: 'USD', decimals: 2, showThousandsSeparator: true };
+
+    it('returns empty string for null', () => {
+      expect(formatCellValue(null, usd)).toBe('');
+    });
+
+    it('returns empty string for empty string', () => {
+      expect(formatCellValue('', usd)).toBe('');
+    });
+  });
+
+  describe('text format (passthrough)', () => {
+    const text: ColumnFormat = { type: 'text' };
+
+    it('returns the value as-is', () => {
+      expect(formatCellValue('hello world', text)).toBe('hello world');
+    });
+
+    it('coerces a number to string', () => {
+      expect(formatCellValue(42, text)).toBe('42');
+    });
+  });
+});


### PR DESCRIPTION
Fixes sub-bug 4 of #329: selecting `Currency` or `Percentage` from the column format dialog had no visible effect. Cells continued rendering the raw value with no currency symbol, no `%`, no thousands separator.

## Root cause

`formatCellValue` in `packages/extensions/csv-spreadsheet/src/utils/formatters.ts` was dead code. The format was stored on the column config but no RevoGrid `cellTemplate` was ever wired to call it. Display fell through to RevoGrid's default `getCellDataParsed` branch which just stringifies the raw source value.

## Fix

`generateColumns` in `SpreadsheetEditor.tsx` now attaches a `cellTemplate` for columns whose format type is `currency`, `percentage`, or `number`:

```ts
cellTemplate: (h, props) => {
  const raw = props.model?.[props.prop as string];
  const value = typeof raw === 'string' || typeof raw === 'number' ? raw : null;
  return h('span', {}, formatCellValue(value, format));
}
```

Edit mode is unaffected. RevoGrid's editor reads `editCell.val` from the raw source via `getCellRaw` (`column.service` in the RevoGrid runtime), not via `cellTemplate`; `cellTemplate` is strictly display-side per the cell-renderer's render branch. Copy / cut / save-to-CSV paths also read source data (`grid.getSource('rgRow')` in `gridOperations.copySelection`), so the clipboard and on-disk file still carry the raw value.

## Scope

The issue body called out currency and percent specifically. I scoped to all three non-text formats (currency, percentage, number) because the dead-code root cause is identical and one wire-up addresses all three. If you would prefer this narrowed to just currency + percent, happy to revert the `number` branch.

The other sub-bugs of #329 (#2 cell label drift, #3 diff state, #5 Cmd+B/U) remain open follow-ups.

## Tests

18 new unit tests in `formatters.test.ts` cover currency (USD, EUR, negatives, pre-formatted input), percentage (0..1 vs >1 input, negatives, zero), number (thousands separator on / off, decimals=0), null / empty, and text passthrough.

## CI note

Main CI is currently red on `TrackerSchemaService.watch.test.ts > hot-loads added, edited, and deleted workspace schemas` since commit `1025c046` (run [25951252238](https://github.com/nimbalyst/nimbalyst/actions/runs/25951252238)). My branch will inherit that failure. Already flagged on #335 for the upstream regression wave; not introduced by this PR.