### PR TITLE
fix(electron): defer MCP tool schemas in CLI sessions via ENABLE_TOOL_SEARCH

### DIFF
--- a/packages/electron/src/main/services/ai/__tests__/claudeCliSpawnConfig.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliSpawnConfig.test.ts
@@ -106,6 +106,19 @@ describe('buildClaudeCliSpawnConfig', () => {
     expect(cfg.env.PATH).toBe('/opt/bin:/usr/bin');
   });
 
+  it('defaults ENABLE_TOOL_SEARCH to auto:2 so MCP tool schemas are deferred (parity with the Agent SDK path)', () => {
+    const cfg = buildClaudeCliSpawnConfig({ ...base, mcpConfigPath: '/tmp/mcp.json' });
+    expect(cfg.env.ENABLE_TOOL_SEARCH).toBe('auto:2');
+  });
+
+  it('lets the user override ENABLE_TOOL_SEARCH from their own env (default does not clobber it)', () => {
+    const cfg = buildClaudeCliSpawnConfig({
+      ...base,
+      baseEnv: { ENABLE_TOOL_SEARCH: 'true' },
+    });
+    expect(cfg.env.ENABLE_TOOL_SEARCH).toBe('true');
+  });
+
   it('merges observation extraEnv (e.g. Phase 3 ANTHROPIC_BASE_URL) but still strips the API key', () => {
     const cfg = buildClaudeCliSpawnConfig({
       ...base,

--- a/packages/electron/src/main/services/ai/claudeCliSpawnConfig.ts
+++ b/packages/electron/src/main/services/ai/claudeCliSpawnConfig.ts
@@ -328,6 +328,18 @@ export function buildClaudeCliSpawnConfig(input: ClaudeCliSpawnInput): ClaudeCli
   merged.TERM = 'xterm-256color';
   merged.COLORTERM = 'truecolor';
   merged.LANG = merged.LANG || 'en_US.UTF-8';
+  // Defer MCP tool descriptions out of the upfront context, matching the Agent
+  // SDK path (sdkOptionsBuilder.ts sets the same `auto:2`). Without this the
+  // genuine CLI loads EVERY enabled server's full tool schema into the system
+  // prompt on turn 1: with Nimbalyst's core MCP servers in the `--mcp-config`
+  // snapshot that is ~30K+ tokens of "MCP tools" baseline (observed via
+  // `/context`) — whereas the SDK session shows the same servers as deferred
+  // (~800 active). `auto:N` defers a server's tools when their descriptions
+  // exceed N% of the context window; `auto:2` is ~20K on 1M / ~4K on 200K.
+  // Set as a default the user can still override via their own shell/`baseEnv`.
+  if (merged.ENABLE_TOOL_SEARCH == null) {
+    merged.ENABLE_TOOL_SEARCH = 'auto:2';
+  }
   if (input.extraEnv) {
     Object.assign(merged, input.extraEnv);
   }


### PR DESCRIPTION
## Summary

- `claude-code-cli` sessions loaded **every** enabled MCP server's full tool schema into the system prompt on turn 1, while `claude-code` (Agent SDK) sessions deferred them.
- Root cause: `sdkOptionsBuilder.ts` sets `ENABLE_TOOL_SEARCH: 'auto:2'`, but `claudeCliSpawnConfig.ts` never set it for the spawned CLI.
- Fix: set the same `ENABLE_TOOL_SEARCH='auto:2'` default when building the CLI env, as a default the user can still override via their own shell/`baseEnv`.

## Why

With Nimbalyst's core MCP servers in the `--strict-mcp-config` snapshot, a fresh CLI session showed **~32K tokens** of `MCP tools` baseline in `/context` — vs the Agent SDK session showing the same servers as **deferred** (`MCP tools: ~800` active, the rest under `MCP tools (deferred)`).

Measured on the same workspace, same enabled servers:

| | `MCP tools` (active) | mode |
|---|---|---|
| Agent SDK (`claude-code`) | ~0.8K (rest deferred) | `ENABLE_TOOL_SEARCH=auto:2` ✅ |
| CLI (`claude-code-cli`) — before | ~32.6K (all upfront) | unset ⚠️ |
| CLI — after this PR | deferred, parity with SDK | `ENABLE_TOOL_SEARCH=auto:2` ✅ |

`auto:N` defers a server's tool descriptions when they exceed N% of the context window (`auto:2` ≈ 20K on 1M / 4K on 200K), matching the rationale already documented in `sdkOptionsBuilder.ts`.

## Implementation notes

- Set in the env-merge block of `buildClaudeCliSpawnConfig`, before the `FORBIDDEN_ENV_KEYS` strip (`ENABLE_TOOL_SEARCH` is not a forbidden key, so it is preserved).
- Guarded with `if (merged.ENABLE_TOOL_SEARCH == null)` so a user-provided value (shell / `baseEnv`) wins — mirrors the `CLAUDE_CODE_ENTRYPOINT` default-with-override pattern in the SDK path.

## Test plan

- [x] `vitest --run claudeCliSpawnConfig` → **47 passed** (added 2: default `auto:2`, and user-override-not-clobbered).
- [x] `vitest --run sdkOptionsBuilder.envKeys` → 4 passed (Agent path unaffected).
- [x] `tsc --noEmit` on `packages/electron` → clean.
- [x] `build:mac:local` produces a working `.app`; `ENABLE_TOOL_SEARCH` present in the packaged `app.asar`.
- [ ] Manual: open a CLI-mode session in the built app, run `/context`, confirm `MCP tools` is deferred (~0.8K active) instead of ~32K.

🤖 Generated with [Claude Code](https://claude.com/claude-code)