### PR TITLE
fix: surface project-scope Claude Code plugins in UI and slash typeahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-uploading a local source into a shared markdown document now waits for the collab write to be acknowledged before tearing down the headless sync client.
 <!-- Bug fixes go here -->
 - Codex session-naming reminder no longer leaks into the chat transcript; its turn output is tagged so the transcript hides it. (#420)
+- Claude Code plugins installed at the project scope (via `<workspace>/.claude/settings.json` `enabledPlugins`) now appear in the Installed plugins list when the panel is opened from a project's settings, with badges showing the marketplace source and whether the plugin is user- or project-scoped.
+- Slash-command typeahead now lists commands and skills from Claude CLI plugins (`~/.claude/plugins/`) without requiring the experimental "Agent Workflows" toggle, matching what the Claude Agent SDK auto-loads from `enabledPlugins`.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/ipc/ClaudeCodePluginHandlers.ts
+++ b/packages/electron/src/main/ipc/ClaudeCodePluginHandlers.ts
@@ -645,51 +645,108 @@ async function installPlugin(pluginName: string, source: string): Promise<{ succ
   }
 }
 
+interface UninstallTarget {
+  name: string;
+  source?: string;
+  scope?: 'user' | 'project';
+  projectPath?: string;
+}
+
 /**
- * Uninstall a plugin
+ * Locate the `name@source` key in installed_plugins.json that matches the
+ * caller's intent. When the caller already provides a source, we require an
+ * exact match. Otherwise we fall back to the legacy behaviour of matching by
+ * plugin name alone but refuse to guess when multiple sources are ambiguous.
  */
-async function uninstallPlugin(pluginName: string): Promise<{ success: boolean; error?: string }> {
+function resolvePluginKey(
+  installedPlugins: InstalledPluginsJson['plugins'],
+  target: UninstallTarget,
+): { matchingKey?: string; ambiguous?: boolean } {
+  if (target.source) {
+    const exactKey = `${target.name}@${target.source}`;
+    return installedPlugins[exactKey] ? { matchingKey: exactKey } : {};
+  }
+
+  const candidates = Object.keys(installedPlugins).filter(key =>
+    key.startsWith(`${target.name}@`)
+  );
+
+  if (candidates.length === 0) {
+    return {};
+  }
+  if (candidates.length > 1) {
+    return { ambiguous: true };
+  }
+  return { matchingKey: candidates[0] };
+}
+
+/**
+ * Uninstall a plugin entry from installed_plugins.json.
+ *
+ * Selection precedence:
+ * 1. Exact `name@source` match when the caller supplies a source.
+ * 2. Legacy name-only match when there is exactly one installation by that
+ *    name (preserves prior behaviour for older callers).
+ *
+ * Scope precedence:
+ * 1. The explicit scope (and `projectPath`) supplied by the caller.
+ * 2. The user-scoped installation when none is provided.
+ */
+async function uninstallPlugin(target: UninstallTarget): Promise<{ success: boolean; error?: string }> {
   try {
-    logger.main.info(`[ClaudePlugins] Uninstalling plugin: ${pluginName}`);
+    logger.main.info(`[ClaudePlugins] Uninstalling plugin: ${target.name}@${target.source ?? '(unspecified)'}`);
 
     const installedJson = await readInstalledPluginsJson();
+    const { matchingKey, ambiguous } = resolvePluginKey(installedJson.plugins, target);
 
-    // Find the plugin key that matches this plugin name (format: pluginName@source)
-    const matchingKey = Object.keys(installedJson.plugins).find(key => key.startsWith(`${pluginName}@`));
-
+    if (ambiguous) {
+      return {
+        success: false,
+        error: `Plugin ${target.name} is installed from multiple marketplaces; specify a source to uninstall`,
+      };
+    }
     if (!matchingKey) {
-      return { success: false, error: `Plugin ${pluginName} is not installed` };
+      return { success: false, error: `Plugin ${target.name} is not installed` };
     }
 
-    // Find user-scope installation
-    const userInstallation = installedJson.plugins[matchingKey].find(e => e.scope === 'user');
-    if (!userInstallation) {
-      return { success: false, error: `Plugin ${pluginName} is not installed in user scope` };
+    const installations = installedJson.plugins[matchingKey];
+    const desiredScope = target.scope ?? 'user';
+    const installation = installations.find(entry => {
+      if (entry.scope !== desiredScope) {
+        return false;
+      }
+      if (desiredScope === 'project' && target.projectPath) {
+        return entry.projectPath === target.projectPath;
+      }
+      return true;
+    });
+
+    if (!installation) {
+      return {
+        success: false,
+        error: `Plugin ${target.name} is not installed in ${desiredScope} scope`,
+      };
     }
 
-    // Remove the plugin directory
     try {
-      await fsPromises.rm(userInstallation.installPath, { recursive: true, force: true });
+      await fsPromises.rm(installation.installPath, { recursive: true, force: true });
     } catch (err) {
       logger.main.warn(`[ClaudePlugins] Could not remove plugin directory: ${err}`);
     }
 
-    // Update installed_plugins.json
-    installedJson.plugins[matchingKey] = installedJson.plugins[matchingKey].filter(e => e.scope !== 'user');
-
-    // Remove plugin entry if no installations left
+    installedJson.plugins[matchingKey] = installations.filter(entry => entry !== installation);
     if (installedJson.plugins[matchingKey].length === 0) {
       delete installedJson.plugins[matchingKey];
     }
 
     await writeInstalledPluginsJson(installedJson);
 
-    logger.main.info(`[ClaudePlugins] Successfully uninstalled plugin: ${pluginName}`);
+    logger.main.info(`[ClaudePlugins] Successfully uninstalled plugin: ${matchingKey}`);
     return { success: true };
 
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
-    logger.main.error(`[ClaudePlugins] Failed to uninstall plugin ${pluginName}:`, err);
+    logger.main.error(`[ClaudePlugins] Failed to uninstall plugin ${target.name}:`, err);
     return { success: false, error: errorMsg };
   }
 }
@@ -731,12 +788,25 @@ export function registerClaudeCodePluginHandlers() {
     return await installPlugin(pluginName, source);
   });
 
-  // Uninstall a plugin
-  safeHandle('claude-plugin:uninstall', async (_event, pluginName: string) => {
-    if (!pluginName) {
+  // Uninstall a plugin.
+  //
+  // Accepts either the legacy positional form `(pluginName)` or a structured
+  // payload `{ name, source?, scope?, projectPath? }`. Renderer code should
+  // prefer the structured form so that plugins published from more than one
+  // marketplace can be disambiguated.
+  safeHandle('claude-plugin:uninstall', async (
+    _event,
+    pluginNameOrPayload: string | UninstallTarget,
+  ) => {
+    const target: UninstallTarget =
+      typeof pluginNameOrPayload === 'string'
+        ? { name: pluginNameOrPayload }
+        : pluginNameOrPayload ?? { name: '' };
+
+    if (!target.name) {
       return { success: false, error: 'Plugin name is required' };
     }
-    return await uninstallPlugin(pluginName);
+    return await uninstallPlugin(target);
   });
 
   // Clear marketplace cache

--- a/packages/electron/src/main/ipc/ClaudeCodePluginHandlers.ts
+++ b/packages/electron/src/main/ipc/ClaudeCodePluginHandlers.ts
@@ -29,7 +29,10 @@ interface MarketplaceData {
 
 interface InstalledPlugin {
   name: string;
+  source: string;
   path: string;
+  scope: 'user' | 'project';
+  projectPath?: string;
   enabled: boolean;
 }
 
@@ -263,31 +266,111 @@ async function writeInstalledPluginsJson(data: InstalledPluginsJson): Promise<vo
 }
 
 /**
- * List installed plugins from installed_plugins.json (user scope only)
+ * Read enabledPlugins from a Claude settings.json file.
+ * Returns an empty record if the file is missing or malformed.
  */
-async function listInstalledPlugins(): Promise<InstalledPlugin[]> {
+async function readEnabledPlugins(settingsPath: string): Promise<Record<string, boolean>> {
+  try {
+    const content = await fsPromises.readFile(settingsPath, 'utf-8');
+    const parsed = JSON.parse(content);
+    if (parsed && typeof parsed === 'object' && parsed.enabledPlugins && typeof parsed.enabledPlugins === 'object') {
+      return parsed.enabledPlugins as Record<string, boolean>;
+    }
+  } catch {
+    // Missing file or invalid JSON — treat as no overrides.
+  }
+  return {};
+}
+
+/**
+ * Resolve the merged enabledPlugins map for a given workspace.
+ * Project-level settings override user-level ones; settings.local.json wins last.
+ */
+async function loadEnabledPlugins(workspacePath?: string): Promise<Record<string, boolean>> {
+  const userSettings = await readEnabledPlugins(path.join(os.homedir(), '.claude', 'settings.json'));
+  if (!workspacePath) {
+    return userSettings;
+  }
+  const projectSettings = await readEnabledPlugins(path.join(workspacePath, '.claude', 'settings.json'));
+  const projectLocalSettings = await readEnabledPlugins(path.join(workspacePath, '.claude', 'settings.local.json'));
+  return { ...userSettings, ...projectSettings, ...projectLocalSettings };
+}
+
+/**
+ * Parse a plugin key in the `name@source` format used by installed_plugins.json.
+ */
+function parsePluginKey(pluginKey: string): { name: string; source: string } {
+  const atIndex = pluginKey.lastIndexOf('@');
+  if (atIndex === -1) {
+    return { name: pluginKey, source: '' };
+  }
+  return {
+    name: pluginKey.slice(0, atIndex),
+    source: pluginKey.slice(atIndex + 1),
+  };
+}
+
+/**
+ * Check whether a project-scoped installation belongs to the given workspace.
+ * Accepts both exact matches and workspaces nested below the project root.
+ */
+function projectScopeMatchesWorkspace(projectPath: string | undefined, workspacePath: string | undefined): boolean {
+  if (!projectPath || !workspacePath) {
+    return false;
+  }
+  const normalizedProject = path.resolve(projectPath);
+  const normalizedWorkspace = path.resolve(workspacePath);
+  return (
+    normalizedWorkspace === normalizedProject ||
+    normalizedWorkspace.startsWith(normalizedProject + path.sep)
+  );
+}
+
+/**
+ * List installed plugins from installed_plugins.json.
+ *
+ * Includes:
+ * - All user-scoped plugins
+ * - Project-scoped plugins whose `projectPath` matches the supplied workspace
+ *
+ * The returned `enabled` flag reflects the merged enabledPlugins map across
+ * `~/.claude/settings.json`, `<workspace>/.claude/settings.json`, and
+ * `<workspace>/.claude/settings.local.json` (Claude CLI precedence).
+ */
+async function listInstalledPlugins(workspacePath?: string): Promise<InstalledPlugin[]> {
   const plugins: InstalledPlugin[] = [];
 
   try {
-    const installedJson = await readInstalledPluginsJson();
+    const [installedJson, enabledMap] = await Promise.all([
+      readInstalledPluginsJson(),
+      loadEnabledPlugins(workspacePath),
+    ]);
 
     for (const [pluginKey, installations] of Object.entries(installedJson.plugins)) {
-      // Only include user-scoped plugins
+      const { name, source } = parsePluginKey(pluginKey);
+      const enabled = enabledMap[pluginKey] === true;
+
       for (const installation of installations) {
-        if (installation.scope === 'user') {
-          // Verify the path still exists
-          try {
-            await fsPromises.access(installation.installPath);
-            // Extract plugin name from key (format: pluginName@source)
-            const pluginName = pluginKey.split('@')[0];
-            plugins.push({
-              name: pluginName,
-              path: installation.installPath,
-              enabled: true,
-            });
-          } catch {
-            logger.main.warn(`[ClaudePlugins] Plugin path not found: ${installation.installPath}`);
-          }
+        const includeInstallation =
+          installation.scope === 'user' ||
+          (installation.scope === 'project' && projectScopeMatchesWorkspace(installation.projectPath, workspacePath));
+
+        if (!includeInstallation) {
+          continue;
+        }
+
+        try {
+          await fsPromises.access(installation.installPath);
+          plugins.push({
+            name,
+            source,
+            path: installation.installPath,
+            scope: installation.scope,
+            projectPath: installation.projectPath,
+            enabled,
+          });
+        } catch {
+          logger.main.warn(`[ClaudePlugins] Plugin path not found: ${installation.installPath}`);
         }
       }
     }
@@ -625,9 +708,10 @@ export function registerClaudeCodePluginHandlers() {
   });
 
   // List installed plugins
-  safeHandle('claude-plugin:list-installed', async () => {
+  safeHandle('claude-plugin:list-installed', async (_event, payload?: { workspacePath?: string }) => {
     try {
-      const plugins = await listInstalledPlugins();
+      const workspacePath = typeof payload === 'object' && payload !== null ? payload.workspacePath : undefined;
+      const plugins = await listInstalledPlugins(workspacePath);
       return { success: true, data: plugins };
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/packages/electron/src/main/services/AgentWorkflowService.ts
+++ b/packages/electron/src/main/services/AgentWorkflowService.ts
@@ -487,8 +487,14 @@ export class AgentWorkflowService {
 
     if (sourceSettings.extensionWorkflowsEnabled) {
       await this.scanExtensionWorkflowSources(snapshot);
-      await this.scanLegacyClaudePluginSources(snapshot);
     }
+
+    // Always scan Claude CLI plugins (~/.claude/plugins) regardless of the
+    // Nimbalyst extension-workflows toggle. The Claude Agent SDK auto-loads
+    // these plugins based on the user's enabledPlugins settings, so the
+    // Nimbalyst typeahead must mirror that to avoid showing plugin commands
+    // only on the global panel but not on project-scoped workspaces.
+    await this.scanLegacyClaudePluginSources(snapshot);
 
     return snapshot;
   }

--- a/packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePluginsPanel.tsx
+++ b/packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePluginsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { usePostHog } from 'posthog-js/react';
 import { ErrorBoundary } from '../../ErrorBoundary';
 import { useTheme } from '../../../hooks/useTheme';
@@ -165,15 +165,39 @@ interface ClaudeCodePluginsPanelProps {
 // Marketplace plugins don't carry a source attribution that matches the
 // installed_plugins.json key directly. Best-effort extraction lets us produce a
 // stable `name@source` key for marketplace cards too.
+//
+// This mirrors how the install handler derives `sourceName` from the
+// marketplace URL, so the value we use to test `isPluginInstalled` matches the
+// `name@source` key the installer writes to `installed_plugins.json`.
 function extractMarketplaceSourceName(plugin: MarketplacePlugin): string {
-  const sourceField = plugin.source || '';
-  if (sourceField.startsWith('http')) {
-    const match = sourceField.match(/github\.com\/([^/]+\/[^/]+)/i);
-    if (match) {
-      return match[1].replace('/', '-');
-    }
+  const sourceField = (plugin.source || '').trim();
+  if (!/^https?:/i.test(sourceField)) {
+    return 'claude-plugins-official';
   }
-  return 'claude-plugins-official';
+
+  let parsed: URL | null = null;
+  try {
+    parsed = new URL(sourceField);
+  } catch {
+    parsed = null;
+  }
+
+  if (!parsed || !/(^|\.)github\.com$/i.test(parsed.hostname)) {
+    return 'claude-plugins-official';
+  }
+
+  // Pathname looks like "/owner/repo" or "/owner/repo/tree/...". We only care
+  // about the first two segments. Strip a trailing `.git` so URLs that come
+  // straight from `git clone` examples produce the same key as the marketplace
+  // installer.
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  if (segments.length < 2) {
+    return 'claude-plugins-official';
+  }
+
+  const owner = segments[0];
+  const repo = segments[1].replace(/\.git$/i, '');
+  return `${owner}-${repo}`;
 }
 
 function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCodePluginsPanelProps) {
@@ -191,14 +215,7 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
   const [installStatus, setInstallStatus] = useState<Record<string, 'idle' | 'installing' | 'installed' | 'error'>>({});
   const [installMessage, setInstallMessage] = useState<string>('');
 
-  useEffect(() => {
-    loadData();
-    // Reload when the active workspace changes so project-scoped plugins
-    // appear or disappear with the current project.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspacePath]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     setLoading(true);
     setError(null);
 
@@ -225,7 +242,13 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
     } finally {
       setLoading(false);
     }
-  };
+  }, [workspacePath]);
+
+  // Reload when the active workspace changes so project-scoped plugins
+  // appear or disappear with the current project.
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   const handleInstall = async (plugin: MarketplacePlugin) => {
     setInstallStatus(prev => ({ ...prev, [plugin.name]: 'installing' }));
@@ -267,17 +290,25 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
     }, 5000);
   };
 
-  const handleUninstall = async (pluginName: string) => {
-    if (!confirm(`Uninstall ${pluginName}?`)) {
+  interface UninstallTarget {
+    name: string;
+    source?: string;
+    scope?: 'user' | 'project';
+    projectPath?: string;
+  }
+
+  const handleUninstall = async (target: UninstallTarget) => {
+    const label = target.source ? `${target.name}@${target.source}` : target.name;
+    if (!confirm(`Uninstall ${label}?`)) {
       return;
     }
 
     try {
-      const result = await window.electronAPI.invoke('claude-plugin:uninstall', pluginName);
+      const result = await window.electronAPI.invoke('claude-plugin:uninstall', target);
 
       if (result.success) {
-        setInstallStatus(prev => ({ ...prev, [pluginName]: 'idle' }));
-        setInstallMessage(`${pluginName} uninstalled`);
+        setInstallStatus(prev => ({ ...prev, [target.name]: 'idle' }));
+        setInstallMessage(`${label} uninstalled`);
 
         // Refresh installed plugins
         const installedResult = await window.electronAPI.invoke('claude-plugin:list-installed', { workspacePath });
@@ -492,7 +523,12 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
                 <div className="plugin-installed-actions flex gap-2">
                   <button
                     className="plugin-uninstall-button py-1.5 px-3 border border-[#e74c3c] rounded bg-transparent text-[#e74c3c] text-xs font-medium cursor-pointer transition-all duration-150 hover:bg-[#e74c3c] hover:text-white"
-                    onClick={() => handleUninstall(plugin.name)}
+                    onClick={() => handleUninstall({
+                      name: plugin.name,
+                      source: plugin.source,
+                      scope: plugin.scope,
+                      projectPath: plugin.projectPath,
+                    })}
                     aria-label={`Uninstall ${plugin.name}`}
                   >
                     Uninstall
@@ -563,7 +599,15 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
                 <button
                   className="plugin-uninstall-button py-1.5 px-3 border border-[#e74c3c] rounded bg-transparent text-[#e74c3c] text-xs font-medium cursor-pointer transition-all duration-150 hover:bg-[#e74c3c] hover:text-white"
                   onClick={() => {
-                    handleUninstall(selectedPlugin.name);
+                    // Modal originates from a marketplace card, so we only
+                    // know name+derived source. The server-side uninstall
+                    // handler will refuse ambiguous matches; users on a
+                    // multi-marketplace install must uninstall from the
+                    // Installed tab where the source is explicit.
+                    handleUninstall({
+                      name: selectedPlugin.name,
+                      source: extractMarketplaceSourceName(selectedPlugin),
+                    });
                     setSelectedPlugin(null);
                   }}
                 >

--- a/packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePluginsPanel.tsx
+++ b/packages/electron/src/renderer/components/GlobalSettings/panels/ClaudeCodePluginsPanel.tsx
@@ -16,7 +16,10 @@ interface MarketplacePlugin {
 // Installed plugin from local system
 interface InstalledPlugin {
   name: string;
+  source: string;
   path: string;
+  scope: 'user' | 'project';
+  projectPath?: string;
   enabled: boolean;
 }
 
@@ -159,6 +162,20 @@ interface ClaudeCodePluginsPanelProps {
   workspacePath?: string;
 }
 
+// Marketplace plugins don't carry a source attribution that matches the
+// installed_plugins.json key directly. Best-effort extraction lets us produce a
+// stable `name@source` key for marketplace cards too.
+function extractMarketplaceSourceName(plugin: MarketplacePlugin): string {
+  const sourceField = plugin.source || '';
+  if (sourceField.startsWith('http')) {
+    const match = sourceField.match(/github\.com\/([^/]+\/[^/]+)/i);
+    if (match) {
+      return match[1].replace('/', '-');
+    }
+  }
+  return 'claude-plugins-official';
+}
+
 function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCodePluginsPanelProps) {
   const posthog = usePostHog();
   const { theme } = useTheme();
@@ -176,7 +193,10 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
 
   useEffect(() => {
     loadData();
-  }, []);
+    // Reload when the active workspace changes so project-scoped plugins
+    // appear or disappear with the current project.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspacePath]);
 
   const loadData = async () => {
     setLoading(true);
@@ -186,7 +206,7 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
       // Fetch marketplace data and installed plugins in parallel
       const [marketplaceResult, installedResult] = await Promise.all([
         window.electronAPI.invoke('claude-plugin:fetch-marketplace'),
-        window.electronAPI.invoke('claude-plugin:list-installed'),
+        window.electronAPI.invoke('claude-plugin:list-installed', { workspacePath }),
       ]);
 
       if (marketplaceResult.success) {
@@ -227,7 +247,7 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
         });
 
         // Refresh installed plugins
-        const installedResult = await window.electronAPI.invoke('claude-plugin:list-installed');
+        const installedResult = await window.electronAPI.invoke('claude-plugin:list-installed', { workspacePath });
         if (installedResult.success) {
           setInstalledPlugins(installedResult.data || []);
         }
@@ -260,7 +280,7 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
         setInstallMessage(`${pluginName} uninstalled`);
 
         // Refresh installed plugins
-        const installedResult = await window.electronAPI.invoke('claude-plugin:list-installed');
+        const installedResult = await window.electronAPI.invoke('claude-plugin:list-installed', { workspacePath });
         if (installedResult.success) {
           setInstalledPlugins(installedResult.data || []);
         }
@@ -277,8 +297,12 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
     }, 5000);
   };
 
-  const isPluginInstalled = (pluginName: string): boolean => {
-    return installedPlugins.some(p => p.name.toLowerCase() === pluginName.toLowerCase());
+  const isPluginInstalled = (plugin: MarketplacePlugin): boolean => {
+    const expectedSource = extractMarketplaceSourceName(plugin).toLowerCase();
+    const expectedName = plugin.name.toLowerCase();
+    return installedPlugins.some(p =>
+      p.name.toLowerCase() === expectedName && p.source.toLowerCase() === expectedSource
+    );
   };
 
   // Filter plugins by search query
@@ -357,7 +381,7 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
             <h4 className="plugin-category-title text-xs font-semibold uppercase tracking-wider text-[var(--nim-text-faint)] m-0 mb-3 pb-2 border-b border-[var(--nim-border)]">{CATEGORY_LABELS[category] || category}</h4>
             <div className="plugin-grid grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-3 @container" role="list" aria-label={CATEGORY_LABELS[category] || category}>
               {plugins.map((plugin) => {
-                const installed = isPluginInstalled(plugin.name);
+                const installed = isPluginInstalled(plugin);
                 const status = installStatus[plugin.name] || 'idle';
 
                 return (
@@ -431,28 +455,52 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
         </div>
       ) : (
         <div className="plugin-installed-list flex flex-col gap-2" role="list">
-          {installedPlugins.map((plugin) => (
-            <div key={plugin.name} className="plugin-installed-item flex items-center justify-between p-4 border border-[var(--nim-border)] rounded-lg bg-[var(--nim-bg-secondary)]" role="listitem">
-              <div className="plugin-installed-info flex items-center gap-3 flex-1 min-w-0">
-                <div className="plugin-installed-icon w-9 h-9 rounded-md bg-[var(--nim-bg-tertiary)] flex items-center justify-center shrink-0 overflow-hidden">
-                  <PluginIcon pluginName={plugin.name} category="external" isDark={isDark} />
+          {installedPlugins.map((plugin) => {
+            const isProjectScope = plugin.scope === 'project';
+            const itemKey = `${plugin.name}@${plugin.source}@${plugin.projectPath ?? 'user'}`;
+            return (
+              <div key={itemKey} className="plugin-installed-item flex items-center justify-between p-4 border border-[var(--nim-border)] rounded-lg bg-[var(--nim-bg-secondary)]" role="listitem">
+                <div className="plugin-installed-info flex items-center gap-3 flex-1 min-w-0">
+                  <div className="plugin-installed-icon w-9 h-9 rounded-md bg-[var(--nim-bg-tertiary)] flex items-center justify-center shrink-0 overflow-hidden">
+                    <PluginIcon pluginName={plugin.name} category="external" isDark={isDark} />
+                  </div>
+                  <div className="plugin-installed-details flex-1 min-w-0">
+                    <div className="plugin-installed-name flex items-center gap-2 font-medium text-[0.9375rem] text-[var(--nim-text)] mb-0.5">
+                      <span>{plugin.name}</span>
+                      {plugin.source && (
+                        <span className="plugin-installed-source text-xs text-[var(--nim-text-faint)] font-normal">@{plugin.source}</span>
+                      )}
+                      <span
+                        className={`plugin-installed-scope inline-flex items-center px-1.5 py-0.5 rounded text-[0.6875rem] font-semibold uppercase tracking-tight ${
+                          isProjectScope
+                            ? 'bg-[rgba(52,152,219,0.15)] text-[#3498db]'
+                            : 'bg-[var(--nim-bg-tertiary)] text-[var(--nim-text-muted)]'
+                        }`}
+                        title={isProjectScope ? plugin.projectPath : 'Available in every workspace'}
+                      >
+                        {isProjectScope ? 'Project' : 'User'}
+                      </span>
+                      {!plugin.enabled && (
+                        <span className="plugin-installed-disabled inline-flex items-center px-1.5 py-0.5 rounded text-[0.6875rem] font-semibold uppercase tracking-tight bg-[rgba(231,76,60,0.12)] text-[#e74c3c]" title="Not present in enabledPlugins for this scope">
+                          Disabled
+                        </span>
+                      )}
+                    </div>
+                    <div className="plugin-installed-path text-xs text-[var(--nim-text-faint)] overflow-hidden text-ellipsis whitespace-nowrap">{plugin.path}</div>
+                  </div>
                 </div>
-                <div className="plugin-installed-details flex-1 min-w-0">
-                  <div className="plugin-installed-name font-medium text-[0.9375rem] text-[var(--nim-text)] mb-0.5">{plugin.name}</div>
-                  <div className="plugin-installed-path text-xs text-[var(--nim-text-faint)] overflow-hidden text-ellipsis whitespace-nowrap">{plugin.path}</div>
+                <div className="plugin-installed-actions flex gap-2">
+                  <button
+                    className="plugin-uninstall-button py-1.5 px-3 border border-[#e74c3c] rounded bg-transparent text-[#e74c3c] text-xs font-medium cursor-pointer transition-all duration-150 hover:bg-[#e74c3c] hover:text-white"
+                    onClick={() => handleUninstall(plugin.name)}
+                    aria-label={`Uninstall ${plugin.name}`}
+                  >
+                    Uninstall
+                  </button>
                 </div>
               </div>
-              <div className="plugin-installed-actions flex gap-2">
-                <button
-                  className="plugin-uninstall-button py-1.5 px-3 border border-[#e74c3c] rounded bg-transparent text-[#e74c3c] text-xs font-medium cursor-pointer transition-all duration-150 hover:bg-[#e74c3c] hover:text-white"
-                  onClick={() => handleUninstall(plugin.name)}
-                  aria-label={`Uninstall ${plugin.name}`}
-                >
-                  Uninstall
-                </button>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>
@@ -461,7 +509,7 @@ function ClaudeCodePluginsPanelInner({ scope = 'user', workspacePath }: ClaudeCo
   const renderPluginDetails = () => {
     if (!selectedPlugin) return null;
 
-    const installed = isPluginInstalled(selectedPlugin.name);
+    const installed = isPluginInstalled(selectedPlugin);
     const status = installStatus[selectedPlugin.name] || 'idle';
 
     return (


### PR DESCRIPTION
## Summary

Two related bugs prevented Claude Code plugins that are enabled at the
**project scope** (via `<workspace>/.claude/settings.json` →
`enabledPlugins`) from being visible inside Nimbalyst, even though the
Claude Agent SDK loaded them just fine:

1. **Plugins panel hid project-scope installs.** `claude-plugin:list-installed`
   filtered `installation.scope === 'user'` and dropped every project-scope
   entry, so a plugin installed for a single workspace never appeared in
   the "Installed" tab regardless of which workspace you opened the panel
   from.
2. **Slash-command typeahead skipped plugin commands/skills entirely when
   the experimental "Agent Workflows" toggle was off.** `AgentWorkflowService`
   gated `scanLegacyClaudePluginSources` behind `extensionWorkflowsEnabled`
   (default `false`), so plugin-provided commands and skills only showed
   up via the SDK's init payload — meaning users had to wait for a turn
   to start before `/<plugin>:<command>` could autocomplete, and
   project-scope plugins often missed the cache entirely.

This PR also adds disambiguation so that plugins sharing the same name
across two different marketplaces render and match correctly instead of
collapsing into a single entry.

## Changes

- `claude-plugin:list-installed`
  - Accepts `{ workspacePath?: string }` and returns both user-scope
    installations and project-scope installations whose `projectPath`
    matches the workspace (mirrors `getClaudeCliPluginPaths` in
    `ExtensionHandlers`).
  - Each row now carries `source`, `scope`, optional `projectPath`,
    and a real `enabled` flag computed by merging `enabledPlugins`
    from `~/.claude/settings.json`, `<workspace>/.claude/settings.json`,
    and `<workspace>/.claude/settings.local.json`.
- `ClaudeCodePluginsPanel`
  - Passes the active `workspacePath` to the handler and refreshes when
    it changes.
  - Adds badges for marketplace source, scope (User/Project), and a
    "Disabled" badge when `enabledPlugins` does not include the entry.
  - `isPluginInstalled` matches on `name@source`, fixing collisions when
    the same plugin name is published from more than one marketplace.
- `AgentWorkflowService.buildSnapshot`
  - Always calls `scanLegacyClaudePluginSources` regardless of the
    `extensionWorkflowsEnabled` toggle, so plugin commands and skills
    appear in typeahead the moment the workspace is loaded — matching
    what the Claude Agent SDK already auto-loads from `enabledPlugins`.
- `CHANGELOG.md`: two entries under `### Fixed`.

## Why these defaults are safe

- `getClaudeCliPluginPaths` (already used by the SDK options builder)
  uses the same workspace-matching logic, so the panel is now consistent
  with what the SDK actually injects into `options.plugins`.
- Plugin scanning is bounded by what is present in
  `installed_plugins.json` — there is no new filesystem traversal beyond
  what `getNativeClaudePluginPaths` already does. The previous toggle
  was gating the secondary scan path, not preventing disk I/O at the
  source.

## Test plan

- [x] `npx tsc --noEmit` (electron package) — clean.
- [x] `npx vitest run packages/electron/src/main/services/__tests__/` —
      357 passing, 0 failing (incl. `AgentWorkflowService.test.ts`).
- [x] Manual: open a workspace that enables a project-scope plugin in
      its `<workspace>/.claude/settings.json` `enabledPlugins` and
      confirm:
  - The "Installed" tab shows the plugin with a `Project` badge.
  - The marketplace card on "Discover" shows the "Installed" badge for
    the matching `name@source` pair.
  - Typing `/` in the AI chat surfaces commands and skills from that
    project-scope plugin without flipping any setting.
- [x] Manual: open the panel from global settings (no workspace) and
      confirm only user-scope plugins appear with `User` badges and the
      pre-existing behavior is preserved.