### PR TITLE
fix: Claude usage indicator no longer hidden due to deprecated navigator.platform

### DIFF
--- a/packages/electron/src/renderer/components/ClaudeUsageIndicator/ClaudeUsageIndicator.tsx
+++ b/packages/electron/src/renderer/components/ClaudeUsageIndicator/ClaudeUsageIndicator.tsx
@@ -17,9 +17,6 @@ import {
 import { ClaudeUsagePopover } from './ClaudeUsagePopover';
 import { refreshClaudeUsage } from '../../store/listeners/claudeUsageListeners';
 
-// This feature is macOS-only (reads from macOS Keychain)
-const isMacOS = navigator.platform.toLowerCase().includes('mac');
-
 const RING_RADIUS = 12;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
@@ -44,11 +41,7 @@ export const ClaudeUsageIndicator: React.FC<ClaudeUsageIndicatorProps> = ({ clas
     await refreshClaudeUsage();
   }, []);
 
-  // Only show if:
-  // 1. On macOS (reads from macOS Keychain)
-  // 2. User has enabled the indicator in settings
-  // 3. We've received usage payload at least once (including error payloads)
-  if (!isMacOS || !isEnabled || !isAvailable) {
+  if (!isEnabled || !isAvailable) {
     return null;
   }
 

--- a/packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePanel.tsx
+++ b/packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePanel.tsx
@@ -91,11 +91,7 @@ export function ClaudeCodePanel({
   // Plan tracking toggle - stores plans in nimbalyst-local/plans/ with tracking frontmatter
   const [planTrackingEnabled, setPlanTrackingEnabledState] = useState(true);
 
-  // Detect Windows platform using navigator.platform (client-side, no IPC needed)
-  const isWindowsPlatform = navigator.platform === 'Win32';
-
-  // Detect macOS platform (usage indicator only available on macOS)
-  const isMacOS = navigator.platform.toLowerCase().includes('mac');
+  const isWindowsPlatform = process.platform === 'win32';
 
   // Load environment variables
   const loadEnvVars = useCallback(async () => {
@@ -338,16 +334,14 @@ export function ClaudeCodePanel({
         }}
       />
 
-      {/* Usage Indicator Toggle - macOS only */}
-      {isMacOS && (
-        <SettingsToggle
-          variant="enable"
-          name="Show Usage Indicator"
-          description="Display API usage limits in the navigation gutter"
-          checked={usageIndicatorEnabled}
-          onChange={setUsageIndicatorEnabled}
-        />
-      )}
+      {/* Usage Indicator Toggle */}
+      <SettingsToggle
+        variant="enable"
+        name="Show Usage Indicator"
+        description="Display API usage limits in the navigation gutter"
+        checked={usageIndicatorEnabled}
+        onChange={setUsageIndicatorEnabled}
+      />
 
       {/* Custom Claude Installation */}
       <div className="provider-enable flex flex-col gap-2 py-4 mb-4 border-b border-[var(--nim-border)]">


### PR DESCRIPTION
## Summary

- `navigator.platform` is deprecated and returns `""` in newer Chromium/Electron, causing the `isMacOS` check to always be `false` and the indicator to never render
- Replaced `navigator.platform` checks with `process.platform` (reliable in Electron renderer)
- Removed the macOS-only restriction on the indicator — the service already supports Windows/Linux via `~/.claude/.credentials.json`
- Removed the macOS-only gate on the settings toggle in `ClaudeCodePanel` so users on all platforms can enable/disable it

Fixes #357

## Test plan

- [ ] Verify the Claude usage indicator appears in the navigation gutter on macOS after app load
- [ ] Verify clicking the indicator opens the popover with usage details
- [ ] Verify the "Show Usage Indicator" toggle appears in Settings > Claude Code on all platforms
- [ ] Verify toggling it off hides the indicator