### PR TITLE
fix(bootstrap): stop EPIPE feedback loop in the uncaught-exception handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Fixed an EPIPE feedback loop where the main-process uncaught-exception handler re-entered itself when stderr was broken on Linux, flooding the log until the process died.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/__tests__/uncaughtException.test.ts
+++ b/packages/electron/src/main/__tests__/uncaughtException.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const showErrorBox = vi.fn();
+vi.mock('electron', () => ({
+  dialog: { showErrorBox: (...args: unknown[]) => showErrorBox(...args) },
+}));
+
+import { createUncaughtExceptionHandler } from '../uncaughtException';
+
+describe('createUncaughtExceptionHandler', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    showErrorBox.mockReset();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('drops EPIPE errors without touching the console (breaks the #502 feedback loop)', () => {
+    const handle = createUncaughtExceptionHandler();
+    const epipe = Object.assign(new Error('write EPIPE'), { name: 'Error', code: 'EPIPE' });
+
+    handle(epipe);
+
+    // The loop only starts if the handler writes to the (broken) console. For
+    // an EPIPE it must not call console.error / console.warn or show a dialog.
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(showErrorBox).not.toHaveBeenCalled();
+  });
+
+  it('logs and shows a dialog for a normal uncaught error', () => {
+    const handle = createUncaughtExceptionHandler();
+    const err = Object.assign(new Error('boom'), { name: 'TypeError' });
+
+    handle(err);
+
+    expect(errorSpy).toHaveBeenCalledWith('[Bootstrap] Uncaught exception:', err);
+    expect(showErrorBox).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses a duplicate error dialog within the throttle window', () => {
+    const handle = createUncaughtExceptionHandler();
+    const err = Object.assign(new Error('dup'), { name: 'Error' });
+
+    handle(err);
+    handle(err);
+
+    expect(showErrorBox).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith('[Bootstrap] Suppressed duplicate error dialog:', 'Error:dup');
+  });
+});

--- a/packages/electron/src/main/bootstrap.ts
+++ b/packages/electron/src/main/bootstrap.ts
@@ -22,9 +22,10 @@
  *   npm run dev -- --user-data-dir=/path/to/dir
  */
 
-import { app, dialog } from 'electron';
+import { app } from 'electron';
 import * as path from 'path';
 import Store from 'electron-store';
+import { createUncaughtExceptionHandler } from './uncaughtException';
 
 // CRITICAL: Strip inherited API keys from process.env before ANY downstream code
 // (SDKs, providers, services) can observe them. See CLAUDE.md, section
@@ -41,54 +42,11 @@ import Store from 'electron-store';
 delete process.env.ANTHROPIC_API_KEY;
 delete process.env.OPENAI_API_KEY;
 
-// Global uncaught exception handler - must be registered early
-// This catches errors that bubble up from async SDK operations
-// Throttling: suppress duplicate errors and cap dialog frequency to prevent dialog floods
-const _recentErrors = new Map<string, number>(); // error key -> timestamp
-const _ERROR_THROTTLE_MS = 5000; // suppress duplicate errors within this window
-const _MAX_DIALOGS_PER_MINUTE = 3;
-let _dialogTimestamps: number[] = [];
-
-process.on('uncaughtException', (error: Error & { code?: string }) => {
-  // Check if this is the known Claude Agent SDK stream error
-  // This happens when the SDK tries to write to a process stdin after it has terminated
-  if (error.code === 'ERR_STREAM_WRITE_AFTER_END' &&
-      error.stack?.includes('claude-agent-sdk')) {
-    // Log the error but don't show a dialog - this is a known SDK issue
-    console.warn('[Bootstrap] Suppressed Claude Agent SDK stream error:', error.message);
-    return;
-  }
-
-  // Always log the error
-  console.error('[Bootstrap] Uncaught exception:', error);
-
-  // Throttle dialogs to prevent flood from rapid-fire errors
-  const now = Date.now();
-  const errorKey = `${error.name}:${error.message}`;
-
-  // Suppress duplicate errors within the throttle window
-  const lastSeen = _recentErrors.get(errorKey);
-  if (lastSeen && (now - lastSeen) < _ERROR_THROTTLE_MS) {
-    console.warn('[Bootstrap] Suppressed duplicate error dialog:', errorKey);
-    return;
-  }
-  _recentErrors.set(errorKey, now);
-
-  // Clean up old entries
-  for (const [key, ts] of _recentErrors) {
-    if ((now - ts) > _ERROR_THROTTLE_MS) _recentErrors.delete(key);
-  }
-
-  // Cap total dialogs per minute
-  _dialogTimestamps = _dialogTimestamps.filter(ts => (now - ts) < 60_000);
-  if (_dialogTimestamps.length >= _MAX_DIALOGS_PER_MINUTE) {
-    console.warn('[Bootstrap] Too many error dialogs, suppressing. Error:', errorKey);
-    return;
-  }
-  _dialogTimestamps.push(now);
-
-  dialog.showErrorBox('Nimbalyst - Uncaught Exception', `${error.name}: ${error.message}\n\n${error.stack || ''}`);
-});
+// Global uncaught exception handler - must be registered early. This catches
+// errors that bubble up from async SDK operations. The throttling and the
+// EPIPE feedback-loop guard (#502) live in ./uncaughtException, extracted so
+// they can be unit tested.
+process.on('uncaughtException', createUncaughtExceptionHandler());
 
 // Parse --user-data-dir from command line args or environment variable
 function getCustomUserDataDir(): string | undefined {

--- a/packages/electron/src/main/uncaughtException.ts
+++ b/packages/electron/src/main/uncaughtException.ts
@@ -1,0 +1,76 @@
+/**
+ * Main-process uncaught-exception handler.
+ *
+ * Extracted from bootstrap.ts so the throttling and the EPIPE guard can be
+ * unit tested. Registered once in bootstrap.ts via
+ * `process.on('uncaughtException', createUncaughtExceptionHandler())`.
+ *
+ * The handler logs the error, suppresses duplicate errors within a short
+ * window, and caps the error-dialog rate.
+ *
+ * It also guards against the EPIPE feedback loop reported in #502: on Linux a
+ * broken main-process stderr pipe (the launcher detaches, journald reconnects)
+ * makes every console.* write throw EPIPE. Logging that EPIPE through the same
+ * console transport throws again and re-enters this handler in a tight loop
+ * (the reported incident logged 7,203 EPIPE pairs in roughly 3ms before the
+ * process died). EPIPE errors are dropped without touching the console, so the
+ * loop cannot start.
+ */
+import { dialog } from 'electron';
+
+const ERROR_THROTTLE_MS = 5000; // suppress duplicate errors within this window
+const MAX_DIALOGS_PER_MINUTE = 3;
+
+export function createUncaughtExceptionHandler(): (error: Error & { code?: string }) => void {
+  const recentErrors = new Map<string, number>(); // error key -> timestamp
+  let dialogTimestamps: number[] = [];
+
+  return function handleUncaughtException(error: Error & { code?: string }): void {
+    // EPIPE feedback-loop guard (#502). A broken stderr pipe makes console.*
+    // throw EPIPE; logging an EPIPE through the console transport below would
+    // throw again and re-enter this handler in a loop. There is nothing
+    // actionable to surface for a broken stderr pipe, so drop it.
+    if (error.code === 'EPIPE') {
+      return;
+    }
+
+    // Known Claude Agent SDK stream error (write after stdin closed). Log it,
+    // but don't show a dialog.
+    if (error.code === 'ERR_STREAM_WRITE_AFTER_END' && error.stack?.includes('claude-agent-sdk')) {
+      console.warn('[Bootstrap] Suppressed Claude Agent SDK stream error:', error.message);
+      return;
+    }
+
+    // Always log the error.
+    console.error('[Bootstrap] Uncaught exception:', error);
+
+    const now = Date.now();
+    const errorKey = `${error.name}:${error.message}`;
+
+    // Suppress duplicate errors within the throttle window.
+    const lastSeen = recentErrors.get(errorKey);
+    if (lastSeen && now - lastSeen < ERROR_THROTTLE_MS) {
+      console.warn('[Bootstrap] Suppressed duplicate error dialog:', errorKey);
+      return;
+    }
+    recentErrors.set(errorKey, now);
+
+    // Clean up old entries.
+    for (const [key, ts] of recentErrors) {
+      if (now - ts > ERROR_THROTTLE_MS) recentErrors.delete(key);
+    }
+
+    // Cap total dialogs per minute.
+    dialogTimestamps = dialogTimestamps.filter((ts) => now - ts < 60_000);
+    if (dialogTimestamps.length >= MAX_DIALOGS_PER_MINUTE) {
+      console.warn('[Bootstrap] Too many error dialogs, suppressing. Error:', errorKey);
+      return;
+    }
+    dialogTimestamps.push(now);
+
+    dialog.showErrorBox(
+      'Nimbalyst - Uncaught Exception',
+      `${error.name}: ${error.message}\n\n${error.stack || ''}`,
+    );
+  };
+}


### PR DESCRIPTION
**What**

On Linux a broken main-process stderr pipe (the launcher detaches, or journald reconnects) makes every `console.*` write throw `EPIPE`. The `[Bootstrap]` uncaught-exception handler logged the caught error via `console.error` before any dedup check, so when the failure mode is itself a broken stderr, logging the `EPIPE` threw another `EPIPE`, which re-entered the handler in a tight loop. The reported incident logged 7,203 EPIPE pairs in roughly 3ms before the process died. The dialog already had dedup; the console-logging path did not.

Reported in #502 with a full stack trace (`transport.writeFn` to `console.error` to the broken `process.stderr` socket) and log evidence.

**Fix**

The handler drops `EPIPE` errors at the top, without any `console.*` write, so the loop cannot start. There is nothing actionable to surface for a broken stderr pipe. All other behavior (the Claude Agent SDK stream-error suppression, duplicate-error throttling, and the per-minute dialog cap) is unchanged.

To make the handler testable (the repo's failing-test-first rule), it is extracted from `bootstrap.ts` into `uncaughtException.ts` as `createUncaughtExceptionHandler()`, which encapsulates the throttle state. `bootstrap.ts` now registers it in one line.

**Test**

`uncaughtException.test.ts`, three cases: an `EPIPE` error is dropped without any console write or dialog (the loop-breaking behavior), a normal error still logs and shows a dialog, and a duplicate error is still suppressed within the throttle window. Without the guard the first case fails.

**Scope and a design note**

This fixes the handler's feedback loop. The contributing factor in the report (a `chokidar` ENOSPC `console.error` flood from watching a very large workspace, fixed by raising `fs.inotify.max_user_watches`) is a separate environment concern and out of scope here.

The handler drops all `EPIPE` uncaught exceptions, not only stderr ones, since it cannot cheaply tell at that point whether stderr is the broken pipe. EPIPE is a benign broken-pipe error, so dropping it is safe, but happy to narrow it to stderr-specific detection if you would prefer.
