### PR TITLE
fix(theme): resolve Monaco editor dark/light from isDark metadata

### DIFF
--- a/packages/electron/src/renderer/hooks/useTheme.ts
+++ b/packages/electron/src/renderer/hooks/useTheme.ts
@@ -347,7 +347,9 @@ function clearCustomThemeVariables(): void {
 /**
  * Get the effective base theme for a theme ID.
  * Handles 'system' and 'auto' by checking OS preference.
- * For file-based themes, we determine dark/light from the theme metadata.
+ * For extension/file-based themes, we determine dark/light from the theme's
+ * `isDark` metadata (the same source the UI uses in applyThemeToDOM), falling
+ * back to the theme ID name only when the theme isn't in the registry yet.
  */
 function getEffectiveBaseTheme(themeId: string): ConfigTheme {
   // Handle 'system' and 'auto' by checking OS preference
@@ -360,7 +362,16 @@ function getEffectiveBaseTheme(themeId: string): ConfigTheme {
   if (themeId === 'light') return 'light';
   if (themeId === 'dark') return 'dark';
 
-  // For file-based themes, we need to check if they're dark or light.
+  // Extension-contributed themes live in the in-memory runtime registry.
+  // Resolve dark/light from their actual `isDark` flag instead of guessing
+  // from the ID, so themes like `rose-pine` resolve dark in Monaco even
+  // though their ID has no `-dark` suffix.
+  const registryTheme = getRuntimeTheme(themeId);
+  if (registryTheme) {
+    return registryTheme.isDark ? 'dark' : 'light';
+  }
+
+  // Fallback for file-based themes not in the registry: infer from the ID name.
   // Common dark theme IDs contain 'dark' in their name.
   if (themeId.includes('dark')) {
     return 'dark';


### PR DESCRIPTION
## Problem

`getEffectiveBaseTheme()` (`packages/electron/src/renderer/hooks/useTheme.ts`) decided an extension theme's dark/light by string-matching `'dark'` in the theme ID. That resolved value is what feeds the Monaco editor.

The internal Nimbalyst UI already resolves dark/light from the theme's real `isDark` flag (`applyThemeToDOM` → `getRuntimeTheme(id).isDark`). So an extension theme **without** a `-dark` suffix (e.g. `rose-pine`) rendered a dark UI but a **light Monaco editor** — the two paths disagreed.

Workaround until now: theme authors had to append `-dark` to the theme ID so the substring check passed.

## Fix

Resolve the base theme from `getRuntimeTheme(id).isDark` — the same registry source the UI uses — and fall back to the ID-name heuristic only for themes not yet in the registry (file-based built-ins like `crystal-dark`/`solarized-*`, whose names already match).

`isDark` becomes the single source of truth for the editor too.

```
useTheme → getEffectiveBaseTheme('com.rosepinetheme.nimbalyst:rose-pine')
  → registry.isDark=true → 'dark'
TabEditor config.theme='dark' → getMonacoTheme('dark', …) → 'vs-dark'
```

Also corrects Lexical, Mermaid, and code-highlight, which consume the same resolved theme.

## Test plan

- [x] Install an extension theme whose ID has no `-dark` suffix and is `isDark: true` (e.g. Rosé Pine). Open a code file → Monaco renders dark.
- [x] Light extension theme (`isDark: false`, no `-light` in ID) → Monaco renders light.
- [x] Built-in `light`/`dark` unchanged.
- [x] File-based `crystal-dark` / `solarized-light` unchanged (registry miss → name fallback).
- [x] `system`/`auto` still follow OS preference.