### PR TITLE
fix(feedback): redact workspace paths and Windows path forms in bug-report anonymizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Bug-report anonymizer now redacts the reporting session's workspace path and recognizes Windows path forms, so workspace directory names and the OS username stop leaking into the prefilled public GitHub issue. The `feedback_anonymize_text` tool documents a `<WORKSPACE>` redaction, but the handler only ever passed `homeDir`, so workspace paths outside the home directory (e.g. `C:\Projects\...`) passed through verbatim. The home-directory match was also exact-string, so forward-slash, Git Bash (`/c/...`), WSL (`/mnt/c/...`), and JSON-escaped path forms bypassed it and leaked the username on Windows. The handler now passes the session workspace path through to the anonymizer, and the path matcher normalizes those forms case-insensitively. (#396)
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/mcp/httpServer.ts
+++ b/packages/electron/src/main/mcp/httpServer.ts
@@ -429,7 +429,7 @@ function createSharedMcpServer(
           return handleTrackerAddComment(args, workspacePath);
 
         case "feedback_anonymize_text":
-          return handleFeedbackAnonymizeText(args);
+          return handleFeedbackAnonymizeText(args, workspacePath);
 
         case "feedback_get_environment":
           return handleFeedbackGetEnvironment();

--- a/packages/electron/src/main/mcp/tools/feedbackToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/feedbackToolHandlers.ts
@@ -70,14 +70,19 @@ function jsonResult(value: unknown, isError = false): McpToolResult {
   return textResult(JSON.stringify(value, null, 2), isError);
 }
 
-export function handleFeedbackAnonymizeText(args: any): McpToolResult {
+export function handleFeedbackAnonymizeText(args: any, callerWorkspacePath?: string): McpToolResult {
   const text = typeof args?.text === 'string' ? args.text : '';
   if (!text) {
     return textResult('Error: `text` is required and must be a non-empty string.', true);
   }
 
   const homeDir = os.homedir();
-  const result = anonymize(text, { homeDir });
+  // Scrub the reporting session's workspace path too, not just the home dir.
+  // Workspaces commonly live outside the home directory (e.g. C:\Projects\...),
+  // so without this they pass through verbatim and leak directory names into
+  // the public GitHub issue.
+  const workspacePaths = callerWorkspacePath ? [callerWorkspacePath] : [];
+  const result = anonymize(text, { homeDir, workspacePaths });
   return textResult(result);
 }
 

--- a/packages/electron/src/main/services/feedback/LogAnonymizer.ts
+++ b/packages/electron/src/main/services/feedback/LogAnonymizer.ts
@@ -18,10 +18,52 @@ function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Produce the string forms the same absolute path can take across logs, so a
+ * single configured path (e.g. `C:\Users\jane`, the value `os.homedir()` returns
+ * on Windows) still matches when a log line renders it differently. Without this
+ * the home/workspace replacement is an exact-string match and Windows path
+ * variants slip through, leaking the OS username and workspace directory names.
+ * Covers: forward-slash (`C:/Users/jane`), Git Bash/MSYS (`/c/Users/jane`),
+ * WSL (`/mnt/c/Users/jane`), and JSON-escaped (`C:\\Users\\jane`) forms.
+ */
+function expandPathVariants(p: string): string[] {
+  const variants = new Set<string>([p]);
+  const fwd = p.replace(/\\/g, '/');
+  const back = p.replace(/\//g, '\\');
+  variants.add(fwd);
+  variants.add(back);
+  variants.add(back.replace(/\\/g, '\\\\')); // JSON-escaped backslashes
+
+  // Windows drive form -> POSIX-ish forms.
+  const win = fwd.match(/^([A-Za-z]):\/(.*)$/);
+  if (win) {
+    const drive = win[1].toLowerCase();
+    const rest = win[2];
+    variants.add(`/${drive}/${rest}`); // Git Bash / MSYS
+    variants.add(`/mnt/${drive}/${rest}`); // WSL
+  }
+
+  // POSIX drive form (/c/... or /mnt/c/...) -> Windows forms.
+  const nix = fwd.match(/^\/(?:mnt\/)?([A-Za-z])\/(.*)$/);
+  if (nix) {
+    const drive = nix[1].toUpperCase();
+    const rest = nix[2];
+    variants.add(`${drive}:/${rest}`);
+    variants.add(`${drive}:\\${rest.replace(/\//g, '\\')}`);
+  }
+
+  // Drop variants too short to match safely (e.g. a bare drive root).
+  return [...variants].filter((v) => v.length >= 4);
+}
+
 function buildPathReplacer(paths: string[], replacement: string): (text: string) => string {
-  if (paths.length === 0) return (text) => text;
-  const sorted = [...new Set(paths.filter(Boolean))].sort((a, b) => b.length - a.length);
-  const pattern = new RegExp(sorted.map(escapeRegExp).join('|'), 'g');
+  const expanded = [...new Set(paths.filter(Boolean).flatMap(expandPathVariants))];
+  if (expanded.length === 0) return (text) => text;
+  // Longest first so a workspace path nested under home (or a longer variant)
+  // wins over a shorter prefix. Case-insensitive because Windows paths are.
+  const sorted = expanded.sort((a, b) => b.length - a.length);
+  const pattern = new RegExp(sorted.map(escapeRegExp).join('|'), 'gi');
   return (text) => text.replace(pattern, replacement);
 }
 

--- a/packages/electron/src/main/services/feedback/__tests__/LogAnonymizer.test.ts
+++ b/packages/electron/src/main/services/feedback/__tests__/LogAnonymizer.test.ts
@@ -75,3 +75,58 @@ describe('LogAnonymizer', () => {
     expect(out).toBe('<WORKSPACE>/a vs <WORKSPACE>/b');
   });
 });
+
+// Windows path forms: os.homedir() returns the backslash form, but logs render
+// the same path several ways. Before the path-variant fix these all leaked the
+// username / workspace dir into the public issue.
+describe('LogAnonymizer Windows path forms', () => {
+  const WIN_HOME = 'C:\\Users\\andre';
+  const WIN_WS = 'C:\\Projects\\client-acme';
+  const winCfg = { homeDir: WIN_HOME, workspacePaths: [WIN_WS] };
+
+  it('redacts the native backslash home path', () => {
+    const out = anonymize('open C:\\Users\\andre\\Desktop\\a.md', winCfg);
+    expect(out).not.toMatch(/andre/i);
+  });
+
+  it('redacts the forward-slash Windows home path', () => {
+    const out = anonymize('open C:/Users/andre/Desktop/a.md', winCfg);
+    expect(out).not.toMatch(/andre/i);
+  });
+
+  it('redacts the Git Bash /c/ home path', () => {
+    const out = anonymize('cwd /c/Users/andre/proj', winCfg);
+    expect(out).not.toMatch(/andre/i);
+  });
+
+  it('redacts the WSL /mnt/c/ home path', () => {
+    const out = anonymize('cwd /mnt/c/Users/andre/proj', winCfg);
+    expect(out).not.toMatch(/andre/i);
+  });
+
+  it('redacts the JSON-escaped home path', () => {
+    const out = anonymize('"cwd":"C:\\\\Users\\\\andre\\\\x"', winCfg);
+    expect(out).not.toMatch(/andre/i);
+  });
+
+  it('matches the home path case-insensitively', () => {
+    const out = anonymize('open c:\\users\\andre\\x', winCfg);
+    expect(out).not.toMatch(/andre/i);
+  });
+
+  it('redacts a Windows workspace path outside the home dir', () => {
+    const out = anonymize('loaded C:\\Projects\\client-acme\\src\\m.ts', winCfg);
+    expect(out).toContain('<WORKSPACE>');
+    expect(out).not.toMatch(/client-acme/i);
+  });
+
+  it('does not over-redact a bare word that only appears as a path segment', () => {
+    // "acme" on its own is not the full workspace path and must pass through.
+    expect(anonymize('the acme module loaded', winCfg)).toContain('acme module');
+  });
+
+  it('still works with no workspace paths supplied', () => {
+    const out = anonymize('open C:\\Users\\andre\\x', { homeDir: WIN_HOME });
+    expect(out).not.toMatch(/andre/i);
+  });
+});


### PR DESCRIPTION
## What

The bug-report flow runs log slices and paths through `feedback_anonymize_text` before they land in the prefilled GitHub issue. Two gaps let identifying paths through:

1. **The `<WORKSPACE>` redaction never fired in production.** `LogAnonymizer` supports `workspacePaths` and the tool description advertises "known workspace paths with `<WORKSPACE>`", but the only caller (`handleFeedbackAnonymizeText`) passed `{ homeDir }` and never the workspace path. Workspaces commonly live outside the home directory (e.g. `C:\Projects\...`), so those paths went into the issue verbatim.

2. **The home-directory match was exact-string.** `os.homedir()` returns one form (e.g. `C:\Users\name`), but the same path shows up in logs as `C:/Users/name`, `/c/Users/name` (Git Bash), `/mnt/c/Users/name` (WSL), and JSON-escaped `C:\Users\name`. None of those matched, so the OS username leaked on Windows.

## Change

- `httpServer` threads the session's `workspacePath` (already in scope at the dispatch site, same pattern the tracker and git tools already use) into `handleFeedbackAnonymizeText`, which passes it as `workspacePaths`.
- `LogAnonymizer.buildPathReplacer` expands each configured path into its Windows/POSIX variants and matches case-insensitively, so one configured path covers all the forms it can take in a log line.

Pure-function change, additive only: it can only redact more, never less. Unix-path behavior is unchanged.

## Tests

Added Windows path-form coverage to `LogAnonymizer.test.ts` (the suite previously only exercised Unix paths): native backslash, forward-slash, Git Bash `/c/`, WSL `/mnt/c/`, JSON-escaped, case-insensitive, a workspace path outside home, the no-workspace-supplied case, and a guard that a bare word appearing only as a path segment is not over-redacted. All 20 pass.

This is a redaction hardening, not a complete privacy guarantee. The AI redaction pass and the user's review of the final body remain the primary safeguards; this closes one concrete leak class.
