### PR TITLE
fix(extensions): GC contributed aiProvider entries from ai-settings on uninstall

### DIFF
--- a/packages/electron/src/main/ipc/ExtensionMarketplaceHandlers.ts
+++ b/packages/electron/src/main/ipc/ExtensionMarketplaceHandlers.ts
@@ -640,6 +640,38 @@ async function installFromGitHubCloneSource(
 }
 
 /**
+ * Remove the given aiProvider ids from the ai-settings store. Used when an
+ * extension is uninstalled so its contributed provider entries (enabled,
+ * models, testStatus...) don't linger and re-populate the Settings UI on
+ * the next boot. Broadcasts `ai-settings:changed` so open renderer windows
+ * refresh their atoms.
+ */
+async function pruneAiSettingsProviders(providerIds: string[]): Promise<void> {
+  if (providerIds.length === 0) return;
+  const { default: Store } = await import('electron-store');
+  const aiStore = new Store<Record<string, unknown>>({ name: 'ai-settings' });
+  const providerSettings = (aiStore.get('providerSettings', {}) as Record<string, unknown>) ?? {};
+  const removed: string[] = [];
+  for (const id of providerIds) {
+    if (id in providerSettings) {
+      delete providerSettings[id];
+      removed.push(id);
+    }
+  }
+  if (removed.length > 0) {
+    aiStore.set('providerSettings', providerSettings);
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed() && !win.webContents.isDestroyed()) {
+        win.webContents.send('ai-settings:changed', {
+          providerIds: removed,
+          apiKeyNames: [],
+        });
+      }
+    }
+  }
+}
+
+/**
  * Uninstall a marketplace-installed extension.
  */
 async function uninstallExtension(extensionId: string): Promise<InstallResult> {
@@ -655,6 +687,29 @@ async function uninstallExtension(extensionId: string): Promise<InstallResult> {
       return { success: false, error: `Extension ${extensionId} was not installed via marketplace` };
     }
 
+    // BEFORE removing the directory, read the manifest to learn which
+    // aiProviders the extension contributed. We need this list to garbage-
+    // collect the matching keys from ai-settings.providerSettings -- without
+    // this step, the user's stored enabled/models choices persist on disk
+    // forever and the renderer SettingsSidebar keeps rendering ghost provider
+    // rows on the next boot even though no extension is registered.
+    let contributedAiProviderIds: string[] = [];
+    try {
+      const manifestPath = path.join(installPath, 'manifest.json');
+      const manifestRaw = await fs.readFile(manifestPath, 'utf8');
+      const manifest = JSON.parse(manifestRaw) as {
+        contributions?: { aiProviders?: Array<{ id?: string }> };
+      };
+      contributedAiProviderIds = (manifest.contributions?.aiProviders ?? [])
+        .map((p) => p?.id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    } catch (err) {
+      logger.main.warn(
+        `[ExtMarketplace] Could not read manifest for ${extensionId} ` +
+        `before uninstall; skipping ai-settings cleanup: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
     // Remove the extension directory
     try {
       await fs.rm(installPath, { recursive: true, force: true });
@@ -668,6 +723,24 @@ async function uninstallExtension(extensionId: string): Promise<InstallResult> {
     // Re-register file types and notify renderer (with unload)
     await initializeExtensionFileTypes();
     notifyExtensionUnloaded(extensionId);
+
+    // Garbage-collect provider entries the uninstalled extension contributed
+    // to ai-settings. Done AFTER notifyExtensionUnloaded so the renderer's
+    // ProviderRegistry.unregister fires before the broadcast that follows.
+    if (contributedAiProviderIds.length > 0) {
+      try {
+        await pruneAiSettingsProviders(contributedAiProviderIds);
+        logger.main.info(
+          `[ExtMarketplace] Pruned ${contributedAiProviderIds.length} aiProvider entry(ies) ` +
+          `from ai-settings for ${extensionId}: ${contributedAiProviderIds.join(', ')}`,
+        );
+      } catch (err) {
+        logger.main.warn(
+          `[ExtMarketplace] Failed to prune ai-settings for ${extensionId}: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
 
     logger.main.info(`[ExtMarketplace] Successfully uninstalled ${extensionId}`);
     return { success: true, extensionId };


### PR DESCRIPTION
Closes #445.

## Summary

Uninstalling a marketplace extension that contributes one or more `aiProviders` currently leaves the user's persisted provider settings (`enabled`, `models`, `testStatus`...) in `ai-settings.json` forever. On the next boot the renderer reads those keys back into the providers atom and `SettingsSidebar` renders ghost provider rows for providers that are no longer registered.

This PR makes `uninstallExtension` garbage-collect the contributed provider keys as part of the uninstall flow.

## Repro

Steps and details are in #445.

## Fix

In `packages/electron/src/main/ipc/ExtensionMarketplaceHandlers.ts`:

1. Before removing the install directory, read the manifest and collect `contributions.aiProviders[*].id` into a list.
2. After the directory removal, marketplace tracking removal, and `notifyExtensionUnloaded` broadcast, call a new `pruneAiSettingsProviders(ids)` helper that opens the `ai-settings` electron-store, deletes each matching key from `providerSettings`, writes back, and broadcasts `ai-settings:changed` with the removed IDs so open renderer windows refresh their atoms in real time.
3. Manifest-read and prune failures warn-log but never block the uninstall, because the directory and tracking removal are the load-bearing steps.

The prune step is gated on the manifest actually being readable -- if a previous failed install left a directory without a manifest, the existing uninstall behaviour is preserved.

## Verification

Verified with a node script that exercises the same logic against an on-disk `ai-settings.json` containing the ghost entries the regression created. The script:

1. Reads the existing `ai-settings.json` (which has `antigravity-gemini` and `antigravity-gemini-agent` keys from a previous extension install and uninstall).
2. Reads the manifest of the extension and extracts the contributed aiProvider IDs.
3. Runs the same delete-from-providerSettings logic the new helper uses.
4. Writes the result back.

Output:

```
BEFORE - antigravity keys present in ai-settings: [ 'antigravity-gemini', 'antigravity-gemini-agent' ]
Manifest contributedAiProviderIds: [ 'antigravity-gemini', 'antigravity-gemini-agent' ]
AFTER  - antigravity keys present in ai-settings: []
Removed: [ 'antigravity-gemini', 'antigravity-gemini-agent' ]
PASS - ghost entries fully purged
```

Local typecheck passes for the `electron` package.

## Scope

This PR only changes the uninstall side. A follow-up worth considering: defense-in-depth filtering of `SettingsSidebar` against `ProviderRegistry.list()` so the sidebar refuses to render provider rows for providers that are not actively registered. That hardens against any other code path that might leak keys in the future. Happy to add it here or as a separate PR.

## Test plan

- [x] Repro the bug on upstream `main` (no fix): install gemini-antigravity, enable, uninstall, restart, confirm ghost provider rows
- [x] Apply this PR, repeat, confirm `ai-settings.providerSettings` no longer contains the contributed keys and the sidebar shows no ghosts
- [x] Typecheck `packages/electron`
- [ ] Reviewer: confirm the manifest read happens before `fs.rm` (it does, line 522-540 in the patched function) so the file is available at the right point