### PR TITLE
fix(excalidraw): register imported Mermaid image so it renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 <!-- Bug fixes go here -->
 - Codex session-naming reminder no longer leaks into the chat transcript; its turn output is tagged so the transcript hides it. (#420)
+- Excalidraw "import mermaid" now registers the rendered diagram image, so it no longer shows as a broken thumbnail. (#428)
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/extensions/excalidraw/src/__tests__/aiTools.importMermaid.test.ts
+++ b/packages/extensions/excalidraw/src/__tests__/aiTools.importMermaid.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// aiTools imports these two @excalidraw value exports at module load. Mock them
+// so the tool can run in plain Node without the browser-only excalidraw bundle.
+vi.mock('@excalidraw/excalidraw', () => ({
+  convertToExcalidrawElements: vi.fn((elements: unknown[]) => elements),
+}));
+vi.mock('@excalidraw/mermaid-to-excalidraw', () => ({
+  parseMermaidToExcalidraw: vi.fn(),
+}));
+
+import { parseMermaidToExcalidraw } from '@excalidraw/mermaid-to-excalidraw';
+import { aiTools } from '../aiTools';
+
+const parseMock = parseMermaidToExcalidraw as unknown as ReturnType<typeof vi.fn>;
+
+function importMermaidHandler(): (params: any, context: any) => Promise<any> {
+  const tool = aiTools.find((t) => t.name === 'import_mermaid');
+  if (!tool) throw new Error('import_mermaid tool not found');
+  return tool.handler as (params: any, context: any) => Promise<any>;
+}
+
+function makeApi(overrides: Record<string, unknown> = {}) {
+  return {
+    getSceneElements: () => [],
+    updateScene: vi.fn(),
+    addFiles: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('import_mermaid tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers the rendered image files via addFiles so they are not dropped (#428)', async () => {
+    const fileId = 'mermaid-file-1';
+    const files = {
+      [fileId]: { id: fileId, mimeType: 'image/png', dataURL: 'data:image/png;base64,AAAA', created: 1 },
+    };
+    parseMock.mockResolvedValue({ elements: [{ type: 'image', fileId }], files });
+
+    const api = makeApi();
+    const result = await importMermaidHandler()({ mermaid: 'flowchart LR; A-->B' }, { editorAPI: api });
+
+    expect(result).toMatchObject({ success: true });
+    // The blob must be registered, otherwise the image element references a
+    // fileId with no data and renders as a broken thumbnail (#428).
+    expect(api.addFiles).toHaveBeenCalledTimes(1);
+    expect(api.addFiles).toHaveBeenCalledWith(Object.values(files));
+    expect(api.updateScene).toHaveBeenCalled();
+  });
+
+  it('does not call addFiles when the diagram produced no files', async () => {
+    parseMock.mockResolvedValue({ elements: [{ type: 'rectangle' }], files: {} });
+
+    const api = makeApi();
+    await importMermaidHandler()({ mermaid: 'flowchart LR; A-->B' }, { editorAPI: api });
+
+    expect(api.addFiles).not.toHaveBeenCalled();
+    expect(api.updateScene).toHaveBeenCalled();
+  });
+});

--- a/packages/extensions/excalidraw/src/aiTools.ts
+++ b/packages/extensions/excalidraw/src/aiTools.ts
@@ -713,6 +713,16 @@ export const aiTools = [
         const newElements = [...currentElements, ...excalidrawElements];
         console.log('[import_mermaid] Updating scene with', newElements.length, 'total elements');
 
+        // Register the image blob(s) Mermaid produced before adding the elements
+        // that reference them. The rendered diagram is an image element whose
+        // data lives in `files`; updateScene does not accept files, so without
+        // addFiles the fileId resolves to nothing and the element renders as a
+        // broken thumbnail (#428).
+        const importedFiles = Object.values(files);
+        if (importedFiles.length > 0) {
+          api.addFiles(importedFiles);
+        }
+
         api.updateScene({
           elements: newElements,
         });


### PR DESCRIPTION
## Problem

`excalidraw_import_mermaid` creates an image element referencing a `fileId`, but the rendered diagram's image blob was never registered with the editor, so the element renders as a broken thumbnail (#428). `parseMermaidToExcalidraw` returns `{ elements, files }`, and the handler destructured `files` but only passed `elements` to `updateScene` (`aiTools.ts:716`). `updateScene` does not accept files.

## Fix

Register the blobs via `api.addFiles(Object.values(files))` before `updateScene`, so the image elements resolve their `fileId`. Guarded so it is a no-op when the diagram has no files. `addFiles` is the standard imperative-API method for adding image data (the type is `addFiles(data: BinaryFileData[])`; `updateScene` has no files key).

## Test

`__tests__/aiTools.importMermaid.test.ts` (new): mocks the excalidraw modules and the editor API, then asserts the handler calls `addFiles` with the parsed files, and does not call it when there are none. Red without the fix, green with it.

## Notes

- Isolated to the excalidraw extension; no behavior change for any other tool.
- Closes #428.
