### PR TITLE
fix: add Dart syntax highlighting in Monaco editor

### DIFF
--- a/packages/electron/src/renderer/utils/fileTypeDetector.ts
+++ b/packages/electron/src/renderer/utils/fileTypeDetector.ts
@@ -127,6 +127,7 @@ export function getMonacoLanguage(filePath: string): string {
     '.kt': 'kotlin',
     '.swift': 'swift',
     '.cs': 'csharp',
+    '.dart': 'dart',
 
     // Scripting
     '.rb': 'ruby',


### PR DESCRIPTION
## Problem

Opening a `.dart` file in the code (Monaco) editor shows no syntax highlighting — the file renders as plain text.

## Cause

`getMonacoLanguage()` in `packages/electron/src/renderer/utils/fileTypeDetector.ts` maps file extensions to Monaco language IDs, but has no entry for `.dart`. So `.dart` falls through to the `|| 'plaintext'` default and loses highlighting — even though Monaco ships a Dart grammar out of the box.

Other compiled languages in the same block (`.go`, `.kt`, `.swift`, `.cs`, `.rs`) are mapped; Dart was simply missing.

## Fix

Add a single mapping next to the other compiled languages:

```ts
'.cs': 'csharp',
'.dart': 'dart',
```

## Test

Open any `.dart` file in the editor — it now highlights as Dart.
