### PR TITLE
feat: fork an AI chat from a specific message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Fork an AI chat from a specific message: hover a message and pick "Fork from here" to branch into a new session that continues from that point, leaving the original untouched.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -89,6 +89,7 @@ import {
   loadInitialQueuedPrompts,
 } from '../../store';
 import { streamCompletionSignalAtom } from '../../store/atoms/sessionTranscript';
+import { branchSessionActionAtom } from '../../store/actions/sessionHistoryActions';
 import { convertToWorkstreamAtom, sessionPromptAdditionsAtom, sessionLastSubmitAtAtom, sessionDraftLocalModifiedAtAtom, nextOptimisticId } from '../../store/atoms/sessions';
 import { clearAIInputHistoryAtom } from '../../store/atoms/aiInputUndo';
 import {
@@ -469,6 +470,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
 
   // Child session creation for "start new session" option
   const createChildSession = useSetAtom(createChildSessionAtom);
+  const dispatchBranchSession = useSetAtom(branchSessionActionAtom);
   const convertToWorkstream = useSetAtom(convertToWorkstreamAtom);
   const sessionChildren = useAtomValue(sessionChildrenAtom(sessionId));
   const sessionParentId = useAtomValue(sessionParentIdAtom(sessionId));
@@ -2399,6 +2401,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
             onOpenInExternalEditor={hasExternalEditor ? handleOpenInExternalEditor : undefined}
             externalEditorName={externalEditorName}
             onCompact={handleCompact}
+            onForkFromMessage={(message) => { void dispatchBranchSession({ sessionId, branchPointMessageId: message.id }); }}
             promptAdditions={showPromptAdditions ? promptAdditions : null}
             currentTeammates={transcriptTeammates}
             waitingForNoun={waitingForNoun}

--- a/packages/electron/src/renderer/store/actions/sessionHistoryActions.ts
+++ b/packages/electron/src/renderer/store/actions/sessionHistoryActions.ts
@@ -345,13 +345,16 @@ export const renameSessionActionAtom = atom(
 /**
  * Branch a session: create a fork at the current message and open the new branch.
  */
-export const branchSessionActionAtom = atom(null, async (get, set, sessionId: string) => {
+export const branchSessionActionAtom = atom(null, async (get, set, params: string | { sessionId: string; branchPointMessageId?: number }) => {
+  const sessionId = typeof params === 'string' ? params : params.sessionId;
+  const branchPointMessageId = typeof params === 'string' ? undefined : params.branchPointMessageId;
   const workspacePath = getWorkspacePath(get);
   if (!workspacePath || typeof window === 'undefined' || !window.electronAPI) return;
 
   try {
     const result = await window.electronAPI.invoke('sessions:branch', {
       parentSessionId: sessionId,
+      branchPointMessageId,
       workspacePath,
     });
 

--- a/packages/runtime/src/ai/server/SessionManager.ts
+++ b/packages/runtime/src/ai/server/SessionManager.ts
@@ -21,6 +21,7 @@ import {
   SessionType,
   ModelIdentifier,
   shouldBlockStartedSessionProviderSwitch,
+  isAgentProvider,
   AgentRole,
 } from './types';
 import type { TranscriptViewMessage } from './transcript/TranscriptProjector';
@@ -933,6 +934,15 @@ export class SessionManager {
       throw new Error(`Parent session ${parentSessionId} not found`);
     }
 
+    // Agent providers (Claude Code, Codex, ...) can only resume a conversation
+    // from its END -- the SDK has no resume-at-message API -- so an earlier
+    // branch point can't be honored natively. Restrict them to a latest-message
+    // fork: drop the branch point and copy the whole conversation (the native
+    // SDK fork then continues exactly from the end).
+    const effectiveBranchPointMessageId = isAgentProvider(parentSession.provider)
+      ? undefined
+      : branchPointMessageId;
+
     // Create a new session ID for the branch
     const branchSessionId = uuidv4();
     const workspace = parentSession.workspacePath;
@@ -985,9 +995,39 @@ export class SessionManager {
       worktreePath: parentSession.worktreePath,
       worktreeProjectPath: parentSession.worktreeProjectPath,
       branchedFromSessionId: parentSessionId,  // The session this branch was forked from
-      branchPointMessageId,
+      branchPointMessageId: effectiveBranchPointMessageId,
       branchedAt: now,
     });
+
+    // Copy the parent's raw transcript up to the branch point into the new
+    // session so the fork is self-contained (survives deletion of the parent)
+    // and immediately shows the prior conversation. Chat providers replay this
+    // history on the next turn; agent providers display it and continue via the
+    // native SDK fork.
+    const parentMessages = await AgentMessagesRepository.list(parentSessionId, {
+      includeHidden: true,
+    });
+    let messagesToCopy = parentMessages;
+    if (effectiveBranchPointMessageId != null) {
+      const cutoff = effectiveBranchPointMessageId;
+      messagesToCopy = parentMessages.filter(
+        (m) => typeof m.id === 'number' && m.id <= cutoff
+      );
+    }
+    if (messagesToCopy.length > 0) {
+      await AgentMessagesRepository.createMany(
+        messagesToCopy.map((m) => ({
+          sessionId: branchSessionId,
+          source: m.source,
+          direction: m.direction,
+          content: m.content,
+          metadata: m.metadata,
+          hidden: m.hidden,
+          createdAt: m.createdAt,
+          providerMessageId: m.providerMessageId,
+        }))
+      );
+    }
 
     const session: SessionData = {
       id: branchSessionId,
@@ -1006,7 +1046,7 @@ export class SessionManager {
       worktreePath: parentSession.worktreePath,
       worktreeProjectPath: parentSession.worktreeProjectPath,
       branchedFromSessionId: parentSessionId,  // The session this branch was forked from
-      branchPointMessageId,
+      branchPointMessageId: effectiveBranchPointMessageId,
       branchedAt: now,
       // Store source session's provider session ID for forking
       branchedFromProviderSessionId,

--- a/packages/runtime/src/ai/server/__tests__/SessionManager.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/SessionManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SessionManager } from '../SessionManager';
 import type {
   SessionStore,
@@ -6,7 +6,19 @@ import type {
   SessionMeta,
   UpdateSessionMetadataPayload,
 } from '../../adapters/sessionStore';
-import { shouldBlockStartedSessionProviderSwitch, type SessionData, type TranscriptViewMessage } from '../types';
+import {
+  shouldBlockStartedSessionProviderSwitch,
+  type SessionData,
+  type TranscriptViewMessage,
+  type AgentMessage,
+  type CreateAgentMessageInput,
+} from '../types';
+import {
+  AgentMessagesRepository,
+  type AgentMessagesStore,
+} from '../../../storage/repositories/AgentMessagesRepository';
+import { TranscriptMigrationRepository } from '../../../storage/repositories/TranscriptMigrationRepository';
+import type { TranscriptMigrationService } from '../transcript/TranscriptMigrationService';
 
 class InMemorySessionStore implements SessionStore {
   private sessions = new Map<string, SessionData>();
@@ -123,6 +135,40 @@ class InMemorySessionStore implements SessionStore {
   }
 }
 
+class InMemoryAgentMessagesStore implements AgentMessagesStore {
+  private rows: AgentMessage[] = [];
+  private nextId = 1;
+
+  async create(message: CreateAgentMessageInput): Promise<void> {
+    this.rows.push({
+      id: this.nextId++,
+      sessionId: message.sessionId,
+      source: message.source,
+      direction: message.direction,
+      content: message.content,
+      metadata: message.metadata,
+      hidden: message.hidden ?? false,
+      createdAt: message.createdAt ? new Date(message.createdAt) : new Date(),
+      providerMessageId: message.providerMessageId,
+    });
+  }
+
+  async createMany(messages: CreateAgentMessageInput[]): Promise<void> {
+    for (const message of messages) {
+      await this.create(message);
+    }
+  }
+
+  async list(
+    sessionId: string,
+    options?: { limit?: number; offset?: number; includeHidden?: boolean }
+  ): Promise<AgentMessage[]> {
+    return this.rows
+      .filter((r) => r.sessionId === sessionId && (options?.includeHidden ? true : !r.hidden))
+      .sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
+  }
+}
+
 describe('SessionManager (runtime server)', () => {
   let store: InMemorySessionStore;
   let manager: SessionManager;
@@ -186,6 +232,61 @@ describe('SessionManager (runtime server)', () => {
     expect(shouldBlockStartedSessionProviderSwitch('claude-code', 'claude', true)).toBe(true);
     expect(shouldBlockStartedSessionProviderSwitch('claude', 'openai', true)).toBe(false);
     expect(shouldBlockStartedSessionProviderSwitch('claude-code', 'openai-codex', false)).toBe(false);
+  });
+
+  describe('branchSession (fork from message)', () => {
+    let agentMessages: InMemoryAgentMessagesStore;
+
+    beforeEach(() => {
+      agentMessages = new InMemoryAgentMessagesStore();
+      AgentMessagesRepository.setStore(agentMessages);
+      // loadSession() projects the canonical transcript; stub it (the fork copy
+      // works off the raw ai_agent_messages rows, which we assert on directly).
+      TranscriptMigrationRepository.setService({
+        getViewMessages: async () => [],
+      } as unknown as TranscriptMigrationService);
+    });
+
+    afterEach(() => {
+      AgentMessagesRepository.clearStore();
+      TranscriptMigrationRepository.clearService();
+    });
+
+    it('copies parent messages up to the branch point for a chat provider', async () => {
+      const parent = await manager.createSession('claude', { content: 'text' }, 'ws');
+      await AgentMessagesRepository.createMany([
+        { sessionId: parent.id, source: 'claude', direction: 'input', content: 'q1' },
+        { sessionId: parent.id, source: 'claude', direction: 'output', content: 'a1' },
+        { sessionId: parent.id, source: 'claude', direction: 'input', content: 'q2' },
+        { sessionId: parent.id, source: 'claude', direction: 'output', content: 'a2' },
+      ]);
+      const parentRows = await AgentMessagesRepository.list(parent.id, { includeHidden: true });
+      const branchPointId = parentRows[1].id!; // through 'a1'
+
+      const branch = await manager.branchSession(parent.id, branchPointId, 'ws');
+
+      const copied = await AgentMessagesRepository.list(branch.id, { includeHidden: true });
+      expect(copied.map((m) => m.content)).toEqual(['q1', 'a1']);
+      expect(branch.branchedFromSessionId).toBe(parent.id);
+      expect(branch.branchPointMessageId).toBe(branchPointId);
+    });
+
+    it('clamps agent-provider forks to the whole conversation (latest only)', async () => {
+      const parent = await manager.createSession('claude-code', { content: 'text' }, 'ws');
+      await AgentMessagesRepository.createMany([
+        { sessionId: parent.id, source: 'claude-code', direction: 'input', content: 'q1' },
+        { sessionId: parent.id, source: 'claude-code', direction: 'output', content: 'a1' },
+        { sessionId: parent.id, source: 'claude-code', direction: 'input', content: 'q2' },
+      ]);
+      const parentRows = await AgentMessagesRepository.list(parent.id, { includeHidden: true });
+      const earlyPoint = parentRows[0].id!; // earlier than the latest message
+
+      const branch = await manager.branchSession(parent.id, earlyPoint, 'ws');
+
+      const copied = await AgentMessagesRepository.list(branch.id, { includeHidden: true });
+      expect(copied.map((m) => m.content)).toEqual(['q1', 'a1', 'q2']);
+      expect(branch.branchPointMessageId).toBeUndefined();
+    });
   });
 
 });

--- a/packages/runtime/src/ui/AgentTranscript/components/AgentTranscriptPanel.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/AgentTranscriptPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import type { SessionData } from '../../../ai/server/types';
+import type { SessionData, TranscriptViewMessage } from '../../../ai/server/types';
 import type { TranscriptSettings, PromptMarker, FileEditSummary } from '../types';
 import { RichTranscriptView } from './RichTranscriptView';
 import { TranscriptSidebar } from './TranscriptSidebar';
@@ -86,6 +86,8 @@ interface AgentTranscriptPanelProps {
   externalEditorName?: string;
   /** Optional: Callback to trigger /compact command */
   onCompact?: () => void;
+  /** Optional: Fork a new session starting from this message (branch point) */
+  onForkFromMessage?: (message: TranscriptViewMessage, index: number) => void;
   /** Optional: Prompt additions for debugging (system prompt, user message, and attachments) */
   promptAdditions?: {
     systemPromptAddition: string | null;
@@ -144,6 +146,7 @@ const AgentTranscriptPanelComponent = React.forwardRef<
   onOpenInExternalEditor,
   externalEditorName,
   onCompact,
+  onForkFromMessage,
   promptAdditions,
   appStartTime,
   renderEmbeddedFile,
@@ -383,6 +386,7 @@ const AgentTranscriptPanelComponent = React.forwardRef<
           onOpenFile={onFileClick}
           onOpenSession={onOpenSession}
           onCompact={onCompact}
+          onForkFromMessage={onForkFromMessage}
           promptAdditions={promptAdditions}
           currentTeammates={currentTeammates ?? sessionData.metadata?.currentTeammates as Array<{ agentId: string; status: 'running' | 'completed' | 'errored' | 'idle' }> | undefined}
           waitingForNoun={waitingForNoun}

--- a/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { VList, type VListHandle, type CacheSnapshot } from 'virtua';
 import type { TranscriptViewMessage, SessionData } from '../../../ai/server/types';
+import { isAgentProvider } from '../../../ai/server/types';
 import type { TranscriptSettings } from '../types';
 import { MessageSegment } from './MessageSegment';
 import { MarkdownRenderer } from './MarkdownRenderer';
@@ -490,6 +491,8 @@ interface RichTranscriptViewProps {
   onOpenSession?: (sessionId: string) => void;
   /** Optional: Callback to trigger /compact command */
   onCompact?: () => void;
+  /** Optional: Fork a new session starting from this message (branch point) */
+  onForkFromMessage?: (message: TranscriptViewMessage, index: number) => void;
   /** Optional: Prompt additions for debugging (system prompt, user message, and attachments) */
   promptAdditions?: {
     systemPromptAddition: string | null;
@@ -1082,7 +1085,7 @@ export const extractEditsFromToolMessage = (message: TranscriptViewMessage): any
 export const RichTranscriptView = React.forwardRef<
   { scrollToMessage: (index: number) => void; scrollToTop: () => void },
   RichTranscriptViewProps
->(({ sessionId, sessionStatus, isProcessing, hasPendingInteractivePrompt, messages, provider, settings: propsSettings, onSettingsChange, showSettings, documentContext, workspacePath, renderEmptyExtra, hideEmptyHelp, readFile, onOpenFile, onOpenSession, onCompact, promptAdditions, currentTeammates, waitingForNoun, appStartTime, renderEmbeddedFile, canEmbedFile, onSearchBarVisibilityChange, persistScrollState = true }, ref) => {
+>(({ sessionId, sessionStatus, isProcessing, hasPendingInteractivePrompt, messages, provider, settings: propsSettings, onSettingsChange, showSettings, documentContext, workspacePath, renderEmptyExtra, hideEmptyHelp, readFile, onOpenFile, onOpenSession, onCompact, onForkFromMessage, promptAdditions, currentTeammates, waitingForNoun, appStartTime, renderEmbeddedFile, canEmbedFile, onSearchBarVisibilityChange, persistScrollState = true }, ref) => {
   const [collapsedMessages, setCollapsedMessages] = useState<Set<number>>(new Set());
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const scrollButtonRef = useRef<HTMLDivElement>(null);
@@ -2246,7 +2249,19 @@ export const RichTranscriptView = React.forwardRef<
 
         <div className={`rich-transcript-message-content relative ${isNewGroup ? 'ml-6' : 'no-indent ml-0'}`}>
           {/* Copy button - shows on hover */}
-          <div className="rich-transcript-message-copy-action absolute -top-1 right-0 z-[1]">
+          <div className="rich-transcript-message-copy-action absolute -top-1 right-0 z-[1] flex items-center gap-1">
+            {onForkFromMessage &&
+              (message.type === 'user_message' || message.type === 'assistant_message') &&
+              (isAgentProvider(provider) ? index === messages.length - 1 : true) && (
+                <button
+                  onClick={() => onForkFromMessage(message, index)}
+                  className="rich-transcript-fork-button p-1.5 rounded-md bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] cursor-pointer transition-all flex items-center justify-center hover:bg-[var(--nim-bg-hover)]"
+                  title="Fork from here"
+                  data-testid="transcript-fork-button"
+                >
+                  <MaterialSymbol icon="alt_route" size={16} className="text-[var(--nim-text-faint)]" />
+                </button>
+              )}
             <button
               onClick={() => copyTranscriptViewMessageContent(message, index)}
               className={`rich-transcript-copy-button p-1.5 rounded-md bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] cursor-pointer transition-all flex items-center justify-center hover:bg-[var(--nim-bg-hover)] ${copiedMessageIndex === index ? 'copied' : ''}`}


### PR DESCRIPTION
## What

Cursor-style chat forking: from any message in an AI chat, branch into a **new session** that continues from that point, leaving the original untouched.

## How

- **Backend** (`SessionManager.branchSession`): copies the parent's transcript up to the chosen branch point into the new session, so the fork is self-contained (survives deletion of the original). Agent providers (Claude Code) are clamped to a latest-message fork — their SDK can only resume from the end and continues via the native session fork; chat providers (Claude/OpenAI/LM Studio) fork at any message and replay the copied history.
- **UI** (`RichTranscriptView` / `AgentTranscriptPanel`): a "Fork from here" hover action next to Copy, shown on every user/assistant message for chat providers and only on the last message for Claude Code.
- **Wiring** (`branchSessionActionAtom` / `SessionTranscript`): forwards the clicked message id as the branch point. The existing whole-session branch keeps working unchanged (the atom still accepts a plain session id).

## Commits

1. feat(ai): copy transcript up to the branch point when forking a session
2. test(ai): cover branchSession history copy and agent-provider clamp
3. feat(transcript): add "Fork from here" action to messages
4. feat(ai-chat): fork from a transcript message into a new session
5. docs: add changelog entry for chat forking

## Testing

- New unit tests in `SessionManager.test.ts` cover the chat-provider copy and the agent-provider clamp.
- Note: not executed in this environment (no local `node_modules`) — please let CI run `vitest` and `tsc`.
- Manual: open a Claude/OpenAI chat, hover a message, choose "Fork from here" → a new session opens with the conversation up to that point. For Claude Code the action appears only on the latest message.