### PR TITLE
chore: enforce test discipline before commits and pushes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__nimbalyst-mcp__developer_git_commit_proposal",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/agent-test-gate.mjs",
+            "timeout": 600,
+            "statusMessage": "Running typecheck + unit tests before commit..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,10 @@ Guidance for Claude Code (claude.ai/code) when working in this repository.
 
 **At release time, condense — don't ship the dev-time bullets verbatim.** `[Unreleased]` accumulates verbose per-commit bullets during development. Before tagging, collapse them: merge a feature's scattered bullets into one line, drop scaffolding, squash near-duplicates. If the release notes are longer than the equivalent section in a recent shipped version, cut harder.
 
+### Write and Run Tests for Behavioral Changes
+
+**Any change to runtime behavior ships with a unit test** — a new test, or an extension of an existing one. Pure refactors already covered by tests, formatting, docs, and config-only changes are exempt. Before pushing, run the gate locally: `npm run typecheck && npm run test:prepush`. The repo's pre-push hook runs this automatically; it installs on `npm install` (or `npm run hooks:install`). Never push to `main` with a red suite — CI on `main` is a backstop, not the gate. For high-risk areas (sync/collab, main-process init, IPC, restart-to-verify bugs) the test comes **first** and must fail before the fix — see [end-to-end-verification.md](./.claude/rules/end-to-end-verification.md).
+
 ### Use @floating-ui/react for All Popover/Tooltip/Menu Positioning
 
 See [floating-ui.md](./.claude/rules/floating-ui.md). Never manually calculate `position: fixed` coordinates — always use `@floating-ui/react` with `FloatingPortal`.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:unit:ui": "vitest --ui",
     "test:unit:coverage": "vitest --coverage",
     "test:provider:integration": "cross-env RUN_AI_PROVIDER_TESTS=true vitest --run",
+    "prepare": "node scripts/install-git-hooks.mjs",
     "hooks:install": "node scripts/install-git-hooks.mjs",
     "extension-sdk:check-public": "bash scripts/extension-sdk-public-checks.sh",
     "analyze": "node scripts/bundle-size.js",

--- a/scripts/agent-test-gate.mjs
+++ b/scripts/agent-test-gate.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Test gate for AI-agent commits. Wired as a Claude Code PreToolUse hook on the
+// git commit-proposal tool (see .claude/settings.json): before an agent commits,
+// run typecheck + the non-provider unit suite. A non-zero exit blocks the commit
+// and feeds the failure back to the agent.
+//
+// To keep docs-only / config-only commits fast, it first checks whether any
+// source or test file actually changed; if not, it exits 0 without running.
+import { execFileSync } from 'node:child_process';
+
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+function changedFiles() {
+  try {
+    const tracked = execFileSync('git', ['diff', '--name-only', 'HEAD'], {
+      encoding: 'utf8',
+    });
+    const untracked = execFileSync('git', ['ls-files', '--others', '--exclude-standard'], {
+      encoding: 'utf8',
+    });
+    return `${tracked}\n${untracked}`
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    // Not a git repo / git unavailable: don't block the agent.
+    return [];
+  }
+}
+
+const CODE = /\.(ts|tsx|js|jsx|mjs|cjs)$/;
+const IGNORE = /(^|\/)(node_modules|dist|out|out2|\.vite|coverage)\//;
+
+const codeChanges = changedFiles().filter((f) => CODE.test(f) && !IGNORE.test(f));
+
+if (codeChanges.length === 0) {
+  // No code touched — nothing to verify.
+  process.exit(0);
+}
+
+console.error(
+  `[test-gate] ${codeChanges.length} code file(s) changed; running typecheck + unit tests before commit...`,
+);
+
+try {
+  execFileSync(npm, ['run', 'typecheck'], { stdio: 'inherit' });
+  execFileSync(npm, ['run', 'test:prepush'], { stdio: 'inherit' });
+} catch {
+  console.error('[test-gate] BLOCKED: typecheck or unit tests failed. Fix them before committing.');
+  process.exit(2);
+}
+
+console.error('[test-gate] typecheck + unit tests passed.');
+process.exit(0);

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -2,6 +2,17 @@ import { chmodSync, existsSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 
+// Installs the repo git hooks by pointing core.hooksPath at .githooks.
+// Runs standalone (`npm run hooks:install`) and automatically via the
+// `prepare` lifecycle on `npm install`. It must NEVER fail the install:
+// in CI checkouts, published tarballs, or any non-git context it warns
+// and exits 0 rather than throwing.
+
+function skip(reason) {
+  console.warn(`[git-hooks] Skipped (${reason}).`);
+  process.exit(0);
+}
+
 function ensureExecutable(dirPath) {
   for (const entry of readdirSync(dirPath)) {
     const fullPath = path.join(dirPath, entry);
@@ -10,25 +21,39 @@ function ensureExecutable(dirPath) {
       ensureExecutable(fullPath);
       continue;
     }
-    chmodSync(fullPath, 0o755);
+    try {
+      chmodSync(fullPath, 0o755);
+    } catch {
+      // chmod may be denied / a no-op on some filesystems (e.g. Windows);
+      // git still honors the hook there, so this is non-fatal.
+    }
   }
 }
 
-const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
-  cwd: process.cwd(),
-  encoding: 'utf8',
-}).trim();
+let repoRoot;
+try {
+  repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  }).trim();
+} catch {
+  skip('not a git repository, or git is unavailable');
+}
 
 const hooksDir = path.join(repoRoot, '.githooks');
 if (!existsSync(hooksDir)) {
-  throw new Error(`Hooks directory not found: ${hooksDir}`);
+  skip(`hooks directory not found at ${hooksDir}`);
 }
 
 ensureExecutable(hooksDir);
 
-execFileSync('git', ['config', 'core.hooksPath', '.githooks'], {
-  cwd: repoRoot,
-  stdio: 'inherit',
-});
+try {
+  execFileSync('git', ['config', 'core.hooksPath', '.githooks'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+} catch {
+  skip('could not set core.hooksPath');
+}
 
-console.log(`[git-hooks] Installed repo hooks from ${hooksDir}`);
+console.log('[git-hooks] Installed repo hooks (core.hooksPath -> .githooks).');


### PR DESCRIPTION
## What this adds

Closes the gap where nothing enforced "tests pass before pushing":

- **Pre-push hook auto-installs** — `package.json` gains a `prepare` script so `npm install` wires `core.hooksPath -> .githooks` automatically; `scripts/install-git-hooks.mjs` is made fail-soft so it never breaks `npm install` in CI or non-git contexts.
- **Agent commit gate** — `.claude/settings.json` adds a PreToolUse hook (`scripts/agent-test-gate.mjs`) that runs typecheck + the non-provider unit suite before an AI agent commits, blocking on failure; it skips when only docs/config changed. This one is opinionated and easy to drop if not wanted.
- **Contributor guidance** — `CLAUDE.md` documents a "write + run tests for behavioral changes" rule.

## Not included (repo settings)

Branch protection requiring CI on `main` is a server-side setting, so it is not part of this diff; maintainers can enable it independently.

## Verification

This exact commit was validated on a fork: GitHub Actions CI (Unit Tests + TypeScript Check + Transcript Bundle) all green, and the agent gate was observed blocking a failing commit and passing a clean one.
