### PR TITLE
fix(extensions): GC also reads aiAgentProviders[*].id on uninstall (follow-up to #446)

### DIFF
--- a/packages/electron/src/main/ipc/ExtensionMarketplaceHandlers.ts
+++ b/packages/electron/src/main/ipc/ExtensionMarketplaceHandlers.ts
@@ -687,20 +687,36 @@ async function uninstallExtension(extensionId: string): Promise<InstallResult> {
       return { success: false, error: `Extension ${extensionId} was not installed via marketplace` };
     }
 
-    // BEFORE removing the directory, read the manifest to learn which
-    // aiProviders the extension contributed. We need this list to garbage-
+    // BEFORE removing the directory, read the manifest to learn which AI
+    // providers the extension contributed. We need this list to garbage-
     // collect the matching keys from ai-settings.providerSettings -- without
     // this step, the user's stored enabled/models choices persist on disk
     // forever and the renderer SettingsSidebar keeps rendering ghost provider
     // rows on the next boot even though no extension is registered.
+    //
+    // Read both `aiProviders` and `aiAgentProviders`. The agent-provider
+    // contribution shape proposed in the Agent-Providers-as-Extensions design
+    // doc uses `aiAgentProviders`, while a future chat-only contribution may
+    // reuse the older `aiProviders` name. Reading both keeps the GC working
+    // across the rename without a follow-up patch when either lands. An
+    // extension that declares both (e.g., for a transitional period) is
+    // handled idempotently downstream because the prune loop skips ids that
+    // are not in providerSettings.
     let contributedAiProviderIds: string[] = [];
     try {
       const manifestPath = path.join(installPath, 'manifest.json');
       const manifestRaw = await fs.readFile(manifestPath, 'utf8');
       const manifest = JSON.parse(manifestRaw) as {
-        contributions?: { aiProviders?: Array<{ id?: string }> };
+        contributions?: {
+          aiProviders?: Array<{ id?: string }>;
+          aiAgentProviders?: Array<{ id?: string }>;
+        };
       };
-      contributedAiProviderIds = (manifest.contributions?.aiProviders ?? [])
+      const collected = [
+        ...(manifest.contributions?.aiProviders ?? []),
+        ...(manifest.contributions?.aiAgentProviders ?? []),
+      ];
+      contributedAiProviderIds = collected
         .map((p) => p?.id)
         .filter((id): id is string => typeof id === 'string' && id.length > 0);
     } catch (err) {


### PR DESCRIPTION
Follow-up to #446.

## Why

The Agent-Providers-as-Extensions design doc introduces `aiAgentProviders` as the contribution point for coding-agent extensions, distinct from `aiProviders` which the doc reserves for a future chat-only contribution. The merged #446 GC reads only `aiProviders[*].id`, so once an extension contributes under the new name, its persisted settings (`enabled`, `models`, `testStatus`...) will not be pruned on uninstall and the ghost-provider regression #446 fixed will return.

This patch closes that gap so it lands before any extension ships on the new shape.

## What

In `uninstallExtension`, extend the manifest read to collect ids from BOTH `aiProviders` and `aiAgentProviders` into the same list. Downstream prune loop in `pruneAiSettingsProviders` is already idempotent on duplicates (`if (id in providerSettings) delete`), so an extension that declares both fields during a transitional period is handled safely.

No behaviour change for extensions that declare neither field, or only the older `aiProviders`. The expanded TypeScript shape for the manifest cast is the only non-trivial diff.

## Test plan

- [x] Local electron typecheck of the changed file is clean. (The wider `tsc --noEmit` reports pre-existing module-resolution errors on `@nimbalyst/collab-adapters` / `@nimbalyst/collab-protocol` / `fractional-indexing` unrelated to this patch -- those modules need `npm install` to resolve.)
- [ ] Reviewer to confirm: when an extension manifest declares only `aiAgentProviders`, uninstall removes the matching keys from `ai-settings.providerSettings`.
- [ ] Reviewer to confirm: when an extension manifest declares both fields with the same id, duplicates do not cause issues (the prune loop's existing `if (id in providerSettings)` guard handles this).

## Context

- #446 (merged) introduced the GC step that this patch extends.
- #96 (in flight) is the community Gemini Antigravity contribution that surfaced the naming question. The Agent-Providers-as-Extensions design doc §9.2 explicitly flags the rename as an open coordination problem; this patch lands the GC half so neither field-name choice creates a regression.

If the doc settles on `aiAgentProviders` only and `aiProviders` will never be a published contribution, the older field read can be removed in a later cleanup. Keeping both for now is conservative.