### PR TITLE
fix: run git hooks with shell PATH so husky yarn hooks resolve (#643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Personal docs sync no longer overwrites newer local edits (or an open editor's unsaved changes) with an older synced copy.
 - "Commit with AI" in a worktree now proposes all uncommitted changes in the worktree, not just the current session's edits.
 - Claude Code CLI sessions now show an install link when the Claude Code CLI isn't installed, instead of a cryptic terminal error.
+- Commit with AI (and other in-app git actions) now run hooks with your shell PATH, so husky hooks that call yarn/node no longer fail with "command not found". (#643)
 - Stop the AskUserQuestion widget from crashing when a question is missing its options.
 - Deleting a custom tracker type no longer fails on the SQLite backend.
 - Launching a sibling session from a normal session no longer moves it (and the new session) into the Meta Agent group in the session list.

--- a/packages/electron/src/main/ipc/GitHandlers.ts
+++ b/packages/electron/src/main/ipc/GitHandlers.ts
@@ -11,6 +11,7 @@ import { existsSync } from 'fs';
 import { dirname, join, relative, isAbsolute, resolve } from 'path';
 import { gitOperationLock } from '../services/GitOperationLock';
 import { executeGitCommit } from '../services/GitCommitService';
+import { getGitSubprocessEnv, simpleGitWithHookEnv } from '../services/gitEnv';
 import { safeHandle } from '../utils/ipcRegistry';
 import { findGitRootForFile } from '../services/GitStatusService';
 import { isFileInWorkspaceOrWorktree } from '../utils/workspaceDetection';
@@ -285,7 +286,7 @@ export function registerGitHandlers(): void {
 
       return gitOperationLock.withLock(workspacePath, 'git:push', async () => {
         try {
-          const git: SimpleGit = simpleGit(workspacePath);
+          const git: SimpleGit = simpleGitWithHookEnv(workspacePath);
           const status = await git.status();
           const branch = normalizeCurrentBranch(status.current);
           if (!branch || branch === 'HEAD') {
@@ -326,7 +327,7 @@ export function registerGitHandlers(): void {
 
       return gitOperationLock.withLock(workspacePath, 'git:pull', async () => {
         try {
-          const git: SimpleGit = simpleGit(workspacePath);
+          const git: SimpleGit = simpleGitWithHookEnv(workspacePath);
           const status = await git.status();
           const branch = normalizeCurrentBranch(status.current);
           if (!branch || branch === 'HEAD') {
@@ -393,7 +394,7 @@ export function registerGitHandlers(): void {
 
       return gitOperationLock.withLock(workspacePath, 'git:rebase', async () => {
         try {
-          const git: SimpleGit = simpleGit(workspacePath);
+          const git: SimpleGit = simpleGitWithHookEnv(workspacePath);
 
           if (options.action === 'continue') {
             await git.rebase(['--continue']);
@@ -469,7 +470,7 @@ export function registerGitHandlers(): void {
       if (!isGitRepository(workspacePath)) return { success: false, error: 'Not a git repository' };
 
       try {
-        const git: SimpleGit = simpleGit(workspacePath);
+        const git: SimpleGit = simpleGitWithHookEnv(workspacePath);
         const status = await git.status();
         const targetBranch = branch || normalizeCurrentBranch(status.current);
         if (!targetBranch || targetBranch === 'HEAD') {
@@ -524,7 +525,7 @@ export function registerGitHandlers(): void {
 
       return gitOperationLock.withLock(workspacePath, 'git:cherry-pick', async () => {
         try {
-          const git: SimpleGit = simpleGit(workspacePath);
+          const git: SimpleGit = simpleGitWithHookEnv(workspacePath);
           await git.raw(['cherry-pick', hash]);
           return { success: true };
         } catch (error) {
@@ -980,6 +981,7 @@ export function registerGitHandlers(): void {
     ): Promise<{ success: boolean; commitHash?: string; commitDate?: string; error?: string }> => {
       return executeGitCommit(workspacePath, message, filesToStage, {
         logContext: '[git:commit]',
+        env: getGitSubprocessEnv(),
       });
     }
   );

--- a/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
@@ -8,6 +8,7 @@ import { notificationService } from "../../services/NotificationService";
 import { TrayManager } from "../../tray/TrayManager";
 import { findWindowIdForWorkspacePath } from "../mcpWorkspaceResolver";
 import { setSessionPendingPrompt } from "../../services/ai/pendingPromptPersistence";
+import { getGitSubprocessEnv } from "../../services/gitEnv";
 import {
   resolveRequestUserInputPromptTargets,
   resolveToolUseIdFromMcpRequest,
@@ -880,7 +881,7 @@ export async function handleGitCommitProposal(
         workspacePath,
         commitMessage,
         filePaths,
-        { logContext: "[git:auto-commit]" }
+        { logContext: "[git:auto-commit]", env: getGitSubprocessEnv() }
       );
     } catch (error) {
       console.error("[MCP Server] Auto-commit failed:", error);

--- a/packages/electron/src/main/services/GitCommitService.ts
+++ b/packages/electron/src/main/services/GitCommitService.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs';
 import { isAbsolute, join, relative } from 'path';
 import simpleGit, { SimpleGit } from 'simple-git';
 import { gitOperationLock } from './GitOperationLock';
+import { GIT_INHERITED_ENV_UNSAFE } from './gitInheritedEnvUnsafe';
 
 export interface GitCommitExecutionResult {
   success: boolean;
@@ -75,6 +76,13 @@ export async function executeGitCommit(
     logContext?: string;
     /** Tuning for index.lock contention backoff. Defaults to 5 retries from 100ms. */
     lockRetry?: { maxRetries?: number; baseDelayMs?: number };
+    /**
+     * Environment for the git subprocess (and any hooks it runs). Production callers
+     * pass an enhanced env (see getGitSubprocessEnv) so husky hooks invoking nvm/Homebrew
+     * binaries like `yarn` resolve, since GUI-launched apps don't inherit the shell PATH.
+     * When omitted, git inherits process.env as usual.
+     */
+    env?: Record<string, string>;
   }
 ): Promise<GitCommitExecutionResult> {
   const logContext = options?.logContext || '[git:commit]';
@@ -104,7 +112,9 @@ export async function executeGitCommit(
         await delay(backoffMs);
       }
       try {
-        const git: SimpleGit = simpleGit(workspacePath);
+        const git: SimpleGit = options?.env
+          ? simpleGit(workspacePath, { unsafe: GIT_INHERITED_ENV_UNSAFE }).env(options.env)
+          : simpleGit(workspacePath);
         const repoHasCommits = await hasCommits(git);
         // log.info(`${logContext} Starting commit in ${workspacePath} with ${filesToStage?.length || 0} files (hasCommits: ${repoHasCommits})`);
 

--- a/packages/electron/src/main/services/GitWorktreeService.ts
+++ b/packages/electron/src/main/services/GitWorktreeService.ts
@@ -13,6 +13,7 @@
  */
 
 import simpleGit, { SimpleGit } from 'simple-git';
+import { simpleGitWithHookEnv } from './gitEnv';
 import * as path from 'path';
 import * as fs from 'fs';
 import { ulid } from 'ulid';
@@ -1356,7 +1357,7 @@ ${newLines.map(line => '+' + line).join('\n')}`;
   private async commitChangesImpl(worktreePath: string, message: string, files?: string[]): Promise<CommitInfo> {
     logger.info('Committing changes', { worktreePath, message, fileCount: files?.length });
 
-    const git: SimpleGit = simpleGit(worktreePath);
+    const git: SimpleGit = simpleGitWithHookEnv(worktreePath);
 
     try {
       // CRITICAL: Check git state before committing
@@ -1449,8 +1450,8 @@ ${newLines.map(line => '+' + line).join('\n')}`;
   private async mergeToMainImpl(worktreePath: string, mainRepoPath: string): Promise<MergeResult> {
     logger.info('Merging worktree to main', { worktreePath, mainRepoPath });
 
-    const worktreeGit: SimpleGit = simpleGit(worktreePath);
-    const mainGit: SimpleGit = simpleGit(mainRepoPath);
+    const worktreeGit: SimpleGit = simpleGitWithHookEnv(worktreePath);
+    const mainGit: SimpleGit = simpleGitWithHookEnv(mainRepoPath);
 
     try {
       // CRITICAL: Check git state before any operations
@@ -1961,7 +1962,7 @@ ${newLines.map(line => '+' + line).join('\n')}`;
   }> {
     logger.info('Rebasing worktree from base branch', { worktreePath, baseBranch });
 
-    const git: SimpleGit = simpleGit(worktreePath);
+    const git: SimpleGit = simpleGitWithHookEnv(worktreePath);
 
     try {
       // CRITICAL: Check git state before any operations
@@ -2379,7 +2380,7 @@ ${newLines.map(line => '+' + line).join('\n')}`;
   private async squashCommitsImpl(worktreePath: string, commitHashes: string[], message: string): Promise<string> {
     logger.info('Squashing commits', { worktreePath, commitCount: commitHashes.length });
 
-    const git: SimpleGit = simpleGit(worktreePath);
+    const git: SimpleGit = simpleGitWithHookEnv(worktreePath);
 
     // Create backup branch name with timestamp
     const backupBranchName = `backup-before-squash-${Date.now()}`;

--- a/packages/electron/src/main/services/__tests__/GitCommitService.test.ts
+++ b/packages/electron/src/main/services/__tests__/GitCommitService.test.ts
@@ -53,6 +53,48 @@ describe('GitCommitService', () => {
     expect(result.error).toContain('HOOK_DETAIL: lint failed');
   });
 
+  it('runs hooks with the injected subprocess env so PATH-dependent hooks resolve', async () => {
+    await git(['init', '-q'], tmpRoot);
+    await git(['config', 'user.email', 'test@example.com'], tmpRoot);
+    await git(['config', 'user.name', 'Test User'], tmpRoot);
+
+    // A binary that lives ONLY in a directory absent from the test process PATH,
+    // standing in for an nvm-managed `yarn` that husky hooks invoke.
+    const fakeBinDir = path.join(tmpRoot, 'fakebin');
+    await fs.mkdir(fakeBinDir, { recursive: true });
+    await fs.writeFile(
+      path.join(fakeBinDir, 'nimbalyst_hook_marker'),
+      '#!/bin/sh\nexit 0\n',
+      { mode: 0o755 }
+    );
+
+    const hooksDir = path.join(tmpRoot, '.git', 'hooks');
+    await fs.mkdir(hooksDir, { recursive: true });
+    await fs.writeFile(
+      path.join(hooksDir, 'pre-commit'),
+      '#!/bin/sh\nnimbalyst_hook_marker\n',
+      { mode: 0o755 }
+    );
+
+    await fs.writeFile(path.join(tmpRoot, 'a.txt'), 'hello\n', 'utf8');
+
+    const result = await executeGitCommit(tmpRoot, 'commit with hook', ['a.txt'], {
+      logContext: '[test:git-commit]',
+      env: {
+        ...process.env,
+        // simple-git's .env() scans the supplied environment and blocks these
+        // unless its unsafe flags are enabled; they are ubiquitous in real
+        // shells, so a working fix must tolerate them.
+        GIT_EDITOR: 'vim',
+        GIT_PAGER: 'less',
+        PATH: `${fakeBinDir}:${process.env.PATH ?? ''}`,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.commitHash).toBeTruthy();
+  });
+
   it('retries past a briefly-held .git/index.lock and commits successfully', async () => {
     await git(['init', '-q'], tmpRoot);
     await git(['config', 'user.email', 'test@example.com'], tmpRoot);

--- a/packages/electron/src/main/services/ai/MobileSessionControlHandler.ts
+++ b/packages/electron/src/main/services/ai/MobileSessionControlHandler.ts
@@ -18,6 +18,7 @@ import {
   resolveGitCommitProposalPromptId,
 } from './gitCommitProposalPromptUtils';
 import { buildToolPermissionResponseRecord } from './claudeCliToolPermission';
+import { getGitSubprocessEnv } from '../gitEnv';
 
 const log = logger.ai;
 
@@ -747,7 +748,7 @@ async function handleGitCommitResponse(
       workspacePath,
       response.message,
       response.files,
-      { logContext: '[GitCommit mobile]' }
+      { logContext: '[GitCommit mobile]', env: getGitSubprocessEnv() }
     );
     await emitProposalResponse(
       createGitCommitProposalResponse(commitResult, response.files, response.message)

--- a/packages/electron/src/main/services/gitEnv.ts
+++ b/packages/electron/src/main/services/gitEnv.ts
@@ -1,0 +1,45 @@
+import simpleGit, { SimpleGit, SimpleGitOptions } from 'simple-git';
+import { getEnhancedPath, getShellEnvironment } from './CLIManager';
+import { GIT_INHERITED_ENV_UNSAFE } from './gitInheritedEnvUnsafe';
+
+/**
+ * Build the environment for git subprocesses that may run hooks (commit, merge,
+ * rebase, etc.).
+ *
+ * GUI-launched apps on macOS/Linux do not inherit the login shell's PATH, so
+ * husky hooks invoking nvm/Homebrew-managed binaries (e.g. `yarn lint`) fail with
+ * "command not found" (exit 127) and the operation aborts. Layering in the
+ * detected shell environment and enhanced PATH makes those binaries resolve the
+ * same way they do in a normal terminal.
+ *
+ * simple-git's `.env(object)` REPLACES the child environment, so we spread
+ * process.env first to preserve everything else git relies on.
+ */
+export function getGitSubprocessEnv(): Record<string, string> {
+  const base: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      base[key] = value;
+    }
+  }
+  return {
+    ...base,
+    ...(getShellEnvironment() ?? {}),
+    PATH: getEnhancedPath(),
+  };
+}
+
+/**
+ * Create a simple-git instance whose subprocesses run with the enhanced shell
+ * environment. Use this for any operation that may fire git hooks (commit, merge,
+ * rebase, pull, cherry-pick) so husky hooks resolve nvm/Homebrew binaries.
+ */
+export function simpleGitWithHookEnv(
+  baseDir: string,
+  options?: Partial<SimpleGitOptions>
+): SimpleGit {
+  // The unsafe flags are required because .env() makes simple-git scan the
+  // supplied (trusted, user-owned) environment for vars like GIT_EDITOR.
+  const git = simpleGit(baseDir, { ...options, unsafe: GIT_INHERITED_ENV_UNSAFE });
+  return git.env(getGitSubprocessEnv());
+}

--- a/packages/electron/src/main/services/gitInheritedEnvUnsafe.ts
+++ b/packages/electron/src/main/services/gitInheritedEnvUnsafe.ts
@@ -8,6 +8,10 @@ import type { SimpleGitOptions } from 'simple-git';
  * implicitly — i.e. no `.env()` call — the scan does not run, which is why
  * normal commits work despite those vars being present.)
  *
+ * The scan lives in the bundled `@simple-git/argv-parser`: its `parseEnv`
+ * maps each GIT_* var to a matching `allowUnsafe*` category, which is why
+ * every flag below is load-bearing rather than dead config.
+ *
  * When we deliberately pass the user's own login-shell environment so hooks run
  * like a real terminal (see getGitSubprocessEnv), we must opt back into allowing
  * those variables. The environment is the user's own trusted machine config —

--- a/packages/electron/src/main/services/gitInheritedEnvUnsafe.ts
+++ b/packages/electron/src/main/services/gitInheritedEnvUnsafe.ts
@@ -1,0 +1,37 @@
+import type { SimpleGitOptions } from 'simple-git';
+
+/**
+ * simple-git's block-unsafe-operations plugin treats ANY explicitly-supplied
+ * environment as potentially attacker-controlled and refuses to spawn git when
+ * that env contains otherwise-legitimate variables such as GIT_EDITOR,
+ * GIT_PAGER, GIT_ASKPASS or GIT_SSH_COMMAND. (When git inherits process.env
+ * implicitly — i.e. no `.env()` call — the scan does not run, which is why
+ * normal commits work despite those vars being present.)
+ *
+ * When we deliberately pass the user's own login-shell environment so hooks run
+ * like a real terminal (see getGitSubprocessEnv), we must opt back into allowing
+ * those variables. The environment is the user's own trusted machine config —
+ * identical to what `git` sees in their terminal — so enabling these flags
+ * restores terminal-equivalent behavior rather than weakening a real boundary.
+ */
+export const GIT_INHERITED_ENV_UNSAFE: SimpleGitOptions['unsafe'] = {
+  allowUnsafeAlias: true,
+  allowUnsafeAskPass: true,
+  allowUnsafeConfigPaths: true,
+  allowUnsafeConfigEnvCount: true,
+  allowUnsafeCredentialHelper: true,
+  allowUnsafeEditor: true,
+  allowUnsafeMergeDriver: true,
+  allowUnsafePager: true,
+  allowUnsafeProtocolOverride: true,
+  allowUnsafePack: true,
+  allowUnsafeSshCommand: true,
+  allowUnsafeGitProxy: true,
+  allowUnsafeHooksPath: true,
+  allowUnsafeDiffExternal: true,
+  allowUnsafeDiffTextConv: true,
+  allowUnsafeFilter: true,
+  allowUnsafeFsMonitor: true,
+  allowUnsafeGpgProgram: true,
+  allowUnsafeTemplateDir: true,
+};


### PR DESCRIPTION
## Summary

Fixes #643. The built-in "Commit with AI" tool (and other in-app git actions) ran `git` via simple-git with no environment override, so on a Finder/Dock-launched macOS build the subprocess inherited the impoverished GUI-app PATH. husky `pre-commit` hooks calling `yarn` (an nvm-managed binary) failed with `yarn: command not found` (exit 127) and the commit never landed.

## Fix

Inject the user's real shell environment + enhanced PATH (reusing the existing `getEnhancedPath()` / `getShellEnvironment()` from `CLIManager`) into git subprocesses that can fire hooks, so hooks resolve binaries the same way a terminal does.

A wrinkle: simple-git's `.env()` opts into a vulnerability scanner that blocks ubiquitous inherited vars (`GIT_EDITOR`, `GIT_PAGER`, `GIT_SSH_COMMAND`, …). Passing a real environment trips it, which would have broken commits for many users. The fix pairs the env with simple-git's `unsafe` allow-flags (`gitInheritedEnvUnsafe.ts`) — restoring terminal-equivalent behavior on the user's own trusted machine.

### Files
- `GitCommitService.ts` — `executeGitCommit` gains an injectable `env` (kept electron-free so its unit tests run); applies env + unsafe config.
- `gitEnv.ts` (new) — `getGitSubprocessEnv()` + `simpleGitWithHookEnv()` helper.
- `gitInheritedEnvUnsafe.ts` (new) — shared unsafe-flag constant.
- Wired the three commit callers (`interactiveToolHandlers`, `MobileSessionControlHandler`, `git:commit` IPC) and broadened the same enhanced env to other hook-triggering ops: worktree commit/merge/rebase/squash (`GitWorktreeService`) and pull/rebase/cherry-pick/push/set-upstream (`GitHandlers`).

## Testing
- Added a regression test that runs a real `pre-commit` hook depending on a PATH-only binary, with `GIT_EDITOR` set. Verified red→green (failed before the fix, passes after).
- `GitCommitService` + `GitWorktreeService` suites: 9/9 pass.
- `tsc --noEmit` (electron package): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
