### PR TITLE
Slash commands anywhere in a message, with clickable command pills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Slash commands now work anywhere in a message and appear as clickable pills that show what each command does and open its source file.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/renderer/components/Typeahead/slashCommandAutocomplete.ts
+++ b/packages/electron/src/renderer/components/Typeahead/slashCommandAutocomplete.ts
@@ -8,6 +8,10 @@ export interface SlashCommandEntry {
   argumentHint?: string;
   source: 'builtin' | 'project' | 'user' | 'plugin';
   kind?: 'command' | 'skill';
+  /** Full command body (instructions). Present for project/user/plugin entries. */
+  content?: string;
+  /** Absolute path to the command/skill source file, when it is file-backed. */
+  filePath?: string;
 }
 
 export function supportsWorkspaceSlashCommands(provider?: string | null): boolean {

--- a/packages/electron/src/renderer/components/Typeahead/typeaheadUtils.ts
+++ b/packages/electron/src/renderer/components/Typeahead/typeaheadUtils.ts
@@ -101,16 +101,17 @@ export function extractTriggerMatch(
 }
 
 /**
- * Slash completion is context-sensitive:
- * - At column 0, show slash commands
- * - Later in the prompt, show skills only
+ * Slash completion offers the full command + skill list wherever a `/` trigger
+ * is valid (column 0 or after whitespace). Built-in commands used to be hidden
+ * once the cursor moved past column 0; they now appear mid-message too so the
+ * menu is identical at the start of a prompt and inside it.
  */
 export function getSlashTypeaheadScope(match: TriggerMatch | null): SlashTypeaheadScope | null {
   if (!match || match.trigger !== '/') {
     return null;
   }
 
-  return match.startIndex === 0 ? 'commands' : 'skills';
+  return 'commands';
 }
 
 /**

--- a/packages/electron/src/renderer/components/UnifiedAI/AIInput.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/AIInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, KeyboardEvent, useState, useCallback, forwardRef, useImperativeHandle } from 'react';
+import React, { useRef, useEffect, KeyboardEvent, useState, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { GenericTypeahead, TypeaheadOption } from '../Typeahead/GenericTypeahead';
 import { extractTriggerMatch, getSlashTypeaheadScope, insertAtTrigger, type SlashTypeaheadScope, TriggerMatch } from '../Typeahead/typeaheadUtils';
@@ -36,6 +36,9 @@ import {
 } from '../../store';
 import { useAIInputUndo } from '../../hooks/useAIInputUndo';
 import type { AIInputSnapshot } from '../../store/atoms/aiInputUndo';
+import { parseCommandTokens, type CommandToken } from './commandPills/parseCommandTokens';
+import { HighlightOverlay } from './commandPills/HighlightOverlay';
+import { CommandPillPopover } from './commandPills/CommandPillPopover';
 
 export interface AIInputRef {
   focus: () => void;
@@ -182,6 +185,11 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
     const [allSlashCommands, setAllSlashCommands] = useState<SlashCommandEntry[]>([]);
     const [dragActive, setDragActive] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
+
+    // Command pills: caret position (to suppress the token being typed) and the
+    // inspect popover opened when a pill is clicked.
+    const [caretPos, setCaretPos] = useState<number | null>(null);
+    const [pillPopover, setPillPopover] = useState<{ command: SlashCommandEntry; rect: DOMRect } | null>(null);
 
     // Track attachments that are being processed (e.g., compressed)
     const [processingAttachments, setProcessingAttachments] = useState<Array<{ id: string; filename: string }>>([]);
@@ -472,6 +480,44 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
     const filterSlashCommands = useCallback((query: string, scope: SlashTypeaheadScope) => {
       setSlashCommandOptions(buildSlashCommandOptions(allSlashCommands, query, scope));
     }, [allSlashCommands]);
+
+    // Known command names drive the inline pills (only known commands highlight).
+    const knownCommandNames = useMemo(
+      () => new Set(allSlashCommands.map((c) => c.name)),
+      [allSlashCommands]
+    );
+
+    // Tokens to render as pills. Suppress the token under the caret so a command
+    // the user is still typing doesn't pill mid-keystroke.
+    const commandTokens = useMemo(
+      () => (enableSlashCommands ? parseCommandTokens(value, knownCommandNames, caretPos) : []),
+      [enableSlashCommands, value, knownCommandNames, caretPos]
+    );
+
+    const handlePillClick = useCallback(
+      (token: CommandToken, rect: DOMRect) => {
+        const command = allSlashCommands.find((c) => c.name === token.name);
+        if (command) setPillPopover({ command, rect });
+      },
+      [allSlashCommands]
+    );
+
+    // Track the caret so pill suppression follows the cursor; cleared on blur so
+    // an unfocused input shows every recognized command as a pill.
+    useEffect(() => {
+      const onSelectionChange = () => {
+        const ta = textareaRef.current;
+        if (ta && document.activeElement === ta) {
+          setCaretPos(ta.selectionStart);
+        }
+      };
+      document.addEventListener('selectionchange', onSelectionChange);
+      return () => document.removeEventListener('selectionchange', onSelectionChange);
+    }, []);
+
+    useEffect(() => {
+      if (!isFocused) setCaretPos(null);
+    }, [isFocused]);
 
     // Check for typeahead trigger when value changes (debounced for performance)
     // NOTE: cursorPosition and fileMentionOptions.length are intentionally excluded
@@ -1340,10 +1386,11 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
             padding: dragActive ? '4px' : '0'
           }}
         >
+          <div className="ai-chat-input-textarea-wrap relative flex flex-1 min-w-0">
           <textarea
             ref={textareaRef}
             data-testid={testId}
-            className="ai-chat-input-field nim-scrollbar-hidden flex-1 min-h-9 py-2 px-3 bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded-md text-[var(--nim-text)] text-[13px] font-[inherit] resize-none outline-none transition-colors duration-200 focus:border-[var(--nim-primary)] disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-[var(--nim-text-faint)]"
+            className={`ai-chat-input-field nim-scrollbar-hidden flex-1 min-h-9 py-2 px-3 bg-[var(--nim-bg)] border border-[var(--nim-border)] rounded-md ${enableSlashCommands ? 'text-transparent caret-[var(--nim-text)]' : 'text-[var(--nim-text)]'} text-[13px] font-[inherit] resize-none outline-none transition-colors duration-200 focus:border-[var(--nim-primary)] disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-[var(--nim-text-faint)]`}
             value={value}
             onChange={(e) => {
               // textarea onChange only fires from real user input events
@@ -1381,6 +1428,15 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
               maxHeight: `${userSetHeight ?? DEFAULT_MAX_PROMPT_HEIGHT}px`,
             }}
           />
+          {enableSlashCommands && (
+            <HighlightOverlay
+              textareaRef={textareaRef}
+              value={value}
+              tokens={commandTokens}
+              onPillClick={handlePillClick}
+            />
+          )}
+          </div>
           {isMemoryMode ? (
             // Memory mode: show save button
             <MemorySaveButton
@@ -1446,6 +1502,17 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
               ? ['Built-in Commands', 'Project Commands', 'User Commands', 'Extension Commands',
                  'Project Skills', 'User Skills', 'Plugin Skills']
               : undefined}
+          />
+        )}
+
+        {pillPopover && (
+          <CommandPillPopover
+            command={pillPopover.command}
+            rect={pillPopover.rect}
+            workspacePath={workspacePath}
+            sessionId={sessionId}
+            provider={currentProvider ?? provider ?? null}
+            onClose={() => setPillPopover(null)}
           />
         )}
 

--- a/packages/electron/src/renderer/components/UnifiedAI/commandPills/CommandPillPopover.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/commandPills/CommandPillPopover.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useSetAtom } from 'jotai';
+import { MarkdownRenderer, MaterialSymbol } from '@nimbalyst/runtime';
+import { useFloatingMenu, FloatingPortal } from '../../../hooks/useFloatingMenu';
+import { openFileInSessionEditorAtom } from '../../../store/atoms/sessionEditors';
+import type { SlashCommandEntry } from '../../Typeahead/slashCommandAutocomplete';
+
+interface CommandPillPopoverProps {
+  /** The command resolved from the loaded slash-command list. */
+  command: SlashCommandEntry;
+  /** Viewport rect of the clicked pill, used to anchor the popover. */
+  rect: DOMRect;
+  workspacePath?: string;
+  sessionId?: string;
+  provider?: string | null;
+  onClose: () => void;
+}
+
+interface CommandDetails {
+  content?: string;
+  filePath?: string;
+}
+
+function getCommandIcon(command: SlashCommandEntry): string {
+  if (command.kind === 'skill') return 'psychology';
+  if (command.source === 'builtin') return 'bolt';
+  return 'code';
+}
+
+/**
+ * Floating card shown when a command pill is clicked. Surfaces the command's
+ * description and body (what it runs) and, for file-backed commands, a button to
+ * open the source `.md` in the session editor. Built-in/provider-native commands
+ * have no body or file, so only their description is shown.
+ */
+export const CommandPillPopover: React.FC<CommandPillPopoverProps> = ({
+  command,
+  rect,
+  workspacePath,
+  sessionId,
+  provider,
+  onClose,
+}) => {
+  const openFileInSessionEditor = useSetAtom(openFileInSessionEditorAtom);
+  const [details, setDetails] = useState<CommandDetails>({
+    content: command.content,
+    filePath: command.filePath,
+  });
+  const [loading, setLoading] = useState(false);
+
+  // Anchor the floating card to the clicked pill's rect.
+  const reference = useMemo(
+    () => ({ getBoundingClientRect: () => rect }),
+    [rect]
+  );
+
+  const { refs, floatingStyles, getFloatingProps } = useFloatingMenu({
+    placement: 'top-start',
+    offsetPx: 6,
+    reference,
+    open: true,
+    onOpenChange: (next) => {
+      if (!next) onClose();
+    },
+  });
+
+  // Lazily fetch the body/path for entries that arrive without it (e.g. native
+  // skills). Built-ins legitimately have neither, so skip them.
+  useEffect(() => {
+    if (command.content || command.source === 'builtin' || !workspacePath) return;
+    let cancelled = false;
+    setLoading(true);
+    window.electronAPI
+      .invoke('slash-command:get', {
+        workspacePath,
+        commandName: command.name,
+        provider: provider ?? 'claude-code',
+      })
+      .then((entry: { content?: string; filePath?: string } | null) => {
+        if (cancelled || !entry) return;
+        setDetails((prev) => ({
+          content: prev.content ?? entry.content,
+          filePath: prev.filePath ?? entry.filePath,
+        }));
+      })
+      .catch((error) => {
+        console.error('[CommandPillPopover] Failed to load command details:', error);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [command.name, command.content, command.source, workspacePath, provider]);
+
+  const handleOpenFile = () => {
+    if (details.filePath && sessionId) {
+      openFileInSessionEditor({ sessionId, filePath: details.filePath });
+    }
+    onClose();
+  };
+
+  return (
+    <FloatingPortal>
+      <div
+        ref={refs.setFloating}
+        style={floatingStyles}
+        {...getFloatingProps()}
+        className="command-pill-popover z-[1000] w-[360px] max-w-[min(360px,90vw)] flex flex-col overflow-hidden rounded-lg border border-nim bg-nim-secondary text-[var(--nim-text)] shadow-lg"
+      >
+        <div className="command-pill-popover-header flex items-center gap-2 px-3 py-2 border-b border-nim">
+          <MaterialSymbol icon={getCommandIcon(command)} size={18} className="shrink-0 text-nim-muted" />
+          <span className="font-semibold text-sm truncate">/{command.name}</span>
+          {command.argumentHint && (
+            <span className="text-xs text-nim-faint truncate">{command.argumentHint}</span>
+          )}
+        </div>
+
+        {command.description && (
+          <div className="command-pill-popover-description px-3 py-2 text-[13px] leading-snug text-nim-muted border-b border-nim select-text">
+            {command.description}
+          </div>
+        )}
+
+        {details.content ? (
+          <div className="command-pill-popover-body px-3 py-2 max-h-[280px] overflow-y-auto text-[13px] select-text">
+            <MarkdownRenderer content={details.content} />
+          </div>
+        ) : loading ? (
+          <div className="command-pill-popover-loading px-3 py-3 text-xs text-nim-faint">Loading…</div>
+        ) : null}
+
+        {details.filePath && sessionId && (
+          <div className="command-pill-popover-footer flex items-center justify-end px-3 py-2 border-t border-nim">
+            <button
+              type="button"
+              className="command-pill-open-file inline-flex items-center gap-1.5 rounded-md border border-nim bg-nim px-2.5 py-1.5 text-[13px] text-nim cursor-pointer transition-colors duration-150 hover:bg-nim-hover"
+              onClick={handleOpenFile}
+            >
+              <MaterialSymbol icon="open_in_new" size={16} />
+              Open file
+            </button>
+          </div>
+        )}
+      </div>
+    </FloatingPortal>
+  );
+};

--- a/packages/electron/src/renderer/components/UnifiedAI/commandPills/HighlightOverlay.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/commandPills/HighlightOverlay.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { CommandToken } from './parseCommandTokens';
+
+/**
+ * Renders a transparent layer over the chat textarea that re-draws the same text
+ * with known `/command` tokens wrapped in clickable pills.
+ *
+ * The textarea keeps ownership of editing (its text is made transparent by the
+ * caller, caret stays visible); this overlay paints the visible glyphs plus the
+ * pills. The backdrop is `pointer-events: none` so caret placement, selection and
+ * typing fall through to the textarea, while individual pill spans re-enable
+ * pointer events so a click opens the inspect popover.
+ *
+ * Alignment is achieved by copying the textarea's computed text metrics (the same
+ * property set the typeahead mirror uses) and translating the content by the
+ * textarea's scroll offset.
+ */
+
+// Computed-style properties that affect text layout/wrapping. Mirrors the list in
+// Typeahead/typeaheadUtils.ts `getCursorCoordinates` so the overlay lays text out
+// identically to the textarea.
+const TEXT_STYLE_PROPS = [
+  'boxSizing',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'borderTopWidth',
+  'borderRightWidth',
+  'borderBottomWidth',
+  'borderLeftWidth',
+  'fontStyle',
+  'fontVariant',
+  'fontWeight',
+  'fontStretch',
+  'fontSize',
+  'fontSizeAdjust',
+  'lineHeight',
+  'fontFamily',
+  'textAlign',
+  'textTransform',
+  'textIndent',
+  'letterSpacing',
+  'wordSpacing',
+  'tabSize',
+  'wordBreak',
+] as const;
+
+interface HighlightOverlayProps {
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  value: string;
+  tokens: CommandToken[];
+  /** Called with the clicked command token and the pill's viewport rect. */
+  onPillClick: (token: CommandToken, rect: DOMRect) => void;
+}
+
+export const HighlightOverlay: React.FC<HighlightOverlayProps> = ({
+  textareaRef,
+  value,
+  tokens,
+  onPillClick,
+}) => {
+  const [style, setStyle] = useState<React.CSSProperties>({});
+  const [scroll, setScroll] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const rafRef = useRef<number | null>(null);
+
+  // Copy text metrics from the live textarea. Re-run on value/size changes so
+  // theme/zoom/font/height adjustments stay in sync. getComputedStyle is read in
+  // a layout effect (pre-paint) to avoid a one-frame misalignment.
+  useLayoutEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const computed = window.getComputedStyle(ta);
+    const next: Record<string, string> = {};
+    for (const prop of TEXT_STYLE_PROPS) {
+      next[prop] = computed[prop as keyof CSSStyleDeclaration] as string;
+    }
+    setStyle(next as React.CSSProperties);
+    setScroll({ top: ta.scrollTop, left: ta.scrollLeft });
+  }, [textareaRef, value]);
+
+  // Keep the overlay's content scrolled with the textarea.
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const sync = () => {
+      if (rafRef.current != null) return;
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        setScroll({ top: ta.scrollTop, left: ta.scrollLeft });
+      });
+    };
+    ta.addEventListener('scroll', sync, { passive: true });
+    return () => {
+      ta.removeEventListener('scroll', sync);
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    };
+  }, [textareaRef]);
+
+  // Split the value into plain segments and pill spans. Tokens are assumed sorted
+  // by start (parseCommandTokens emits them in order).
+  const segments = useMemo(() => {
+    const nodes: React.ReactNode[] = [];
+    let cursor = 0;
+    tokens.forEach((token, i) => {
+      if (token.start > cursor) {
+        nodes.push(value.slice(cursor, token.start));
+      }
+      nodes.push(
+        <span
+          key={`pill-${token.start}-${i}`}
+          className="command-pill"
+          data-command-name={token.name}
+          style={{ pointerEvents: 'auto', cursor: 'pointer' }}
+          // Keep the textarea focused and stop the caret from being placed
+          // inside the pill when it is clicked.
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onPillClick(token, (e.currentTarget as HTMLElement).getBoundingClientRect());
+          }}
+        >
+          {value.slice(token.start, token.end)}
+        </span>
+      );
+      cursor = token.end;
+    });
+    if (cursor < value.length) {
+      nodes.push(value.slice(cursor));
+    }
+    // A trailing newline needs a placeholder so the final line box matches the
+    // textarea (which always shows an empty last line). Zero-width space.
+    if (value.endsWith('\n')) {
+      nodes.push('\u200B');
+    }
+    return nodes;
+  }, [value, tokens, onPillClick]);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="command-pill-overlay absolute inset-0 overflow-hidden pointer-events-none"
+      style={{
+        ...style,
+        // The visible glyphs are painted here (textarea text is transparent).
+        color: 'var(--nim-text)',
+        borderColor: 'transparent',
+        borderStyle: 'solid',
+        background: 'transparent',
+        whiteSpace: 'pre-wrap',
+        overflowWrap: 'break-word',
+      }}
+    >
+      <div
+        className="command-pill-overlay-text"
+        style={{
+          transform: `translate(${-scroll.left}px, ${-scroll.top}px)`,
+          font: 'inherit',
+          letterSpacing: 'inherit',
+          wordSpacing: 'inherit',
+          lineHeight: 'inherit',
+          whiteSpace: 'inherit',
+          overflowWrap: 'inherit',
+          wordBreak: 'inherit',
+          textAlign: 'inherit',
+          textIndent: 'inherit',
+        }}
+      >
+        {segments}
+      </div>
+    </div>
+  );
+};

--- a/packages/electron/src/renderer/components/UnifiedAI/commandPills/__tests__/parseCommandTokens.test.ts
+++ b/packages/electron/src/renderer/components/UnifiedAI/commandPills/__tests__/parseCommandTokens.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { parseCommandTokens } from '../parseCommandTokens';
+
+const known = new Set(['commit', 'deep-research', 'planning:implement', 'review']);
+
+describe('parseCommandTokens', () => {
+  it('returns no tokens when none are known', () => {
+    expect(parseCommandTokens('/unknown thing', known)).toEqual([]);
+  });
+
+  it('detects a command at the start of the value', () => {
+    expect(parseCommandTokens('/commit', known)).toEqual([
+      { start: 0, end: 7, name: 'commit' },
+    ]);
+  });
+
+  it('detects a command mid-message after whitespace', () => {
+    const value = 'please /commit now';
+    expect(parseCommandTokens(value, known)).toEqual([
+      { start: 7, end: 14, name: 'commit' },
+    ]);
+    expect(value.slice(7, 14)).toBe('/commit');
+  });
+
+  it('ignores unknown commands but keeps known ones on the same line', () => {
+    expect(parseCommandTokens('/nope and /review', known)).toEqual([
+      { start: 10, end: 17, name: 'review' },
+    ]);
+  });
+
+  it('does not treat file paths as commands', () => {
+    expect(parseCommandTokens('open /Users/me/file', known)).toEqual([]);
+  });
+
+  it('does not match a slash inside a word', () => {
+    expect(parseCommandTokens('foo/commit', known)).toEqual([]);
+  });
+
+  it('stops the token at the first space so arguments are excluded', () => {
+    expect(parseCommandTokens('/review src/app.ts', known)).toEqual([
+      { start: 0, end: 7, name: 'review' },
+    ]);
+  });
+
+  it('detects a command after a newline', () => {
+    const value = 'intro\n/deep-research';
+    expect(parseCommandTokens(value, known)).toEqual([
+      { start: 6, end: 20, name: 'deep-research' },
+    ]);
+    expect(value.slice(6, 20)).toBe('/deep-research');
+  });
+
+  it('supports namespaced command names with a colon', () => {
+    expect(parseCommandTokens('/planning:implement', known)).toEqual([
+      { start: 0, end: 19, name: 'planning:implement' },
+    ]);
+  });
+
+  it('detects multiple known commands in one value', () => {
+    expect(parseCommandTokens('/commit then /review', known)).toEqual([
+      { start: 0, end: 7, name: 'commit' },
+      { start: 13, end: 20, name: 'review' },
+    ]);
+  });
+
+  it('suppresses the token the caret is currently editing', () => {
+    expect(parseCommandTokens('/commit', known, 7)).toEqual([]);
+    expect(parseCommandTokens('/commit ', known, 8)).toEqual([
+      { start: 0, end: 7, name: 'commit' },
+    ]);
+  });
+
+  it('returns nothing for an empty value', () => {
+    expect(parseCommandTokens('', known)).toEqual([]);
+  });
+});

--- a/packages/electron/src/renderer/components/UnifiedAI/commandPills/parseCommandTokens.ts
+++ b/packages/electron/src/renderer/components/UnifiedAI/commandPills/parseCommandTokens.ts
@@ -1,0 +1,58 @@
+/**
+ * Detect slash-command tokens (`/command-name`) inside a textarea value so they
+ * can be rendered as pills. Mirrors the trigger rules in `extractTriggerMatch`
+ * (Typeahead/typeaheadUtils.ts): a token starts at column 0 or after whitespace,
+ * the name is a run of non-whitespace / non-slash characters, and the token ends
+ * at whitespace or end-of-input. Path-like values (`/Users/me`) never match
+ * because the name cannot contain a slash and must be followed by whitespace/EOL.
+ *
+ * Only names present in `knownNames` are emitted, so an unknown `/foo` stays
+ * plain text. When `caretPos` sits inside (or at the end of) a token, that token
+ * is skipped so a command the user is still typing doesn't flicker into a pill
+ * while the autocomplete is open.
+ */
+export interface CommandToken {
+  /** Index of the leading slash in the value. */
+  start: number;
+  /** Index one past the last character of the name. */
+  end: number;
+  /** Command name without the leading slash. */
+  name: string;
+}
+
+// Capture the boundary (start or whitespace) separately so the slash index can
+// be derived; `[^\s/]+` keeps names slash-free, and the lookahead requires the
+// token to end at whitespace or end-of-input.
+const COMMAND_TOKEN_REGEX = /(^|\s)\/([^\s/]+)(?=\s|$)/g;
+
+export function parseCommandTokens(
+  value: string,
+  knownNames: ReadonlySet<string>,
+  caretPos?: number | null
+): CommandToken[] {
+  const tokens: CommandToken[] = [];
+  if (!value || knownNames.size === 0) {
+    return tokens;
+  }
+
+  const regex = new RegExp(COMMAND_TOKEN_REGEX);
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(value)) !== null) {
+    const name = match[2];
+    if (!knownNames.has(name)) {
+      continue;
+    }
+    const start = match.index + match[1].length;
+    const end = start + 1 + name.length; // leading slash + name
+
+    // Skip the token the caret is currently editing (collapsed caret only) so
+    // it doesn't pill mid-keystroke while the typeahead is still open.
+    if (caretPos != null && caretPos >= start && caretPos <= end) {
+      continue;
+    }
+
+    tokens.push({ start, end, name });
+  }
+
+  return tokens;
+}

--- a/packages/electron/src/renderer/index.css
+++ b/packages/electron/src/renderer/index.css
@@ -390,3 +390,18 @@ body[data-dev-mode="true"] .nav-quick-access::before {
   outline: 2px solid var(--nim-primary);
   outline-offset: -2px;
 }
+
+/* Command pills: highlight known /command tokens inside the AI chat input.
+   The overlay text sits over a transparent textarea, so a pill must NOT change
+   glyph advance -- tint via background + box-shadow spread (no padding/border/
+   font-weight change) so the caret stays aligned with the text beneath. */
+.command-pill {
+  color: var(--nim-primary);
+  background-color: color-mix(in srgb, var(--nim-primary) 14%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--nim-primary) 14%, transparent);
+  border-radius: 4px;
+}
+.command-pill:hover {
+  background-color: color-mix(in srgb, var(--nim-primary) 24%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--nim-primary) 24%, transparent);
+}


### PR DESCRIPTION
## What

Three improvements to the AI chat input:

1. **Slash commands work anywhere in a message**, not only at the start. Built-in commands were hidden once the cursor moved past column 0; the `/` menu now offers the same full list mid-message.
2. **Recognized `/command` tokens are highlighted as clickable pills** in the input (only names that match a known command; unknown `/foo` stays plain text).
3. **Clicking a pill opens an inspect card** with the command's description + body, plus an **Open file** button for file-backed commands (hidden for built-ins).

## Approach

Implemented as a transparent **highlight overlay** over the existing `<textarea>`, not a rich-editor (Lexical) rewrite. The textarea keeps ownership of editing, so undo/redo, IME, paste, drag-and-drop, `@`/`@@` mentions, memory mode, voice and resize are **untouched**. The draft value stays plain text (`/command-name`), so send/serialization/persistence are unchanged.

Trade-off: pills are a render layer, so backspace deletes char-by-char rather than removing the whole chip atomically.

## Commits (granular)

- `feat: show slash commands anywhere in a message, not just the start`
- `feat: detect known /command tokens in chat input text` (+ unit tests)
- `feat: add command-pill highlight overlay for the chat input`
- `feat: add command inspect popover with description, body and open-file`
- `feat: enable command pills and inspect popover in the AI chat input`

## Testing

- `parseCommandTokens` is covered by unit tests (boundaries, file-path rejection, mid-message detection, multi-token lines, caret-under-token suppression).

## Notes

- Reuses existing `useFloatingMenu` (floating-ui), `MarkdownRenderer`, and `openFileInSessionEditorAtom`.
- CHANGELOG `[Unreleased]` updated with a single user-facing bullet.
