### PR TITLE
fix(session-import): label imported sessions with the model actually used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Imported Claude Code sessions are now labelled with the model that was actually used instead of always showing Sonnet. The importer (`ClaudeCodeSessionSync`) never set a `model` on the new `ai_sessions` row, so the renderer fell back to a hardcoded `claude-code:sonnet` and every imported session showed Sonnet regardless of the real model. The importer now reads the per-turn model recorded on the JSONL assistant entries (e.g. `claude-opus-4-7`), maps it to the matching claude-code variant, and stores it on the session, falling back to the real default (`claude-code:opus-1m`) rather than Sonnet when no model is present. (#394)
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/services/ClaudeCodeSessionSync.ts
+++ b/packages/electron/src/main/services/ClaudeCodeSessionSync.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import { homedir } from 'os';
 import type { SessionStore } from '@nimbalyst/runtime';
 import type { AgentMessagesStore } from '@nimbalyst/runtime/storage/repositories/AgentMessagesRepository';
+import { DEFAULT_MODELS } from '@nimbalyst/runtime/ai/modelConstants';
 import { logger } from '../utils/logger';
 import { encodeWorkspaceDir, extractSessionMetadata, type ClaudeCodeEntry, type SessionMetadata } from './ClaudeCodeSessionScanner';
 
@@ -211,6 +212,28 @@ async function loadPersistedOutput(text: string): Promise<string | null> {
     log.warn(`Failed to inline persisted-output from ${externalPath}: ${error?.message ?? error}`);
     return null;
   }
+}
+
+/**
+ * Map a Claude Code session's per-turn model id to a claude-code variant.
+ *
+ * Claude Code JSONL records the model on each assistant entry (e.g.
+ * "claude-opus-4-7", new in 2.1.x). Imports previously stored no model at all,
+ * so the renderer fell back to a hardcoded `claude-code:sonnet` and every
+ * imported session showed Sonnet regardless of the model actually used (#394).
+ * Walk the entries newest-first and return the most recent recognisable model
+ * as a `claude-code:<variant>` string; undefined when none carry a model.
+ */
+export function importedClaudeCodeModel(entries: ClaudeCodeEntry[]): string | undefined {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const raw = entries[i]?.message?.model;
+    if (typeof raw !== 'string' || raw.length === 0) continue;
+    const id = raw.toLowerCase();
+    if (id.includes('opus')) return 'claude-code:opus';
+    if (id.includes('sonnet')) return 'claude-code:sonnet';
+    if (id.includes('haiku')) return 'claude-code:haiku';
+  }
+  return undefined;
 }
 
 /**
@@ -597,6 +620,10 @@ export async function syncSession(
         id: metadata.sessionId,
         workspaceId: metadata.workspacePath,
         provider: 'claude-code',
+        // Label the imported session with the model actually used (read from the
+        // per-turn model on the JSONL assistant entries), falling back to the
+        // real claude-code default rather than the renderer's hardcoded Sonnet (#394).
+        model: importedClaudeCodeModel(entries) ?? DEFAULT_MODELS['claude-code'],
         title: metadata.title || 'Imported Session',
         sessionType: 'session',
         providerSessionId: metadata.sessionId, // CRITICAL: Pass the Claude Code session ID so SDK can resume

--- a/packages/electron/src/main/services/__tests__/ClaudeCodeSessionSync.importedModel.test.ts
+++ b/packages/electron/src/main/services/__tests__/ClaudeCodeSessionSync.importedModel.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for importedClaudeCodeModel - the helper that derives a
+ * Nimbalyst model id from the raw per-turn model on imported Claude Code
+ * entries. Before this, imported sessions had no model and the renderer
+ * fell back to Sonnet, so an Opus session displayed as Sonnet (#394).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { importedClaudeCodeModel } from '../ClaudeCodeSessionSync';
+import type { ClaudeCodeEntry } from '../ClaudeCodeSessionScanner';
+
+function assistant(model: string | undefined): ClaudeCodeEntry {
+  return { type: 'assistant', message: model === undefined ? {} : { model } };
+}
+
+describe('importedClaudeCodeModel', () => {
+  it('maps an opus turn to claude-code:opus', () => {
+    expect(importedClaudeCodeModel([assistant('claude-opus-4-7')])).toBe(
+      'claude-code:opus',
+    );
+  });
+
+  it('maps a sonnet turn to claude-code:sonnet', () => {
+    expect(importedClaudeCodeModel([assistant('claude-sonnet-4-6')])).toBe(
+      'claude-code:sonnet',
+    );
+  });
+
+  it('maps a haiku turn to claude-code:haiku', () => {
+    expect(importedClaudeCodeModel([assistant('claude-haiku-4-5-20251001')])).toBe(
+      'claude-code:haiku',
+    );
+  });
+
+  it('uses the most recent recognizable turn when models differ', () => {
+    // A session that started on Sonnet and switched to Opus should report Opus.
+    const entries = [assistant('claude-sonnet-4-6'), assistant('claude-opus-4-7')];
+    expect(importedClaudeCodeModel(entries)).toBe('claude-code:opus');
+  });
+
+  it('skips entries that carry no model (user / tool turns)', () => {
+    const entries: ClaudeCodeEntry[] = [
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+      assistant('claude-opus-4-7'),
+      { type: 'user', message: { role: 'user', content: 'thanks' } },
+    ];
+    expect(importedClaudeCodeModel(entries)).toBe('claude-code:opus');
+  });
+
+  it('returns undefined for an empty session', () => {
+    expect(importedClaudeCodeModel([])).toBeUndefined();
+  });
+
+  it('returns undefined when no turn has a model', () => {
+    const entries: ClaudeCodeEntry[] = [
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+      assistant(undefined),
+    ];
+    expect(importedClaudeCodeModel(entries)).toBeUndefined();
+  });
+
+  it('returns undefined for an unrecognized model id (caller defaults it)', () => {
+    expect(importedClaudeCodeModel([assistant('some-future-model')])).toBeUndefined();
+  });
+
+  it('ignores an empty-string model', () => {
+    expect(importedClaudeCodeModel([assistant('')])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #394. Reported by @nicholas-anthony-ai.

Imported Claude Code sessions always displayed Sonnet, even when the session ran on Opus.

## Root cause

The importer (`ClaudeCodeSessionSync.syncSession`) created the `ai_sessions` row without a `model`, so the renderer fell back to a hardcoded `claude-code:sonnet`. Every imported session showed Sonnet regardless of the model actually used.

## Fix

Claude Code JSONL records the model on each assistant entry (`message.model`, e.g. `claude-opus-4-7`, new in 2.1.x). The importer now walks the entries newest-first, maps the most recent recognisable model to its `claude-code:<variant>`, and stores it on the session. When no entry carries a model it falls back to the real default (`claude-code:opus-1m`) rather than Sonnet.

One new helper (`importedClaudeCodeModel`) plus the `model` field on the create call. Unit-tested (9 cases: opus/sonnet/haiku mapping, latest-turn-wins, skips model-less turns, and empty/unknown/empty-string falling through to the default).

## Scope

Fixes the import path (the repro). Two things left as deliberate follow-ups to keep this single-concern:
- Already-imported sessions keep their stored (absent) model until re-synced.
- The renderer still has hardcoded `claude-code:sonnet` fallbacks at `sessions.ts` lines 662, 1088, 1428, 2048 for the no-model case. Worth replacing with the claude-code default, but that is a separate change.
