### PR TITLE
fix: prune stale projects from Android index cache on full snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-- Mobile project list no longer holds onto projects that the server has dropped from the sync snapshot.
+- Mobile project list no longer holds onto projects that the server has dropped from the sync snapshot, and no longer wipes itself when a transient decryption failure shrinks the snapshot.
 
 ### Removed
 <!-- Removed features go here -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Mobile project list no longer holds onto projects that the server has dropped from the sync snapshot.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/android/app/src/main/java/com/nimbalyst/app/data/NimbalystRepository.kt
+++ b/packages/android/app/src/main/java/com/nimbalyst/app/data/NimbalystRepository.kt
@@ -42,6 +42,36 @@ class NimbalystRepository(
         }
     }
 
+    suspend fun reconcileIndexSnapshot(
+        projects: List<ProjectEntity>,
+        sessions: List<SessionEntity>,
+        syncedAt: Long
+    ) {
+        database.withTransaction {
+            val projectIds = projects.map { it.id }
+            if (projectIds.isEmpty()) {
+                database.projectDao().deleteAll()
+            } else {
+                database.projectDao().deleteNotIn(projectIds)
+            }
+            if (projects.isNotEmpty()) {
+                database.projectDao().upsertAll(projects)
+            }
+            if (sessions.isNotEmpty()) {
+                database.sessionDao().upsertAll(sessions)
+            }
+            database.projectDao().refreshAllProjectStats()
+            database.syncStateDao().upsert(
+                SyncStateEntity(
+                    roomId = INDEX_SYNC_ROOM_ID,
+                    lastCursor = null,
+                    lastSequence = 0,
+                    lastSyncedAt = syncedAt
+                )
+            )
+        }
+    }
+
     suspend fun upsertSession(session: SessionEntity) {
         database.withTransaction {
             database.sessionDao().upsertAll(listOf(session))

--- a/packages/android/app/src/main/java/com/nimbalyst/app/data/ProjectDao.kt
+++ b/packages/android/app/src/main/java/com/nimbalyst/app/data/ProjectDao.kt
@@ -13,6 +13,12 @@ interface ProjectDao {
     @Query("DELETE FROM projects WHERE id = :projectId")
     suspend fun deleteById(projectId: String)
 
+    @Query("DELETE FROM projects WHERE id NOT IN (:projectIds)")
+    suspend fun deleteNotIn(projectIds: List<String>)
+
+    @Query("DELETE FROM projects")
+    suspend fun deleteAll()
+
     @Query(
         """
         UPDATE projects

--- a/packages/android/app/src/main/java/com/nimbalyst/app/sync/SyncManager.kt
+++ b/packages/android/app/src/main/java/com/nimbalyst/app/sync/SyncManager.kt
@@ -680,7 +680,7 @@ class SyncManager(
         val projects = response.projects.mapNotNull(::processProjectEntry)
         val sessions = response.sessions.mapNotNull { processSessionEntry(it) }
         val syncedAt = System.currentTimeMillis()
-        repository.replaceIndexSnapshot(
+        repository.reconcileIndexSnapshot(
             projects = projects,
             sessions = sessions.map { it.session },
             syncedAt = syncedAt

--- a/packages/android/app/src/main/java/com/nimbalyst/app/sync/SyncManager.kt
+++ b/packages/android/app/src/main/java/com/nimbalyst/app/sync/SyncManager.kt
@@ -16,6 +16,7 @@ import com.nimbalyst.app.pairing.PairingCredentials
 import com.nimbalyst.app.pairing.PairingStore
 import android.content.Context
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
@@ -42,6 +43,52 @@ class SyncManager(
 
     companion object {
         private const val TAG = "SyncManager"
+
+        /**
+         * Applies an index snapshot to [repository], choosing between the
+         * pruning path ([NimbalystRepository.reconcileIndexSnapshot]) and the
+         * safe upsert-only path ([NimbalystRepository.replaceIndexSnapshot]).
+         *
+         * The gate: if [projects].size < [rawProjectCount], one or more entries
+         * failed to decrypt. Pruning in that case would silently wipe
+         * stale-but-valid cache entries. We fall back to upsert-only so those
+         * entries survive until the next clean snapshot arrives.
+         *
+         * Exposed as an [internal] companion function so that unit tests can
+         * drive the routing logic and verify real repository effects without
+         * constructing a [SyncManager] instance (which requires
+         * [com.nimbalyst.app.pairing.PairingStore] ->
+         * [androidx.security.crypto.EncryptedSharedPreferences] ->
+         * Android KeyStore, unavailable in Robolectric unit tests).
+         */
+        @VisibleForTesting
+        internal suspend fun applyIndexSnapshot(
+            repository: NimbalystRepository,
+            projects: List<ProjectEntity>,
+            sessions: List<SessionEntity>,
+            rawProjectCount: Int,
+            syncedAt: Long
+        ) {
+            val canPrune = projects.size == rawProjectCount
+            if (canPrune) {
+                repository.reconcileIndexSnapshot(
+                    projects = projects,
+                    sessions = sessions,
+                    syncedAt = syncedAt
+                )
+            } else {
+                Log.w(
+                    TAG,
+                    "[handleIndexSyncResponse] decrypted ${projects.size}/$rawProjectCount project entries;" +
+                        " skipping prune to avoid wiping stale-but-valid cache entries"
+                )
+                repository.replaceIndexSnapshot(
+                    projects = projects,
+                    sessions = sessions,
+                    syncedAt = syncedAt
+                )
+            }
+        }
     }
     private val indexClient = WebSocketClient(scope)
     private val sessionClient = WebSocketClient(scope)
@@ -677,12 +724,15 @@ class SyncManager(
 
     private suspend fun handleIndexSyncResponse(message: String) {
         val response = parse<IndexSyncResponse>(message) ?: return
+        val rawProjectCount = response.projects.size
         val projects = response.projects.mapNotNull(::processProjectEntry)
         val sessions = response.sessions.mapNotNull { processSessionEntry(it) }
         val syncedAt = System.currentTimeMillis()
-        repository.reconcileIndexSnapshot(
+        applyIndexSnapshot(
+            repository = repository,
             projects = projects,
             sessions = sessions.map { it.session },
+            rawProjectCount = rawProjectCount,
             syncedAt = syncedAt
         )
         sessions.forEach { syncQueuedPrompts(it) }

--- a/packages/android/app/src/test/java/com/nimbalyst/app/data/NimbalystDaoTest.kt
+++ b/packages/android/app/src/test/java/com/nimbalyst/app/data/NimbalystDaoTest.kt
@@ -196,6 +196,84 @@ class NimbalystDaoTest {
         assertEquals(2, byId["/p/b"]!!.sessionCount)
     }
 
+    @Test
+    fun `deleteNotIn removes only projects whose id is absent from the list`() = runTest {
+        projectDao.upsertAll(
+            listOf(project(id = "/p/a"), project(id = "/p/b"), project(id = "/p/c"))
+        )
+
+        projectDao.deleteNotIn(listOf("/p/a", "/p/b"))
+
+        val remaining = projectDao.observeAll().first().map { it.id }.toSet()
+        assertEquals(setOf("/p/a", "/p/b"), remaining)
+    }
+
+    @Test
+    fun `deleteAll clears every project`() = runTest {
+        projectDao.upsertAll(listOf(project(id = "/p/a"), project(id = "/p/b")))
+
+        projectDao.deleteAll()
+
+        assertTrue(projectDao.observeAll().first().isEmpty())
+    }
+
+    // ---------------------------------------------------------------------
+    // NimbalystRepository.reconcileIndexSnapshot
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `reconcileIndexSnapshot prunes projects missing from the incoming list`() = runTest {
+        val repo = NimbalystRepository(db)
+        projectDao.upsertAll(
+            listOf(project(id = "/p/a"), project(id = "/p/b"), project(id = "/p/c"))
+        )
+
+        repo.reconcileIndexSnapshot(
+            projects = listOf(project(id = "/p/a"), project(id = "/p/b")),
+            sessions = emptyList(),
+            syncedAt = 1_700_000_500_000L
+        )
+
+        val remaining = projectDao.observeAll().first().map { it.id }.toSet()
+        assertEquals(setOf("/p/a", "/p/b"), remaining)
+    }
+
+    @Test
+    fun `reconcileIndexSnapshot with empty project list clears the table`() = runTest {
+        val repo = NimbalystRepository(db)
+        projectDao.upsertAll(listOf(project(id = "/p/a"), project(id = "/p/b")))
+
+        repo.reconcileIndexSnapshot(
+            projects = emptyList(),
+            sessions = emptyList(),
+            syncedAt = 1_700_000_500_000L
+        )
+
+        assertTrue(projectDao.observeAll().first().isEmpty())
+    }
+
+    @Test
+    fun `reconcileIndexSnapshot upserts new entries and records the sync watermark`() = runTest {
+        val repo = NimbalystRepository(db)
+        projectDao.upsertAll(listOf(project(id = "/p/a", name = "Old A")))
+
+        repo.reconcileIndexSnapshot(
+            projects = listOf(
+                project(id = "/p/a", name = "New A"),
+                project(id = "/p/d", name = "Delta")
+            ),
+            sessions = emptyList(),
+            syncedAt = 1_700_000_500_000L
+        )
+
+        val byId = projectDao.observeAll().first().associateBy { it.id }
+        assertEquals(setOf("/p/a", "/p/d"), byId.keys)
+        assertEquals("New A", byId["/p/a"]!!.name)
+
+        val state = syncStateDao.getByRoomId(NimbalystRepository.INDEX_SYNC_ROOM_ID)!!
+        assertEquals(1_700_000_500_000L, state.lastSyncedAt)
+    }
+
     // ---------------------------------------------------------------------
     // SessionDao
     // ---------------------------------------------------------------------

--- a/packages/android/app/src/test/java/com/nimbalyst/app/sync/HandleIndexSyncResponseTest.kt
+++ b/packages/android/app/src/test/java/com/nimbalyst/app/sync/HandleIndexSyncResponseTest.kt
@@ -1,0 +1,185 @@
+package com.nimbalyst.app.sync
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.nimbalyst.app.data.NimbalystDatabase
+import com.nimbalyst.app.data.NimbalystRepository
+import com.nimbalyst.app.data.ProjectEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for the canPrune gate in [SyncManager.applyIndexSnapshot].
+ *
+ * Strategy: Approach B — the gate logic is extracted into the internal companion
+ * seam [SyncManager.applyIndexSnapshot]. Tests call it directly with a real
+ * [NimbalystRepository] backed by an in-memory Room database. No SyncManager
+ * instance is constructed, which sidesteps the [PairingStore] ->
+ * [EncryptedSharedPreferences] -> Android KeyStore dependency that is
+ * unavailable in Robolectric unit tests.
+ *
+ * The four scenarios from the PR review spec:
+ *   raw=3, decoded=0  -> replace path: stale entries survive, no prune
+ *   raw=3, decoded=2  -> replace path: stale entries survive, no prune
+ *   raw=3, decoded=3  -> reconcile path: stale entry pruned, decoded entries present
+ *   raw=0, decoded=0  -> reconcile with empty list: cache is cleared (server is genuinely empty)
+ *
+ * The discriminator: seed a "stale" project whose id is NOT in the decoded
+ * list. After applyIndexSnapshot, assert its survival (replace path) or
+ * pruning (reconcile path).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class HandleIndexSyncResponseTest {
+
+    private lateinit var db: NimbalystDatabase
+    private lateinit var repository: NimbalystRepository
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        db = Room.inMemoryDatabaseBuilder(context, NimbalystDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = NimbalystRepository(db)
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    private fun project(id: String, name: String = "Project $id") = ProjectEntity(
+        id = id,
+        name = name,
+        sessionCount = 0,
+        lastUpdatedAt = 1_700_000_000_000L,
+        sortOrder = 0
+    )
+
+    private val syncedAt = 1_700_000_000_000L
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * raw=3, decoded=0: all entries failed to decrypt.
+     * Expect replace path: stale project in cache must survive.
+     */
+    @Test
+    fun `raw=3 decoded=0 uses replace path and stale project survives`() = runTest {
+        repository.replaceIndexSnapshot(
+            projects = listOf(project("stale")),
+            sessions = emptyList(),
+            syncedAt = syncedAt - 1
+        )
+
+        SyncManager.applyIndexSnapshot(
+            repository = repository,
+            projects = emptyList(),
+            sessions = emptyList(),
+            rawProjectCount = 3,
+            syncedAt = syncedAt
+        )
+
+        val projects = repository.observeProjects().first()
+        assertEquals(
+            "stale project must survive when all entries fail to decrypt",
+            listOf("stale"),
+            projects.map { it.id }
+        )
+    }
+
+    /**
+     * raw=3, decoded=2: partial decrypt failure.
+     * Expect replace path: stale project must survive, decoded entries upserted.
+     */
+    @Test
+    fun `raw=3 decoded=2 uses replace path and stale project survives`() = runTest {
+        repository.replaceIndexSnapshot(
+            projects = listOf(project("stale")),
+            sessions = emptyList(),
+            syncedAt = syncedAt - 1
+        )
+
+        val decoded = listOf(project("p1"), project("p2"))
+        SyncManager.applyIndexSnapshot(
+            repository = repository,
+            projects = decoded,
+            sessions = emptyList(),
+            rawProjectCount = 3,
+            syncedAt = syncedAt
+        )
+
+        val ids = repository.observeProjects().first().map { it.id }.toSet()
+        assertTrue("stale project must survive after partial decrypt failure", "stale" in ids)
+        assertTrue("decoded p1 must be upserted", "p1" in ids)
+        assertTrue("decoded p2 must be upserted", "p2" in ids)
+    }
+
+    /**
+     * raw=3, decoded=3: all entries decrypted successfully.
+     * Expect reconcile path: stale project is pruned, exactly the 3 decoded entries remain.
+     */
+    @Test
+    fun `raw=3 decoded=3 uses reconcile path and stale project is pruned`() = runTest {
+        repository.replaceIndexSnapshot(
+            projects = listOf(project("stale")),
+            sessions = emptyList(),
+            syncedAt = syncedAt - 1
+        )
+
+        val decoded = listOf(project("p1"), project("p2"), project("p3"))
+        SyncManager.applyIndexSnapshot(
+            repository = repository,
+            projects = decoded,
+            sessions = emptyList(),
+            rawProjectCount = 3,
+            syncedAt = syncedAt
+        )
+
+        val ids = repository.observeProjects().first().map { it.id }.toSet()
+        assertEquals("exactly 3 entries must remain after reconcile", setOf("p1", "p2", "p3"), ids)
+        assertTrue("stale project must be pruned by reconcile", "stale" !in ids)
+    }
+
+    /**
+     * raw=0, decoded=0: server sent an empty list (user has no projects).
+     * Expect reconcile path with deleteAll: cache is cleared.
+     */
+    @Test
+    fun `raw=0 decoded=0 uses reconcile path and clears the cache`() = runTest {
+        repository.replaceIndexSnapshot(
+            projects = listOf(project("existing")),
+            sessions = emptyList(),
+            syncedAt = syncedAt - 1
+        )
+
+        SyncManager.applyIndexSnapshot(
+            repository = repository,
+            projects = emptyList(),
+            sessions = emptyList(),
+            rawProjectCount = 0,
+            syncedAt = syncedAt
+        )
+
+        val projects = repository.observeProjects().first()
+        assertTrue(
+            "cache must be empty when server sends an empty project list",
+            projects.isEmpty()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Android's `replaceIndexSnapshot` was upsert-only, so projects the server stopped reporting stayed in the mobile project list forever.
- Adds a snapshot-reconcile path that prunes projects missing from the incoming list. Scoped to the full-snapshot handler so single-project broadcasts still work.

## Notes
- This fixes the Android-side accumulation. A user can still see stale entries today if the **server** keeps emitting them (the personal index room aggregates from session metadata and retains entries after a project is disabled on desktop). That gap lives in the sibling `nimbalyst-collab` repo and is filed separately.
- Once the server eventually drops a project (either by future server fix or current TTL), Android will now correctly prune it instead of holding on indefinitely.

## Test plan
- [x] Added Robolectric tests for `deleteNotIn`, `deleteAll`, and three `reconcileIndexSnapshot` scenarios (prune, empty list, upsert+watermark).
- [x] `./gradlew :app:testDebugUnitTest` passes locally on JDK 17.
- [x] Built debug APK and installed on a physical tablet; reconcile path runs on the next `indexSyncRequest` after WebSocket connect.
- [ ] Reviewer: confirm the single-project `handleProjectBroadcast` path is still on `replaceIndexSnapshot` (not the new reconcile) so it doesn't wipe siblings.