### PR TITLE
fix(agent): show Blitz/Super Loops/Meta Agent in the new-session menu without developer mode

### DIFF
--- a/packages/electron/src/renderer/components/AgentMode/AgentMode.tsx
+++ b/packages/electron/src/renderer/components/AgentMode/AgentMode.tsx
@@ -120,9 +120,11 @@ export const AgentMode = forwardRef<AgentModeRef, AgentModeProps>(function Agent
 
   // Check if worktrees feature is available (developer mode + feature enabled)
   const isWorktreesAvailable = useAtomValue(worktreesFeatureAvailableAtom);
-  // Blitz requires both worktrees and the blitz alpha feature
+  // Blitz is gated by its alpha feature alone (like Meta Agent), not developer
+  // mode. The worktrees it creates still require a git repo, enforced in
+  // createNewBlitz and on the New Blitz button (disabled when !isGitRepo).
   const isBlitzAlphaEnabled = useAtomValue(alphaFeatureEnabledAtom('blitz'));
-  const isBlitzAvailable = isWorktreesAvailable && isBlitzAlphaEnabled;
+  const isBlitzAvailable = isBlitzAlphaEnabled;
 
   // Keep Super Loop listeners active even when session history is collapsed/hidden.
   useSuperLoopInit(workspacePath);
@@ -545,9 +547,9 @@ export const AgentMode = forwardRef<AgentModeRef, AgentModeProps>(function Agent
 
   // Create new blitz - opens the blitz dialog
   const createNewBlitz = useCallback(() => {
-    if (!isWorktreesAvailable || !isGitRepo) return;
+    if (!isBlitzAlphaEnabled || !isGitRepo) return;
     setShowBlitzDialog(true);
-  }, [isWorktreesAvailable, isGitRepo]);
+  }, [isBlitzAlphaEnabled, isGitRepo]);
 
   // Handle blitz creation result
   const handleBlitzCreated = useCallback(async (result: any) => {

--- a/packages/electron/src/renderer/components/AgenticCoding/SessionHistory.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/SessionHistory.tsx
@@ -31,7 +31,7 @@ import {
   addSessionFullAtom,
   type SessionMeta,
 } from '../../store';
-import { alphaFeatureEnabledAtom, worktreesFeatureAvailableAtom } from '../../store/atoms/appSettings';
+import { alphaFeatureEnabledAtom } from '../../store/atoms/appSettings';
 import { worktreeDisplayNameUpdateAtom } from '../../store/atoms/worktrees';
 import { blitzCreatedAtom, blitzDisplayNameUpdateAtom } from '../../store/atoms/blitz';
 import { superLoopListAtom, upsertSuperLoopAtom, removeSuperLoopAtom } from '../../store/atoms/superLoop';
@@ -241,9 +241,11 @@ const SessionHistoryComponent: React.FC<SessionHistoryProps> = ({
   const updateSessionStore = useSetAtom(updateSessionStoreAtom);
   const removeSessionFromAtom = useSetAtom(removeSessionFullAtom);
 
-  const isWorktreesAvailable = useAtomValue(worktreesFeatureAvailableAtom);
   const isSuperLoopsAlphaEnabled = useAtomValue(alphaFeatureEnabledAtom('super-loops'));
-  const isSuperLoopsAvailable = isWorktreesAvailable && isSuperLoopsAlphaEnabled;
+  // Super Loops is gated by its alpha feature alone (like Meta Agent), not by
+  // developer mode. The worktree it creates still requires a git repo, which is
+  // enforced on the New Super Loop button (disabled when !isGitRepo).
+  const isSuperLoopsAvailable = isSuperLoopsAlphaEnabled;
   const isMetaAgentEnabled = useAtomValue(alphaFeatureEnabledAtom('meta-agent'));
 
   // === Super Loop state ===
@@ -1902,7 +1904,18 @@ const SessionHistoryComponent: React.FC<SessionHistoryProps> = ({
 
   // Handle new button click - if only one option available, trigger it directly
   const handleNewButtonClick = () => {
-    const availableOptions = [onNewSession, onNewWorktreeSession, onNewBlitz, onNewTerminal].filter(Boolean);
+    // Count the atom-gated alpha items (Meta Agent, Super Loop) alongside the
+    // prop callbacks so enabling an alpha feature opens the dropdown instead of
+    // firing New Session directly. Without this, standard mode never shows the
+    // menu even when alpha options are available.
+    const availableOptions = [
+      onNewSession,
+      onNewWorktreeSession,
+      onNewBlitz,
+      onNewTerminal,
+      isSuperLoopsAvailable || null,
+      isMetaAgentEnabled || null,
+    ].filter(Boolean);
     if (availableOptions.length === 1) {
       // Only one option available, trigger it directly
       if (onNewSession) onNewSession();


### PR DESCRIPTION
## What

Decouples the Blitz and Super Loops new-session options from developer mode so they follow their alpha-feature toggle alone, matching Meta Agent and the alpha registry's "available to all users" contract. Also makes the "+" button open the dropdown when an alpha option is available.

Fixes #437.

## Why

See #437. Blitz and Super Loops were gated by `isWorktreesAvailable` (which requires developer mode), so enabling their alpha features did nothing in standard mode, and in developer mode only Meta Agent appeared. The "+" also skipped the dropdown entirely in standard mode because it never counted the alpha items.

## Changes

- `AgentMode.tsx`: `isBlitzAvailable = isBlitzAlphaEnabled` (was `isWorktreesAvailable && isBlitzAlphaEnabled`); the `createNewBlitz` guard now checks `isBlitzAlphaEnabled`. Still requires a git repo for the worktree it creates.
- `SessionHistory.tsx`: `isSuperLoopsAvailable = isSuperLoopsAlphaEnabled` (was `isWorktreesAvailable && ...`); removed the now-unused `isWorktreesAvailable` and its import; `handleNewButtonClick` now counts `isSuperLoopsAvailable` and `isMetaAgentEnabled` so the dropdown opens in standard mode.
- New Worktree stays developer-mode-gated, unchanged.

## Testing

- Standard mode, alpha features on: "+" opens the dropdown with New Session, New Blitz, New Super Loop, New Meta Agent. Blitz and Super Loop are disabled with a tooltip outside a git repo.
- Developer mode: all options including New Worktree appear.
- Verified the three alpha options render in the dropdown on a clean build.
