### PR TITLE
fix(editor): surface AI diffs for blockquote edits in Files Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extension docs now cover all four markdown/transcript contribution surfaces in both the internal architecture doc and the public SDK docs, including declarative module exports, diff handlers, transcript renderer hooks, and the current `@nimbalyst/runtime` import surface.
 
 ### Fixed
+- Files Mode editor now surfaces AI edits to blockquote lines as red/green diffs, the same as plain paragraphs. (#433)
 - Project quick open now loads recent projects from stored recents instead of crawling every workspace on open.
 - Rebuild Extensions submenu now lists buildable extensions alphabetically.
 - Tracker list, table, and kanban views now share the session-style `#tag` typeahead filter.

--- a/packages/runtime/src/editor/plugins/DiffPlugin/__tests__/unit/basic/blockquotes.test.ts
+++ b/packages/runtime/src/editor/plugins/DiffPlugin/__tests__/unit/basic/blockquotes.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  assertApproveProducesTarget,
+  assertRejectProducesOriginal,
+  assertReplacementApplied,
+  setupMarkdownReplaceTest,
+} from '../../utils/replaceTestUtils';
+
+describe('Markdown Replace - Blockquotes', () => {
+  test('Updates blockquote text', () => {
+    const originalMarkdown = `> Original quote text`;
+    const replacements = [
+      {
+        oldText: 'Original',
+        newText: 'Updated',
+      },
+    ];
+
+    const result = setupMarkdownReplaceTest(originalMarkdown, replacements);
+
+    assertReplacementApplied(result, ['Updated'], ['Original']);
+    assertApproveProducesTarget(result);
+    assertRejectProducesOriginal(result);
+  });
+
+  test('Prepends word to a blockquote line (issue #433)', () => {
+    const originalMarkdown = `> Some blockquote content`;
+    const replacements = [
+      {
+        oldText: 'Some blockquote',
+        newText: 'Test Some blockquote',
+      },
+    ];
+
+    const result = setupMarkdownReplaceTest(originalMarkdown, replacements);
+
+    assertReplacementApplied(result, ['Test '], []);
+    assertApproveProducesTarget(result);
+    assertRejectProducesOriginal(result);
+  });
+
+  test('Multiple blockquote edits all surface as diffs', () => {
+    const originalMarkdown = `> First blockquote line
+
+> Second blockquote line
+
+> Third blockquote line`;
+
+    const replacements = [
+      {
+        oldText: 'First',
+        newText: 'Test First',
+      },
+      {
+        oldText: 'Second',
+        newText: 'Test Second',
+      },
+    ];
+
+    const result = setupMarkdownReplaceTest(originalMarkdown, replacements);
+
+    assertReplacementApplied(result, ['Test ', 'Test '], []);
+    assertApproveProducesTarget(result);
+    assertRejectProducesOriginal(result);
+  });
+});

--- a/packages/runtime/src/editor/plugins/DiffPlugin/core/diffUtils.ts
+++ b/packages/runtime/src/editor/plugins/DiffPlugin/core/diffUtils.ts
@@ -146,6 +146,7 @@ import {DefaultDiffHandler} from '../handlers/DefaultDiffHandler';
 import {ListDiffHandler} from '../handlers/ListDiffHandler';
 import {HeadingDiffHandler} from '../handlers/HeadingDiffHandler';
 import {ParagraphDiffHandler} from '../handlers/ParagraphDiffHandler';
+import {QuoteDiffHandler} from '../handlers/QuoteDiffHandler';
 import {TableDiffHandler} from '../handlers/TableDiffHandler';
 import {CodeBlockDiffHandler} from '../handlers/CodeBlockDiffHandler';
 import {MermaidDiffHandler} from '../handlers/MermaidDiffHandler';
@@ -174,6 +175,7 @@ export function initializeHandlers() {
   diffHandlerRegistry.register(new CodeBlockDiffHandler());
   diffHandlerRegistry.register(new MermaidDiffHandler());
   diffHandlerRegistry.register(new ParagraphDiffHandler());
+  diffHandlerRegistry.register(new QuoteDiffHandler());
   diffHandlerRegistry.register(new HeadingDiffHandler());
   diffHandlerRegistry.register(new ListDiffHandler());
   diffHandlerRegistry.register(new DefaultDiffHandler());

--- a/packages/runtime/src/editor/plugins/DiffPlugin/handlers/QuoteDiffHandler.ts
+++ b/packages/runtime/src/editor/plugins/DiffPlugin/handlers/QuoteDiffHandler.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {
+  DiffHandlerContext,
+  DiffHandlerResult,
+  DiffNodeHandler,
+} from './DiffNodeHandler';
+import type {ElementNode, LexicalNode, SerializedLexicalNode} from 'lexical';
+
+import {$isElementNode} from 'lexical';
+
+import {$applyInlineTextDiff} from '../core/inlineTextDiff';
+
+/**
+ * Handler for blockquote (quote) nodes. Without it, quote nodes fall through to
+ * DefaultDiffHandler, which marks the node 'modified' but never applies the
+ * inline text diff, so edits to a blockquote line never surface in the editor's
+ * red/green diff view (#433). Mirrors ParagraphDiffHandler, since a blockquote
+ * holds paragraph-like text.
+ */
+export class QuoteDiffHandler implements DiffNodeHandler {
+  readonly nodeType = 'quote';
+
+  canHandle(context: DiffHandlerContext): boolean {
+    return context.liveNode.getType() === 'quote';
+  }
+
+  handleUpdate(context: DiffHandlerContext): DiffHandlerResult {
+    const {liveNode, sourceNode, targetNode} = context;
+
+    if (!$isElementNode(liveNode)) {
+      return {handled: false};
+    }
+
+    const sourceChildren =
+      'children' in sourceNode && Array.isArray(sourceNode.children)
+        ? sourceNode.children
+        : [];
+
+    const targetChildren =
+      'children' in targetNode && Array.isArray(targetNode.children)
+        ? targetNode.children
+        : [];
+
+    // Use the unified inline text diff system
+    $applyInlineTextDiff(liveNode, sourceChildren, targetChildren);
+
+    return {handled: true, skipChildren: true};
+  }
+
+  handleAdd(
+    targetNode: SerializedLexicalNode,
+    parentNode: ElementNode,
+    position: number,
+  ): DiffHandlerResult {
+    // For adds, we can use the default behavior
+    return {handled: false};
+  }
+
+  handleRemove(liveNode: LexicalNode): DiffHandlerResult {
+    // For removes, we can use the default behavior
+    return {handled: false};
+  }
+}

--- a/packages/runtime/src/editor/plugins/DiffPlugin/handlers/index.ts
+++ b/packages/runtime/src/editor/plugins/DiffPlugin/handlers/index.ts
@@ -18,5 +18,6 @@ export {HeadingDiffHandler} from './HeadingDiffHandler';
 export {NoopDiffHandler} from './NoopDiffHandler';
 export {ListDiffHandler} from './ListDiffHandler';
 export {ParagraphDiffHandler} from './ParagraphDiffHandler';
+export {QuoteDiffHandler} from './QuoteDiffHandler';
 export {CodeBlockDiffHandler} from './CodeBlockDiffHandler';
 export {MermaidDiffHandler} from './MermaidDiffHandler';


### PR DESCRIPTION
## Problem

When an AI agent edits a markdown blockquote line (`> ...`), the change lands on disk but never appears in the Files Mode editor's red/green diff view (#433). Plain paragraph edits to the same file surface immediately.

Root cause: the DiffPlugin registers per-node-type handlers, but there is no handler for the blockquote (`quote`) node. Quote nodes fall through to `DefaultDiffHandler`, which marks the node `'modified'` but never calls `$applyInlineTextDiff()`, the function `ParagraphDiffHandler` and `HeadingDiffHandler` use to produce the inline add/remove nodes that drive the visible diff. So the edit is tracked in DiffState but never rendered.

## Fix

Add `QuoteDiffHandler` (`handlers/QuoteDiffHandler.ts`), mirroring `ParagraphDiffHandler`, and register it in `initializeHandlers()` before the catch-all `DefaultDiffHandler`. A blockquote holds paragraph-like text, so the same inline-text-diff path applies.

## Test

`__tests__/unit/basic/blockquotes.test.ts` (new), mirroring `headings.test.ts`: a single edit, a word prepend (the exact #433 reproduction), and multiple blockquote edits. All three fail before the fix (no diff produced) and pass after.

## Notes

- Only `quote` nodes route to the new handler; all other node types are unchanged. Approve and reject paths are covered by the test.
- Closes #433. Thanks @karlwirth for the precise repro.
