### PR TITLE
Add Claude Opus 4.8 to the Claude model list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Claude Opus 4.8 (`claude-opus-4-8`) is available in the Claude model picker.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/ios/NimbalystNative/Sources/Utils/ModelLabel.swift
+++ b/packages/ios/NimbalystNative/Sources/Utils/ModelLabel.swift
@@ -104,6 +104,7 @@ public enum ModelLabel {
 
     /// Mirrors `CLAUDE_MODELS[*].shortName` in `modelConstants.ts`.
     private static let claudeApiShortNames: [String: String] = [
+        "claude-opus-4-8": "Opus 4.8",
         "claude-opus-4-7": "Opus 4.7",
         "claude-opus-4-6": "Opus 4.6",
         "claude-sonnet-4-6": "Sonnet 4.6",

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -12,6 +12,15 @@ export interface ModelDefinition {
 
 export const CLAUDE_MODELS: ModelDefinition[] = [
   {
+    id: 'claude-opus-4-8',
+    displayName: 'Claude Opus 4.8 (1M)',
+    shortName: 'Opus 4.8',
+    maxTokens: 8192,
+    // Opus 4.8 uses the 1M context window natively — no beta header required
+    // (unlike Opus 4.6 which needed `context-1m-2025-08-07`).
+    contextWindow: 1000000,
+  },
+  {
     id: 'claude-opus-4-7',
     displayName: 'Claude Opus 4.7 (1M)',
     shortName: 'Opus 4.7',


### PR DESCRIPTION
## What

Adds **Claude Opus 4.8** (`claude-opus-4-8`) to the Claude model list so it shows up in the model picker, mirroring the existing **Opus 4.7** entry.

## Changes

- **`packages/runtime/src/ai/modelConstants.ts`** — new entry at the top of `CLAUDE_MODELS`, copied field-for-field from the Opus 4.7 entry: `id: 'claude-opus-4-8'`, `displayName: 'Claude Opus 4.8 (1M)'`, `shortName: 'Opus 4.8'`, `maxTokens: 8192`, and the native **1M** `contextWindow: 1000000` (no beta header, same as 4.7). Ordering follows the existing newest-first convention.
- **`packages/ios/NimbalystNative/Sources/Utils/ModelLabel.swift`** — matching `"claude-opus-4-8": "Opus 4.8"` entry in the `claudeApiShortNames` mirror, keeping every Claude model id explicitly labeled.
- **`CHANGELOG.md`** — note under `[Unreleased] › Added`.

## Wiring / behavior

No behavior changes beyond the new selectable model:
- `ClaudeProvider.isModelAllowed()` and the renderer's `modelUtils.ts` both derive from `CLAUDE_MODELS`, so the entry surfaces in the picker and passes the allow-check automatically.
- `ClaudeProvider.supportsTemperature()` already treats `claude-opus-4-N` for N≥7 as temperature-deprecated, so 4.8 is covered without changes.

## Testing

`node --check` passes on the edited `modelConstants.ts`. The full `tsc --noEmit` / `npm run typecheck` was not run: this was prepared from a fresh clone without `node_modules`, and a full `npm install` on the monorepo was out of scope for this change. The addition is structurally identical to the existing `ModelDefinition` entries and introduces no new imports.

## Note

Prepared with AI assistance and reviewed by me.
