### PR TITLE
fix(claude-cli): launch claude.exe/.cmd on Windows instead of the npm shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Windows: Claude Code CLI chat sessions now start instead of failing immediately on launch. (#684)
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliSpawnConfig.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliSpawnConfig.test.ts
@@ -433,3 +433,38 @@ describe('resolveClaudeCliModelArg', () => {
     expect(resolveClaudeCliModelArg('   ')).toBeUndefined();
   });
 });
+
+// #684: node-pty runs a `.cmd`/`.bat` through cmd.exe, which is line-oriented, so
+// a newline inside an arg truncates the command line. Nimbalyst's multi-line
+// `--append-system-prompt` must be single-lined for the `.cmd` launch path.
+describe('buildClaudeCliSpawnConfig Windows .cmd newline handling (#684)', () => {
+  const base = { cwd: 'C:\\work', baseEnv: {} as Record<string, string | undefined> };
+
+  it('collapses newline args on the Windows .cmd path so the multi-line --append-system-prompt survives', () => {
+    const cfg = buildClaudeCliSpawnConfig({
+      ...base,
+      claudeExecutable: 'C:\\Users\\t\\AppData\\Roaming\\npm\\claude.cmd',
+      platform: 'win32',
+    });
+    expect(cfg.args.some((a) => /[\r\n]/.test(a))).toBe(false);
+    const i = cfg.args.indexOf('--append-system-prompt');
+    expect(i).toBeGreaterThan(-1);
+    expect(cfg.args[i + 1]).toContain('Nimbalyst');
+    expect(/[\r\n]/.test(cfg.args[i + 1])).toBe(false);
+  });
+
+  it('also collapses for a .bat executable on win32', () => {
+    const cfg = buildClaudeCliSpawnConfig({ ...base, claudeExecutable: 'C:\\x\\claude.bat', platform: 'win32' });
+    expect(cfg.args.some((a) => /[\r\n]/.test(a))).toBe(false);
+  });
+
+  it('leaves multi-line args intact off the .cmd path (a real .exe, or non-Windows)', () => {
+    const onExe = buildClaudeCliSpawnConfig({ ...base, claudeExecutable: 'C:\\x\\claude.exe', platform: 'win32' });
+    const onDarwin = buildClaudeCliSpawnConfig({ ...base, claudeExecutable: '/usr/local/bin/claude', platform: 'darwin' });
+    for (const cfg of [onExe, onDarwin]) {
+      const i = cfg.args.indexOf('--append-system-prompt');
+      expect(i).toBeGreaterThan(-1);
+      expect(/[\r\n]/.test(cfg.args[i + 1])).toBe(true);
+    }
+  });
+});

--- a/packages/electron/src/main/services/ai/__tests__/claudeExecutableResolver.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeExecutableResolver.test.ts
@@ -73,3 +73,50 @@ describe('isClaudeExecutableInstalled', () => {
     expect(installed([HOMEBREW])).toBe(true);
   });
 });
+
+// #684: on Windows the launchable claude is claude.exe/claude.cmd, not the
+// extensionless Unix sh-shim npm drops alongside them. The old resolver returned
+// the shim, which node-pty cannot spawn (error 193 ERROR_BAD_EXE_FORMAT). Paths
+// are built with the same path.join the resolver uses so the strings match on a
+// Linux CI runner regardless of separator.
+const WIN_HOME = 'C:\\Users\\tester';
+const winMake = (existing: string[], enhancedPath?: string) =>
+  resolveClaudeExecutablePath({
+    homedir: WIN_HOME,
+    pathExists: (p: string) => existing.includes(p),
+    enhancedPath,
+    pathDelimiter: ';',
+    platform: 'win32',
+  });
+
+describe('resolveClaudeExecutablePath on Windows (#684)', () => {
+  const localBinBase = path.join(WIN_HOME, '.claude', 'local', 'node_modules', '.bin', 'claude');
+  const dotLocalBase = path.join(WIN_HOME, '.local', 'bin', 'claude');
+  const npmGlobalCmd = path.join(WIN_HOME, 'AppData', 'Roaming', 'npm', 'claude') + '.cmd';
+
+  it('prefers claude.cmd over the extensionless sh-shim in ~/.claude/local', () => {
+    expect(winMake([localBinBase, localBinBase + '.cmd'])).toBe(localBinBase + '.cmd');
+  });
+
+  it('prefers claude.exe over claude.cmd when both exist', () => {
+    expect(winMake([localBinBase + '.cmd', localBinBase + '.exe'])).toBe(localBinBase + '.exe');
+  });
+
+  it('resolves claude.cmd from ~/.local/bin even when the sh-shim is also present', () => {
+    // The exact #684 repro: where claude lists the shim first, next to claude.cmd.
+    expect(winMake([dotLocalBase, dotLocalBase + '.cmd'])).toBe(dotLocalBase + '.cmd');
+  });
+
+  it('resolves claude.cmd from the Windows npm-global dir (AppData/Roaming/npm)', () => {
+    expect(winMake([npmGlobalCmd])).toBe(npmGlobalCmd);
+  });
+
+  it('resolves claude.exe from a PATH entry', () => {
+    const dir = 'C:\\tools\\bin';
+    expect(winMake([path.join(dir, 'claude') + '.exe'], dir)).toBe(path.join(dir, 'claude') + '.exe');
+  });
+
+  it('still falls back to the bare command when nothing is on disk', () => {
+    expect(winMake([], 'C:\\nowhere;C:\\also-nowhere')).toBe('claude');
+  });
+});

--- a/packages/electron/src/main/services/ai/claudeCliSpawnConfig.ts
+++ b/packages/electron/src/main/services/ai/claudeCliSpawnConfig.ts
@@ -142,6 +142,8 @@ export interface ClaudeCliSpawnInput {
   pluginDirs?: string[];
   /** Extra CLI args appended verbatim (escape hatch for flags we pass through). */
   extraArgs?: string[];
+  /** Platform (process.platform); injectable for cross-platform tests. */
+  platform?: NodeJS.Platform;
 }
 
 export interface ClaudeCliSpawnConfig {
@@ -345,5 +347,17 @@ export function buildClaudeCliSpawnConfig(input: ClaudeCliSpawnInput): ClaudeCli
     }
   }
 
-  return { executable, args, env };
+  // On Windows, node-pty runs a `.cmd`/`.bat` through cmd.exe, which is
+  // line-oriented: a newline inside an argument truncates the command line at
+  // that point, dropping everything after it. Nimbalyst passes a multi-line
+  // `--append-system-prompt`, so collapse CR/LF runs to a single space for the
+  // `.cmd`/`.bat` launch path. The append is plain instructions, so single-lining
+  // is semantically harmless; a real `.exe` or the SDK path is unaffected. (#684)
+  const platform = input.platform ?? process.platform;
+  const launchArgs =
+    platform === 'win32' && /\.(cmd|bat)$/i.test(executable)
+      ? args.map((arg) => arg.replace(/[\r\n]+/g, ' '))
+      : args;
+
+  return { executable, args: launchArgs, env };
 }

--- a/packages/electron/src/main/services/ai/claudeExecutableResolver.ts
+++ b/packages/electron/src/main/services/ai/claudeExecutableResolver.ts
@@ -29,18 +29,35 @@ export interface ResolveClaudeExecutableDeps {
   enhancedPath?: string;
   /** PATH delimiter (path.delimiter); injectable for cross-platform tests. */
   pathDelimiter?: string;
+  /** Platform (process.platform); injectable for cross-platform tests. */
+  platform?: NodeJS.Platform;
 }
 
 export function resolveClaudeExecutablePath(deps: ResolveClaudeExecutableDeps): string {
-  const { homedir, pathExists, enhancedPath, pathDelimiter = path.delimiter } = deps;
+  const { homedir, pathExists, enhancedPath, pathDelimiter = path.delimiter, platform = process.platform } = deps;
+
+  // On Windows the launchable `claude` is `claude.exe` / `claude.cmd`, not the
+  // extensionless Unix sh-shim that npm drops alongside them. node-pty cannot
+  // CreateProcess the sh-shim (it is not a PE binary) and fails with error 193
+  // (ERROR_BAD_EXE_FORMAT), so each candidate must resolve the real Windows
+  // executable. Prefer `.exe`, then `.cmd`, then extensionless. (#684)
+  const extensions = platform === 'win32' ? ['.exe', '.cmd', ''] : [''];
+  const firstExisting = (base: string): string | undefined => {
+    for (const ext of extensions) {
+      const candidate = base + ext;
+      if (pathExists(candidate)) return candidate;
+    }
+    return undefined;
+  };
 
   // 1. Official ~/.claude/local install — the version `claude update` maintains.
-  const localCandidates = [
+  const localBases = [
     path.join(homedir, '.claude', 'local', 'node_modules', '.bin', 'claude'),
     path.join(homedir, '.claude', 'local', 'claude'),
   ];
-  for (const candidate of localCandidates) {
-    if (pathExists(candidate)) return candidate;
+  for (const base of localBases) {
+    const hit = firstExisting(base);
+    if (hit) return hit;
   }
 
   // 2. First `claude` on the login-shell PATH (what the user's terminal runs).
@@ -50,20 +67,22 @@ export function resolveClaudeExecutablePath(deps: ResolveClaudeExecutableDeps): 
       .map((entry) => entry.trim().replace(/^"(.*)"$/, '$1'))
       .filter(Boolean);
     for (const entry of entries) {
-      const candidate = path.join(entry, 'claude');
-      if (pathExists(candidate)) return candidate;
+      const hit = firstExisting(path.join(entry, 'claude'));
+      if (hit) return hit;
     }
   }
 
-  // 3. Legacy hardcoded install locations.
-  const legacyCandidates = [
+  // 3. Legacy hardcoded install locations (incl. the Windows npm-global dir).
+  const legacyBases = [
     path.join(homedir, '.local', 'bin', 'claude'),
     '/opt/homebrew/bin/claude',
     '/usr/local/bin/claude',
     path.join(homedir, '.npm-global', 'bin', 'claude'),
+    path.join(homedir, 'AppData', 'Roaming', 'npm', 'claude'),
   ];
-  for (const candidate of legacyCandidates) {
-    if (pathExists(candidate)) return candidate;
+  for (const base of legacyBases) {
+    const hit = firstExisting(base);
+    if (hit) return hit;
   }
 
   // 4. Bare command — node-pty resolves it against the spawned (enhanced) PATH.


### PR DESCRIPTION
Closes #684.

On Windows, Claude authenticates but every `claude-code-cli` prompt fails at PTY launch with `CreateProcess` error 193 (`ERROR_BAD_EXE_FORMAT`). @karlwirth diagnosed it precisely, including the detection-vs-launch asymmetry. The full fix is two parts (both Windows-only).

**Part 1: resolve the real Windows executable.** `claudeExecutableResolver.ts` only probed an extensionless `claude` at every candidate (`~/.claude/local/...`, each PATH entry, the legacy list). On Windows the npm install drops a Unix sh-shim named `claude` next to `claude.cmd`, so the resolver returned the shim, which node-pty cannot `CreateProcess`. (`CLIManager` detection already probes `claude.exe`/`claude.cmd`, hence the asymmetry: the app shows Claude installed while launch fails.) Fix: on `win32`, probe `.exe`, then `.cmd`, then extensionless at each candidate, and add the Windows npm-global dir. Off-Windows the extension list is `['']`, so resolution is byte-for-byte unchanged.

**Part 2: newline-safe args on the `.cmd` path.** With Part 1 the session launches, but node-pty runs a `.cmd` through cmd.exe, which is line-oriented: a newline inside an argument truncates the command line. Nimbalyst passes a multi-line `--append-system-prompt`, so without this it would arrive truncated at its first line (with a dangling quote). Fix: collapse CR/LF runs to a space in arg values when the resolved executable is a `.cmd`/`.bat` on `win32`. The append is plain instructions, so single-lining is harmless; a real `.exe` or the SDK path is untouched. (A `cmd.exe` wrap does not help here - the truncation is cmd.exe's own line parsing.)

**Verification (real, on Windows):**
- Resolver: new unit tests (prefer `.cmd` over the shim, prefer `.exe` over `.cmd`, the `~/.local/bin` + npm-global cases), red without the fix, green with it.
- Spawn config: new unit tests (newlines collapsed on the `.cmd`/`.bat` path, preserved off it), red without the fix, green with it.
- node-pty on Windows with the real `claude` install: the shim throws 193; `claude.cmd` launches; a multi-line arg truncates through `claude.cmd`; the collapsed arg (plus a trailing `--model`) round-trips intact.
- `packages/electron` typecheck clean.

**Regression risk:** none off-Windows (both changes are gated on `win32` plus, for Part 2, a `.cmd`/`.bat` executable). On Windows it changes which `claude` file launches (shim to `.exe`/`.cmd`) and single-lines the system-prompt nudge on the `.cmd` path - both intended.
