### PR TITLE
fix: restore all projects on reload in multi-project mode

### DIFF
--- a/packages/electron/src/main/ipc/WindowHandlers.ts
+++ b/packages/electron/src/main/ipc/WindowHandlers.ts
@@ -26,10 +26,17 @@ export function registerWindowHandlers() {
         if (!state) return null;
 
         if (state.mode === 'workspace' && state.workspacePath) {
+            // Expose the full window project set so the renderer can rebuild
+            // the multi-project rail after a reload. `windowStates` survives
+            // a renderer reload but resets on cold launch, so a populated
+            // `additionalWorkspacePaths` already signals "this was a refresh"
+            // — the rail restores every warm project, not just the primary (#530).
             return {
                 mode: 'workspace',
                 workspacePath: state.workspacePath,
                 workspaceName: basename(state.workspacePath),
+                additionalWorkspacePaths: state.additionalWorkspacePaths ?? [],
+                activeWorkspacePath: state.activeWorkspacePath ?? state.workspacePath,
             };
         }
 

--- a/packages/electron/src/renderer/App.tsx
+++ b/packages/electron/src/renderer/App.tsx
@@ -125,7 +125,7 @@ import { ProjectRail } from './components/ProjectRail';
 import {
   activeWorkspacePathAtom,
   multiProjectModeAtom,
-  addOpenProjectAtom as addOpenProjectAction,
+  seedRailFromInitialState,
 } from './store/atoms/openProjects';
 import { registerDocumentLinkPlugin } from './plugins/registerDocumentLinkPlugin';
 import { registerAIChatPlugin } from './plugins/registerAIChatPlugin';
@@ -439,7 +439,6 @@ export default function App() {
   // (which is wired to that state) re-renders for the new project.
   const isMultiProjectMode = useAtomValue(multiProjectModeAtom);
   const railActivePath = useAtomValue(activeWorkspacePathAtom);
-  const addOpenProject = useSetAtom(addOpenProjectAction);
   const setRailActivePath = useSetAtom(activeWorkspacePathAtom);
   // NOTE: fileTree, sidebarWidth, isNewFileDialogOpen, newFileDirectory, isHistoryDialogOpen moved to EditorMode
   // NOTE: Navigation dialogs (QuickOpen, SessionQuickOpen, PromptQuickOpen, ProjectQuickOpen) are now managed by DialogProvider
@@ -1605,13 +1604,18 @@ export default function App() {
               // Initialize unified navigation history
               await initNavigationHistory(initialState.workspacePath);
 
-              // Seed the multi-project rail: this window's primary
-              // workspace is always represented in the rail (visible only
-              // when multiProjectMode is on, hidden otherwise).
-              addOpenProject({
-                path: initialState.workspacePath,
-                name: initialState.workspaceName ?? initialState.workspacePath,
-                openedAt: Date.now(),
+              // Re-seed the multi-project rail from the window's full
+              // project set. The primary workspace is always represented
+              // (visible only when multiProjectMode is on). On a renderer
+              // reload the main-process window state still holds every warm
+              // additional project, so the rail restores all of them plus
+              // the in-view active path; on cold launch the additional set
+              // is empty and only the primary is seeded (#530).
+              seedRailFromInitialState(store, {
+                workspacePath: initialState.workspacePath,
+                workspaceName: initialState.workspaceName ?? undefined,
+                additionalWorkspacePaths: initialState.additionalWorkspacePaths,
+                activeWorkspacePath: initialState.activeWorkspacePath,
               });
             }
           }
@@ -1624,7 +1628,7 @@ export default function App() {
     };
 
     loadInitialState();
-  }, [addOpenProject]);
+  }, []);
 
   // Multi-project rail switch: when the rail's active path changes, mirror
   // it into the legacy `workspacePath` useState so the rest of the App

--- a/packages/electron/src/renderer/electron.d.ts
+++ b/packages/electron/src/renderer/electron.d.ts
@@ -129,7 +129,7 @@ interface ElectronAPI {
   reportUserActivity?: () => void;
 
   // Get initial window state
-  getInitialState: () => Promise<{ mode: string; workspacePath?: string; workspaceName?: string } | null>;
+  getInitialState: () => Promise<{ mode: string; workspacePath?: string; workspaceName?: string; additionalWorkspacePaths?: string[]; activeWorkspacePath?: string | null } | null>;
 
   // Workspace operations
   getFolderContents: (dirPath: string) => Promise<FileTreeItem[]>;

--- a/packages/electron/src/renderer/store/atoms/__tests__/openProjects.test.ts
+++ b/packages/electron/src/renderer/store/atoms/__tests__/openProjects.test.ts
@@ -8,6 +8,7 @@ import {
   closeOpenProjectAtom,
   isOpenProjectsAtCapAtom,
   attachWorkspaceSwitchCleanup,
+  seedRailFromInitialState,
   type OpenProject,
 } from '../openProjects';
 import { activeSessionIdAtom, selectedWorkstreamAtom } from '../sessions';
@@ -231,6 +232,67 @@ describe('openProjects atoms', () => {
       jotaiStore.set(activeWorkspacePathAtom, '/ws/b');
 
       expect(jotaiStore.get(activeSessionIdAtom)).toBe('session-from-a');
+    });
+  });
+
+  describe('seedRailFromInitialState', () => {
+    // Regression for issue #530: a renderer reload (Cmd+R) in multi-project
+    // mode collapsed the rail to the single primary project because
+    // `loadInitialState` only re-seeded `workspacePath`. The main-process
+    // `windowStates` map still holds every warm project across a reload, so
+    // the rail must rebuild the full set from the initial-state payload.
+    it('restores the primary plus every additional project after reload', () => {
+      seedRailFromInitialState(jotaiStore, {
+        workspacePath: '/ws/a',
+        workspaceName: 'a',
+        additionalWorkspacePaths: ['/ws/b', '/ws/c'],
+        activeWorkspacePath: '/ws/b',
+      });
+
+      expect(jotaiStore.get(openProjectsAtom).map((p) => p.path)).toEqual([
+        '/ws/a',
+        '/ws/b',
+        '/ws/c',
+      ]);
+    });
+
+    it('restores the in-view active project, not the last one added', () => {
+      seedRailFromInitialState(jotaiStore, {
+        workspacePath: '/ws/a',
+        additionalWorkspacePaths: ['/ws/b', '/ws/c'],
+        activeWorkspacePath: '/ws/b',
+      });
+
+      // addOpenProjectAtom activates each project as it is added, so without
+      // the final restore the active path would leak to '/ws/c'.
+      expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/b');
+    });
+
+    it('falls back to the primary as active when activeWorkspacePath is absent', () => {
+      seedRailFromInitialState(jotaiStore, {
+        workspacePath: '/ws/a',
+        additionalWorkspacePaths: ['/ws/b'],
+      });
+
+      expect(jotaiStore.get(openProjectsAtom).map((p) => p.path)).toEqual(['/ws/a', '/ws/b']);
+      expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/a');
+    });
+
+    it('seeds only the primary when there are no additional projects (cold launch)', () => {
+      seedRailFromInitialState(jotaiStore, { workspacePath: '/ws/a', workspaceName: 'a' });
+
+      expect(jotaiStore.get(openProjectsAtom).map((p) => p.path)).toEqual(['/ws/a']);
+      expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/a');
+    });
+
+    it('ignores blank and duplicate additional paths', () => {
+      seedRailFromInitialState(jotaiStore, {
+        workspacePath: '/ws/a',
+        additionalWorkspacePaths: ['', '/ws/a', '/ws/b'],
+        activeWorkspacePath: '/ws/a',
+      });
+
+      expect(jotaiStore.get(openProjectsAtom).map((p) => p.path)).toEqual(['/ws/a', '/ws/b']);
     });
   });
 });

--- a/packages/electron/src/renderer/store/atoms/openProjects.ts
+++ b/packages/electron/src/renderer/store/atoms/openProjects.ts
@@ -261,6 +261,61 @@ export function attachWorkspaceSwitchCleanup(jotaiStore: JotaiStore): () => void
 }
 
 /**
+ * Shape of the per-window initial state used to rebuild the rail. Mirrors
+ * the `get-initial-state` IPC payload (`WindowHandlers.ts`).
+ */
+export interface RailInitialState {
+  workspacePath: string;
+  workspaceName?: string;
+  /** Warm rail projects beyond the primary, kept alive across reload. */
+  additionalWorkspacePaths?: string[];
+  /** Project that was in-view before reload; defaults to the primary. */
+  activeWorkspacePath?: string | null;
+}
+
+/**
+ * Re-seed the multi-project rail from a window's initial state.
+ *
+ * Adds the primary workspace plus every warm `additionalWorkspacePaths`
+ * entry, then restores the in-view project via `activeWorkspacePath`. This
+ * is the renderer-side counterpart to the main-process `windowStates` map:
+ * the map survives a renderer reload (Cmd+R) but resets on a cold launch, so
+ * its `additionalWorkspacePaths` already encode "this was a refresh" — the
+ * rail rebuilds the full set instead of collapsing to the primary (#530).
+ *
+ * `addOpenProjectAtom` activates each project as it is added, so the final
+ * `activeWorkspacePathAtom` write restores the project that was visible
+ * before reload rather than whichever was added last. Dedups and the
+ * 8-project cap are enforced by `addOpenProjectAtom`.
+ */
+export function seedRailFromInitialState(
+  jotaiStore: JotaiStore,
+  initialState: RailInitialState
+): void {
+  const { workspacePath, workspaceName, additionalWorkspacePaths, activeWorkspacePath } =
+    initialState;
+  if (!workspacePath) return;
+
+  jotaiStore.set(addOpenProjectAtom, {
+    path: workspacePath,
+    name: workspaceName ?? basenameFromPath(workspacePath),
+    openedAt: Date.now(),
+  });
+
+  for (const path of additionalWorkspacePaths ?? []) {
+    if (typeof path === 'string' && path.length > 0 && path !== workspacePath) {
+      jotaiStore.set(addOpenProjectAtom, {
+        path,
+        name: basenameFromPath(path),
+        openedAt: Date.now(),
+      });
+    }
+  }
+
+  jotaiStore.set(activeWorkspacePathAtom, activeWorkspacePath ?? workspacePath);
+}
+
+/**
  * Notify the main process about the new active workspace path so the
  * single-active-per-window resources (file watcher, runtime-global
  * FileSystemService) transition atomically. Centralized here so every


### PR DESCRIPTION
## Description

Fixes #530. In multi-project mode with 2+ projects open, a renderer reload (Cmd+R) collapsed the rail to a single project — every other open project was closed and had to be reopened manually.

## Root cause

A reload reuses the same `BrowserWindow`, so the main-process `windowStates` map stays warm: `state.additionalWorkspacePaths` still holds every extra project. But the renderer re-seed path only restored the primary:

- `get-initial-state` returned only `workspacePath`, never `additionalWorkspacePaths` / `activeWorkspacePath`, so the renderer had no per-window source to rebuild the rail.
- `loadInitialState` seeded just the primary into the rail.

Because `windowStates` survives a reload but resets on a cold launch, the presence of `additionalWorkspacePaths` already distinguishes refresh from cold launch — no extra flag needed.

## Changes

- `get-initial-state` now exposes the window's full project set (`additionalWorkspacePaths` + `activeWorkspacePath`).
- New `seedRailFromInitialState` helper re-seeds the rail with the primary plus every warm project, then restores the in-view active path (not whichever was added last).
- `loadInitialState` routes through the helper. On cold launch the additional set is empty, so only the primary is seeded — unchanged behavior.

## Test plan

- [x] TDD red->green: 5 new unit tests in `openProjects.test.ts` cover the reload repro plus edge cases (active in-view wins, primary fallback, cold launch, blank/dup paths). 23/23 pass.
- [x] Related suite green: `MultiProjectRailHandlers.test.ts` (13/13).
- [x] `tsc --noEmit`: clean.