### PR TITLE
fix(sync): match worktree sessions against parent project in mobile sync filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-uploading a local source into a shared markdown document now waits for the collab write to be acknowledged before tearing down the headless sync client.
 <!-- Bug fixes go here -->
 - Codex session-naming reminder no longer leaks into the chat transcript; its turn output is tagged so the transcript hides it. (#420)
+- Mobile sync now picks up Codex sessions running in git worktrees by resolving worktree workspaceIds to the parent project path when matching against enabled sync projects. (#430) Thanks @stamkivi.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/services/SyncManager.ts
+++ b/packages/electron/src/main/services/SyncManager.ts
@@ -26,6 +26,7 @@ import { getProjectFileSyncService } from './ProjectFileSyncService';
 import { startProjectFileSync } from '../file/WorkspaceWatcher';
 import { windowStates } from '../window/WindowManager';
 import { getNormalizedGitRemote } from '../utils/gitUtils';
+import { resolveProjectPath } from '../utils/workspaceDetection';
 import { createHash } from 'crypto';
 import { setSleepPreventionMode, setSyncConnected, shutdownSleepPrevention, type PreventSleepMode } from './PowerSaveService';
 import { reconnectAllTrackerSyncs } from './TrackerSyncManager';
@@ -619,9 +620,19 @@ export async function initializeSync(baseStore: SessionStore): Promise<SessionSt
             continue;
           }
 
-          // Skip sessions from disabled projects (if project filtering is enabled)
-          if (enabledProjectIds && !enabledProjectIds.has(localSession.workspaceId)) {
-            continue;
+          // Skip sessions from disabled projects (if project filtering is enabled).
+          // Sessions running in a git worktree may have a workspaceId of
+          // ".../<project>_worktrees/<name>" rather than the parent project path
+          // the user enabled in Settings > Sync. Claude sessions normally adopt
+          // the parent path via adoptWorktreeForSession(), but the Codex
+          // provider currently does not, so a Codex worktree session keeps the
+          // raw worktree path and is silently filtered out here. Resolve to the
+          // parent project path and accept either form against the enabled set.
+          if (enabledProjectIds) {
+            const projectPath = resolveProjectPath(localSession.workspaceId);
+            if (!enabledProjectIds.has(localSession.workspaceId) && !enabledProjectIds.has(projectPath)) {
+              continue;
+            }
           }
 
           const serverSession = serverSessionMap.get(localSession.id);
@@ -1041,9 +1052,14 @@ export async function triggerIncrementalSync(): Promise<void> {
         continue;
       }
 
-      // Skip sessions from disabled projects
-      if (enabledProjectIds && !enabledProjectIds.has(localSession.workspaceId)) {
-        continue;
+      // Skip sessions from disabled projects. Resolve worktree paths to their
+      // parent project path so Codex worktree sessions (which do not adopt the
+      // parent path the way Claude sessions do) match the user's enabled set.
+      if (enabledProjectIds) {
+        const projectPath = resolveProjectPath(localSession.workspaceId);
+        if (!enabledProjectIds.has(localSession.workspaceId) && !enabledProjectIds.has(projectPath)) {
+          continue;
+        }
       }
 
       const serverSession = serverSessionMap.get(localSession.id);


### PR DESCRIPTION
## Summary

Mobile session sync silently drops Codex sessions that run inside a git worktree (#430). Reporter (@stamkivi) confirmed the mechanism end-to-end: Claude worktree sessions adopt the parent project path via `adoptWorktreeForSession()` (`AIService.ts:3681`) and so match the user's enabled sync projects, but the Codex provider path never triggers that adoption. A Codex worktree session keeps the raw worktree workspaceId (`.../<project>_worktrees/<name>`), which never string-matches the parent project in `Settings > Sync`, and the sync loop's `enabledProjectIds.has(localSession.workspaceId)` skips it.

stamkivi's diagnostic (#430#issuecomment-4543126987): Claude worktree sessions emit `"Adopted worktree path"` 16+ times per session in `main.log`; Codex worktree sessions in the same workspace emit zero. The reporter's enabled project was `~/git/plural-pulse`; the Codex session's stored `cwd` was `~/git/plural-pulse_worktrees/solid-marsh`. No string match, no sync.

## Fix

In both filter sites in `SyncManager.ts` (`:622-625` startup, `:1044-1047` triggered), call `resolveProjectPath(localSession.workspaceId)` and accept either the raw workspaceId or the resolved parent project path against `enabledProjectIds`. `resolveProjectPath` is a safe no-op for non-worktree paths (returns input unchanged), so existing non-worktree sessions are unaffected.

## Out of scope

The underlying asymmetry - why Codex provider sessions never invoke `adoptWorktreeForSession()` - is left for a separate change. Both call sites in `MessageStreamingHandler.ts` (`:1250` via `inferWorktreePathFromFilePath`, `:1411` via `inferWorktreePathFromCommand`) appear to handle Codex chunk shapes per their comments, but in practice they don't fire for Codex worktree sessions. Worth a follow-up trace; not blocking this user-visible fix.

## Testing

- Manually verified by the reporter (#430). Their Codex worktree session ran in `~/git/plural-pulse_worktrees/solid-marsh` while only `~/git/plural-pulse` was enabled; pre-fix it was silently skipped, post-fix it would be accepted via the resolved parent path.
- `resolveProjectPath` itself is exercised by `packages/electron/src/main/utils/__tests__/workspaceDetection.test.ts`.
- No new tests for SyncManager - the change is a single conditional add on top of an already-guarded code path, and the helper is independently covered.

## Regression risk

Walked the 8-check assessment: the only new behavior is "accept the parent-project path in addition to the raw workspaceId for the enabled-set match." Existing users whose enabled-projects strings already match `localSession.workspaceId` directly are unaffected (the `||` short-circuit on `has()` keeps the old path first). Users who explicitly enabled a worktree path in Settings (unusual but supported by the data shape) continue to match on the raw form. No existing test relies on a Codex worktree session being skipped.

Closes #430.