### PR TITLE
fix(ui): raise Claude Usage popover stacking above the tracker toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-uploading a local source into a shared markdown document now waits for the collab write to be acknowledged before tearing down the headless sync client.
 <!-- Bug fixes go here -->
 - Codex session-naming reminder no longer leaks into the chat transcript; its turn output is tagged so the transcript hides it. (#420)
+- Claude Usage popover now renders above the tracker toolbar by raising its stacking order so the usage panel is no longer covered by the toolbar's search bar. (#440) Thanks @Yogitmeister.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/renderer/components/ClaudeUsageIndicator/ClaudeUsagePopover.tsx
+++ b/packages/electron/src/renderer/components/ClaudeUsageIndicator/ClaudeUsagePopover.tsx
@@ -139,11 +139,15 @@ export const ClaudeUsagePopover: React.FC<ClaudeUsagePopoverProps> = ({
 
   return (
     <FloatingPortal>
+      {/* z-[60] (above the default z-50) so the popover renders above the
+          tracker toolbar's host stacking context. FloatingPortal escapes to
+          document.body, but ancestor stacking on the toolbar route can still
+          outrank a plain z-50 in practice (#440). */}
       <div
         ref={menu.refs.setFloating}
         style={menu.floatingStyles}
         {...menu.getFloatingProps()}
-        className="w-60 bg-nim-secondary border border-nim rounded-lg shadow-lg z-50 overflow-y-auto"
+        className="w-60 bg-nim-secondary border border-nim rounded-lg shadow-lg z-[60] overflow-y-auto"
         data-testid="claude-usage-popover"
       >
         {/* Header */}


### PR DESCRIPTION
## Summary

The Claude Usage popover renders via `<FloatingPortal>` at `z-50` on `document.body` (`packages/electron/src/renderer/components/ClaudeUsageIndicator/ClaudeUsagePopover.tsx:146`). Reporter (@Yogitmeister, #440) sees the tracker toolbar's search bar visually covering the usage panel's weekly-usage section.

A repo-wide grep of the renderer for `z-5\d` / `z-6\d` / `z-7\d` etc. returns no other elements, so the popover is the only z-5x in play. The reason a plain `z-50` is being outranked despite the FloatingPortal escape is that the toolbar's host stacking context (the tracker mode wrapper at `App.tsx:2161` with `overflow-hidden`, and the toolbar `.tracker-toolbar` itself at `TrackerMainView.tsx:577`) can paint over a body-level z-50 in practice when the painting order interacts with ancestor stacking. Bumping the popover's own z-index to `z-[60]` puts it unambiguously above the toolbar.

## Fix

Single-character class change on the popover's root div: `z-50` -> `z-[60]`. The JSX comment above the `<div>` documents why so the next reader sees it without spelunking the issue.

## Why not the height-clamp variant

I initially shipped a `constrainHeight: false` variant on this same PR, on the hypothesis that the popover's height clamp was hiding the weekly-usage section. After re-checking the floating-ui middleware semantics: removing `size` middleware unclaps the popover, but `shift` middleware can only translate, not resize. On viewports smaller than the popover's natural content height (a real case for laptop users with dev tools docked), the popover would overflow the viewport and `overflow-y-auto` would not add an internal scrollbar because no `max-height` is set. That swap traded one problem for another, so I reverted it before force-pushing.

The z-bump in this PR has no equivalent regression: it is strictly higher in the stacking order, no element in the renderer was sitting at z-51+ to be incorrectly outranked.

## Adjacent surface (not bundled)

`CodexUsagePopover.tsx:106` uses the same useFloatingMenu pattern and the same `z-50` class on its root div. If Codex users hit the same overlap the same one-character change applies there; not bundled here to keep the PR narrow to the reported surface.

## Testing

- Manual: the popover is the only z-50+ in the renderer (verified by `git grep -nE 'z-\[?(5\d|6\d|7\d|8\d|9\d)' -- '*.tsx'`), so bumping its z does not displace anything else.
- No new tests; this is a Tailwind class swap on a single rendered div.

## Regression risk

8-check assessment:

1. **Existing valid configurations**: the popover renders above the tracker toolbar; nothing else changes. Existing users see the same popover, just no longer covered by the toolbar.
2. **Default behavior**: unchanged outside the affected stacking interaction.
3. **Error handling**: no new error paths.
4. **Caller impact**: zero - this is a leaf rendered class.
5. **Cross-platform**: Tailwind class, no platform dependency.
6. **Concurrency**: irrelevant.
7. **Tests**: existing snapshot/visual tests on the popover (if any) re-run; class change is the kind of small visual diff that should pass naturally.
8. **Docs**: CHANGELOG entry updated to describe the actual fix.

Closes #440.