### PR TITLE
Add Claude Fable 5 to the Claude model list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Claude Fable 5 (`claude-fable-5`) is available in the Claude model picker.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/ios/NimbalystNative/Sources/Utils/ModelLabel.swift
+++ b/packages/ios/NimbalystNative/Sources/Utils/ModelLabel.swift
@@ -105,6 +105,7 @@ public enum ModelLabel {
 
     /// Mirrors `CLAUDE_MODELS[*].shortName` in `modelConstants.ts`.
     private static let claudeApiShortNames: [String: String] = [
+        "claude-fable-5": "Fable 5",
         "claude-opus-4-8": "Opus 4.8",
         "claude-opus-4-7": "Opus 4.7",
         "claude-opus-4-6": "Opus 4.6",

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -12,6 +12,16 @@ export interface ModelDefinition {
 
 export const CLAUDE_MODELS: ModelDefinition[] = [
   {
+    id: 'claude-fable-5',
+    displayName: 'Claude Fable 5 (1M)',
+    shortName: 'Fable 5',
+    maxTokens: 128000,
+    // Fable 5 (Anthropic's Mythos class) ships with a 1M context window
+    // natively and a 128k max output. The API id is dateless and pinned to
+    // this snapshot — see platform.claude.com/docs/en/about-claude/models/overview.
+    contextWindow: 1000000,
+  },
+  {
     id: 'claude-opus-4-8',
     displayName: 'Claude Opus 4.8 (1M)',
     shortName: 'Opus 4.8',

--- a/packages/runtime/src/ai/server/providers/ClaudeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeProvider.ts
@@ -974,9 +974,10 @@ export class ClaudeProvider extends BaseAIProvider {
    * same pattern.
    *
    * Strategy: denylist of known-rejecting prefixes. Today that is
-   * `claude-opus-4-N` for N >= 7. Everything else -- all Sonnet variants
-   * (3.x and 4.x), all Haiku variants, Opus 4 / 4.1 / 4.5 / 4.6, and any
-   * `claude-3-*` Opus model -- still accepts `temperature`.
+   * `claude-opus-4-N` for N >= 7 plus the Mythos-class models
+   * (`claude-fable-*`, `claude-mythos-*`). Everything else -- all Sonnet
+   * variants (3.x and 4.x), all Haiku variants, Opus 4 / 4.1 / 4.5 / 4.6,
+   * and any `claude-3-*` Opus model -- still accepts `temperature`.
    *
    * The denylist is intentionally narrow. The fail-open default preserves
    * user-configured `temperature` for new Claude models; if Anthropic
@@ -1002,6 +1003,14 @@ export class ClaudeProvider extends BaseAIProvider {
     if (opusMinor) {
       const minor = parseInt(opusMinor[1], 10);
       return minor < 7;
+    }
+
+    // Mythos-class models (Claude Fable 5, Claude Mythos 5 / Mythos Preview)
+    // reject sampling parameters the same way Opus 4.7+ does -- adaptive
+    // thinking is always on and `temperature` returns a 400. Prefix-matching
+    // keeps future `claude-fable-N` / `claude-mythos-N` covered.
+    if (id.startsWith('claude-fable-') || id.startsWith('claude-mythos-')) {
+      return false;
     }
 
     return true;

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeProvider.temperature.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeProvider.temperature.test.ts
@@ -37,6 +37,23 @@ describe('ClaudeProvider.supportsTemperature', () => {
     });
   });
 
+  describe('rejects temperature for Mythos-class models (Fable 5, Mythos 5)', () => {
+    // Fable 5 / Mythos 5 use always-on adaptive thinking and reject
+    // `temperature` / `top_p` / `top_k` with a 400, the same posture as Opus 4.7+.
+    it('returns false for claude-fable-5', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-fable-5')).toBe(false);
+    });
+
+    it('returns false for claude-mythos-5 and claude-mythos-preview', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-mythos-5')).toBe(false);
+      expect(ClaudeProvider.supportsTemperature('claude-mythos-preview')).toBe(false);
+    });
+
+    it('matches case-insensitively and trims', () => {
+      expect(ClaudeProvider.supportsTemperature('  CLAUDE-FABLE-5  ')).toBe(false);
+    });
+  });
+
   describe('accepts temperature for older Opus 4.x', () => {
     it('returns true for Opus 4 (no minor / claude-opus-4-20250514)', () => {
       // The 8-digit date suffix on Opus 4.0 must NOT be parsed as a minor


### PR DESCRIPTION
## What

Adds **Claude Fable 5** (`claude-fable-5`) — Anthropic's new generally-available **Mythos-class** model (released 2026-06-09) — to the Claude model picker, and wires up the sampling-parameter handling it requires.

## Why this is more than a list entry

Fable 5 is a **new model family**, so two pieces of family-aware logic need it, not just the model list:

- `ClaudeProvider.supportsTemperature()` was hardcoded to `claude-opus-4-N (N≥7)`. Fable 5 (like Opus 4.7+/4.8) rejects `temperature` / `top_p` / `top_k` with HTTP 400 — adaptive thinking is always on. Without the fix, selecting Fable 5 would send `temperature` and error. Added a `claude-fable-*` / `claude-mythos-*` rule.
- iOS `ModelLabel.claudeApiLabel` falls back to opus/sonnet/haiku family detection, which doesn't recognize "fable", so it needs an explicit `claudeApiShortNames` entry to avoid mislabeling Fable as plain "Claude".

## Changes

- **`packages/runtime/src/ai/modelConstants.ts`** — new `claude-fable-5` entry at the top of `CLAUDE_MODELS`: `Claude Fable 5 (1M)` / `Fable 5`, `contextWindow: 1000000` (1M, native), `maxTokens: 128000` (128k max output).
- **`packages/runtime/src/ai/server/providers/ClaudeProvider.ts`** — `supportsTemperature()` returns `false` for `claude-fable-*` / `claude-mythos-*` (+ doc-comment update). `isModelAllowed()` and the renderer's `modelUtils.ts` already derive from `CLAUDE_MODELS`, so they pick up Fable automatically.
- **`packages/runtime/src/ai/server/providers/__tests__/ClaudeProvider.temperature.test.ts`** — coverage for Fable 5 / Mythos 5 / Mythos Preview → no temperature.
- **`packages/ios/NimbalystNative/Sources/Utils/ModelLabel.swift`** — `"claude-fable-5": "Fable 5"` mirror.
- **`CHANGELOG.md`** — `[Unreleased]` note.

## Notes

- **`maxTokens: 128000`** reflects Fable 5's true 128k max output. Every other Claude entry — including Opus 4.8, which also has a 128k cap — uses a conservative `maxTokens: 8192`; happy to switch Fable to `8192` if you'd prefer to keep that column uniform.
- **Claude Mythos 5** (`claude-mythos-5`) is intentionally **not** added — it's invitation-only (Project Glasswing), not generally available, so it doesn't belong in a user-facing picker. The `supportsTemperature` rule still covers it defensively.
- Specs verified against Anthropic's Models overview: 1M context, 128k max output, GA 2026-06-09.

## Testing

`node --check` passes on the edited TypeScript files. The full `tsc --noEmit` / `vitest` suite wasn't run here — this was prepared from a fresh clone without `node_modules`, and a full monorepo `npm install` was out of scope for this change. The change is additive and the new `supportsTemperature` branch is covered by the added unit tests.

Prepared with AI assistance and reviewed by me.
