### PR TITLE
fix: open context usage breakdown on click instead of hover (closes #429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR review cache tables are now created on the better-sqlite3 backend too (migration registered with the SQLite runner), not only on PGLite. (#307)
 - PR review: merged PRs now show as "Merged" (not "Closed") in the list, the Approve/Merge buttons refresh immediately after a merge (cache-bypassed refetch), and a success notice / "Merged" badge confirms the action. (#307)
 <!-- Bug fixes go here -->
+- Context usage meter now opens its breakdown on click instead of hover, so the popover no longer lingers over and blocks the queued-prompt controls. (#429)
 - Effort Level selector now takes effect: sessions follow the selected/default effort instead of always running at "high".
 - Typing in the chat box no longer has keystrokes hijacked into an open markdown file while an agent is editing it.
 - Restored diff application in headless mode (tests and server-side diffing), which had started throwing on `getRootElement` after the chat-box focus fix.

--- a/packages/electron/src/renderer/components/UnifiedAI/ContextUsageDisplay.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/ContextUsageDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useId, useMemo, useState, useRef, useCallback } from 'react';
+import React, { useId, useMemo, useState, useRef, useCallback, useEffect } from 'react';
 import type { TokenUsageCategory } from '@nimbalyst/runtime/ai/server/types';
 import { MaterialSymbol } from '@nimbalyst/runtime';
 import { getHelpContent } from '../../help';
@@ -62,7 +62,7 @@ export function ContextUsageDisplay({
   const [helpExpanded, setHelpExpanded] = useState(false);
   const tooltipId = useId();
   const helpContent = getHelpContent('context-indicator');
-  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
 
   // Calculate percentage used (only meaningful with context window)
   const percentage = hasContextWindow ? Math.round((displayTokens / displayContextWindow) * 100) : 0;
@@ -116,28 +116,48 @@ export function ContextUsageDisplay({
   const enableTooltip = hasTokenData && (formattedCategories.length > 0 || inputTokens > 0 || outputTokens > 0);
   const shouldShowTooltip = tooltipVisible && enableTooltip;
 
-  // Clear any pending hide timeout
-  const clearHideTimeout = useCallback(() => {
-    if (hideTimeoutRef.current) {
-      clearTimeout(hideTimeoutRef.current);
-      hideTimeoutRef.current = null;
-    }
-  }, []);
+  // Click-to-open: the meter is shaped like a button (model/thinking/action
+  // buttons next to it) and sits where the cursor travels often, so a hover
+  // popover lingered and blocked the queued-prompt controls underneath it (#429).
+  const closeTooltip = useCallback(() => setTooltipVisible(false), []);
 
-  // Show tooltip immediately, hide with delay to allow moving mouse to tooltip
-  const handleMouseEnter = useCallback(() => {
-    clearHideTimeout();
+  const toggleTooltip = useCallback(() => {
     if (enableTooltip) {
-      setTooltipVisible(true);
+      setTooltipVisible(visible => !visible);
     }
-  }, [enableTooltip, clearHideTimeout]);
+  }, [enableTooltip]);
 
-  const handleMouseLeave = useCallback(() => {
-    // Delay hiding to allow moving mouse to tooltip
-    hideTimeoutRef.current = setTimeout(() => {
-      setTooltipVisible(false);
-    }, 150);
-  }, []);
+  const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleTooltip();
+    } else if (event.key === 'Escape') {
+      closeTooltip();
+    }
+  }, [toggleTooltip, closeTooltip]);
+
+  // Dismiss on outside click or Escape while the panel is open.
+  useEffect(() => {
+    if (!tooltipVisible) {
+      return;
+    }
+    const onPointerDown = (event: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setTooltipVisible(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setTooltipVisible(false);
+      }
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [tooltipVisible]);
 
   const getUsageClass = (): string => {
     if (!hasTokenData) return 'usage-normal';
@@ -176,15 +196,15 @@ export function ContextUsageDisplay({
 
   return (
     <div
-      className={`context-usage-display ${usageClass} relative inline-flex items-center py-0.5 px-2 rounded-md text-[11px] font-medium whitespace-nowrap bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] ml-auto cursor-default gap-1 focus:outline-2 focus:outline-[var(--nim-primary)] focus:outline-offset-2 max-[400px]:hidden ${usageStyles[usageClass as keyof typeof usageStyles]}`}
+      ref={rootRef}
+      className={`context-usage-display ${usageClass} relative inline-flex items-center py-0.5 px-2 rounded-md text-[11px] font-medium whitespace-nowrap bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] ml-auto ${enableTooltip ? 'cursor-pointer' : 'cursor-default'} gap-1 focus:outline-2 focus:outline-[var(--nim-primary)] focus:outline-offset-2 max-[400px]:hidden ${usageStyles[usageClass as keyof typeof usageStyles]}`}
       tabIndex={hasTokenData ? 0 : -1}
       aria-label={label}
       aria-describedby={shouldShowTooltip ? tooltipId : undefined}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      onFocus={handleMouseEnter}
-      onBlur={handleMouseLeave}
-      role="group"
+      aria-expanded={enableTooltip ? shouldShowTooltip : undefined}
+      onClick={toggleTooltip}
+      onKeyDown={handleKeyDown}
+      role={enableTooltip ? 'button' : 'group'}
       data-testid="context-indicator"
     >
       <span className={`usage-text ${textStyles[usageClass as keyof typeof textStyles]}`}>{getDisplayText()}</span>
@@ -194,8 +214,6 @@ export function ContextUsageDisplay({
           className="context-usage-tooltip absolute right-0 bottom-[calc(100%+8px)] w-[280px] max-w-[calc(100vw-32px)] p-3 rounded-[10px] bg-[var(--nim-bg)] border border-[var(--nim-border)] shadow-[0_12px_32px_rgba(0,0,0,0.35)] z-10 text-[var(--nim-text)] overflow-hidden box-border"
           id={tooltipId}
           role="tooltip"
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
         >
           <div className="tooltip-header flex justify-between items-center text-xs mb-2 text-[var(--nim-text-muted)]">
             <div className="tooltip-header-left flex items-center gap-1.5">

--- a/packages/electron/src/renderer/components/UnifiedAI/__tests__/ContextUsageDisplay.test.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/__tests__/ContextUsageDisplay.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { fireEvent, render, screen, cleanup } from '@testing-library/react';
+import { ContextUsageDisplay } from '../ContextUsageDisplay';
+
+vi.mock('@nimbalyst/runtime', () => ({ MaterialSymbol: () => null }));
+vi.mock('../../../help', () => ({ getHelpContent: () => undefined }));
+
+// inputTokens > 0 makes the breakdown panel eligible (enableTooltip).
+const props = {
+  inputTokens: 80_000,
+  outputTokens: 20_000,
+  totalTokens: 100_000,
+  contextWindow: 200_000,
+  currentContext: { tokens: 132_000, contextWindow: 200_000 },
+};
+
+afterEach(() => cleanup());
+
+describe('ContextUsageDisplay - context meter opens on click, not hover (#429)', () => {
+  it('does NOT open the breakdown panel on hover', () => {
+    render(<ContextUsageDisplay {...props} />);
+    fireEvent.mouseEnter(screen.getByTestId('context-indicator'));
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('toggles the panel open and closed on click', () => {
+    render(<ContextUsageDisplay {...props} />);
+    const meter = screen.getByTestId('context-indicator');
+    fireEvent.click(meter);
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+    fireEvent.click(meter);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('closes the panel on an outside click', () => {
+    render(<ContextUsageDisplay {...props} />);
+    fireEvent.click(screen.getByTestId('context-indicator'));
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('closes the panel on Escape', () => {
+    render(<ContextUsageDisplay {...props} />);
+    fireEvent.click(screen.getByTestId('context-indicator'));
+    expect(screen.getByRole('tooltip')).toBeTruthy();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('exposes the meter as a button with aria-expanded when a breakdown exists', () => {
+    render(<ContextUsageDisplay {...props} />);
+    const meter = screen.getByTestId('context-indicator');
+    expect(meter.getAttribute('role')).toBe('button');
+    expect(meter.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(meter);
+    expect(meter.getAttribute('aria-expanded')).toBe('true');
+  });
+});


### PR DESCRIPTION
Closes #429.

The context usage meter opened its breakdown panel on hover. The meter is button-shaped and sits in the workspace where the cursor travels a lot (over the queued-prompt controls like edit and re-run), so the popover appeared and lingered, blocking clicks on those controls.

@ghinkle confirmed the direction in the issue thread: make the context meter click-to-view while keeping hover tooltips elsewhere. This change is scoped to `ContextUsageDisplay` only and does not touch the global tooltip behavior.

## What changed
- Click toggles the breakdown panel instead of hover opening it.
- Dismisses on outside-click and Escape; the 150ms hover hide-delay is removed.
- Keyboard accessible: the meter is `role=button` with `aria-expanded`, and Enter/Space toggles it.
- Existing CSS-based positioning is unchanged, so no `@floating-ui` migration was needed (it does not do manual coordinate math).

## Test
New renderer test `ContextUsageDisplay.test.tsx`: hover does nothing, click toggles, outside-click and Escape close, and `aria-expanded` tracks state. Verified red on the old hover code and green on this change (5/5).
