### PR TITLE
Add configurable session progress auto-refresh for Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
-- Agent Features settings now include an option to auto-refresh session title and phase from progress reviews for OpenAI Codex sessions, including a configurable review cadence.
+- Agent Features settings now include an option to auto-refresh session title and phase from progress reviews for OpenAI Codex sessions, including a configurable review cadence and a user-defined title template with a `{name}` placeholder.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Agent Features settings now include an option to auto-refresh session title and phase from progress reviews for OpenAI Codex sessions, including a configurable review cadence.
 
 ### Changed
 <!-- Changes to existing functionality go here -->
+- OpenAI Codex session naming can now re-run on later milestones instead of only on the first turn, so long sessions can keep their title and phase aligned with current progress.
 
 ### Fixed
 <!-- Bug fixes go here -->

--- a/packages/electron/src/main/ipc/SettingsHandlers.ts
+++ b/packages/electron/src/main/ipc/SettingsHandlers.ts
@@ -124,22 +124,28 @@ export function registerSettingsHandlers() {
     });
 
     safeHandle('session-progress-naming:get', () => {
-        const current = getAppSetting<{ enabled?: boolean; cadenceTurns?: number }>('sessionProgressNaming');
+        const current = getAppSetting<{ enabled?: boolean; cadenceTurns?: number; titleTemplate?: string }>('sessionProgressNaming');
+        const template = typeof current?.titleTemplate === 'string' ? current.titleTemplate.trim() : '';
         return {
             enabled: current?.enabled === true,
             cadenceTurns: Number.isFinite(Number(current?.cadenceTurns))
                 ? Math.max(1, Math.min(50, Math.round(Number(current?.cadenceTurns))))
                 : 10,
+            titleTemplate: template.includes('{name}') ? template.slice(0, 200) : '',
         };
     });
 
     safeHandle('session-progress-naming:set', (_event, config: unknown) => {
-        const raw = (config && typeof config === 'object') ? config as { enabled?: unknown; cadenceTurns?: unknown } : {};
+        const raw = (config && typeof config === 'object')
+            ? config as { enabled?: unknown; cadenceTurns?: unknown; titleTemplate?: unknown }
+            : {};
+        const rawTemplate = typeof raw.titleTemplate === 'string' ? raw.titleTemplate.trim() : '';
         const normalized = {
             enabled: raw.enabled === true,
             cadenceTurns: Number.isFinite(Number(raw.cadenceTurns))
                 ? Math.max(1, Math.min(50, Math.round(Number(raw.cadenceTurns))))
                 : 10,
+            titleTemplate: rawTemplate.includes('{name}') ? rawTemplate.slice(0, 200) : '',
         };
         setAppSetting('sessionProgressNaming', normalized);
         SessionNamingService.getInstance().setSessionProgressNaming(normalized);

--- a/packages/electron/src/main/ipc/SettingsHandlers.ts
+++ b/packages/electron/src/main/ipc/SettingsHandlers.ts
@@ -123,6 +123,29 @@ export function registerSettingsHandlers() {
         return getAppSetting<string>('preferredAgentLanguage') ?? '';
     });
 
+    safeHandle('session-progress-naming:get', () => {
+        const current = getAppSetting<{ enabled?: boolean; cadenceTurns?: number }>('sessionProgressNaming');
+        return {
+            enabled: current?.enabled === true,
+            cadenceTurns: Number.isFinite(Number(current?.cadenceTurns))
+                ? Math.max(1, Math.min(50, Math.round(Number(current?.cadenceTurns))))
+                : 10,
+        };
+    });
+
+    safeHandle('session-progress-naming:set', (_event, config: unknown) => {
+        const raw = (config && typeof config === 'object') ? config as { enabled?: unknown; cadenceTurns?: unknown } : {};
+        const normalized = {
+            enabled: raw.enabled === true,
+            cadenceTurns: Number.isFinite(Number(raw.cadenceTurns))
+                ? Math.max(1, Math.min(50, Math.round(Number(raw.cadenceTurns))))
+                : 10,
+        };
+        setAppSetting('sessionProgressNaming', normalized);
+        SessionNamingService.getInstance().setSessionProgressNaming(normalized);
+        return normalized;
+    });
+
     // Get the enhanced PATH that Nimbalyst uses for spawning processes
     // This includes custom user paths, detected paths, and common system paths
     safeHandle('environment:get-enhanced-path', () => {

--- a/packages/electron/src/main/mcp/sessionNamingServer.ts
+++ b/packages/electron/src/main/mcp/sessionNamingServer.ts
@@ -11,6 +11,11 @@ import { createServer, IncomingMessage, ServerResponse } from "http";
 import { parse as parseUrl } from "url";
 import { randomUUID } from "crypto";
 import { requireMcpAuth } from "./mcpAuth";
+import {
+  buildSessionNamingTemplateInstruction,
+  formatSessionTitleWithTemplate,
+  getSessionProgressNamingConfig,
+} from "@nimbalyst/runtime/ai/server";
 
 // Store active SSE transports and their metadata
 interface TransportMetadata {
@@ -303,7 +308,7 @@ function createSessionNamingMcpServer(aiSessionId: string): Server {
               name: {
                 type: "string",
                 description:
-                  'A concise session name (2-5 words) with descriptive part first. Examples: "Authentication bug fix", "Dark mode implementation", "Database layer refactor". Only set this on the first call, or when the user explicitly asks you to rename the session.',
+                  `A concise session name (2-5 words) with descriptive part first. Examples: "Authentication bug fix", "Dark mode implementation", "Database layer refactor". Only set this on the first call, or when the user explicitly asks you to rename the session. ${buildSessionNamingTemplateInstruction(getSessionProgressNamingConfig().titleTemplate)}`,
               },
               add: {
                 type: "array",
@@ -382,6 +387,7 @@ function createSessionNamingMcpServer(aiSessionId: string): Server {
       // Capture state before changes for the widget transition display
       const before = await snapshotMeta();
       const notes: string[] = [];
+      const titleTemplate = getSessionProgressNamingConfig().titleTemplate;
 
       // Handle name (write-once)
       if (sessionName) {
@@ -410,8 +416,9 @@ function createSessionNamingMcpServer(aiSessionId: string): Server {
         }
 
         try {
-          await updateSessionTitleFn!(aiSessionId, sessionName);
-          notes.push(`Set name: "${sessionName}"`);
+          const formattedSessionName = formatSessionTitleWithTemplate(sessionName, titleTemplate);
+          await updateSessionTitleFn!(aiSessionId, formattedSessionName);
+          notes.push(`Set name: "${formattedSessionName}"`);
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : "Unknown error";
           console.error("[Session Naming MCP] Failed to update session title:", error);

--- a/packages/electron/src/main/mcp/settingsServer.ts
+++ b/packages/electron/src/main/mcp/settingsServer.ts
@@ -243,7 +243,7 @@ const TOOLS = [
   {
     name: "ai_set_session_progress_naming",
     description:
-      "Enable or disable automatic session title/phase refresh based on progress reviews, and configure how many user turns elapse between reviews. Currently applies to OpenAI Codex sessions.",
+      "Enable or disable automatic session title/phase refresh based on progress reviews, configure how many user turns elapse between reviews, and optionally set a session title template using the {name} placeholder. Currently applies to OpenAI Codex sessions.",
     inputSchema: {
       type: "object",
       properties: {
@@ -251,6 +251,10 @@ const TOOLS = [
         cadenceTurns: {
           type: "number",
           description: "How many user turns between progress reviews. Integer from 1 to 50.",
+        },
+        titleTemplate: {
+          type: "string",
+          description: "Optional session title template. Must include the {name} placeholder, for example 【{name}】 or Session: {name}.",
         },
       },
       required: ["enabled"],
@@ -411,6 +415,7 @@ function createSettingsMcpServer(aiSessionId: string, workspaceId: string | unde
             await svc.setSessionProgressNaming(aiSessionId, {
               enabled: !!args.enabled,
               cadenceTurns: args.cadenceTurns,
+              titleTemplate: args.titleTemplate,
             }),
           );
 

--- a/packages/electron/src/main/mcp/settingsServer.ts
+++ b/packages/electron/src/main/mcp/settingsServer.ts
@@ -241,6 +241,22 @@ const TOOLS = [
     },
   },
   {
+    name: "ai_set_session_progress_naming",
+    description:
+      "Enable or disable automatic session title/phase refresh based on progress reviews, and configure how many user turns elapse between reviews. Currently applies to OpenAI Codex sessions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        enabled: { type: "boolean" },
+        cadenceTurns: {
+          type: "number",
+          description: "How many user turns between progress reviews. Integer from 1 to 50.",
+        },
+      },
+      required: ["enabled"],
+    },
+  },
+  {
     name: "features_toggle",
     description:
       "Toggle an alpha, beta, or developer feature flag by tag. Alpha and developer toggles require Developer Mode to already be enabled; if not, returns requiresUserAction='developer-mode' and you should ask the user to enable it from Settings > Advanced.",
@@ -388,6 +404,14 @@ function createSettingsMcpServer(aiSessionId: string, workspaceId: string | unde
         case "ai_set_preferred_language":
           return respond(
             await svc.setPreferredAgentLanguage(aiSessionId, { language: args.language ?? "" }),
+          );
+
+        case "ai_set_session_progress_naming":
+          return respond(
+            await svc.setSessionProgressNaming(aiSessionId, {
+              enabled: !!args.enabled,
+              cadenceTurns: args.cadenceTurns,
+            }),
           );
 
         case "features_toggle":

--- a/packages/electron/src/main/services/SessionNamingService.ts
+++ b/packages/electron/src/main/services/SessionNamingService.ts
@@ -1,5 +1,14 @@
 import { BrowserWindow } from 'electron';
-import { SessionManager, ClaudeCodeProvider, OpenAICodexProvider, OpenAICodexACPProvider, OpenCodeProvider, setPreferredAgentLanguage as setRuntimePreferredAgentLanguage } from '@nimbalyst/runtime/ai/server';
+import {
+  SessionManager,
+  ClaudeCodeProvider,
+  OpenAICodexProvider,
+  OpenAICodexACPProvider,
+  OpenCodeProvider,
+  setPreferredAgentLanguage as setRuntimePreferredAgentLanguage,
+  setSessionProgressNamingConfig as setRuntimeSessionProgressNamingConfig,
+  type SessionProgressNamingConfig,
+} from '@nimbalyst/runtime/ai/server';
 import { AISessionsRepository } from '@nimbalyst/runtime';
 import {
   startSessionNamingServer,
@@ -13,7 +22,7 @@ import {
 } from '../mcp/sessionNamingServer';
 import { getDatabase } from '../database/initialize';
 import { createWorktreeStore } from './WorktreeStore';
-import { getPreferredAgentLanguage } from '../utils/store';
+import { getAppSetting, getPreferredAgentLanguage } from '../utils/store';
 
 /**
  * Service to manage the session naming MCP server
@@ -61,6 +70,7 @@ export class SessionNamingService {
         // dependency. Renderer changes call SessionNamingService.setLanguage()
         // to keep this in sync at runtime.
         setRuntimePreferredAgentLanguage(getPreferredAgentLanguage());
+        setRuntimeSessionProgressNamingConfig(getAppSetting('sessionProgressNaming'));
 
         // Set the update function that will be called by the MCP server
         // This is called once at startup and captures sessionManager in the closure
@@ -251,6 +261,10 @@ export class SessionNamingService {
    */
   public setLanguage(language: string | undefined): void {
     setRuntimePreferredAgentLanguage(language);
+  }
+
+  public setSessionProgressNaming(config: Partial<SessionProgressNamingConfig> | undefined): void {
+    setRuntimeSessionProgressNamingConfig(config);
   }
 
   /**

--- a/packages/electron/src/main/services/SettingsControlService.ts
+++ b/packages/electron/src/main/services/SettingsControlService.ts
@@ -163,7 +163,7 @@ export class SettingsControlService {
       completionSoundEnabled: getAppSetting<boolean>('completionSoundEnabled') ?? false,
       spellcheckEnabled: getAppSetting<boolean>('spellcheckEnabled') ?? true,
       preferredAgentLanguage: getAppSetting<string>('preferredAgentLanguage') ?? '',
-      sessionProgressNaming: getAppSetting('sessionProgressNaming') ?? { enabled: false, cadenceTurns: 10 },
+      sessionProgressNaming: getAppSetting('sessionProgressNaming') ?? { enabled: false, cadenceTurns: 10, titleTemplate: '' },
       voiceMode: getAppSetting<unknown>('voiceMode') ?? null,
       sessionSync: sync
         ? {
@@ -454,20 +454,22 @@ export class SettingsControlService {
 
   async setSessionProgressNaming(
     sessionId: string,
-    args: { enabled: boolean; cadenceTurns?: number },
+    args: { enabled: boolean; cadenceTurns?: number; titleTemplate?: string },
   ): Promise<
     SettingsToolResult<
-      { enabled: boolean; cadenceTurns: number } | undefined,
-      { enabled: boolean; cadenceTurns: number }
+      { enabled: boolean; cadenceTurns: number; titleTemplate: string } | undefined,
+      { enabled: boolean; cadenceTurns: number; titleTemplate: string }
     >
   > {
     rateLimit(sessionId);
-    const before = getAppSetting<{ enabled?: boolean; cadenceTurns?: number }>('sessionProgressNaming');
+    const before = getAppSetting<{ enabled?: boolean; cadenceTurns?: number; titleTemplate?: string }>('sessionProgressNaming');
+    const rawTemplate = typeof args.titleTemplate === 'string' ? args.titleTemplate.trim() : '';
     const normalized = {
       enabled: args.enabled === true,
       cadenceTurns: Number.isFinite(Number(args.cadenceTurns))
         ? Math.max(1, Math.min(50, Math.round(Number(args.cadenceTurns))))
         : 10,
+      titleTemplate: rawTemplate.includes('{name}') ? rawTemplate.slice(0, 200) : '',
     };
     setAppSetting('sessionProgressNaming', normalized);
     SessionNamingService.getInstance().setSessionProgressNaming(normalized);
@@ -480,6 +482,9 @@ export class SettingsControlService {
             cadenceTurns: Number.isFinite(Number(before.cadenceTurns))
               ? Math.max(1, Math.min(50, Math.round(Number(before.cadenceTurns))))
               : 10,
+            titleTemplate: typeof before.titleTemplate === 'string' && before.titleTemplate.trim().includes('{name}')
+              ? before.titleTemplate.trim().slice(0, 200)
+              : '',
           }
         : undefined,
       after: normalized,

--- a/packages/electron/src/main/services/SettingsControlService.ts
+++ b/packages/electron/src/main/services/SettingsControlService.ts
@@ -68,6 +68,7 @@ export const ALLOWED_APP_KEYS = [
   'analyticsEnabled',
   'defaultAIModel',
   'preferredAgentLanguage',
+  'sessionProgressNaming',
   'sessionSync',
   'voiceMode',
   'alphaFeatures',
@@ -162,6 +163,7 @@ export class SettingsControlService {
       completionSoundEnabled: getAppSetting<boolean>('completionSoundEnabled') ?? false,
       spellcheckEnabled: getAppSetting<boolean>('spellcheckEnabled') ?? true,
       preferredAgentLanguage: getAppSetting<string>('preferredAgentLanguage') ?? '',
+      sessionProgressNaming: getAppSetting('sessionProgressNaming') ?? { enabled: false, cadenceTurns: 10 },
       voiceMode: getAppSetting<unknown>('voiceMode') ?? null,
       sessionSync: sync
         ? {
@@ -448,6 +450,40 @@ export class SettingsControlService {
     SessionNamingService.getInstance().setLanguage(args.language);
     this.audit('ai_set_preferred_language', sessionId, { before, after: args.language });
     return { ok: true, before, after: args.language };
+  }
+
+  async setSessionProgressNaming(
+    sessionId: string,
+    args: { enabled: boolean; cadenceTurns?: number },
+  ): Promise<
+    SettingsToolResult<
+      { enabled: boolean; cadenceTurns: number } | undefined,
+      { enabled: boolean; cadenceTurns: number }
+    >
+  > {
+    rateLimit(sessionId);
+    const before = getAppSetting<{ enabled?: boolean; cadenceTurns?: number }>('sessionProgressNaming');
+    const normalized = {
+      enabled: args.enabled === true,
+      cadenceTurns: Number.isFinite(Number(args.cadenceTurns))
+        ? Math.max(1, Math.min(50, Math.round(Number(args.cadenceTurns))))
+        : 10,
+    };
+    setAppSetting('sessionProgressNaming', normalized);
+    SessionNamingService.getInstance().setSessionProgressNaming(normalized);
+    this.audit('ai_set_session_progress_naming', sessionId, { before, after: normalized });
+    return {
+      ok: true,
+      before: before
+        ? {
+            enabled: before.enabled === true,
+            cadenceTurns: Number.isFinite(Number(before.cadenceTurns))
+              ? Math.max(1, Math.min(50, Math.round(Number(before.cadenceTurns))))
+              : 10,
+          }
+        : undefined,
+      after: normalized,
+    };
   }
 
   // ── Feature flags ────────────────────────────────────────────────

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -19,6 +19,8 @@ import {
   ModelRegistry,
   isAgentProvider,
   onAgentMessageBatch,
+  formatSessionTitleWithTemplate,
+  getSessionProgressNamingConfig,
   type AIProvider,
   type SessionManager,
 } from '@nimbalyst/runtime/ai/server';
@@ -395,7 +397,8 @@ export class MessageStreamingHandler {
     // Update session title if this is the first user message
     if (session.messages.length === 0 || (session.messages.length === 1 && session.messages[0].type === 'user_message')) {
       // Generate a provisional title from the first message without locking out auto-naming
-      const title = message.length > 100 ? message.substring(0, 97) + '...' : message;
+      const rawTitle = message.length > 100 ? message.substring(0, 97) + '...' : message;
+      const title = formatSessionTitleWithTemplate(rawTitle, getSessionProgressNamingConfig().titleTemplate);
       await this.svc.sessionManager.updateSessionTitle(session.id, title, {
         force: true,
         markAsNamed: false,

--- a/packages/electron/src/main/utils/store.ts
+++ b/packages/electron/src/main/utils/store.ts
@@ -29,6 +29,7 @@ export interface TrackerSyncPolicySetting {
 export interface SessionProgressNamingSetting {
   enabled?: boolean;
   cadenceTurns?: number;
+  titleTemplate?: string;
 }
 
 /**

--- a/packages/electron/src/main/utils/store.ts
+++ b/packages/electron/src/main/utils/store.ts
@@ -26,6 +26,11 @@ export interface TrackerSyncPolicySetting {
   scope?: 'project' | 'workspace';
 }
 
+export interface SessionProgressNamingSetting {
+  enabled?: boolean;
+  cadenceTurns?: number;
+}
+
 /**
  * Extension settings stored per extension.
  * Tracks enabled state and extension-specific configuration.
@@ -163,6 +168,9 @@ interface AppStoreSchema {
   // Empty/undefined means no preference -- the agent picks based on the
   // conversation language.
   preferredAgentLanguage?: string;
+  // Periodically review whether the session title/phase still reflect the
+  // latest progress, then auto-update if the agent decides they are stale.
+  sessionProgressNaming?: SessionProgressNamingSetting;
   // Walkthrough guide system state
   walkthroughs?: WalkthroughState;
   // First-open tracking for editor types (for walkthrough triggers)

--- a/packages/electron/src/renderer/components/Settings/AgentFeaturesPanel.tsx
+++ b/packages/electron/src/renderer/components/Settings/AgentFeaturesPanel.tsx
@@ -34,6 +34,7 @@ interface WorkflowExportSettings {
 interface SessionProgressNamingSettings {
   enabled: boolean;
   cadenceTurns: number;
+  titleTemplate: string;
 }
 
 export function AgentFeaturesPanel() {
@@ -53,6 +54,7 @@ export function AgentFeaturesPanel() {
   const [sessionProgressNaming, setSessionProgressNaming] = useState<SessionProgressNamingSettings>({
     enabled: false,
     cadenceTurns: 10,
+    titleTemplate: '',
   });
   const [workflowSourceSettings, setWorkflowSourceSettings] = useState<WorkflowSourceSettings>({
     workspaceClaudeCompatibilityEnabled: false,
@@ -123,6 +125,7 @@ export function AgentFeaturesPanel() {
           cadenceTurns: Number.isFinite(Number(config?.cadenceTurns))
             ? Math.max(1, Math.min(50, Math.round(Number(config.cadenceTurns))))
             : 10,
+          titleTemplate: typeof config?.titleTemplate === 'string' ? config.titleTemplate : '',
         });
       } catch (err) {
         console.error('Failed to load session progress naming settings:', err);
@@ -148,6 +151,7 @@ export function AgentFeaturesPanel() {
         cadenceTurns: Number.isFinite(Number(saved?.cadenceTurns))
           ? Math.max(1, Math.min(50, Math.round(Number(saved.cadenceTurns))))
           : 10,
+        titleTemplate: typeof saved?.titleTemplate === 'string' ? saved.titleTemplate : '',
       });
     } catch (err) {
       console.error('Failed to save session progress naming settings:', err);
@@ -271,6 +275,34 @@ export function AgentFeaturesPanel() {
               />
               <span className="text-sm text-[var(--nim-text-muted)]">turns</span>
             </div>
+          </div>
+
+          <div className="mt-3 ml-12 flex items-start justify-between gap-4">
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium text-[var(--nim-text)] leading-tight">
+                Title template
+              </div>
+              <div className="text-xs text-[var(--nim-text-muted)] leading-snug mt-0.5">
+                Optional wrapper that Nimbalyst applies around the generated core title. Must include <code>{'{name}'}</code>. Examples: <code>【{'{name}'}】</code> or <code>Session: {'{name}'}</code>.
+              </div>
+            </div>
+            <input
+              type="text"
+              value={sessionProgressNaming.titleTemplate}
+              disabled={!sessionProgressNaming.enabled}
+              placeholder="e.g. 【{name}】"
+              onChange={(e) => {
+                setSessionProgressNaming({
+                  ...sessionProgressNaming,
+                  titleTemplate: e.target.value,
+                });
+              }}
+              onBlur={() => {
+                void persistSessionProgressNaming(sessionProgressNaming);
+              }}
+              className="w-64 py-1.5 px-3 rounded-md text-sm bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] disabled:opacity-50"
+              data-testid="session-progress-naming-template-input"
+            />
           </div>
         </div>
       </div>

--- a/packages/electron/src/renderer/components/Settings/AgentFeaturesPanel.tsx
+++ b/packages/electron/src/renderer/components/Settings/AgentFeaturesPanel.tsx
@@ -31,6 +31,11 @@ interface WorkflowExportSettings {
   claudeGeneratedExtensionWorkflowsEnabled: boolean;
 }
 
+interface SessionProgressNamingSettings {
+  enabled: boolean;
+  cadenceTurns: number;
+}
+
 export function AgentFeaturesPanel() {
   const posthog = usePostHog();
   const [settings] = useAtom(advancedSettingsAtom);
@@ -45,6 +50,10 @@ export function AgentFeaturesPanel() {
   const { showToolCalls, chatShowToolCalls, aiDebugLogging, showPromptAdditions } = aiDebugSettings;
   const [workflowSettingsLoading, setWorkflowSettingsLoading] = useState(false);
   const [preferredAgentLanguage, setPreferredAgentLanguage] = useState<string>('');
+  const [sessionProgressNaming, setSessionProgressNaming] = useState<SessionProgressNamingSettings>({
+    enabled: false,
+    cadenceTurns: 10,
+  });
   const [workflowSourceSettings, setWorkflowSourceSettings] = useState<WorkflowSourceSettings>({
     workspaceClaudeCompatibilityEnabled: false,
     includeProjectClaudeSources: false,
@@ -105,12 +114,43 @@ export function AgentFeaturesPanel() {
     loadPreferredAgentLanguage();
   }, []);
 
+  useEffect(() => {
+    const loadSessionProgressNaming = async () => {
+      try {
+        const config = await window.electronAPI.invoke('session-progress-naming:get');
+        setSessionProgressNaming({
+          enabled: config?.enabled === true,
+          cadenceTurns: Number.isFinite(Number(config?.cadenceTurns))
+            ? Math.max(1, Math.min(50, Math.round(Number(config.cadenceTurns))))
+            : 10,
+        });
+      } catch (err) {
+        console.error('Failed to load session progress naming settings:', err);
+      }
+    };
+    loadSessionProgressNaming();
+  }, []);
+
   const handlePreferredAgentLanguageChange = useCallback(async (value: string) => {
     setPreferredAgentLanguage(value);
     try {
       await window.electronAPI.invoke('preferred-agent-language:set', value);
     } catch (err) {
       console.error('Failed to save preferred agent language:', err);
+    }
+  }, []);
+
+  const persistSessionProgressNaming = useCallback(async (next: SessionProgressNamingSettings) => {
+    try {
+      const saved = await window.electronAPI.invoke('session-progress-naming:set', next);
+      setSessionProgressNaming({
+        enabled: saved?.enabled === true,
+        cadenceTurns: Number.isFinite(Number(saved?.cadenceTurns))
+          ? Math.max(1, Math.min(50, Math.round(Number(saved.cadenceTurns))))
+          : 10,
+      });
+    } catch (err) {
+      console.error('Failed to save session progress naming settings:', err);
     }
   }, []);
 
@@ -183,6 +223,55 @@ export function AgentFeaturesPanel() {
             className="w-40 py-1.5 px-3 rounded-md text-sm bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)]"
             data-testid="preferred-agent-language-input"
           />
+        </div>
+
+        <div className="agent-session-progress-naming py-3 border-t border-[var(--nim-border)]">
+          <SettingsToggle
+            checked={sessionProgressNaming.enabled}
+            onChange={(checked) => {
+              const next = { ...sessionProgressNaming, enabled: checked };
+              setSessionProgressNaming(next);
+              void persistSessionProgressNaming(next);
+            }}
+            name="Auto-update Session Title From Progress"
+            description="Periodically review whether the current session title and phase still match the latest milestone, then refresh them automatically when they are stale. Currently applied to OpenAI Codex sessions."
+          />
+
+          <div className="mt-3 ml-12 flex items-start justify-between gap-4">
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium text-[var(--nim-text)] leading-tight">
+                Review cadence
+              </div>
+              <div className="text-xs text-[var(--nim-text-muted)] leading-snug mt-0.5">
+                How many user turns should pass before the agent reviews whether the session title and phase need to be refreshed.
+              </div>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <input
+                type="number"
+                min={1}
+                max={50}
+                step={1}
+                value={sessionProgressNaming.cadenceTurns}
+                disabled={!sessionProgressNaming.enabled}
+                onChange={(e) => {
+                  const raw = Number(e.target.value);
+                  setSessionProgressNaming({
+                    ...sessionProgressNaming,
+                    cadenceTurns: Number.isFinite(raw)
+                      ? Math.max(1, Math.min(50, Math.round(raw)))
+                      : sessionProgressNaming.cadenceTurns,
+                  });
+                }}
+                onBlur={() => {
+                  void persistSessionProgressNaming(sessionProgressNaming);
+                }}
+                className="w-20 py-1.5 px-3 rounded-md text-sm bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] disabled:opacity-50"
+                data-testid="session-progress-naming-cadence-input"
+              />
+              <span className="text-sm text-[var(--nim-text-muted)]">turns</span>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/packages/runtime/src/ai/server/__tests__/sessionProgressNaming.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/sessionProgressNaming.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildInitialSessionNamingReminderPrompt,
+  buildSessionNamingTemplateInstruction,
   buildClaudeSessionProgressReviewPrompt,
   buildSessionProgressNamingReminderPrompt,
   countUserTurns,
+  formatSessionTitleWithTemplate,
   parseClaudeSessionProgressReviewResponse,
   shouldReviewSessionProgressNaming,
   SESSION_PROGRESS_NAMING_NO_CHANGE,
@@ -47,9 +50,9 @@ describe('sessionProgressNaming', () => {
       userMessage('4'),
     ];
 
-    expect(shouldReviewSessionProgressNaming(messages, { enabled: false, cadenceTurns: 2 })).toBe(false);
-    expect(shouldReviewSessionProgressNaming(messages, { enabled: true, cadenceTurns: 3 })).toBe(false);
-    expect(shouldReviewSessionProgressNaming(messages, { enabled: true, cadenceTurns: 4 })).toBe(true);
+    expect(shouldReviewSessionProgressNaming(messages, { enabled: false, cadenceTurns: 2, titleTemplate: '' })).toBe(false);
+    expect(shouldReviewSessionProgressNaming(messages, { enabled: true, cadenceTurns: 3, titleTemplate: '' })).toBe(false);
+    expect(shouldReviewSessionProgressNaming(messages, { enabled: true, cadenceTurns: 4, titleTemplate: '' })).toBe(true);
   });
 
   it('parses claude review replies and ignores NO_CHANGE', () => {
@@ -66,11 +69,24 @@ describe('sessionProgressNaming', () => {
     expect(normalizeSessionProgressNamingConfig({ enabled: true, cadenceTurns: 0 })).toEqual({
       enabled: true,
       cadenceTurns: 1,
+      titleTemplate: '',
     });
     expect(normalizeSessionProgressNamingConfig({ enabled: true, cadenceTurns: 88 })).toEqual({
       enabled: true,
       cadenceTurns: 50,
+      titleTemplate: '',
     });
+    expect(normalizeSessionProgressNamingConfig({ enabled: true, cadenceTurns: 5, titleTemplate: '【{name}】' })).toEqual({
+      enabled: true,
+      cadenceTurns: 5,
+      titleTemplate: '【{name}】',
+    });
+  });
+
+  it('formats titles with configured templates', () => {
+    expect(formatSessionTitleWithTemplate('Nimbalyst/开发 标题状态更新', '【{name}】')).toBe('【Nimbalyst/开发 标题状态更新】');
+    expect(formatSessionTitleWithTemplate('Nimbalyst/开发 标题状态更新', '')).toBe('Nimbalyst/开发 标题状态更新');
+    expect(buildSessionNamingTemplateInstruction('【{name}】')).toContain('A session title template is configured');
   });
 
   it('builds prompts with current title and phase context', () => {
@@ -78,16 +94,22 @@ describe('sessionProgressNaming', () => {
       currentTitle: '【Nimbalyst/开发】代码开发',
       currentPhase: 'implementing',
       cadenceTurns: 10,
+      titleTemplate: '【{name}】',
     });
     expect(reminderPrompt).toContain('Current title: "【Nimbalyst/开发】代码开发"');
     expect(reminderPrompt).toContain('Current phase: "implementing"');
+    expect(reminderPrompt).toContain('A session title template is configured: "【{name}】"');
 
     const claudePrompt = buildClaudeSessionProgressReviewPrompt({
       currentTitle: '【Nimbalyst/开发】代码开发',
       currentPhase: 'implementing',
       cadenceTurns: 10,
+      titleTemplate: '【{name}】',
     });
     expect(claudePrompt).toContain('name|phase');
     expect(claudePrompt).toContain('Current title: 【Nimbalyst/开发】代码开发');
+
+    const initialPrompt = buildInitialSessionNamingReminderPrompt('【{name}】');
+    expect(initialPrompt).toContain('A session title template is configured: "【{name}】"');
   });
 });

--- a/packages/runtime/src/ai/server/__tests__/sessionProgressNaming.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/sessionProgressNaming.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildClaudeSessionProgressReviewPrompt,
+  buildSessionProgressNamingReminderPrompt,
+  countUserTurns,
+  parseClaudeSessionProgressReviewResponse,
+  shouldReviewSessionProgressNaming,
+  SESSION_PROGRESS_NAMING_NO_CHANGE,
+} from '../sessionProgressNaming';
+import {
+  DEFAULT_SESSION_PROGRESS_NAMING_CONFIG,
+  normalizeSessionProgressNamingConfig,
+} from '../sessionProgressNamingConfig';
+import type { Message } from '../types';
+
+function userMessage(content: string, isUserInput: boolean = true): Message {
+  return {
+    role: 'user',
+    content,
+    timestamp: Date.now(),
+    isUserInput,
+  };
+}
+
+describe('sessionProgressNaming', () => {
+  it('counts only real user turns', () => {
+    const messages: Message[] = [
+      userMessage('real 1'),
+      { role: 'assistant', content: 'reply', timestamp: Date.now() },
+      userMessage('<SYSTEM_REMINDER>hidden</SYSTEM_REMINDER>', false),
+      { role: 'system', content: 'note', timestamp: Date.now() },
+      userMessage('real 2'),
+    ];
+
+    expect(countUserTurns(messages)).toBe(2);
+  });
+
+  it('reviews progress only when enabled and cadence is reached', () => {
+    const messages: Message[] = [
+      userMessage('1'),
+      { role: 'assistant', content: 'a', timestamp: Date.now() },
+      userMessage('2'),
+      { role: 'assistant', content: 'b', timestamp: Date.now() },
+      userMessage('3'),
+      { role: 'assistant', content: 'c', timestamp: Date.now() },
+      userMessage('4'),
+    ];
+
+    expect(shouldReviewSessionProgressNaming(messages, { enabled: false, cadenceTurns: 2 })).toBe(false);
+    expect(shouldReviewSessionProgressNaming(messages, { enabled: true, cadenceTurns: 3 })).toBe(false);
+    expect(shouldReviewSessionProgressNaming(messages, { enabled: true, cadenceTurns: 4 })).toBe(true);
+  });
+
+  it('parses claude review replies and ignores NO_CHANGE', () => {
+    expect(parseClaudeSessionProgressReviewResponse(SESSION_PROGRESS_NAMING_NO_CHANGE)).toBeNull();
+    expect(parseClaudeSessionProgressReviewResponse('【Nimbalyst/开发】开发完成|validating')).toEqual({
+      name: '【Nimbalyst/开发】开发完成',
+      phase: 'validating',
+    });
+    expect(parseClaudeSessionProgressReviewResponse('bad|done')).toBeNull();
+  });
+
+  it('normalizes progress naming config safely', () => {
+    expect(normalizeSessionProgressNamingConfig(undefined)).toEqual(DEFAULT_SESSION_PROGRESS_NAMING_CONFIG);
+    expect(normalizeSessionProgressNamingConfig({ enabled: true, cadenceTurns: 0 })).toEqual({
+      enabled: true,
+      cadenceTurns: 1,
+    });
+    expect(normalizeSessionProgressNamingConfig({ enabled: true, cadenceTurns: 88 })).toEqual({
+      enabled: true,
+      cadenceTurns: 50,
+    });
+  });
+
+  it('builds prompts with current title and phase context', () => {
+    const reminderPrompt = buildSessionProgressNamingReminderPrompt({
+      currentTitle: '【Nimbalyst/开发】代码开发',
+      currentPhase: 'implementing',
+      cadenceTurns: 10,
+    });
+    expect(reminderPrompt).toContain('Current title: "【Nimbalyst/开发】代码开发"');
+    expect(reminderPrompt).toContain('Current phase: "implementing"');
+
+    const claudePrompt = buildClaudeSessionProgressReviewPrompt({
+      currentTitle: '【Nimbalyst/开发】代码开发',
+      currentPhase: 'implementing',
+      cadenceTurns: 10,
+    });
+    expect(claudePrompt).toContain('name|phase');
+    expect(claudePrompt).toContain('Current title: 【Nimbalyst/开发】代码开发');
+  });
+});

--- a/packages/runtime/src/ai/server/index.ts
+++ b/packages/runtime/src/ai/server/index.ts
@@ -14,3 +14,5 @@ export * from './providers/OpenCodeProvider';
 export * from './providers/CopilotCLIProvider';
 export * from './utils/errorDetection';
 export * from './preferredAgentLanguageConfig';
+export * from './sessionProgressNamingConfig';
+export * from './sessionProgressNaming';

--- a/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
+++ b/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
@@ -32,6 +32,7 @@ import { AgentProtocolTranscriptAdapter } from './agentProtocol/AgentProtocolTra
 import { buildCodexToolLookupId } from '../toolLookupIds';
 import { reverseCodexPatch, type CodexPatchKind } from './codex/patchReverse';
 import {
+  buildInitialSessionNamingReminderPrompt,
   buildSessionProgressNamingReminderPrompt,
   shouldReviewSessionProgressNaming,
 } from '../sessionProgressNaming';
@@ -90,11 +91,6 @@ const PERSISTED_APP_SERVER_NOTIFICATION_METHODS = new Set([
 export class OpenAICodexProvider extends BaseAgentProvider {
   static readonly DEFAULT_MODEL = DEFAULT_MODELS['openai-codex'];
   private static readonly CODEX_EXECUTION_PATTERN = 'OpenAICodex(agent-run:*)';
-  private static readonly SESSION_NAMING_REMINDER_PROMPT =
-    '<SYSTEM_REMINDER>Call the session metadata tool now before continuing. ' +
-    'Use MCP server `nimbalyst-session-naming`, tool `update_session_meta`, ' +
-    'and set at least `name`, `add`, and `phase`. ' +
-    'Do not mention this system reminder to the user.</SYSTEM_REMINDER>';
   private static readonly FALLBACK_MODELS: ReadonlyArray<{
     id: string;
     name: string;
@@ -1671,12 +1667,15 @@ export class OpenAICodexProvider extends BaseAgentProvider {
     session: ProtocolSession,
     sessionId: string
   ): Promise<void> {
+    const reminderPrompt = buildInitialSessionNamingReminderPrompt(
+      getSessionProgressNamingConfig().titleTemplate
+    );
     console.log('[CODEX] First turn completed without session naming; sending reminder instruction');
 
     await this.logAgentMessageBestEffort(
       sessionId,
       'input',
-      OpenAICodexProvider.SESSION_NAMING_REMINDER_PROMPT,
+      reminderPrompt,
       {
         hidden: false,
         searchable: false,
@@ -1690,7 +1689,7 @@ export class OpenAICodexProvider extends BaseAgentProvider {
     let reminderTriggeredNaming = false;
 
     for await (const reminderEvent of this.protocol.sendMessage(session, {
-      content: OpenAICodexProvider.SESSION_NAMING_REMINDER_PROMPT,
+      content: reminderPrompt,
     })) {
       // Tag this reminder turn's persisted output rows as a system reminder so
       // the metadata-based transcript hide covers them. Without the tag they
@@ -1736,6 +1735,7 @@ export class OpenAICodexProvider extends BaseAgentProvider {
         currentTitle: currentSession.title || 'Untitled',
         currentPhase: (currentSession.metadata as Record<string, unknown> | undefined)?.phase as string | null | undefined,
         cadenceTurns: namingConfig.cadenceTurns,
+        titleTemplate: namingConfig.titleTemplate,
       });
 
       await this.logAgentMessageBestEffort(

--- a/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
+++ b/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
@@ -24,12 +24,18 @@ import { PermissionMode, TrustChecker, PermissionPatternSaver, PermissionPattern
 import { CodexSdkModuleLike, loadCodexSdkModule } from './codex/codexSdkLoader';
 import { resolvePackagedCodexBinaryPath } from './codex/codexBinaryPath';
 import { McpConfigService } from '../services/McpConfigService';
+import { SessionManager } from '../SessionManager';
 import { MCPServerConfig } from '../../../types/MCPServerConfig';
 import { safeJSONSerialize } from '../../../utils/serialization';
 import { AskUserQuestionPrompt, AskUserQuestionPromptOption } from './shared/askUserQuestionTypes';
 import { AgentProtocolTranscriptAdapter } from './agentProtocol/AgentProtocolTranscriptAdapter';
 import { buildCodexToolLookupId } from '../toolLookupIds';
 import { reverseCodexPatch, type CodexPatchKind } from './codex/patchReverse';
+import {
+  buildSessionProgressNamingReminderPrompt,
+  shouldReviewSessionProgressNaming,
+} from '../sessionProgressNaming';
+import { getSessionProgressNamingConfig } from '../sessionProgressNamingConfig';
 
 /**
  * Codex transport selection.
@@ -1361,14 +1367,12 @@ export class OpenAICodexProvider extends BaseAgentProvider {
         console.error('[CODEX] WARNING: Stream completed but thread ID was never captured!');
       }
 
-      if (
-        sessionId &&
-        !isResumedThread &&
-        hasSessionNamingServer &&
-        !usedSessionNamingToolThisTurn &&
-        !abortController.signal.aborted
-      ) {
-        await this.sendSessionNamingReminder(session, sessionId);
+      if (sessionId && hasSessionNamingServer && !usedSessionNamingToolThisTurn && !abortController.signal.aborted) {
+        if (!isResumedThread) {
+          await this.sendSessionNamingReminder(session, sessionId);
+        } else {
+          await this.maybeSendSessionProgressNamingReminder(session, sessionId);
+        }
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -1708,6 +1712,68 @@ export class OpenAICodexProvider extends BaseAgentProvider {
 
     if (!reminderTriggeredNaming) {
       console.warn('[CODEX] Session naming reminder turn completed without update_session_meta call');
+    }
+  }
+
+  private async maybeSendSessionProgressNamingReminder(
+    session: ProtocolSession,
+    sessionId: string
+  ): Promise<void> {
+    const namingConfig = getSessionProgressNamingConfig();
+    if (!namingConfig.enabled) {
+      return;
+    }
+
+    try {
+      const manager = new SessionManager();
+      await manager.initialize();
+      const currentSession = await manager.loadSession(sessionId);
+      if (!currentSession || !shouldReviewSessionProgressNaming(currentSession.messages, namingConfig)) {
+        return;
+      }
+
+      const reminderPrompt = buildSessionProgressNamingReminderPrompt({
+        currentTitle: currentSession.title || 'Untitled',
+        currentPhase: (currentSession.metadata as Record<string, unknown> | undefined)?.phase as string | null | undefined,
+        cadenceTurns: namingConfig.cadenceTurns,
+      });
+
+      await this.logAgentMessageBestEffort(
+        sessionId,
+        'input',
+        reminderPrompt,
+        {
+          hidden: true,
+          searchable: false,
+          metadata: {
+            promptType: 'system_reminder',
+            reminderKind: 'session_progress_naming',
+          },
+        }
+      );
+
+      let reminderTriggeredNaming = false;
+      for await (const reminderEvent of this.protocol.sendMessage(session, {
+        content: reminderPrompt,
+      })) {
+        await this.storeRawEventIfPresent(reminderEvent, sessionId, {
+          promptType: 'system_reminder',
+          reminderKind: 'session_progress_naming',
+        });
+
+        if (reminderEvent.type === 'tool_call' && reminderEvent.toolCall) {
+          if (OpenAICodexProvider.isSessionNamingToolCall(reminderEvent.toolCall.name)) {
+            reminderTriggeredNaming = true;
+          }
+          this.handleAskUserQuestionToolCall(reminderEvent.toolCall, sessionId);
+        }
+      }
+
+      if (!reminderTriggeredNaming) {
+        console.log('[CODEX] Session progress naming review completed without metadata changes');
+      }
+    } catch (error) {
+      console.warn('[CODEX] Session progress naming review failed:', (error as Error)?.message ?? error);
     }
   }
 

--- a/packages/runtime/src/ai/server/sessionProgressNaming.ts
+++ b/packages/runtime/src/ai/server/sessionProgressNaming.ts
@@ -2,6 +2,7 @@ import type { Message, TranscriptViewMessage } from './types';
 import type { SessionProgressNamingConfig } from './sessionProgressNamingConfig';
 
 export const SESSION_PROGRESS_NAMING_NO_CHANGE = 'NO_CHANGE';
+export const SESSION_PROGRESS_NAMING_TEMPLATE_PLACEHOLDER = '{name}';
 
 const VALID_PHASES = new Set(['backlog', 'planning', 'implementing', 'validating']);
 
@@ -25,10 +26,32 @@ export function shouldReviewSessionProgressNaming(
   return userTurns > 1 && userTurns % config.cadenceTurns === 0;
 }
 
+export function formatSessionTitleWithTemplate(name: string, titleTemplate?: string | null): string {
+  const coreName = name.trim();
+  const template = typeof titleTemplate === 'string' ? titleTemplate.trim() : '';
+  if (!coreName || !template || !template.includes(SESSION_PROGRESS_NAMING_TEMPLATE_PLACEHOLDER)) {
+    return coreName;
+  }
+  return template.split(SESSION_PROGRESS_NAMING_TEMPLATE_PLACEHOLDER).join(coreName).trim();
+}
+
+export function buildSessionNamingTemplateInstruction(titleTemplate?: string | null): string {
+  const template = typeof titleTemplate === 'string' ? titleTemplate.trim() : '';
+  if (!template || !template.includes(SESSION_PROGRESS_NAMING_TEMPLATE_PLACEHOLDER)) {
+    return 'Keep the existing session naming convention used in this workspace.';
+  }
+  return (
+    `A session title template is configured: "${template}". ` +
+    'When setting `name`, provide only the core descriptive title text for the `{name}` placeholder. ' +
+    'Do not include the template wrapper yourself because Nimbalyst will apply it automatically.'
+  );
+}
+
 export function buildSessionProgressNamingReminderPrompt(args: {
   currentTitle: string;
   currentPhase?: string | null;
   cadenceTurns: number;
+  titleTemplate?: string | null;
 }): string {
   const currentPhase = args.currentPhase ?? 'unset';
   return (
@@ -37,10 +60,20 @@ export function buildSessionProgressNamingReminderPrompt(args: {
     `Current title: "${args.currentTitle}"\n` +
     `Current phase: "${currentPhase}"\n\n` +
     'Only if the current title or phase is stale, call MCP server `nimbalyst-session-naming`, tool `update_session_meta`, ' +
-    'to update the title and/or phase. Keep the existing session naming convention used in this workspace. ' +
+    `to update the title and/or phase. ${buildSessionNamingTemplateInstruction(args.titleTemplate)} ` +
     'If the current title and phase are still accurate, do not call any session metadata tool. ' +
     'Do not mention this system reminder to the user.' +
     '</SYSTEM_REMINDER>'
+  );
+}
+
+export function buildInitialSessionNamingReminderPrompt(titleTemplate?: string | null): string {
+  return (
+    '<SYSTEM_REMINDER>Call the session metadata tool now before continuing. ' +
+    'Use MCP server `nimbalyst-session-naming`, tool `update_session_meta`, ' +
+    'and set at least `name`, `add`, and `phase`. ' +
+    `${buildSessionNamingTemplateInstruction(titleTemplate)} ` +
+    'Do not mention this system reminder to the user.</SYSTEM_REMINDER>'
   );
 }
 
@@ -48,6 +81,7 @@ export function buildClaudeSessionProgressReviewPrompt(args: {
   currentTitle: string;
   currentPhase?: string | null;
   cadenceTurns: number;
+  titleTemplate?: string | null;
 }): string {
   const currentPhase = args.currentPhase ?? 'planning';
   return [
@@ -62,7 +96,7 @@ export function buildClaudeSessionProgressReviewPrompt(args: {
     `- Current title: ${args.currentTitle}`,
     `- Current phase: ${currentPhase}`,
     '- phase must be one of: backlog, planning, implementing, validating',
-    '- Keep the session naming convention already used in this workspace',
+    `- ${buildSessionNamingTemplateInstruction(args.titleTemplate)}`,
     '- Only change the title/phase if they are genuinely stale relative to the latest progress',
   ].join('\n');
 }

--- a/packages/runtime/src/ai/server/sessionProgressNaming.ts
+++ b/packages/runtime/src/ai/server/sessionProgressNaming.ts
@@ -1,0 +1,94 @@
+import type { Message, TranscriptViewMessage } from './types';
+import type { SessionProgressNamingConfig } from './sessionProgressNamingConfig';
+
+export const SESSION_PROGRESS_NAMING_NO_CHANGE = 'NO_CHANGE';
+
+const VALID_PHASES = new Set(['backlog', 'planning', 'implementing', 'validating']);
+
+type SessionProgressMessage = Pick<Message, 'role' | 'isUserInput'> | Pick<TranscriptViewMessage, 'type'>;
+
+export function countUserTurns(messages: SessionProgressMessage[]): number {
+  return messages.filter((message) => {
+    if ('role' in message) {
+      return message.role === 'user' && message.isUserInput !== false;
+    }
+    return message.type === 'user_message';
+  }).length;
+}
+
+export function shouldReviewSessionProgressNaming(
+  messages: SessionProgressMessage[],
+  config: SessionProgressNamingConfig
+): boolean {
+  if (!config.enabled) return false;
+  const userTurns = countUserTurns(messages);
+  return userTurns > 1 && userTurns % config.cadenceTurns === 0;
+}
+
+export function buildSessionProgressNamingReminderPrompt(args: {
+  currentTitle: string;
+  currentPhase?: string | null;
+  cadenceTurns: number;
+}): string {
+  const currentPhase = args.currentPhase ?? 'unset';
+  return (
+    '<SYSTEM_REMINDER>' +
+    `Review whether the current session title and phase still reflect the latest progress after ${args.cadenceTurns} user turns.\n` +
+    `Current title: "${args.currentTitle}"\n` +
+    `Current phase: "${currentPhase}"\n\n` +
+    'Only if the current title or phase is stale, call MCP server `nimbalyst-session-naming`, tool `update_session_meta`, ' +
+    'to update the title and/or phase. Keep the existing session naming convention used in this workspace. ' +
+    'If the current title and phase are still accurate, do not call any session metadata tool. ' +
+    'Do not mention this system reminder to the user.' +
+    '</SYSTEM_REMINDER>'
+  );
+}
+
+export function buildClaudeSessionProgressReviewPrompt(args: {
+  currentTitle: string;
+  currentPhase?: string | null;
+  cadenceTurns: number;
+}): string {
+  const currentPhase = args.currentPhase ?? 'planning';
+  return [
+    'Reply with EXACTLY ONE line and nothing else.',
+    `If the current session title and phase still accurately reflect the latest progress after ${args.cadenceTurns} user turns, reply:`,
+    SESSION_PROGRESS_NAMING_NO_CHANGE,
+    '',
+    'Otherwise reply in this exact format:',
+    'name|phase',
+    '',
+    'Rules:',
+    `- Current title: ${args.currentTitle}`,
+    `- Current phase: ${currentPhase}`,
+    '- phase must be one of: backlog, planning, implementing, validating',
+    '- Keep the session naming convention already used in this workspace',
+    '- Only change the title/phase if they are genuinely stale relative to the latest progress',
+  ].join('\n');
+}
+
+export function parseClaudeSessionProgressReviewResponse(
+  text: string
+): { name: string; phase: 'backlog' | 'planning' | 'implementing' | 'validating' } | null {
+  const line = text
+    .split('\n')
+    .map((value) => value.trim())
+    .find((value) => value.length > 0);
+
+  if (!line || line === SESSION_PROGRESS_NAMING_NO_CHANGE || !line.includes('|')) {
+    return null;
+  }
+
+  const [nameRaw, phaseRaw] = line.split('|');
+  const name = (nameRaw ?? '').trim();
+  const phase = (phaseRaw ?? '').trim().toLowerCase();
+
+  if (!name || !VALID_PHASES.has(phase)) {
+    return null;
+  }
+
+  return {
+    name,
+    phase: phase as 'backlog' | 'planning' | 'implementing' | 'validating',
+  };
+}

--- a/packages/runtime/src/ai/server/sessionProgressNamingConfig.ts
+++ b/packages/runtime/src/ai/server/sessionProgressNamingConfig.ts
@@ -1,11 +1,13 @@
 export interface SessionProgressNamingConfig {
   enabled: boolean;
   cadenceTurns: number;
+  titleTemplate: string;
 }
 
 export const DEFAULT_SESSION_PROGRESS_NAMING_CONFIG: SessionProgressNamingConfig = {
   enabled: false,
   cadenceTurns: 10,
+  titleTemplate: '',
 };
 
 let sessionProgressNamingConfig: SessionProgressNamingConfig = DEFAULT_SESSION_PROGRESS_NAMING_CONFIG;
@@ -17,10 +19,15 @@ export function normalizeSessionProgressNamingConfig(
   const cadenceTurns = Number.isFinite(rawCadence)
     ? Math.max(1, Math.min(50, Math.round(rawCadence)))
     : DEFAULT_SESSION_PROGRESS_NAMING_CONFIG.cadenceTurns;
+  const rawTemplate = typeof input?.titleTemplate === 'string' ? input.titleTemplate.trim() : '';
+  const titleTemplate = rawTemplate.includes('{name}')
+    ? rawTemplate.slice(0, 200)
+    : DEFAULT_SESSION_PROGRESS_NAMING_CONFIG.titleTemplate;
 
   return {
     enabled: input?.enabled === true,
     cadenceTurns,
+    titleTemplate,
   };
 }
 

--- a/packages/runtime/src/ai/server/sessionProgressNamingConfig.ts
+++ b/packages/runtime/src/ai/server/sessionProgressNamingConfig.ts
@@ -1,0 +1,35 @@
+export interface SessionProgressNamingConfig {
+  enabled: boolean;
+  cadenceTurns: number;
+}
+
+export const DEFAULT_SESSION_PROGRESS_NAMING_CONFIG: SessionProgressNamingConfig = {
+  enabled: false,
+  cadenceTurns: 10,
+};
+
+let sessionProgressNamingConfig: SessionProgressNamingConfig = DEFAULT_SESSION_PROGRESS_NAMING_CONFIG;
+
+export function normalizeSessionProgressNamingConfig(
+  input: Partial<SessionProgressNamingConfig> | null | undefined
+): SessionProgressNamingConfig {
+  const rawCadence = Number(input?.cadenceTurns);
+  const cadenceTurns = Number.isFinite(rawCadence)
+    ? Math.max(1, Math.min(50, Math.round(rawCadence)))
+    : DEFAULT_SESSION_PROGRESS_NAMING_CONFIG.cadenceTurns;
+
+  return {
+    enabled: input?.enabled === true,
+    cadenceTurns,
+  };
+}
+
+export function setSessionProgressNamingConfig(
+  input: Partial<SessionProgressNamingConfig> | null | undefined
+): void {
+  sessionProgressNamingConfig = normalizeSessionProgressNamingConfig(input);
+}
+
+export function getSessionProgressNamingConfig(): SessionProgressNamingConfig {
+  return sessionProgressNamingConfig;
+}


### PR DESCRIPTION
## Summary
- add a persisted setting for progress-based session title/phase refresh with a configurable turn cadence
- re-run session naming reminders on later OpenAI Codex milestones so long sessions can keep metadata aligned with current progress
- cover the new helper logic with runtime unit tests and expose the option in Agent Features

## Testing
- npm run test:unit -- --run packages/runtime/src/ai/server/__tests__/sessionProgressNaming.test.ts
- npm run typecheck --workspace packages/runtime --workspace packages/electron