### PR TITLE
build(android): disable Room schema export to fix CI Empty schema file race

### DIFF
--- a/packages/android/app/src/main/java/com/nimbalyst/app/data/NimbalystDatabase.kt
+++ b/packages/android/app/src/main/java/com/nimbalyst/app/data/NimbalystDatabase.kt
@@ -17,7 +17,13 @@ import org.json.JSONObject
         SyncStateEntity::class,
     ],
     version = 1,
-    exportSchema = true
+    // packages/android/app/schemas/ is gitignored, so the exported schema is
+    // never committed and not used for migration validation. Leaving export on
+    // can trip an intermittent CI race in Room KSP between the Debug and
+    // Release variants writing to the shared schema directory ("Empty schema
+    // file" from SchemaBundle.deserialize during exportSchema). Turn it off
+    // until/unless we introduce real migration testing.
+    exportSchema = false
 )
 abstract class NimbalystDatabase : RoomDatabase() {
     abstract fun projectDao(): ProjectDao


### PR DESCRIPTION
## Summary
CI's Android Build job runs `./gradlew :app:testDebugUnitTest :app:assembleRelease`, which executes both `kspDebugKotlin` and `kspReleaseKotlin`. Both exporters write to the same `room.schemaLocation` directory (`app/schemas/`). When their writes interleave, one can truncate the schema file to 0 bytes while the other is mid-read inside `androidx.room.vo.Database.exportSchema`, producing:

```
e: [ksp] java.lang.IllegalStateException: Empty schema file
  at androidx.room.migration.bundle.SchemaBundle$Companion.deserialize(SchemaBundle.kt:69)
  at androidx.room.vo.Database.exportSchema(Database.kt:110)
```

The interleaving is environment-dependent. It deterministically tripped PR #701's Android Build (3/3 fails over multiple retriggers) and never tripped PRs #698 / #700 / #702 over similar retriggers — and never reproduces on a typical dev machine (10/10 cold builds locally with `--no-daemon --no-build-cache --max-workers=4`). The asymmetry is timing — what's deterministic is "this combination of CI scheduler + this branch's compile-time shape sometimes hits the window."

## Confirmation experiment
On PR #701 with this exact change applied as a probe commit on top: Android Build went green (`28307263914`). Reverting the probe: failed again. One-bit-different repro, one CI run.

## Why this is safe here
`packages/android/app/schemas/` is gitignored (`.gitignore:203`). The exported schema is never committed and is not used for migration validation — turning the export off has no behavioral impact on the app, debug builds, release builds, or unit tests.

If migration testing is introduced later (committed schemas + `MigrationTestHelper` exercise), the right path is to re-enable export and add the Room Gradle plugin's variant-aware `room { schemaDirectory(...) }` configuration (which writes per-variant directories to eliminate the collision). That's deferred — it's out of scope until there are actual migrations.

## Scope
- Single-line change on `NimbalystDatabase.kt`. Comment in the file explains the why.
- No CHANGELOG entry — internal build hygiene, no user-visible change.
- No tests added or modified.

## Test plan
- [x] Confirmed locally that `./gradlew :app:testDebugUnitTest :app:assembleRelease` still passes with this change.
- [x] Confirmed via probe commit on PR #701 that CI's Android Build now passes.
- [ ] Reviewer: confirm acceptance of `exportSchema = false` given the gitignored schema dir, or request the Room Gradle plugin variant-aware setup instead.