### PR TITLE
fix: allow mode='auto' in ai_sessions so SQLite migration works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR review cache tables are now created on the better-sqlite3 backend too (migration registered with the SQLite runner), not only on PGLite. (#307)
 - PR review: merged PRs now show as "Merged" (not "Closed") in the list, the Approve/Merge buttons refresh immediately after a merge (cache-bypassed refetch), and a success notice / "Merged" badge confirms the action. (#307)
 <!-- Bug fixes go here -->
+- SQLite migration dry-run no longer aborts on sessions created in `Allow All` permission mode: the `ai_sessions.mode` CHECK constraint now allows `auto` alongside `planning`/`agent`. (#379)
 - Context usage meter now opens its breakdown on click instead of hover, so the popover no longer lingers over and blocks the queued-prompt controls. (#429)
 - Effort Level selector now takes effect: sessions follow the selected/default effort instead of always running at "high".
 - Typing in the chat box no longer has keystrokes hijacked into an open markdown file while an agent is editing it.

--- a/packages/electron/src/main/database/sqlite/__tests__/MigrationOrchestrator.fixtureRoundtrip.test.ts
+++ b/packages/electron/src/main/database/sqlite/__tests__/MigrationOrchestrator.fixtureRoundtrip.test.ts
@@ -202,6 +202,15 @@ describe('MigrationOrchestrator fixture round-trip', () => {
        VALUES ($1, $2, $3, $4, $5)`,
       ['sess-4', 'ws-B', 'claude', 'Old archived session', true],
     );
+    // Regression: `mode='auto'` comes from the "Allow All" permission feature
+    // (sends mode:auto to Claude Code so the classifier gates tools). The SQLite
+    // ai_sessions CHECK once allowed only planning/agent and aborted the entire
+    // migration on this row.
+    await db.query(
+      `INSERT INTO ai_sessions(id, workspace_id, provider, title, mode)
+       VALUES ($1, $2, $3, $4, $5)`,
+      ['sess-5', 'ws-A', 'claude', 'Auto-mode allow-all session', 'auto'],
+    );
 
     // Messages -- mix of searchable=true and false. Phase 2 of
     // canonical-transcript-deprecation: FTS now requires searchable_text,
@@ -277,7 +286,14 @@ describe('MigrationOrchestrator fixture round-trip', () => {
         `SELECT id, title FROM ai_sessions WHERE workspace_id = $1 ORDER BY title`,
         ['ws-A'],
       );
-      expect(sessionRows.map((r) => r.id).sort()).toEqual(['sess-1', 'sess-2', 'sess-3']);
+      expect(sessionRows.map((r) => r.id).sort()).toEqual(['sess-1', 'sess-2', 'sess-3', 'sess-5']);
+
+      // Regression: mode='auto' survives migration (CHECK now allows it).
+      const { rows: autoModeRows } = await adapter.query<{ mode: string }>(
+        `SELECT mode FROM ai_sessions WHERE id = $1`,
+        ['sess-5'],
+      );
+      expect(autoModeRows[0].mode).toBe('auto');
 
       // Worktrees: archived filter works
       const { rows: activeWt } = await adapter.query<{ id: string }>(

--- a/packages/electron/src/main/database/sqlite/schemas/0001_initial.sql
+++ b/packages/electron/src/main/database/sqlite/schemas/0001_initial.sql
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS ai_sessions (
   has_been_named INTEGER NOT NULL DEFAULT 0,
   status TEXT DEFAULT 'idle' CHECK (status IN ('idle', 'running', 'waiting_for_input', 'error')),
   last_activity TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-  mode TEXT DEFAULT 'agent' CHECK (mode IN ('planning', 'agent')),
+  mode TEXT DEFAULT 'agent' CHECK (mode IN ('planning', 'agent', 'auto')),
   is_archived INTEGER NOT NULL DEFAULT 0,
   last_document_state TEXT,                       -- JSON
   worktree_id TEXT REFERENCES worktrees(id) ON DELETE SET NULL,

--- a/packages/electron/src/main/database/worker.js
+++ b/packages/electron/src/main/database/worker.js
@@ -712,12 +712,12 @@ class PGLiteWorker {
           ALTER TABLE ai_sessions ADD COLUMN has_been_named BOOLEAN DEFAULT FALSE;
         END IF;
 
-        -- Add mode column for session behavior (planning vs agent)
+        -- Add mode column for session behavior (planning, agent, or auto)
         IF NOT EXISTS (
           SELECT 1 FROM information_schema.columns
           WHERE table_name = 'ai_sessions' AND column_name = 'mode'
         ) THEN
-          ALTER TABLE ai_sessions ADD COLUMN mode TEXT DEFAULT 'agent' CHECK (mode IN ('planning', 'agent'));
+          ALTER TABLE ai_sessions ADD COLUMN mode TEXT DEFAULT 'agent' CHECK (mode IN ('planning', 'agent', 'auto'));
         END IF;
 
         -- Add is_archived column for session archiving feature


### PR DESCRIPTION
## Problem

The PGLite -> SQLite migration dry-run aborts with:

```
Dry run failed: CHECK constraint failed: mode IN ('planning', 'agent')
```

## Root cause

The `ai_sessions.mode` CHECK constraint is stale, it predates `mode='auto'`, introduced by the "Allow All" permission feature in #379 (sends `permissionMode: 'auto'` to Claude Code so the classifier gates tools instead of Nimbalyst). `SessionMode = 'planning' | 'agent' | 'auto'`, but both DB CHECK constraints only allowed `planning`/`agent`.

PGLite has no CHECK on `mode`, so `auto` rows live there fine. The strict SQLite target schema rejects them on copy, aborting the whole dry-run.

## Fix

Add `'auto'` to the allowed set in both CHECK constraints:

- `packages/electron/src/main/database/sqlite/schemas/0001_initial.sql` (SQLite target schema, fixes the dry-run)
- `packages/electron/src/main/database/worker.js` (PGLite migration, consistency for fresh installs)

## Test

`MigrationOrchestrator.fixtureRoundtrip.test.ts` now seeds a `mode='auto'` session. Verified red -> green:

- old 2-value CHECK -> reproduces the exact error `CHECK constraint failed: mode IN ('planning', 'agent')`
- new 3-value CHECK -> passes

## Related

- #379 the "Allow All" permission feature that introduced `mode='auto'`.
