### PR TITLE
fix(session-naming): tag reminder turn output so it stops leaking into the transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Codex session-naming reminder no longer leaks into the chat transcript; its turn output is tagged so the transcript hides it. (#420)
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
+++ b/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
@@ -1668,7 +1668,15 @@ export class OpenAICodexProvider extends BaseAgentProvider {
     for await (const reminderEvent of this.protocol.sendMessage(session, {
       content: OpenAICodexProvider.SESSION_NAMING_REMINDER_PROMPT,
     })) {
-      await this.storeRawEventIfPresent(reminderEvent, sessionId);
+      // Tag this reminder turn's persisted output rows as a system reminder so
+      // the metadata-based transcript hide covers them. Without the tag they
+      // carry only { eventType, codexProvider, transport } and fall back to the
+      // exact <SYSTEM_REMINDER> tag regex, which a fragmented streamed tag
+      // defeats, leaking the naming nudge into the visible transcript.
+      await this.storeRawEventIfPresent(reminderEvent, sessionId, {
+        promptType: 'system_reminder',
+        reminderKind: 'session_naming',
+      });
 
       if (reminderEvent.type === 'tool_call' && reminderEvent.toolCall) {
         if (OpenAICodexProvider.isSessionNamingToolCall(reminderEvent.toolCall.name)) {
@@ -2120,7 +2128,8 @@ export class OpenAICodexProvider extends BaseAgentProvider {
    */
   private async storeRawEventIfPresent(
     event: ProtocolEvent,
-    sessionId: string
+    sessionId: string,
+    extraMetadata?: Record<string, unknown>
   ): Promise<void> {
     if (event.type !== 'raw_event') {
       return;
@@ -2145,6 +2154,7 @@ export class OpenAICodexProvider extends BaseAgentProvider {
         eventType: method,
         codexProvider: true,
         transport: 'app-server',
+        ...extraMetadata,
       };
       if (editGroupId) metadata.editGroupId = editGroupId;
       await this.logAgentMessage(
@@ -2201,6 +2211,7 @@ export class OpenAICodexProvider extends BaseAgentProvider {
       eventType: rawEventType,
       codexProvider: true,
       rawEventSerializationFallback: usedFallback,
+      ...extraMetadata,
     };
     if (editGroupId) {
       metadata.editGroupId = editGroupId;

--- a/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.persistence.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.persistence.test.ts
@@ -194,6 +194,83 @@ describe('OpenAICodexProvider persistence', () => {
     });
   });
 
+  it('tags the session naming reminder turn output rows so the transcript hides them', async () => {
+    OpenAICodexProvider.setSessionNamingServerPort(41003);
+
+    let turn = 0;
+    const protocol = {
+      platform: 'codex-sdk',
+      async createSession() {
+        return { id: 'thread-reminder-raw', platform: 'codex-sdk', raw: {} };
+      },
+      async resumeSession() {
+        throw new Error('not used');
+      },
+      async forkSession() {
+        throw new Error('not used');
+      },
+      async *sendMessage(_session: unknown, _payload: { content: string }) {
+        turn += 1;
+        if (turn === 1) {
+          // First turn completes without naming the session, which triggers the
+          // reminder turn below.
+          yield { type: 'text', content: 'first turn complete' };
+          yield {
+            type: 'complete',
+            content: '',
+            usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+          };
+          return;
+        }
+        // Reminder turn: emit a raw event whose persisted output row must carry
+        // the system_reminder tag so it does not leak into the transcript.
+        yield {
+          type: 'raw_event',
+          metadata: { rawEvent: { type: 'reminder.output', payload: { step: 1 } } },
+        };
+        yield {
+          type: 'complete',
+          content: '',
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        };
+      },
+      abortSession: vi.fn(),
+      cleanupSession: vi.fn(),
+    } as any;
+
+    const permissionService = {
+      resolvePermission: vi.fn(),
+      rejectAllPending: vi.fn(),
+      clearSessionCache: vi.fn(),
+    } as any;
+
+    const provider = new OpenAICodexProvider(
+      { apiKey: 'test-key' },
+      { protocol, permissionService }
+    );
+
+    await provider.initialize({
+      apiKey: 'test-key',
+      model: 'openai-codex:gpt-5',
+    });
+
+    for await (const _chunk of provider.sendMessage('name the session', undefined, 'session-reminder-raw', [], process.cwd())) {
+      // drain
+    }
+
+    const reminderOutputRow = createdMessages.find(
+      (message) =>
+        message.direction === 'output' &&
+        (message.metadata as any)?.eventType === 'reminder.output'
+    );
+
+    expect(reminderOutputRow).toBeDefined();
+    expect(reminderOutputRow?.metadata).toMatchObject({
+      promptType: 'system_reminder',
+      reminderKind: 'session_naming',
+    });
+  });
+
   it('stamps a synthetic edit-group ID onto raw event metadata and tool_call chunks for codex tool items', async () => {
     const itemStarted = {
       type: 'item.started',


### PR DESCRIPTION
## Problem

Fixes #420. On the OpenAI Codex provider, the internal session-naming `<SYSTEM_REMINDER>` leaks into the visible chat transcript (often garbled) and the auto-naming silently fails. The leaked text even includes "Do not mention this system reminder to the user."

## Root cause

`sendSessionNamingReminder` dispatches the reminder as a real model turn and persists its streamed output via `storeRawEventIfPresent`, which tags rows with `{ eventType, codexProvider, transport }` only. The transcript hides reminder rows when either `metadata.promptType === 'system_reminder'` or the content matches the exact `<SYSTEM_REMINDER>` tag regex (`CodexRawParser.isSystemReminderContent`). The input copy carries the metadata flag, but the output rows did not, so they relied on the exact-tag regex, which a fragmented or garbled streamed tag defeats.

## Fix

Thread an optional `extraMetadata` through `storeRawEventIfPresent` and tag the reminder turn's output rows with `promptType: 'system_reminder'` and `reminderKind: 'session_naming'`, so the metadata-based hide covers them instead of the brittle regex.

## Test

Added a unit test in `OpenAICodexProvider.persistence.test.ts` that drives the reminder turn with a raw event and asserts the persisted output row is tagged. Verified both ways: it fails on current main (1 failed, 4 passed) and passes with the fix (5 passed).

## Notes

- Provider-specific: this path lives only in `OpenAICodexProvider`; Claude and claude-code do not hit it.
- No change for sessions that name on the first turn (the reminder never fires) or for non-Codex providers; the new parameter is optional and existing callers are unaffected.
