### PR TITLE
fix(blitz): surface error when worktree creation fails on no-commit repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Blitz no longer silently dismisses the dialog when run against a workspace whose git repo has no commits.
 
 ### Removed
 <!-- Removed features go here -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
-- Blitz no longer silently dismisses the dialog when run against a workspace whose git repo has no commits.
+- Blitz no longer silently dismisses the dialog when run against a workspace whose git repo has no commits. (#455)
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/ipc/BlitzHandlers.ts
+++ b/packages/electron/src/main/ipc/BlitzHandlers.ts
@@ -14,7 +14,7 @@
 
 import { ipcMain, BrowserWindow } from 'electron';
 import log from 'electron-log/main';
-import { GitWorktreeService } from '../services/GitWorktreeService';
+import { GitWorktreeService, WorkspaceHasNoCommitsError } from '../services/GitWorktreeService';
 import { createWorktreeStore } from '../services/WorktreeStore';
 import { getDatabase } from '../database/initialize';
 import { getQueuedPromptsStore } from '../services/RepositoryManager';
@@ -158,6 +158,12 @@ export function registerBlitzHandlers(): void {
       if (totalWorktrees > MAX_BLITZ_WORKTREES) {
         throw new Error(`Total worktrees (${totalWorktrees}) exceeds maximum of ${MAX_BLITZ_WORKTREES}`);
       }
+
+      // Pre-flight: confirm the workspace's HEAD resolves to a commit. Without
+      // this, a `git init`-ed-but-never-committed workspace would create the
+      // parent blitz row, then fail on every per-worktree git call, and the
+      // user would see the dialog disappear with no toast. Fail fast here.
+      await gitWorktreeService.validateWorkspaceHasCommits(workspacePath);
 
       const db = getDatabase();
       if (!db) {
@@ -336,6 +342,22 @@ export function registerBlitzHandlers(): void {
       // Emit event to renderer
       emitBlitzCreated(blitzId, workspacePath);
 
+      // If every worktree creation failed, treat the whole call as a failure
+      // so the renderer can surface an error toast instead of dismissing the
+      // dialog as if the blitz succeeded.
+      const successCount = worktreeResults.filter(r => r.success).length;
+      if (successCount === 0) {
+        return {
+          success: false,
+          error: errors[0] || 'No worktrees could be created',
+          blitzSessionId: blitzId,
+          worktrees: worktreeResults,
+          sessionIds,
+          models: worktreeAssignments.map(a => a.model),
+          errors,
+        };
+      }
+
       return {
         success: true,
         blitzSessionId: blitzId,
@@ -346,9 +368,12 @@ export function registerBlitzHandlers(): void {
       };
     } catch (error) {
       logger.error('Failed to create blitz:', error);
+      const message = error instanceof WorkspaceHasNoCommitsError
+        ? error.message
+        : (error instanceof Error ? error.message : 'Failed to create blitz');
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Failed to create blitz',
+        error: message,
       };
     }
   });

--- a/packages/electron/src/main/services/GitWorktreeService.ts
+++ b/packages/electron/src/main/services/GitWorktreeService.ts
@@ -697,6 +697,15 @@ export class GitWorktreeService {
     if (!workspacePath) {
       throw new Error('workspacePath is required');
     }
+    // Differentiate "not a git repo at all" from "git repo with no commits".
+    // simple-git's checkIsRepo defaults to IN_TREE which walks UP the directory
+    // tree and would return true if any ancestor has a .git. We need the
+    // workspacePath itself to be the repo root for worktree ops, so do a
+    // direct fs check for `.git` (file or directory - submodules use a file).
+    const gitMeta = path.join(workspacePath, '.git');
+    if (!fs.existsSync(gitMeta)) {
+      throw new Error(`Not a git repository: ${workspacePath}`);
+    }
     const git: SimpleGit = simpleGit(workspacePath);
     try {
       await git.raw(['rev-parse', '--verify', 'HEAD']);

--- a/packages/electron/src/main/services/GitWorktreeService.ts
+++ b/packages/electron/src/main/services/GitWorktreeService.ts
@@ -23,6 +23,20 @@ import { gitOperationLock } from './GitOperationLock';
 const logger = log.scope('GitWorktreeService');
 
 /**
+ * Thrown when a workspace's git repository has no commits yet, so HEAD
+ * does not resolve to a tree-ish. Worktree operations cannot proceed.
+ */
+export class WorkspaceHasNoCommitsError extends Error {
+  constructor(workspacePath: string) {
+    super(
+      `Workspace '${workspacePath}' has no commits yet, so worktrees cannot be created. ` +
+      `Make an initial commit, or open a different folder that already has commits.`
+    );
+    this.name = 'WorkspaceHasNoCommitsError';
+  }
+}
+
+/**
  * Worktree data structure (matches runtime types)
  */
 export interface Worktree {
@@ -674,6 +688,24 @@ export class GitWorktreeService {
   }
 
   /**
+   * Throws WorkspaceHasNoCommitsError if the repo's HEAD does not resolve
+   * to a commit. This is the empty-repo case (`git init` ran, no commits).
+   * Cheap pre-flight that lets callers fail fast with a friendly message
+   * before any worktree-record or session-row gets created.
+   */
+  async validateWorkspaceHasCommits(workspacePath: string): Promise<void> {
+    if (!workspacePath) {
+      throw new Error('workspacePath is required');
+    }
+    const git: SimpleGit = simpleGit(workspacePath);
+    try {
+      await git.raw(['rev-parse', '--verify', 'HEAD']);
+    } catch {
+      throw new WorkspaceHasNoCommitsError(workspacePath);
+    }
+  }
+
+  /**
    * Get the current branch of a git repository (private helper)
    * @private
    */
@@ -683,7 +715,14 @@ export class GitWorktreeService {
       return branch.trim();
     } catch (error) {
       logger.error('Failed to get current branch', { error });
-      throw new Error(`Failed to get current branch: ${error instanceof Error ? error.message : String(error)}`);
+      const message = error instanceof Error ? error.message : String(error);
+      // Recognize the empty-repo failure mode and rethrow as a typed error
+      // so callers can show a friendly message. Git emits this stderr when
+      // HEAD points at a symbolic ref whose target does not exist (no commits).
+      if (message.includes("ambiguous argument 'HEAD'")) {
+        throw new WorkspaceHasNoCommitsError('repository');
+      }
+      throw new Error(`Failed to get current branch: ${message}`);
     }
   }
 

--- a/packages/electron/src/main/services/__tests__/GitWorktreeService.test.ts
+++ b/packages/electron/src/main/services/__tests__/GitWorktreeService.test.ts
@@ -54,4 +54,12 @@ describe('GitWorktreeService.validateWorkspaceHasCommits', () => {
       .rejects
       .toThrow('workspacePath is required');
   });
+
+  it('throws "Not a git repository" for a folder that was never `git init`-ed', async () => {
+    // tmpDir exists but has no .git. Differentiates from the empty-repo case
+    // so callers can show a remediation message that matches the real cause.
+    await expect(service.validateWorkspaceHasCommits(tmpDir))
+      .rejects
+      .toThrow(/Not a git repository/);
+  });
 });

--- a/packages/electron/src/main/services/__tests__/GitWorktreeService.test.ts
+++ b/packages/electron/src/main/services/__tests__/GitWorktreeService.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import simpleGit from 'simple-git';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { GitWorktreeService, WorkspaceHasNoCommitsError } from '../GitWorktreeService';
+
+/**
+ * Regression coverage for the empty-repo silent-failure case: when a Blitz
+ * is run against a `git init`-ed-but-never-committed workspace, the worktree
+ * service used to throw the raw "fatal: ambiguous argument 'HEAD'" stderr and
+ * the renderer dismissed the dialog as if the call succeeded. The service now
+ * pre-flights with `git rev-parse --verify HEAD` and throws a typed error.
+ */
+describe('GitWorktreeService.validateWorkspaceHasCommits', () => {
+  let tmpDir: string;
+  const service = new GitWorktreeService();
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nimbalyst-gws-test-'));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore Windows file-lock noise during teardown
+    }
+  });
+
+  it('throws WorkspaceHasNoCommitsError for a `git init`-ed repo with no commits', async () => {
+    const git = simpleGit(tmpDir);
+    await git.init();
+
+    await expect(service.validateWorkspaceHasCommits(tmpDir))
+      .rejects
+      .toBeInstanceOf(WorkspaceHasNoCommitsError);
+  });
+
+  it('resolves cleanly when the repo has at least one commit', async () => {
+    const git = simpleGit(tmpDir);
+    await git.init();
+    await git.addConfig('user.email', 'test@example.com', false, 'local');
+    await git.addConfig('user.name', 'Test', false, 'local');
+    fs.writeFileSync(path.join(tmpDir, 'README.md'), 'hi');
+    await git.add('README.md');
+    await git.commit('initial');
+
+    await expect(service.validateWorkspaceHasCommits(tmpDir)).resolves.toBeUndefined();
+  });
+
+  it('throws when workspacePath is empty', async () => {
+    await expect(service.validateWorkspaceHasCommits(''))
+      .rejects
+      .toThrow('workspacePath is required');
+  });
+});


### PR DESCRIPTION
## Summary

`GitWorktreeService.getCurrentBranch` threw the raw `fatal: ambiguous argument 'HEAD'` stderr on a `git init`-ed-but-never-committed workspace, and `BlitzHandlers.createBlitzSession` returned `{ success: true }` even when every per-worktree creation errored. The dialog dismissed silently, leaving the user with no feedback and an orphan `ai_sessions` row.

This PR fixes the empty-repo creation path completely and surfaces the 0/N runtime failure to the renderer. It does not yet add fully-transactional rollback for other worktree failure modes (rate-limit, disk full, etc.) - see "Honest scope" below.

## Changes

- `GitWorktreeService.ts`: exported `WorkspaceHasNoCommitsError` and a public `validateWorkspaceHasCommits(workspacePath)` pre-flight. The check uses `fs.existsSync('.git')` first (simple-git's `checkIsRepo` defaults to `IN_TREE` which walks up the directory tree and would mis-report `true` for a plain folder whose ancestor has a `.git`), then `git rev-parse --verify HEAD` for the empty-repo case. `getCurrentBranch` recognises the same English stderr signature and rethrows the typed error so other callers benefit.
- `BlitzHandlers.ts`: pre-flight runs before the parent `ai_sessions` insert, so the empty-repo path no longer creates an orphan row. `createBlitzSession` returns `success: false` with the error chain when zero worktrees succeeded at runtime, so the renderer can show an error toast instead of dismissing the dialog. The outer catch maps `WorkspaceHasNoCommitsError` to a verbatim friendly message.
- `GitWorktreeService.test.ts`: four unit tests cover empty-repo, populated-repo, empty-`workspacePath` argument, and non-git-repo folder. Vitest passes 4/4.
- `CHANGELOG.md`: one-line entry under `[Unreleased]` Fixed with the PR reference.

## How verified

- Reproduced the bug in a tmp `git init`-only repo: `git rev-parse --abbrev-ref HEAD` returns exit 128 with `fatal: ambiguous argument 'HEAD'`, matching the error in `main.log`.
- `npx vitest run packages/electron/src/main/services/__tests__/GitWorktreeService.test.ts` flips from raw-error red to all-pass green with the fix applied.
- Self-`/code-review` pass caught two issues addressed in the second commit on this branch: `validateWorkspaceHasCommits` was giving a misleading "no commits yet" message for non-git-repo folders, and the CHANGELOG entry was missing the PR reference.
- Marker-scanned (em-dash, en-dash, arrows, curly quotes, ellipsis, and the AI-marker word list) on every touched file before each commit.

## Honest scope

The empty-repo case is the originally-reported failure mode and is fully fixed by the pre-flight: no parent `ai_sessions` row is written, the dialog gets a typed error.

For other worktree creation failure modes (rate limit hits mid-loop, disk full, fork detach, permission denied), the parent `ai_sessions` row is still written at the current call-site before the loop starts, so an orphan can still appear. The renderer at least sees `success: false` now and can show a toast, but a follow-up PR would move the parent insert to AFTER at least one worktree exists, or wrap the whole flow in try/finally with rollback. Happy to PR that separately once this lands - the change would touch the same handler and benefits from being reviewed standalone.

Known limitation: the `getCurrentBranch` empty-repo detection in this PR uses an English string-match on `"ambiguous argument 'HEAD'"`. For users on non-English git locales the typed error would not fire from `getCurrentBranch` directly, and the raw localized stderr would surface. The Blitz path is unaffected because the pre-flight uses `rev-parse --verify` (exit code only, no string match). `SuperLoop` and `WorktreeHandlers` go through `getCurrentBranch` and would still leak for those locales until they get their own pre-flights.

## Regression risk

8-check pass:

1. Existing valid configurations: workspaces with commits are unaffected. `validateWorkspaceHasCommits` no-ops when HEAD resolves.
2. Default behaviour: same as before for the happy path.
3. Error handling: failure case now surfaces a typed error instead of a raw stderr string.
4. Callers: only `BlitzHandlers.createBlitzSession` adds the pre-flight call. Other callers of `getCurrentBranch` (SuperLoop, Worktree) now also get the typed error on the empty-repo case in English locales.
5. Cross-platform: pure git CLI invocation through simple-git plus a `fs.existsSync('.git')` check, no platform-specific paths.
6. Concurrency: pre-flight is two fast filesystem and git calls, no shared state.
7. Tests: new unit test added; no existing tests modified.
8. Docs: CHANGELOG one-liner updated with PR reference.

## Not bundled

- Renderer-side `+` dropdown freeze after deleting the active session (#453). Separate concern, renderer atom layer.
- Codex tool-subprocess kill stdout leaking into the parser (#454). Likely upstream, can ship a same-codebase workaround if maintainers prefer.

Closes #452.