### PR TITLE
fix(mcp-config): surface guidance when Codex rejects a url-based MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 <!-- Bug fixes go here -->
 - Codex session-naming reminder no longer leaks into the chat transcript; its turn output is tagged so the transcript hides it. (#420)
+- Codex sessions now append actionable guidance when `~/.codex/config.toml` has a url-based MCP server the bundled Codex rejects, instead of an opaque config-load failure. (#424)
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/runtime/src/ai/server/protocols/CodexAppServerProtocol.ts
+++ b/packages/runtime/src/ai/server/protocols/CodexAppServerProtocol.ts
@@ -29,6 +29,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import path from 'node:path';
 import { buildDocumentAttachmentPromptText } from '../providers/codex/documentAttachmentPrompt';
+import { describeCodexConfigError } from './codexConfigError';
 import { reverseCodexPatch, type CodexPatchKind } from '../providers/codex/patchReverse';
 import {
   AgentProtocol,
@@ -429,7 +430,9 @@ export class CodexAppServerProtocol implements AgentProtocol {
       try { client.close('init failed'); } catch { /* noop */ }
       try { child.kill(); } catch { /* noop */ }
       const tail = stderrTail.join('').slice(-2000);
-      throw new Error(`[CodexAppServer] initialize failed: ${err instanceof Error ? err.message : String(err)}${tail ? `\nstderr tail: ${tail}` : ''}`);
+      const rawError = `${err instanceof Error ? err.message : String(err)}${tail ? `\nstderr tail: ${tail}` : ''}`;
+      const configHint = describeCodexConfigError(rawError);
+      throw new Error(`[CodexAppServer] initialize failed: ${rawError}${configHint ? `\n\n${configHint}` : ''}`);
     }
     return {
       child,

--- a/packages/runtime/src/ai/server/protocols/CodexSDKProtocol.ts
+++ b/packages/runtime/src/ai/server/protocols/CodexSDKProtocol.ts
@@ -27,6 +27,7 @@
  */
 
 import { buildDocumentAttachmentPromptText } from '../providers/codex/documentAttachmentPrompt';
+import { describeCodexConfigError } from './codexConfigError';
 import {
   AgentProtocol,
   ProtocolSession,
@@ -313,9 +314,10 @@ export class CodexSDKProtocol implements AgentProtocol {
         (session.raw?.options as { abortSignal?: AbortSignal })?.abortSignal?.aborted || /abort|cancel/i.test(errorMessage);
 
       if (!isAbort) {
+        const configHint = describeCodexConfigError(errorMessage);
         yield {
           type: 'error',
-          error: errorMessage,
+          error: configHint ? `${errorMessage}\n\n${configHint}` : errorMessage,
         };
       }
     }

--- a/packages/runtime/src/ai/server/protocols/__tests__/codexConfigError.test.ts
+++ b/packages/runtime/src/ai/server/protocols/__tests__/codexConfigError.test.ts
@@ -23,6 +23,15 @@ describe('describeCodexConfigError', () => {
     expect(msg).toContain('MY_SERVER_API_KEY');
   });
 
+  it('quotes the TOML table key when the server name contains a dot', () => {
+    const msg = describeCodexConfigError(
+      'Error loading config.toml: url is not supported for stdio in mcp_servers.customer.io'
+    );
+    expect(msg).toContain('[mcp_servers."customer.io"]');
+    expect(msg).toContain('[mcp_servers."customer.io".env]');
+    expect(msg).toContain('CUSTOMER_IO_API_KEY');
+  });
+
   it('returns null for unrelated or empty errors', () => {
     expect(describeCodexConfigError('network error: ECONNREFUSED')).toBeNull();
     expect(describeCodexConfigError('Codex Exec exited with code 1')).toBeNull();

--- a/packages/runtime/src/ai/server/protocols/__tests__/codexConfigError.test.ts
+++ b/packages/runtime/src/ai/server/protocols/__tests__/codexConfigError.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { describeCodexConfigError } from '../codexConfigError';
+
+describe('describeCodexConfigError', () => {
+  const raw =
+    'Codex Exec exited with code 1: Error loading config.toml: url is not supported for stdio in mcp_servers.linear';
+
+  it('returns actionable guidance naming the offending server', () => {
+    const msg = describeCodexConfigError(raw);
+    expect(msg).not.toBeNull();
+    expect(msg).toContain('"linear"');
+    expect(msg).toContain('[mcp_servers.linear]');
+    expect(msg).toContain('mcp-remote');
+    expect(msg).toContain('Personal API Key');
+    expect(msg).toContain('LINEAR_API_KEY');
+  });
+
+  it('derives the env var name from the server name', () => {
+    const msg = describeCodexConfigError(
+      'Error loading config.toml: url is not supported for stdio in mcp_servers.my-server'
+    );
+    expect(msg).toContain('[mcp_servers.my-server]');
+    expect(msg).toContain('MY_SERVER_API_KEY');
+  });
+
+  it('returns null for unrelated or empty errors', () => {
+    expect(describeCodexConfigError('network error: ECONNREFUSED')).toBeNull();
+    expect(describeCodexConfigError('Codex Exec exited with code 1')).toBeNull();
+    expect(describeCodexConfigError('')).toBeNull();
+  });
+});

--- a/packages/runtime/src/ai/server/protocols/codexConfigError.ts
+++ b/packages/runtime/src/ai/server/protocols/codexConfigError.ts
@@ -15,21 +15,24 @@ export function describeCodexConfigError(raw: string): string | null {
   if (!match) return null;
 
   const name = match[1];
+  // TOML bare keys allow only [A-Za-z0-9_-]. A name with any other character
+  // (e.g. a dot) must be quoted, or `[mcp_servers.a.b]` parses as nested tables.
+  const tomlKey = /^[A-Za-z0-9_-]+$/.test(name) ? name : JSON.stringify(name);
   const envKey = `${name.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}_API_KEY`;
 
   return [
-    `The MCP server "${name}" in ~/.codex/config.toml uses a "url", which this Codex build does not support (it only launches stdio MCP servers via a "command"). Convert that entry one of two ways, then restart:`,
+    `The MCP server "${name}" in ~/.codex/config.toml uses a "url", which this Codex build does not support (it only launches stdio MCP servers via a "command"). Convert that entry, then restart.`,
     ``,
-    `1) Keep the same remote server, wrapped as a stdio process:`,
-    `     [mcp_servers.${name}]`,
+    `Universal fix - wrap the remote server as a stdio process:`,
+    `     [mcp_servers.${tomlKey}]`,
     `     command = "npx"`,
     `     args = ["-y", "mcp-remote", "<url>"]`,
     ``,
-    `2) Switch to a local stdio server authenticated with a Personal API Key (avoids OAuth token expiry):`,
-    `     [mcp_servers.${name}]`,
+    `If you run a local stdio build of this server (for example, a Personal API Key version that avoids OAuth token expiry), point Codex at it instead:`,
+    `     [mcp_servers.${tomlKey}]`,
     `     command = "python"`,
-    `     args = ["/path/to/${name}-mcp/server.py"]`,
-    `     [mcp_servers.${name}.env]`,
+    `     args = ["/path/to/${name}-server.py"]`,
+    `     [mcp_servers.${tomlKey}.env]`,
     `     ${envKey} = "<your key>"`,
   ].join('\n');
 }

--- a/packages/runtime/src/ai/server/protocols/codexConfigError.ts
+++ b/packages/runtime/src/ai/server/protocols/codexConfigError.ts
@@ -1,0 +1,35 @@
+/**
+ * When Codex fails to load `config.toml` because an MCP server entry uses a
+ * remote `url` that the bundled Codex build does not accept (older builds only
+ * support stdio MCP servers), the raw error is opaque: "url is not supported for
+ * stdio in mcp_servers.<name>". Detect that case and return actionable guidance
+ * that names the offending server and shows how to convert it to a stdio entry.
+ *
+ * Returns null when the error is not a recognized url-vs-stdio MCP config error,
+ * so callers can fall back to the raw message.
+ */
+export function describeCodexConfigError(raw: string): string | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+
+  const match = raw.match(/url is not supported for stdio in mcp_servers\.([A-Za-z0-9._-]+)/i);
+  if (!match) return null;
+
+  const name = match[1];
+  const envKey = `${name.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}_API_KEY`;
+
+  return [
+    `The MCP server "${name}" in ~/.codex/config.toml uses a "url", which this Codex build does not support (it only launches stdio MCP servers via a "command"). Convert that entry one of two ways, then restart:`,
+    ``,
+    `1) Keep the same remote server, wrapped as a stdio process:`,
+    `     [mcp_servers.${name}]`,
+    `     command = "npx"`,
+    `     args = ["-y", "mcp-remote", "<url>"]`,
+    ``,
+    `2) Switch to a local stdio server authenticated with a Personal API Key (avoids OAuth token expiry):`,
+    `     [mcp_servers.${name}]`,
+    `     command = "python"`,
+    `     args = ["/path/to/${name}-mcp/server.py"]`,
+    `     [mcp_servers.${name}.env]`,
+    `     ${envKey} = "<your key>"`,
+  ].join('\n');
+}


### PR DESCRIPTION
## Problem

Fixes #424. When `~/.codex/config.toml` has an MCP server with a `url` (a remote / streamable-HTTP server) that the bundled `@openai/codex-sdk@^0.130.0` does not accept, Codex fails to load the config and the session dies before it starts:

```
Codex Exec exited with code 1: Error loading config.toml: url is not supported for stdio in mcp_servers.linear
```

The raw error names the problem but gives no recovery steps. Newer Codex supports url-based MCP servers; the bundled SDK is older and treats every `[mcp_servers.*]` as stdio, so it rejects the `url`.

## Fix

Add `describeCodexConfigError(raw)` (`protocols/codexConfigError.ts`), a pure function that detects `url is not supported for stdio in mcp_servers.<name>` and returns guidance naming the offending server and two ways to convert it to a stdio entry:

1. wrap the remote URL as a stdio process via `npx -y mcp-remote <url>`, or
2. switch to a local stdio server authenticated with a Personal API Key (avoids OAuth token expiry).

Wired into both Codex transports so the surfaced error carries the fix steps:

- SDK transport (`codex exec`): the error yield in `CodexSDKProtocol.ts`.
- app-server transport: the initialize-failure throw in `CodexAppServerProtocol.ts`.

It falls back to the raw error for anything it does not recognize, so no other error path changes.

## Test

`protocols/__tests__/codexConfigError.test.ts` (3 cases): the guidance names the server and includes both conversion paths, the env-var name is derived from the server name, and unrelated or empty errors return null. Passes locally (3/3).

## Notes

- Does not overlap PR #421 (that touches `OpenAICodexProvider.ts`; this is the two protocol files plus a new helper).
- No behavior change for sessions without a url-based MCP server, or for non-Codex providers.
