### PR TITLE
docs(test): document waitUntil race in TrackerSyncEngine round-trip test

### DIFF
--- a/packages/runtime/src/sync/__tests__/TrackerSyncEngine.integration.test.ts
+++ b/packages/runtime/src/sync/__tests__/TrackerSyncEngine.integration.test.ts
@@ -159,6 +159,12 @@ describe('TrackerSyncEngine (in-memory)', () => {
     const { clientMutationId } = await a.engine.upsertItem(payload);
 
     // Wait for both the local projection (after ack) and B's delta to land.
+    // KNOWN RACE: this only polls B's projection but the assertions below check
+    // A's envelope.syncId. The server's ack-to-A and broadcast-to-B are
+    // independent paths; on a slow runner B can land first and leave
+    // localA?.envelope.syncId at 0, tripping the toBeGreaterThan(0) below.
+    // If the flake recurs, add a second wait that also polls A, e.g.
+    // `await waitUntil(() => (a.persistence.items.get('round-trip-1')?.envelope.syncId ?? 0) > 0);`
     await waitUntil(() => appliedOnB.includes('round-trip-1'));
 
     // Local projection on A holds the decrypted payload.


### PR DESCRIPTION
## Summary
Adds a comment in `TrackerSyncEngine.integration.test.ts` around line 162 noting a race in the test's own synchronization.

## Context
The 'round-trips an upsert' test does:

```ts
await waitUntil(() => appliedOnB.includes('round-trip-1'));  // waits on B
...
expect(localA?.envelope.syncId).toBeGreaterThan(0);          // asserts on A
```

The server's ack-to-A and broadcast-to-B are independent code paths. On a slow CI runner, B can satisfy the `waitUntil` while A's own ack is still being applied, leaving `localA?.envelope.syncId` at `0` and tripping the assertion.

Observed once on an unrelated PR (the Android keyboard padding fix in #702 hit it once during its own diagnosis). Pre-existing — the test passes on every other PR and on main; it's a sub-1% intermittent flake.

## Why comment-only, not a code fix
- The race is in the test, not the product code. The fix (a second `waitUntil` polling A's syncId) is one line but it's a real test-logic change and deserves its own review when someone actually hits the flake repeatedly.
- Adding the comment now means the next person hitting `AssertionError: expected 0 to be greater than 0` at line 167 sees the diagnosis inline instead of re-tracing.

## Test plan
- [x] Comment-only change; no test logic modified. Vitest behavior unchanged.
- [ ] Reviewer: if you'd prefer the actual fix bundled instead of just the note, let me know and I'll add the `waitUntil` on `(a.persistence.items.get(...)?.envelope.syncId ?? 0) > 0`.