### PR TITLE
feat: add Claude Fable 5 to the Claude Code model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
-- Claude Fable 5 (`claude-fable-5`) is selectable in the Claude Code agent and subscription-CLI model pickers. On Pro/Max subscriptions it is included through 2026-06-22; from 2026-06-23, continued use requires prepaid usage credits billed at API rates.
+- Claude Fable 5 (`claude-fable-5`) is selectable in the Claude Code agent and subscription-CLI model pickers, with a clear in-app message if the model isn't available on your plan. On Pro/Max subscriptions it is included through 2026-06-22; from 2026-06-23, continued use requires prepaid usage credits billed at API rates.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Claude Fable 5 (`claude-fable-5`) is selectable in the Claude Code agent and subscription-CLI model pickers.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
-- Claude Fable 5 (`claude-fable-5`) is selectable in the Claude Code agent and subscription-CLI model pickers.
+- Claude Fable 5 (`claude-fable-5`) is selectable in the Claude Code agent and subscription-CLI model pickers. On Pro/Max subscriptions it is included through 2026-06-22; from 2026-06-23, continued use requires prepaid usage credits billed at API rates.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/main/services/ClaudeCodeSessionSync.ts
+++ b/packages/electron/src/main/services/ClaudeCodeSessionSync.ts
@@ -229,6 +229,7 @@ export function importedClaudeCodeModel(entries: ClaudeCodeEntry[]): string | un
     const raw = entries[i]?.message?.model;
     if (typeof raw !== 'string' || raw.length === 0) continue;
     const id = raw.toLowerCase();
+    if (id.includes('fable')) return 'claude-code:fable-5';
     if (id.includes('opus')) return 'claude-code:opus';
     if (id.includes('sonnet')) return 'claude-code:sonnet';
     if (id.includes('haiku')) return 'claude-code:haiku';

--- a/packages/electron/src/main/services/__tests__/ClaudeCodeSessionSync.importedModel.test.ts
+++ b/packages/electron/src/main/services/__tests__/ClaudeCodeSessionSync.importedModel.test.ts
@@ -20,6 +20,14 @@ describe('importedClaudeCodeModel', () => {
     );
   });
 
+  it('maps a fable turn to claude-code:fable-5', () => {
+    // A genuine-CLI session run on claude-fable-5 must import as Fable, not fall
+    // through to the Opus default (the #394 bug class, for the flagship variant).
+    expect(importedClaudeCodeModel([assistant('claude-fable-5')])).toBe(
+      'claude-code:fable-5',
+    );
+  });
+
   it('maps a sonnet turn to claude-code:sonnet', () => {
     expect(importedClaudeCodeModel([assistant('claude-sonnet-4-6')])).toBe(
       'claude-code:sonnet',

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -107,6 +107,7 @@ import { MessageStreamingHandler } from './MessageStreamingHandler';
 import { HooklessAgentFileWatcher } from './HooklessAgentFileWatcher';
 import { getAgentWorkflowService } from '../AgentWorkflowService';
 import { tryClaimAndDispatchNextQueuedPrompt } from './queuedPromptDispatcher';
+import { DEFAULT_CLAUDE_CODE_ENABLED_MODELS, insertClaudeCodeVariant } from './claudeCodeModelDefaults';
 import { supportsWorkspaceSlashWorkflowProvider } from '../../../shared/agentWorkflowProviders';
 
 const execFileAsync = promisify(execFile);
@@ -387,24 +388,26 @@ export class AIService {
       'claude-code:opus-4-7',
       'claude-code:opus',
     );
+    // Fable 5 is the flagship, so it sorts ahead of opus in the picker.
+    this.migrateClaudeCodeVariantInsertion(
+      'migrations.claudeCodeFable5Added',
+      'claude-code:fable-5',
+      'claude-code:opus',
+      'before',
+    );
   }
 
   private migrateClaudeCodeVariantInsertion(
     migrationKey: string,
     variantId: string,
-    insertAfterId: string,
+    anchorId: string,
+    position: 'before' | 'after' = 'after',
   ): void {
     if (this.settingsStore!.get(migrationKey)) return;
     const providerSettings = this.settingsStore!.get('providerSettings', {}) as any;
     const claudeCode = providerSettings?.['claude-code'];
     if (claudeCode && Array.isArray(claudeCode.models) && !claudeCode.models.includes(variantId)) {
-      const anchorIndex = claudeCode.models.indexOf(insertAfterId);
-      const insertAt = anchorIndex >= 0 ? anchorIndex + 1 : claudeCode.models.length;
-      claudeCode.models = [
-        ...claudeCode.models.slice(0, insertAt),
-        variantId,
-        ...claudeCode.models.slice(insertAt),
-      ];
+      claudeCode.models = insertClaudeCodeVariant(claudeCode.models, variantId, anchorId, position);
       this.settingsStore!.set('providerSettings', providerSettings);
     }
     this.settingsStore!.set(migrationKey, true);
@@ -434,7 +437,7 @@ export class AIService {
                 enabled: true,
                 testStatus: "idle",
                 installStatus: "not-installed",
-                models: ["claude-code:opus", "claude-code:opus-4-7", "claude-code:opus-4-6", "claude-code:sonnet", "claude-code:haiku"]
+                models: [...DEFAULT_CLAUDE_CODE_ENABLED_MODELS]
               },
               openai: {
                 enabled: false,

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliSpawnConfig.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliSpawnConfig.test.ts
@@ -113,6 +113,11 @@ describe('buildClaudeCliSpawnConfig', () => {
     expect(cfg.args[cfg.args.indexOf('--model') + 1]).toBe('opus[1m]');
   });
 
+  it('spawns the pinned Fable 5 selection with --model claude-fable-5 (not the bare `fable-5` the CLI rejects)', () => {
+    const cfg = buildClaudeCliSpawnConfig({ ...base, model: 'claude-code-cli:fable-5' });
+    expect(cfg.args[cfg.args.indexOf('--model') + 1]).toBe('claude-fable-5');
+  });
+
   // NIM-806: the genuine CLI ships its own built-in AskUserQuestion that renders
   // in the TUI and never routes through MCP. Disallow it so the model is forced
   // onto our mcp__nimbalyst-mcp__AskUserQuestion equivalent (which renders a
@@ -342,6 +347,14 @@ describe('resolveClaudeCliModelArg', () => {
   it('collapses pinned opus variants to the CLI `opus` alias (non-extended → no [1m])', () => {
     expect(resolveClaudeCliModelArg('claude-code-cli:opus-4-7')).toBe('opus');
     expect(resolveClaudeCliModelArg('claude-code-cli:opus-4-6')).toBe('opus');
+  });
+
+  it('resolves the pinned fable-5 variant to its full claude-fable-5 model id (CLI has no bare `fable` alias)', () => {
+    // Unlike opus pins, `fable-5` has no CLI alias to collapse to, so it must use
+    // the full Anthropic id from CLAUDE_CODE_PINNED_SDK_MODELS. Passing bare
+    // `fable-5` would make `claude --model fable-5` fail at launch.
+    expect(resolveClaudeCliModelArg('claude-code-cli:fable-5')).toBe('claude-fable-5');
+    expect(resolveClaudeCliModelArg('claude-code-cli:fable-5-1m')).toBe('claude-fable-5[1m]');
   });
 
   it('passes a bare variant through (normalized), translating -1m to [1m]', () => {

--- a/packages/electron/src/main/services/ai/__tests__/claudeCodeModelDefaults.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCodeModelDefaults.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { ClaudeCodeProvider } from '@nimbalyst/runtime/ai/server/providers/ClaudeCodeProvider';
+import {
+  DEFAULT_CLAUDE_CODE_ENABLED_MODELS,
+  insertClaudeCodeVariant,
+} from '../claudeCodeModelDefaults';
+
+/**
+ * Mirrors the claude-code model-id gate inside `AIService` `ai:getModels`
+ * (the `provider.models` filter). A row only reaches the picker when its id is
+ * in the enabled list, or it's a `-1m` row whose base id is enabled. Replayed
+ * here so we can prove Fable 5 survives the gate without standing up the full
+ * IPC handler. Keep in sync with AIService if that filter changes.
+ */
+function survivesPickerGate(modelId: string, enabled: readonly string[]): boolean {
+  if (enabled.length === 0) return true;
+  if (enabled.includes(modelId)) return true;
+  if (modelId.includes('-1m') && enabled.includes(modelId.replace(/-1m$/, ''))) return true;
+  return false;
+}
+
+describe('DEFAULT_CLAUDE_CODE_ENABLED_MODELS', () => {
+  it('seeds Fable 5 ahead of opus for fresh installs', () => {
+    expect(DEFAULT_CLAUDE_CODE_ENABLED_MODELS).toContain('claude-code:fable-5');
+    expect(DEFAULT_CLAUDE_CODE_ENABLED_MODELS.indexOf('claude-code:fable-5')).toBeLessThan(
+      DEFAULT_CLAUDE_CODE_ENABLED_MODELS.indexOf('claude-code:opus'),
+    );
+  });
+});
+
+describe('insertClaudeCodeVariant (existing-user migration)', () => {
+  // A list as it would have been persisted before Fable 5 shipped.
+  const legacy = [
+    'claude-code:opus',
+    'claude-code:opus-4-7',
+    'claude-code:opus-4-6',
+    'claude-code:sonnet',
+    'claude-code:haiku',
+  ];
+
+  it('back-fills Fable 5 immediately before opus', () => {
+    const result = insertClaudeCodeVariant(legacy, 'claude-code:fable-5', 'claude-code:opus', 'before');
+    expect(result.indexOf('claude-code:fable-5')).toBe(result.indexOf('claude-code:opus') - 1);
+  });
+
+  it('is idempotent — a list that already has the variant is unchanged', () => {
+    const once = insertClaudeCodeVariant(legacy, 'claude-code:fable-5', 'claude-code:opus', 'before');
+    const twice = insertClaudeCodeVariant(once, 'claude-code:fable-5', 'claude-code:opus', 'before');
+    expect(twice).toEqual(once);
+  });
+
+  it('does not mutate the input list', () => {
+    const snapshot = [...legacy];
+    insertClaudeCodeVariant(legacy, 'claude-code:fable-5', 'claude-code:opus', 'before');
+    expect(legacy).toEqual(snapshot);
+  });
+
+  it("defaults 'after' insertion and falls back to the end when the anchor is missing", () => {
+    const result = insertClaudeCodeVariant(legacy, 'claude-code:fable-5', 'claude-code:nope');
+    expect(result[result.length - 1]).toBe('claude-code:fable-5');
+  });
+
+  it("'before' insertion falls back to the front when the anchor is missing", () => {
+    const result = insertClaudeCodeVariant(legacy, 'claude-code:fable-5', 'claude-code:nope', 'before');
+    expect(result[0]).toBe('claude-code:fable-5');
+  });
+});
+
+describe('Fable 5 picker visibility (catalog filtered by enabled list)', () => {
+  it('Fable 5 rows from the real catalog survive the default enabled list', async () => {
+    const ids = (await ClaudeCodeProvider.getModels()).map((m) => m.id);
+    const visible = ids.filter((id) => survivesPickerGate(id, DEFAULT_CLAUDE_CODE_ENABLED_MODELS));
+    expect(visible).toContain('claude-code:fable-5');
+    expect(visible).toContain('claude-code:fable-5-1m');
+  });
+
+  it('regression guard: a pre-Fable enabled list hides both rows', async () => {
+    // This is the bug the fix closes: catalog had the rows, but the enabled
+    // list (default or migrated) did not, so the gate dropped them.
+    const preFable = [
+      'claude-code:opus',
+      'claude-code:opus-4-7',
+      'claude-code:opus-4-6',
+      'claude-code:sonnet',
+      'claude-code:haiku',
+    ];
+    const ids = (await ClaudeCodeProvider.getModels()).map((m) => m.id);
+    const visible = ids.filter((id) => survivesPickerGate(id, preFable));
+    expect(visible).not.toContain('claude-code:fable-5');
+    expect(visible).not.toContain('claude-code:fable-5-1m');
+  });
+});

--- a/packages/electron/src/main/services/ai/claudeCliSpawnConfig.ts
+++ b/packages/electron/src/main/services/ai/claudeCliSpawnConfig.ts
@@ -18,7 +18,7 @@
  */
 
 import { ModelIdentifier } from '@nimbalyst/runtime/ai/server/types';
-import { normalizeClaudeCodeVariant } from '@nimbalyst/runtime/ai/modelConstants';
+import { normalizeClaudeCodeVariant, CLAUDE_CODE_PINNED_SDK_MODELS } from '@nimbalyst/runtime/ai/modelConstants';
 
 /**
  * Resolve a Nimbalyst model id to the alias the genuine `claude` CLI accepts for
@@ -48,8 +48,16 @@ export function resolveClaudeCliModelArg(model: string | undefined): string | un
 
   const variant = normalizeClaudeCodeVariant(variantInput);
   if (variant) {
-    // Collapse pinned opus variants (opus-4-7 / opus-4-6) to the CLI's `opus` alias.
-    const alias = variant.startsWith('opus') ? 'opus' : variant;
+    // Collapse pinned opus variants (opus-4-7 / opus-4-6) to the CLI's `opus`
+    // alias — the CLI has no pinned-opus alias and `opus` tracks the current
+    // generation. Other pinned variants have no bare CLI alias at all (e.g.
+    // `fable-5`), so they MUST resolve to their full Anthropic model id from
+    // CLAUDE_CODE_PINNED_SDK_MODELS (`claude-fable-5`); passing the bare
+    // `fable-5` makes `claude --model fable-5` fail at launch. This mirrors the
+    // Agent SDK path's pin resolution (resolveClaudeCodeModelVariant).
+    const alias = variant.startsWith('opus')
+      ? 'opus'
+      : CLAUDE_CODE_PINNED_SDK_MODELS[variant] ?? variant;
     return isExtended ? `${alias}[1m]` : alias;
   }
 

--- a/packages/electron/src/main/services/ai/claudeCodeModelDefaults.ts
+++ b/packages/electron/src/main/services/ai/claudeCodeModelDefaults.ts
@@ -1,0 +1,47 @@
+/**
+ * Default + migration helpers for the Claude Code picker's enabled-models list.
+ *
+ * `ai:getModels` filters the full Claude Code catalog down to the variant ids
+ * stored in `providerSettings['claude-code'].models`. A variant that isn't in
+ * that list never reaches the picker, even though the catalog produces it. So
+ * adding a new variant (e.g. `fable-5`) requires seeding it here for new
+ * installs (the default list) and back-filling it for existing users (the
+ * migration in AIService). Extracted so both paths are unit-testable without
+ * standing up the full AIService.
+ */
+
+/** Default enabled Claude Code variants shown in a fresh install's picker, in display order. */
+export const DEFAULT_CLAUDE_CODE_ENABLED_MODELS: readonly string[] = [
+  'claude-code:fable-5',
+  'claude-code:opus',
+  'claude-code:opus-4-7',
+  'claude-code:opus-4-6',
+  'claude-code:sonnet',
+  'claude-code:haiku',
+];
+
+/**
+ * Insert `variantId` into a persisted claude-code enabled-models list, before
+ * or after `anchorId`. Returns a new array; the input is never mutated. If
+ * `variantId` is already present the list is returned unchanged. When the
+ * anchor is absent the variant falls back to the front (`'before'`) or the end
+ * (`'after'`).
+ */
+export function insertClaudeCodeVariant(
+  models: readonly string[],
+  variantId: string,
+  anchorId: string,
+  position: 'before' | 'after' = 'after',
+): string[] {
+  if (models.includes(variantId)) return [...models];
+  const anchorIndex = models.indexOf(anchorId);
+  const insertAt =
+    position === 'before'
+      ? anchorIndex >= 0
+        ? anchorIndex
+        : 0
+      : anchorIndex >= 0
+        ? anchorIndex + 1
+        : models.length;
+  return [...models.slice(0, insertAt), variantId, ...models.slice(insertAt)];
+}

--- a/packages/electron/src/renderer/utils/modelUtils.ts
+++ b/packages/electron/src/renderer/utils/modelUtils.ts
@@ -241,13 +241,13 @@ export function getModelShortName(provider: string, modelId: string): string {
 
 /**
  * Check if a model supports effort level configuration.
- * Supported: Claude Code Opus (4.6+) and Sonnet (4.6+) variants including pinned
- * versions, plus OpenAI Codex models.
+ * Supported: Claude Code Fable 5, Opus (4.6+) and Sonnet (4.6+) variants
+ * including pinned versions, plus OpenAI Codex models.
  */
 export function supportsEffortLevel(modelId?: string): boolean {
   if (!modelId) return false;
   const variant = extractClaudeCodeVariant(modelId);
-  if (variant === 'opus' || variant === 'opus-4-6' || variant === 'sonnet') return true;
+  if (variant === 'fable-5' || variant === 'opus' || variant === 'opus-4-6' || variant === 'sonnet') return true;
   // OpenAI Codex models support reasoning effort (both SDK and ACP transports)
   const parsed = ModelIdentifier.tryParse(modelId);
   if (parsed?.provider === 'openai-codex' || parsed?.provider === 'openai-codex-acp') return true;

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -199,7 +199,7 @@ export const OPENAI_MODELS: ModelDefinition[] = [
  *   the previous-generation Opus selectable after bumping the canonical
  *   `opus` to the next version.
  */
-export type ClaudeCodeVariant = 'opus' | 'sonnet' | 'haiku' | 'opus-4-7' | 'opus-4-6';
+export type ClaudeCodeVariant = 'fable-5' | 'opus' | 'sonnet' | 'haiku' | 'opus-4-7' | 'opus-4-6';
 export type ClaudeCodeVariantInput = ClaudeCodeVariant | 'opus-4-8';
 
 /**
@@ -211,6 +211,7 @@ export type ClaudeCodeVariantInput = ClaudeCodeVariant | 'opus-4-8';
  * duplicate visible picker entry.
  */
 export const CLAUDE_CODE_ACCEPTED_VARIANT_INPUTS: readonly ClaudeCodeVariantInput[] = [
+  'fable-5',
   'opus',
   'opus-4-8',
   'opus-4-7',
@@ -220,6 +221,7 @@ export const CLAUDE_CODE_ACCEPTED_VARIANT_INPUTS: readonly ClaudeCodeVariantInpu
 ] as const;
 
 const CLAUDE_CODE_VARIANT_INPUT_MAP: Readonly<Record<ClaudeCodeVariantInput, ClaudeCodeVariant>> = {
+  'fable-5': 'fable-5',
   opus: 'opus',
   'opus-4-8': 'opus',
   'opus-4-7': 'opus-4-7',
@@ -233,6 +235,7 @@ export function normalizeClaudeCodeVariant(variant: string): ClaudeCodeVariant |
 }
 
 export const CLAUDE_CODE_VARIANT_VERSIONS: Record<ClaudeCodeVariant, string> = {
+  'fable-5': '5',
   opus: '4.8',
   sonnet: '4.6',
   haiku: '4.5',
@@ -241,6 +244,7 @@ export const CLAUDE_CODE_VARIANT_VERSIONS: Record<ClaudeCodeVariant, string> = {
 };
 
 export const CLAUDE_CODE_MODEL_LABELS: Record<ClaudeCodeVariant, string> = {
+  'fable-5': 'Fable',
   opus: 'Opus',
   sonnet: 'Sonnet',
   haiku: 'Haiku',
@@ -254,12 +258,14 @@ export const CLAUDE_CODE_MODEL_LABELS: Record<ClaudeCodeVariant, string> = {
  * string (or missing entry) means "pass the variant name straight through".
  */
 export const CLAUDE_CODE_PINNED_SDK_MODELS: Partial<Record<ClaudeCodeVariant, string>> = {
+  'fable-5': 'claude-fable-5',
   'opus-4-7': 'claude-opus-4-7',
   'opus-4-6': 'claude-opus-4-6',
 };
 
 /** Variants that support a 1M-context extended picker row. */
 export const CLAUDE_CODE_VARIANTS_WITH_1M: readonly ClaudeCodeVariant[] = [
+  'fable-5',
   'opus',
   'sonnet',
   'opus-4-7',

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -1084,7 +1084,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
 
                 if (errorChunk?.type === 'result') {
                   errorMessage = extractResultChunkErrorMessage(errorChunk);
-                  const { isAuthError, isExpiredSessionError, isServerError } = detectResultChunkErrorFlags(errorMessage);
+                  const { isAuthError, isExpiredSessionError, isServerError, isModelUnavailable } = detectResultChunkErrorFlags(errorMessage);
 
                   if (isExpiredSessionError && sessionId) {
                     this.sessions.expireSession(sessionId);
@@ -1094,12 +1094,15 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
                   const isBedrockToolError = isBedrockToolSearchError(errorMessage);
                   if (isServerError) errorMessage += '\n\nClaude may be experiencing issues. Check https://status.anthropic.com for service status.';
                   if (isBedrockToolError) errorMessage = buildBedrockToolErrorGuidance(errorMessage);
+                  // Auth failures already carry their own guidance; only add the
+                  // billing/plan hint when the model itself was rejected.
+                  if (isModelUnavailable && !isAuthError) errorMessage += '\n\nThis model may require prepaid usage credits or may not be available on your current plan. Check your plan in Settings, or pick a different model.';
 
                   const isRateLimitError = /rate limit/i.test(errorMessage);
                   const is1mModel = this.config.model != null && this.config.model.includes('-1m');
                   if (isRateLimitError && is1mModel) errorMessage += '\n\nThis 1M context model may not be available on your plan.';
 
-                  const errorType = isAuthError ? 'authentication_error' : isBedrockToolError ? 'bedrock_tool_error' : isExpiredSessionError ? 'expired_session_error' : 'api_error';
+                  const errorType = isAuthError ? 'authentication_error' : isBedrockToolError ? 'bedrock_tool_error' : isExpiredSessionError ? 'expired_session_error' : isModelUnavailable ? 'model_unavailable_error' : 'api_error';
                   this.logError(sessionId, 'claude-code', new Error(errorMessage), 'result_chunk', errorType, hideMessages);
                   transcriptAdapter?.systemMessage(errorMessage, 'error');
 
@@ -1110,6 +1113,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
                     ...(isBedrockToolError && { isBedrockToolError: true }),
                     ...(isExpiredSessionError && { isExpiredSessionError: true }),
                     ...(isServerError && { isServerError: true }),
+                    ...(isModelUnavailable && !isAuthError && { isModelUnavailable: true }),
                   };
 
                   await this.flushPendingWrites();

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.getModels.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.getModels.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { ClaudeCodeProvider } from '../ClaudeCodeProvider';
+
+/**
+ * The Claude Code picker is sourced from `ClaudeCodeProvider.getModels()`
+ * filtered by the user's enabled-models list. These cases lock in that the
+ * catalog actually produces the Fable 5 rows the picker needs, in the right
+ * order. Without them, the variant could resolve correctly yet never appear.
+ */
+describe('ClaudeCodeProvider.getModels — Fable 5 catalog rows', () => {
+  it('emits standard and 1M Fable 5 rows', async () => {
+    const ids = (await ClaudeCodeProvider.getModels()).map((m) => m.id);
+    expect(ids).toContain('claude-code:fable-5');
+    expect(ids).toContain('claude-code:fable-5-1m');
+  });
+
+  it('orders Fable 5 ahead of opus (flagship first)', async () => {
+    const ids = (await ClaudeCodeProvider.getModels()).map((m) => m.id);
+    expect(ids.indexOf('claude-code:fable-5')).toBeLessThan(ids.indexOf('claude-code:opus'));
+  });
+
+  it('labels the rows "Fable 5" and "Fable 5 (1M)"', async () => {
+    const models = await ClaudeCodeProvider.getModels();
+    const base = models.find((m) => m.id === 'claude-code:fable-5');
+    const extended = models.find((m) => m.id === 'claude-code:fable-5-1m');
+    expect(base?.name).toContain('Fable 5');
+    expect(base?.contextWindow).toBe(200000);
+    expect(extended?.name).toContain('Fable 5');
+    expect(extended?.name).toContain('(1M)');
+    expect(extended?.contextWindow).toBe(1000000);
+  });
+});

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts
@@ -77,6 +77,17 @@ describe('resolveClaudeCodeModelVariant', () => {
   });
 
   describe('pinned-version variants', () => {
+    it('fable-5 resolves to the full claude-fable-5 SDK model ID', () => {
+      // Claude Fable 5 is pinned to its dateless alias, like the opus-4-N pins.
+      const result = resolveClaudeCodeModelVariant('claude-code:fable-5', DEFAULT_MODEL);
+      expect(result).toBe('claude-fable-5');
+    });
+
+    it('fable-5-1m resolves to claude-fable-5[1m]', () => {
+      const result = resolveClaudeCodeModelVariant('claude-code:fable-5-1m', DEFAULT_MODEL);
+      expect(result).toBe('claude-fable-5[1m]');
+    });
+
     it('opus-4-8 resolves to the canonical opus SDK alias', () => {
       const result = resolveClaudeCodeModelVariant('claude-code:opus-4-8', DEFAULT_MODEL);
       expect(result).toBe('opus');

--- a/packages/runtime/src/ai/server/providers/claudeCode/__tests__/resultChunkUtils.test.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/__tests__/resultChunkUtils.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { detectResultChunkErrorFlags, extractResultChunkErrorMessage } from '../resultChunkUtils';
+
+describe('detectResultChunkErrorFlags', () => {
+  describe('isModelUnavailable (billing / plan rejection)', () => {
+    // The motivating case: a subscription model that now needs prepaid usage
+    // credits (e.g. Fable 5 after its plan-inclusion window) must classify as a
+    // billing/plan rejection, not an auth error, so the UI shows a useful hint
+    // instead of a raw API string or a "re-login" prompt.
+    const billingMessages = [
+      'Your credit balance is too low to access the Anthropic API.',
+      'This request requires prepaid usage credits.',
+      'API Error: 402 Payment Required',
+      'The model claude-fable-5 is not available on your plan.',
+      'claude-fable-5 is not available on your subscription.',
+      'Your organization does not have access to model claude-fable-5.',
+      'model not found: claude-fable-5',
+    ];
+
+    it.each(billingMessages)('flags %j as model-unavailable', (msg) => {
+      expect(detectResultChunkErrorFlags(msg).isModelUnavailable).toBe(true);
+    });
+
+    it('does not misclassify billing messages as auth errors', () => {
+      for (const msg of billingMessages) {
+        expect(detectResultChunkErrorFlags(msg).isAuthError).toBe(false);
+      }
+    });
+
+    it('does not flag unrelated errors as model-unavailable', () => {
+      const unrelated = [
+        'Invalid API key. Please run /login.',
+        'Internal server error',
+        'rate limit exceeded',
+        'No conversation found for this session.',
+      ];
+      for (const msg of unrelated) {
+        expect(detectResultChunkErrorFlags(msg).isModelUnavailable).toBe(false);
+      }
+    });
+  });
+
+  describe('existing classifications still hold', () => {
+    it('flags auth errors', () => {
+      expect(detectResultChunkErrorFlags('401 Unauthorized: invalid API key').isAuthError).toBe(true);
+    });
+
+    it('flags expired sessions', () => {
+      expect(detectResultChunkErrorFlags('No conversation found').isExpiredSessionError).toBe(true);
+    });
+
+    it('flags server errors', () => {
+      expect(detectResultChunkErrorFlags('Internal server error (500)').isServerError).toBe(true);
+    });
+  });
+});
+
+describe('extractResultChunkErrorMessage', () => {
+  it('unwraps the nested API error message', () => {
+    const chunk = {
+      result: 'API Error: 402 {"error":{"message":"Your credit balance is too low to access the Anthropic API."}}',
+    };
+    const msg = extractResultChunkErrorMessage(chunk);
+    expect(msg).toBe('Your credit balance is too low to access the Anthropic API.');
+    // And the unwrapped message must still classify as a billing rejection.
+    expect(detectResultChunkErrorFlags(msg).isModelUnavailable).toBe(true);
+  });
+});

--- a/packages/runtime/src/ai/server/providers/claudeCode/resultChunkUtils.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/resultChunkUtils.ts
@@ -25,6 +25,7 @@ export function detectResultChunkErrorFlags(errorMessage: string): {
   isAuthError: boolean;
   isExpiredSessionError: boolean;
   isServerError: boolean;
+  isModelUnavailable: boolean;
 } {
   const lowerError = errorMessage.toLowerCase();
 
@@ -47,10 +48,27 @@ export function detectResultChunkErrorFlags(errorMessage: string): {
     errorMessage.includes('"type":"api_error"')
   );
 
+  // Model rejected for billing/plan reasons rather than auth. Covers a
+  // subscription model that now requires prepaid usage credits (e.g. Fable 5
+  // after its plan-inclusion window), a model not enabled on the current plan,
+  // and the standard low-credit-balance API response.
+  const isModelUnavailable = (
+    lowerError.includes('credit balance') ||
+    lowerError.includes('usage credit') ||
+    lowerError.includes('prepaid') ||
+    lowerError.includes('payment required') ||
+    lowerError.includes('402') ||
+    lowerError.includes('model not found') ||
+    lowerError.includes('not available on your plan') ||
+    lowerError.includes('not available on your subscription') ||
+    lowerError.includes('does not have access to')
+  );
+
   return {
     isAuthError,
     isExpiredSessionError,
     isServerError,
+    isModelUnavailable,
   };
 }
 

--- a/packages/runtime/src/ai/server/types.ts
+++ b/packages/runtime/src/ai/server/types.ts
@@ -200,7 +200,7 @@ export function shouldBlockStartedSessionProviderSwitch(
  * the canonical `opus` alias to 4.8, so users can still choose previous
  * generations. See CLAUDE_CODE_PINNED_SDK_MODELS in modelConstants.ts.
  */
-export const CLAUDE_CODE_VARIANTS = ['opus', 'opus-4-7', 'opus-4-6', 'sonnet', 'haiku'] as const;
+export const CLAUDE_CODE_VARIANTS = ['fable-5', 'opus', 'opus-4-7', 'opus-4-6', 'sonnet', 'haiku'] as const;
 
 /**
  * Resolves a configured model string to the SDK model value.

--- a/packages/runtime/src/ai/server/types.ts
+++ b/packages/runtime/src/ai/server/types.ts
@@ -444,6 +444,7 @@ export interface StreamChunk {
   isAuthError?: boolean; // True when error is an authentication failure (SDK first-class detection)
   isBedrockToolError?: boolean; // True when error is a Bedrock tool search error
   isServerError?: boolean; // True when error is a 500/internal server error (Claude may be down)
+  isModelUnavailable?: boolean; // True when the model is rejected for billing/plan reasons (e.g. needs usage credits)
   isCodexAuthRequired?: boolean; // True when a Codex app-server session was blocked because the user is not signed in to OpenAI
   isComplete?: boolean;
   config?: unknown; // For stream_edit_start


### PR DESCRIPTION
## Summary

- Adds `claude-fable-5` (Anthropic's Mythos-class GA model, released 2026-06-09; 1M context, 128k max output) as a pinned Claude Code variant `fable-5`, so it is selectable in both Claude Code agent pickers: **Claude Agent (Claude Code Based)** (`claude-code`) and **Claude Code CLI (Subscription)** (`claude-code-cli`), which share the variant namespace.
- Pins `fable-5` to the dateless `claude-fable-5` SDK id via `CLAUDE_CODE_PINNED_SDK_MODELS`, mirroring the `opus-4-7` / `opus-4-6` pattern.
- Adds `fable-5` to `CLAUDE_CODE_VARIANTS_WITH_1M` (Fable 5 is natively 1M, like Opus 4.8), so the picker shows both a standard and a 1M row.
- Closes the picker-visibility gap: the catalog produced the rows, but the `ai:getModels` enabled-models gate filtered them out. Seeds `fable-5` in the default enabled list, back-fills existing installs via a `claudeCodeFable5Added` migration (inserted ahead of `opus`), enables effort levels for Fable 5, and adds regression tests.
- Scope note: this covers the Claude Code agent path only. #610 separately adds Fable 5 to the API-key `claude` chat provider (`CLAUDE_MODELS`); the two model lists are distinct, so both are needed for full coverage.

## Files

| Path | Change |
| --- | --- |
| `packages/runtime/src/ai/modelConstants.ts` | `fable-5` added to the `ClaudeCodeVariant` type, `CLAUDE_CODE_ACCEPTED_VARIANT_INPUTS` + input map, `CLAUDE_CODE_VARIANT_VERSIONS` (`5`), `CLAUDE_CODE_MODEL_LABELS` (`Fable`), `CLAUDE_CODE_PINNED_SDK_MODELS` (`claude-fable-5`), `CLAUDE_CODE_VARIANTS_WITH_1M` |
| `packages/runtime/src/ai/server/types.ts` | `CLAUDE_CODE_VARIANTS` adds `fable-5` (doc comment for the variant set) |
| `packages/electron/src/main/services/ai/AIService.ts` | Default enabled-models list seeds `fable-5`; `claudeCodeFable5Added` migration back-fills existing installs (insertion helper extracted, supports before/after anchors) |
| `packages/electron/src/main/services/ai/claudeCodeModelDefaults.ts` | New: `DEFAULT_CLAUDE_CODE_ENABLED_MODELS` + pure `insertClaudeCodeVariant` helper |
| `packages/electron/src/renderer/utils/modelUtils.ts` | `supportsEffortLevel` includes `fable-5` |
| `packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts` | New pinned-variant cases: `fable-5` resolves to `claude-fable-5`, `fable-5-1m` to `claude-fable-5[1m]` |
| `packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.getModels.test.ts` | New: catalog emits Fable 5 standard + 1M rows, ordered ahead of opus, with correct labels and context windows |
| `packages/electron/src/main/services/ai/__tests__/claudeCodeModelDefaults.test.ts` | New: default list, migration insertion, and picker-visibility gate tests (includes a regression guard showing a pre-Fable enabled list hides the rows) |
| `CHANGELOG.md` | `[Unreleased] > Added` entry |

## Test plan

- [x] New unit cases: `resolveClaudeCodeModelVariant('claude-code:fable-5')` resolves to `claude-fable-5`; `claude-code:fable-5-1m` to `claude-fable-5[1m]` (in the existing `pinned-version variants` suite)
- [x] Model id `claude-fable-5` confirmed against Anthropic's GA alias (1M context, 128k max output, GA 2026-06-09) and a live `claude --model claude-fable-5` invocation on a Pro/Max subscription
- [x] `npx vitest --run packages/runtime/src/ai`: 61 files, 822 tests passed. Electron suite `claudeCodeModelDefaults.test.ts`: 8 passed. `tsc --noEmit` clean on `packages/runtime` and `packages/electron`.
- [x] Manual picker check, verified live in dev mode on this branch (see Picker evidence below).

## Picker evidence

Live dev-mode verification on this branch: **Fable 5** and **Fable 5 (1M)** appear at the top of the Claude Code picker, above Opus 4.8, with Fable 5 selected.

![Claude Code picker showing Fable 5 selected at the top, above Opus 4.8](https://raw.githubusercontent.com/paretoimproved/nimbalyst/pr-611-evidence/evidence/pr-611-fable5-picker.png)

Corroborated by persisted state and logs:
- `ai-settings.json`: `migrations.claudeCodeFable5Added: true`, and `claude-code:fable-5` first in `providerSettings['claude-code'].models` (back-filled by the migration; the list previously had no Fable entry)
- `main.log`: `[SessionHandlers] Model changed to claude-code:fable-5, invalidating provider for session ...` (two sessions)

_(Image hosted on the `pr-611-evidence` branch of the head fork; safe to delete after merge.)_

## Notes for reviewers

- `[1m]` on a natively-1M model mirrors the `opus` variant. If Fable rejects the 1M beta header, drop `fable-5` from `CLAUDE_CODE_VARIANTS_WITH_1M`.
- iOS `ModelLabel` is not touched. PR #473 added a `claudeApiShortNames` entry for the API id; the Claude Code variant path may want the analogous mapping (`"fable-5": "5"` in `ModelLabel.swift`). Flagged as a small follow-up.
- The `claude-code-cli` provider's `sendMessage` is the Phase 1 stub in this tree; this PR only wires the model catalog/variant so the picker entry, validation, and variant resolution work.