### PR TITLE
fix: inherit agent permissions for nested worktrees and subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Git worktrees with branch-style names (e.g. `feature/x`) and project subfolders now inherit the parent project's agent permissions instead of re-prompting for every tool call.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/services/PermissionService.ts
+++ b/packages/electron/src/main/services/PermissionService.ts
@@ -17,7 +17,7 @@ import {
 import { logger } from '../utils/logger';
 import { getDatabase } from '../database/initialize';
 import { createWorktreeStore } from './WorktreeStore';
-import { resolveProjectPath, isWorktreePath } from '../utils/workspaceDetection';
+import { resolveProjectPath, isWorktreePath, findNearestAncestor } from '../utils/workspaceDetection';
 
 type PermissionMode = 'ask' | 'allow-all' | 'bypass-all';
 
@@ -32,27 +32,54 @@ type PermissionMode = 'ask' | 'allow-all' | 'bypass-all';
  * @returns The parent project path for worktrees, or the original path for regular workspaces
  */
 export async function resolveWorkspacePathForPermissions(workspacePath: string): Promise<string> {
-  // Fast path: if the path doesn't match worktree naming pattern, skip database lookup
-  if (!isWorktreePath(workspacePath)) {
-    return workspacePath;
+  // Step 1: map a worktree (incl. nested/branch-style names) to its parent
+  // project. Prefer the authoritative DB mapping; fall back to the path pattern.
+  let resolved = workspacePath;
+  if (isWorktreePath(workspacePath)) {
+    const db = getDatabase();
+    if (!db) {
+      throw new Error('Database not initialized - cannot resolve worktree path for permissions');
+    }
+
+    const worktreeStore = createWorktreeStore(db);
+    const worktree = await worktreeStore.getByPath(workspacePath);
+
+    if (worktree) {
+      const workspaceName = path.basename(workspacePath) || workspacePath;
+      logger.main.info(`[PermissionService:${workspaceName}] Resolved worktree to parent project: ${worktree.projectPath}`);
+      resolved = worktree.projectPath;
+    } else {
+      // Path looks like a worktree but not in database - pattern-based fallback.
+      resolved = resolveProjectPath(workspacePath);
+    }
   }
 
-  const db = getDatabase();
-  if (!db) {
-    throw new Error('Database not initialized - cannot resolve worktree path for permissions');
-  }
+  // Step 2: subfolder cascade - inherit settings from the nearest ancestor that
+  // has an explicit permission mode (the project the user trusted), matching the
+  // sync read-path resolution. No trusted ancestor -> use the resolved path.
+  return findNearestAncestor(resolved, (dir) => getAgentPermissions(dir)?.permissionMode != null) ?? resolved;
+}
 
-  const worktreeStore = createWorktreeStore(db);
-  const worktree = await worktreeStore.getByPath(workspacePath);
-
-  if (worktree) {
-    const workspaceName = path.basename(workspacePath) || workspacePath;
-    logger.main.info(`[PermissionService:${workspaceName}] Resolved worktree to parent project: ${worktree.projectPath}`);
-    return worktree.projectPath;
-  }
-
-  // Path looks like a worktree but not in database - use pattern-based resolution as fallback
-  return resolveProjectPath(workspacePath);
+/**
+ * Resolve the path whose stored permissions apply when READING permission state.
+ *
+ * 1. Map a worktree (including nested/branch-style names) to its parent project.
+ * 2. Walk up to the nearest ancestor that has an explicit permission mode, so a
+ *    subfolder inherits the project's trust the same way a worktree does.
+ *
+ * Falls back to the worktree-resolved path when no trusted ancestor exists
+ * (preserving today's "untrusted -> prompt" behavior for brand-new projects).
+ *
+ * Writes deliberately do NOT use this (they stay on resolveProjectPath) so a
+ * mode set on a subfolder never silently overwrites an ancestor's mode.
+ */
+function resolvePermissionReadPath(workspacePath: string): string {
+  const projectPath = resolveProjectPath(workspacePath);
+  const trustedAncestor = findNearestAncestor(
+    projectPath,
+    (dir) => getAgentPermissions(dir)?.permissionMode != null,
+  );
+  return trustedAncestor ?? projectPath;
 }
 
 /**
@@ -118,8 +145,8 @@ export class PermissionService {
    * Check if a workspace is trusted
    */
   public isWorkspaceTrusted(workspacePath: string): boolean {
-    // Resolve worktree paths to parent project so trust is shared
-    const projectPath = resolveProjectPath(workspacePath);
+    // Resolve worktrees + subfolders to the project whose trust applies
+    const projectPath = resolvePermissionReadPath(workspacePath);
     const stored = getAgentPermissions(projectPath);
     return stored?.permissionMode !== null && stored?.permissionMode !== undefined;
   }
@@ -135,8 +162,8 @@ export class PermissionService {
       return testMode;
     }
 
-    // Resolve worktree paths to parent project so trust is shared
-    const projectPath = resolveProjectPath(workspacePath);
+    // Resolve worktrees + subfolders to the project whose trust applies
+    const projectPath = resolvePermissionReadPath(workspacePath);
     const stored = getAgentPermissions(projectPath);
     return stored?.permissionMode ?? null;
   }
@@ -160,7 +187,7 @@ export class PermissionService {
    * (issue #628). Off by default — "Allow All" is literal allow-all.
    */
   public getAllowAllUsesClassifier(workspacePath: string): boolean {
-    const projectPath = resolveProjectPath(workspacePath);
+    const projectPath = resolvePermissionReadPath(workspacePath);
     const stored = getAgentPermissions(projectPath);
     return stored?.allowAllUsesClassifier === true;
   }

--- a/packages/electron/src/main/utils/__tests__/workspaceDetection.test.ts
+++ b/packages/electron/src/main/utils/__tests__/workspaceDetection.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import {
   resolveProjectPath,
   isWorktreePath,
+  findNearestAncestor,
   getAdditionalDirectoriesForWorkspace,
 } from '../workspaceDetection';
 
@@ -22,6 +23,37 @@ describe('resolveProjectPath', () => {
       .toBe('/Users/dev/my-app');
     expect(resolveProjectPath('/home/user/code/myrepo_worktrees/test-123'))
       .toBe('/home/user/code/myrepo');
+  });
+
+  it('resolves NESTED worktree paths (branch-style names) to parent project', () => {
+    // Regression for re-prompting in worktrees whose branch name contains a
+    // slash (e.g. `feature/foo`), which create nested directories.
+    expect(resolveProjectPath('/path/to/project_worktrees/feature/my-branch'))
+      .toBe('/path/to/project');
+    expect(resolveProjectPath('/Users/dev/Belegify_worktrees/feature/assign-people-on-receipts'))
+      .toBe('/Users/dev/Belegify');
+    expect(resolveProjectPath('/Users/dev/nimbalyst_worktrees/improvement/fix-askme-for-worktrees'))
+      .toBe('/Users/dev/nimbalyst');
+  });
+
+  it('resolves a subfolder inside a nested worktree to the parent project', () => {
+    expect(resolveProjectPath('/path/to/project_worktrees/feature/my-branch/packages/electron'))
+      .toBe('/path/to/project');
+  });
+
+  it('resolves nested worktrees with underscore project names', () => {
+    expect(resolveProjectPath('/path/to/my_cool_project_worktrees/feature/x'))
+      .toBe('/path/to/my_cool_project');
+  });
+
+  it('handles trailing slashes on nested worktree paths', () => {
+    expect(resolveProjectPath('/path/to/project_worktrees/feature/my-branch/'))
+      .toBe('/path/to/project');
+  });
+
+  it('does not resolve a plain subfolder of a non-worktree project (the permission cascade handles that)', () => {
+    expect(resolveProjectPath('/path/to/project/packages/electron'))
+      .toBe('/path/to/project/packages/electron');
   });
 
   it('handles trailing slashes on worktree paths', () => {
@@ -67,6 +99,16 @@ describe('isWorktreePath', () => {
     expect(isWorktreePath('/path/to/project_worktrees/swift-falcon')).toBe(true);
     expect(isWorktreePath('/Users/dev/my-app_worktrees/brave-eagle')).toBe(true);
     expect(isWorktreePath('/home/user/code/myrepo_worktrees/test-123')).toBe(true);
+  });
+
+  it('returns true for NESTED worktree paths (branch-style names)', () => {
+    expect(isWorktreePath('/path/to/project_worktrees/feature/my-branch')).toBe(true);
+    expect(isWorktreePath('/Users/dev/Belegify_worktrees/feature/assign-people')).toBe(true);
+    expect(isWorktreePath('/path/to/project_worktrees/feature/my-branch/packages/electron')).toBe(true);
+  });
+
+  it('does not match the _worktrees_backup decoy with nested children', () => {
+    expect(isWorktreePath('/path/to/project_worktrees_backup/feature/x')).toBe(false);
   });
 
   it('handles trailing slashes', () => {
@@ -138,5 +180,34 @@ describe('getAdditionalDirectoriesForWorkspace', () => {
   it('survives a missing _worktrees directory', () => {
     // No worktrees dir created. Should not throw, just return empty.
     expect(getAdditionalDirectoriesForWorkspace(projectPath)).toEqual([]);
+  });
+});
+
+describe('findNearestAncestor', () => {
+  const trusted = new Set(['/path/to/project']);
+  const pred = (dir: string) => trusted.has(dir);
+
+  it('returns the start path itself when it matches', () => {
+    expect(findNearestAncestor('/path/to/project', pred)).toBe('/path/to/project');
+  });
+
+  it('walks up to the nearest matching ancestor (subfolder cascade)', () => {
+    expect(findNearestAncestor('/path/to/project/packages/electron', pred))
+      .toBe('/path/to/project');
+    expect(findNearestAncestor('/path/to/project/src', pred)).toBe('/path/to/project');
+  });
+
+  it('returns null when no ancestor matches', () => {
+    expect(findNearestAncestor('/some/other/place', pred)).toBe(null);
+  });
+
+  it('returns the most specific matching ancestor when several match', () => {
+    const t2 = new Set(['/a', '/a/b/c']);
+    expect(findNearestAncestor('/a/b/c/d', (d) => t2.has(d))).toBe('/a/b/c');
+  });
+
+  it('handles empty input and trailing slashes', () => {
+    expect(findNearestAncestor('', pred)).toBe(null);
+    expect(findNearestAncestor('/path/to/project/packages/', pred)).toBe('/path/to/project');
   });
 });

--- a/packages/electron/src/main/utils/workspaceDetection.ts
+++ b/packages/electron/src/main/utils/workspaceDetection.ts
@@ -67,7 +67,8 @@ export function getRelativeWorkspacePath(filePath: string, workspacePath: string
 
 /**
  * Resolve a workspace path to its parent project path.
- * If the path is a worktree (matches {project}_worktrees/{name}/ pattern),
+ * If the path is a worktree (matches {project}_worktrees/<name> pattern, where
+ * <name> may be nested for branch-style worktree names like `feature/foo`),
  * returns the parent project path. Otherwise returns the original path.
  *
  * This is used by the permission system to ensure worktrees inherit
@@ -84,10 +85,13 @@ export function resolveProjectPath(workspacePath: string): string {
   // Normalize the path to remove trailing slashes for consistent matching
   const normalizedPath = normalizeWorkspacePath(workspacePath);
 
-  // Match pattern: /{project}_worktrees/{name}
-  // This matches our worktree creation pattern in GitWorktreeService
-  // Use [\\/] to match both forward and backslash (Windows and Unix)
-  const match = normalizedPath.match(/^(.+)_worktrees[\\/][^\\/]+$/);
+  // Match pattern: /{project}_worktrees/{...name}
+  // The trailing segment may itself contain slashes: branch-style worktree
+  // names like `feature/foo` create nested directories
+  // (`{project}_worktrees/feature/foo`). Match the whole remainder, not a
+  // single segment, so those resolve to the project too. The greedy (.+)
+  // anchors on the last `_worktrees/`. Use [\\/] for forward+backslash.
+  const match = normalizedPath.match(/^(.+)_worktrees[\\/].+$/);
   return match ? match[1] : normalizedPath;
 }
 
@@ -103,8 +107,42 @@ export function isWorktreePath(workspacePath: string): boolean {
   }
 
   const normalizedPath = normalizeWorkspacePath(workspacePath);
-  // Use [\\/] to match both forward and backslash (Windows and Unix)
-  return /_worktrees[\\/][^\\/]+$/.test(normalizedPath);
+  // Use [\\/] to match both forward and backslash (Windows and Unix).
+  // `.+$` (not `[^\\/]+$`) so nested/branch-style worktree names match too.
+  return /_worktrees[\\/].+$/.test(normalizedPath);
+}
+
+/**
+ * Walk up the directory tree from `startPath` (inclusive) and return the first
+ * ancestor for which `predicate` is true, or null if none match up to the
+ * filesystem root.
+ *
+ * Used by the permission layer so a subfolder inherits the agent permissions of
+ * the nearest ancestor directory that has them explicitly set (the project the
+ * user trusted). Pure and synchronous — the caller supplies the lookup.
+ */
+export function findNearestAncestor(
+  startPath: string,
+  predicate: (dir: string) => boolean,
+): string | null {
+  if (!startPath) {
+    return null;
+  }
+
+  let current = normalizeWorkspacePath(startPath);
+  const root = path.parse(current).root;
+
+  // Bounded by the filesystem root; dirname() converges to the root.
+  while (true) {
+    if (predicate(current)) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current || current === root) {
+      return null;
+    }
+    current = parent;
+  }
 }
 
 /**

--- a/packages/electron/src/shared/__tests__/pathUtils.test.ts
+++ b/packages/electron/src/shared/__tests__/pathUtils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { getRelativeWorkspacePath, isPathInWorkspace } from '../pathUtils';
+import {
+  getRelativeWorkspacePath,
+  isPathInWorkspace,
+  isWorktreePath,
+  resolveProjectPath,
+} from '../pathUtils';
 
 describe('pathUtils workspace boundaries', () => {
   it('treats files inside the workspace as in-bounds', () => {
@@ -18,5 +23,51 @@ describe('pathUtils workspace boundaries', () => {
 
     expect(isPathInWorkspace(memoryPath, workspacePath)).toBe(false);
     expect(getRelativeWorkspacePath(memoryPath, workspacePath)).toBeNull();
+  });
+});
+
+// Mirrors the worktree-resolution cases in
+// main/utils/__tests__/workspaceDetection.test.ts so the renderer-side copy of
+// these functions (forward-slash variant) can't silently regress.
+describe('pathUtils.resolveProjectPath', () => {
+  it('returns the same path for regular workspaces', () => {
+    expect(resolveProjectPath('/path/to/project')).toBe('/path/to/project');
+  });
+
+  it('resolves single-segment worktree paths to parent project', () => {
+    expect(resolveProjectPath('/path/to/project_worktrees/swift-falcon'))
+      .toBe('/path/to/project');
+  });
+
+  it('resolves NESTED worktree paths (branch-style names) to parent project', () => {
+    expect(resolveProjectPath('/path/to/project_worktrees/feature/my-branch'))
+      .toBe('/path/to/project');
+    expect(resolveProjectPath('/Users/dev/nimbalyst_worktrees/improvement/fix-askme-for-worktrees'))
+      .toBe('/Users/dev/nimbalyst');
+  });
+
+  it('resolves a subfolder inside a nested worktree to the parent project', () => {
+    expect(resolveProjectPath('/path/to/project_worktrees/feature/my-branch/packages/electron'))
+      .toBe('/path/to/project');
+  });
+
+  it('does not match the _worktrees_backup decoy', () => {
+    expect(resolveProjectPath('/path/to/project_worktrees_backup/folder'))
+      .toBe('/path/to/project_worktrees_backup/folder');
+  });
+});
+
+describe('pathUtils.isWorktreePath', () => {
+  it('returns false for regular workspaces', () => {
+    expect(isWorktreePath('/path/to/project')).toBe(false);
+  });
+
+  it('returns true for single-segment and nested worktree paths', () => {
+    expect(isWorktreePath('/path/to/project_worktrees/swift-falcon')).toBe(true);
+    expect(isWorktreePath('/path/to/project_worktrees/feature/my-branch')).toBe(true);
+  });
+
+  it('does not match the _worktrees_backup decoy', () => {
+    expect(isWorktreePath('/path/to/project_worktrees_backup/folder')).toBe(false);
   });
 });

--- a/packages/electron/src/shared/pathUtils.ts
+++ b/packages/electron/src/shared/pathUtils.ts
@@ -78,7 +78,8 @@ export function getRelativeWorkspacePath(filePath: string, workspacePath: string
 
 /**
  * Check if a path is a worktree path.
- * Matches the pattern: {project}_worktrees/{name}
+ * Matches the pattern: {project}_worktrees/{...name}
+ * The trailing name may be nested (branch-style names like `feature/foo`).
  *
  * Mirrors workspaceDetection.ts isWorktreePath() but uses forward slashes.
  */
@@ -87,13 +88,14 @@ export function isWorktreePath(workspacePath: string): boolean {
     return false;
   }
   const normalized = normalizePath(workspacePath);
-  return /_worktrees\/[^/]+$/.test(normalized);
+  return /_worktrees\/.+$/.test(normalized);
 }
 
 /**
  * Resolve a workspace path to its parent project path.
- * If the path is a worktree (matches {project}_worktrees/{name}/ pattern),
- * returns the parent project path. Otherwise returns the original path.
+ * If the path is a worktree (matches {project}_worktrees/<name> pattern, where
+ * <name> may be nested for branch-style names like `feature/foo`), returns the
+ * parent project path. Otherwise returns the original path.
  *
  * Mirrors workspaceDetection.ts resolveProjectPath() but uses forward slashes.
  */
@@ -102,6 +104,6 @@ export function resolveProjectPath(workspacePath: string): string {
     return workspacePath;
   }
   const normalized = normalizePath(workspacePath);
-  const match = normalized.match(/^(.+)_worktrees\/[^/]+$/);
+  const match = normalized.match(/^(.+)_worktrees\/.+$/);
   return match ? match[1] : workspacePath;
 }


### PR DESCRIPTION
## Problem
Git worktrees created with branch-style names (e.g. `feature/foo`, `improvement/bar`) live in nested directories like `<project>_worktrees/feature/foo`. These paths — and subfolders of a project opened as a workspace — did not inherit the parent project's agent-permission mode, so the agent re-prompted for permission on every tool call even when the project was set to "Allow All" / bypass-all.

## Root cause
`resolveProjectPath` and `isWorktreePath` (in `packages/electron/src/main/utils/workspaceDetection.ts`, mirrored in `packages/electron/src/shared/pathUtils.ts`) matched only a single path segment after `_worktrees/` (`[^/]+$`). Nested worktree paths have more than one segment, so they failed to match, never resolved to the parent project, and were treated as untrusted workspaces.

## Fix
- Broaden the worktree path regexes (`[^/]+$` → `.+$`) so nested/branch-style worktree names resolve to their parent project. The greedy prefix anchors on the last `_worktrees/`, preserving the existing `_worktrees_backup` decoy and underscore-project-name cases.
- Add a `findNearestAncestor` helper and use it in the `PermissionService` read paths (`getPermissionMode`, `isWorkspaceTrusted`, `getAllowAllUsesClassifier`, and the async settings-path resolver) so a project subfolder inherits the nearest trusted ancestor's permission mode. Writes stay on the worktree→parent resolution, so a mode set on a subfolder never overwrites an ancestor.

## Testing
- Added unit cases for nested worktree paths, subfolders inside worktrees, `_worktrees_backup` decoys, and the ancestor walk-up in `workspaceDetection.test.ts` and `pathUtils.test.ts`.
- Verified the resolution logic against the real source (31/31 assertions) via Node type-stripping, since the dev `node_modules` was not installed locally; all touched files pass a type-stripped syntax check. Full `tsc` and vitest runs are left to CI.

## Notes
- The user-level `~/.claude/settings.json` deny/allow list is unaffected; this only fixes Nimbalyst's per-workspace permission-mode inheritance.

Internal tracker: NIM-1
