### PR TITLE
fix(meta-agent): inherit parent provider+model for spawned child sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Meta-agent child sessions now inherit the parent session's provider and model instead of silently falling back to a Claude/Opus default for non-Claude parents.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -350,11 +350,33 @@ export class MetaAgentService {
       throw new Error('useWorktree and worktreeId cannot be combined');
     }
 
-    const defaultModel = getDefaultAIModel() || 'claude-code:opus';
+    // Inherit the calling session's provider+model as the primary fallback so a
+    // non-Claude parent (Gemini, OpenAI-Codex, LM Studio, etc.) spawning a child
+    // via the meta-agent tools without an explicit model does NOT silently land
+    // on the hardcoded Opus default and bill the user's Anthropic pool. Only fall
+    // through to getDefaultAIModel() / the last-resort default when the parent
+    // session cannot be loaded (orphan call) or carries no usable provider+model.
+    // An explicit args.provider/args.model still wins; that is what they are for.
+    let parentProvider: string | null = null;
+    let parentModel: string | null = null;
+    try {
+      const parentSession = await AISessionsRepository.get(metaSessionId);
+      if (parentSession) {
+        parentProvider = parentSession.provider ?? null;
+        parentModel = parentSession.model ?? null;
+      }
+    } catch {
+      // Best-effort lookup; fall through to the hardcoded default below.
+    }
+
+    const defaultModel = parentModel || getDefaultAIModel() || 'claude-code:opus';
     const model = args.model || defaultModel;
     const parsed = ModelIdentifier.tryParse(model);
-    const provider = (args.provider || parsed?.provider || 'claude-code') as AIProviderType;
-    const normalizedModel = args.model || ModelIdentifier.getDefaultModelId(provider);
+    const provider = (args.provider || parsed?.provider || parentProvider || 'claude-code') as AIProviderType;
+    // When the caller didn't pass an explicit model, prefer the inherited parent
+    // model verbatim (so a gemini-flash-3.5 parent keeps flash-3.5, not whatever
+    // ModelIdentifier.getDefaultModelId returns for that provider).
+    const normalizedModel = args.model || parentModel || ModelIdentifier.getDefaultModelId(provider);
     const callerProvidedTitle = !!args.title?.trim();
     const title = (args.title || this.deriveTitleFromPrompt(args.prompt) || 'Meta Task').trim();
 

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.providerInheritance.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.providerInheritance.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors the mock surface of MetaAgentService.workstreamSync.test.ts, with two
+// additions needed to exercise the child-spawn path:
+//   1. AISessionsRepository.get  - the parent-session lookup the fix relies on.
+//   2. A working ModelIdentifier.tryParse / getDefaultModelId (the sibling test
+//      stubs ModelIdentifier as {}, which throws once tryParse is reached).
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    create: vi.fn(),
+    updateMetadata: vi.fn(),
+    get: vi.fn(),
+  },
+  AgentMessagesRepository: {},
+  SessionFilesRepository: {},
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  ClaudeCodeProvider: { setMetaAgentServerPort: vi.fn() },
+  OpenAICodexProvider: { setMetaAgentServerPort: vi.fn() },
+  OpenAICodexACPProvider: { setMetaAgentServerPort: vi.fn() },
+  SessionManager: class {
+    async initialize() {}
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: {
+    tryParse: (id: string) => {
+      const i = typeof id === 'string' ? id.indexOf(':') : -1;
+      return i > 0 ? { provider: id.slice(0, i), model: id.slice(i + 1) } : null;
+    },
+    getDefaultModelId: (provider: string) => `${provider}:default`,
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn() }),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+vi.mock('../SyncManager', () => ({ getSyncProvider: () => ({ pushChange: vi.fn() }) }));
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => null }));
+vi.mock('../../utils/timestampUtils', () => ({ toMillis: (v: unknown) => v }));
+vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
+vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({ database: { query: vi.fn() } }));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => null }));
+vi.mock('../../file/GitRefWatcher', () => ({ gitRefWatcher: {} }));
+vi.mock('./ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({
+  startMetaAgentServer: vi.fn(),
+  setMetaAgentToolFns: vi.fn(),
+  shutdownMetaAgentServer: vi.fn(),
+}));
+vi.mock('../metaAgentNotificationSignature', () => ({ computeNotificationSignature: vi.fn() }));
+vi.mock('../metaAgentMessageText', () => ({
+  extractMessageText: vi.fn(),
+  extractUserPrompts: vi.fn(),
+}));
+
+import { AISessionsRepository } from '@nimbalyst/runtime';
+import { MetaAgentService } from '../MetaAgentService';
+
+const GEMINI_PARENT = {
+  id: 'parent-gemini-session',
+  provider: 'antigravity-gemini-agent',
+  model: 'antigravity-gemini-agent:gemini-flash-3.5',
+};
+
+describe('MetaAgentService child-spawn provider inheritance', () => {
+  beforeEach(() => {
+    vi.mocked(AISessionsRepository.create).mockReset();
+    vi.mocked(AISessionsRepository.get).mockReset();
+  });
+
+  it('inherits a non-Claude parent provider+model when the spawn omits an explicit model (no silent claude-code:opus fallback)', async () => {
+    const service = MetaAgentService.getInstance();
+    // The child-spawn path guards on this.aiService being present.
+    (service as any).aiService = { queuePromptForSession: vi.fn() };
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(GEMINI_PARENT as any);
+
+    // No explicit model/provider - the case the model hits when it leaves the
+    // optional `model` arg off. getDefaultAIModel() is mocked to null, so the
+    // pre-fix code would resolve to the hardcoded 'claude-code:opus'.
+    await (service as any).createChildSessionInternal('parent-gemini-session', '/workspace/path', {});
+
+    expect(AISessionsRepository.create).toHaveBeenCalledTimes(1);
+
+    // Behavior is the contract: the child carries the parent's provider+model.
+    const created = vi.mocked(AISessionsRepository.create).mock.calls[0][0] as any;
+    expect(created.provider).toBe('antigravity-gemini-agent');
+    expect(created.model).toBe('antigravity-gemini-agent:gemini-flash-3.5');
+    // The regression guard: a Gemini parent must never spawn a Claude/Opus child.
+    expect(created.provider).not.toBe('claude-code');
+    expect(created.model).not.toBe('claude-code:opus');
+  });
+
+  it('still lets an explicit model arg win over the inherited parent', async () => {
+    const service = MetaAgentService.getInstance();
+    (service as any).aiService = { queuePromptForSession: vi.fn() };
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(GEMINI_PARENT as any);
+
+    await (service as any).createChildSessionInternal('parent-gemini-session', '/workspace/path', {
+      model: 'openai-codex:gpt-5.4',
+    });
+
+    const created = vi.mocked(AISessionsRepository.create).mock.calls[0][0] as any;
+    expect(created.provider).toBe('openai-codex');
+    expect(created.model).toBe('openai-codex:gpt-5.4');
+  });
+
+  it('falls back to the hardcoded default for a genuine orphan call (no parent session found)', async () => {
+    const service = MetaAgentService.getInstance();
+    (service as any).aiService = { queuePromptForSession: vi.fn() };
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(null as any);
+
+    await (service as any).createChildSessionInternal('orphan-session', '/workspace/path', {});
+
+    const created = vi.mocked(AISessionsRepository.create).mock.calls[0][0] as any;
+    // With no parent and getDefaultAIModel() null, the child falls back to the
+    // claude-code provider's default (stored as normalizedModel via
+    // ModelIdentifier.getDefaultModelId('claude-code')). The invariant that
+    // matters: an orphan call still resolves to claude-code, unchanged by the fix.
+    expect(created.provider).toBe('claude-code');
+    expect(created.model).toMatch(/^claude-code:/);
+  });
+});


### PR DESCRIPTION
**What**

A child session spawned through the meta-agent tools did not inherit the calling session's provider when the model left the optional `model` arg off. `createChildSessionInternal` resolved `getDefaultAIModel() || 'claude-code:opus'` and `provider` parsed to `claude-code`, never consulting the parent. So a non-Claude parent (Gemini, OpenAI-Codex, LM Studio) spawning a child without an explicit model silently ran it on Claude and billed the user's Anthropic pool. The user-visible impact is a cost surprise on a non-Claude account.

**Fix**

`createChildSessionInternal` looks up the parent session and inherits its provider and model as the primary fallback. An explicit `args.model` or `args.provider` still wins. A genuine orphan call (no parent found) falls back to the prior default, unchanged.

**Relationship to `inheritModel`**

There is an existing `inheritModel` opt-in on a different spawn path (`args.model ?? (args.inheritModel ? parent.model : undefined)`). This change makes provider inheritance the default for the meta-agent path rather than opt-in, on purpose: the meta-agent's model cannot know it should set `inheritModel`, and the failure here is silent cross-provider billing, not a cosmetic model mismatch. The two are complementary. Glad to fold them into one mechanism if you would prefer that.

**Test**

`MetaAgentService.providerInheritance.test.ts` covers three cases: provider inheritance, explicit-model-wins, and orphan fallback. Without the fix the inheritance case fails with `Expected "antigravity-gemini-agent", Received "claude-code"`; with the fix it passes.

**Scope**

This fixes the inheritance derivation in `MetaAgentService` only. Provider-specific child-spawn correctness downstream is each provider's responsibility and out of scope here. I also audited the codebase for the same `getDefaultAIModel() || 'claude-code:opus'` shape and found four sister sites (`AIService.ts` x2, `SyncManager.ts`, `VoiceModeService.ts`). Those are default-when-nothing-specified contexts with no parent to inherit from, so they need separate analysis and are intentionally not touched here. Flagging them for a follow-up.
