### PR TITLE
fix(httpServer): require bearer token auth on /clip endpoint

### DIFF
--- a/packages/electron/src/main/mcp/httpServer.ts
+++ b/packages/electron/src/main/mcp/httpServer.ts
@@ -517,7 +517,7 @@ async function tryCreateServer(port: number): Promise<any> {
             res.writeHead(200, {
               "Access-Control-Allow-Origin": "*",
               "Access-Control-Allow-Methods": "POST, OPTIONS",
-              "Access-Control-Allow-Headers": "Content-Type",
+              "Access-Control-Allow-Headers": "Content-Type, Authorization",
             });
           } else {
             res.writeHead(200, {
@@ -530,10 +530,10 @@ async function tryCreateServer(port: number): Promise<any> {
           return;
         }
 
-        // Issue #146: every non-OPTIONS request to /mcp must carry the
-        // per-launch bearer token. /clip stays open below (intentional, per
-        // plan: web-clipper extension fires from the user's browser).
-        if (pathname === "/mcp" && !requireMcpAuth(req)) {
+        // Issue #146: every non-OPTIONS request to /mcp or /clip must carry
+        // the per-launch bearer token. The browser extension must be configured
+        // with the token to authenticate clip requests.
+        if ((pathname === "/mcp" || pathname === "/clip") && !requireMcpAuth(req)) {
           res.writeHead(401);
           res.end("Unauthorized");
           return;


### PR DESCRIPTION
## Summary

Closes #525

The `/clip` endpoint in `packages/electron/src/main/mcp/httpServer.ts` accepts unauthenticated POST requests and responds with `Access-Control-Allow-Origin: *`, allowing any website to write markdown files into the user's active workspace via a cross-origin fetch. This PR extends the existing `requireMcpAuth()` bearer-token gate (already protecting `/mcp` since #146) to also cover `/clip`.

## Related issue

Closes #525 — Unauthenticated `/clip` endpoint allows cross-origin file writes to workspace.

## Testing

- Verified that unauthenticated `POST /clip` now returns `401 Unauthorized`.
- Verified that `POST /clip` with a valid `Authorization: Bearer <token>` header succeeds and creates the clip file as before.
- Verified that the CORS preflight (`OPTIONS /clip`) now includes `Authorization` in `Access-Control-Allow-Headers`, so the browser extension can send the token.
- Confirmed the `/mcp` endpoint behavior is unchanged.

## Notes for reviewers

**Vulnerability details (CWE-284 — Improper Access Control)**

The HTTP server binds to localhost and serves two endpoints: `/mcp` (for MCP protocol messages) and `/clip` (for a browser extension to save web clippings as markdown files). After #146, `/mcp` requires a per-launch bearer token, but `/clip` was intentionally left open. Combined with `Access-Control-Allow-Origin: *` on the `/clip` response, this means any webpage the user visits can silently POST to `http://localhost:<port>/clip` and write a file into the active workspace.

**Proof of concept**

From any browser tab while Nimbalyst is running with a workspace open:

```javascript
fetch('http://localhost:22140/clip', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify({
    title: 'injected-by-attacker',
    url: 'https://evil.example.com',
    content: '# You have been clipped\n\nThis file was written by a webpage you visited.'
  })
});
```

This creates `injected-by-attacker.md` in the workspace clips directory with no user interaction or authentication. The attacker needs to know or guess the port (default 22140).

**What the fix does**

The change is minimal — one condition is widened from `pathname === "/mcp"` to `(pathname === "/mcp" || pathname === "/clip")` in the auth guard at line 536, and the CORS preflight for `/clip` adds `Authorization` to the allowed headers so the browser extension can authenticate. No new dependencies, no behavioral changes for authenticated callers.

**Adversarial review**

Before submitting, we considered whether this is actually exploitable given that the server binds to localhost. It is: the `Access-Control-Allow-Origin: *` header explicitly permits cross-origin requests from any webpage, and browsers will happily send a `POST` with `Content-Type: application/json` to localhost. The same-origin policy does not protect localhost services that opt into CORS with `*`. The port is predictable (default 22140), and even if randomized, a scanning loop over a small range is trivial. The file-write impact is real — files land in the user's workspace and appear in the file tree.