### PR TITLE
feat: edit a previously-sent message and rewind the conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Edit a message you already sent and rewind the conversation to it: fix or redirect it, discard everything after, and re-run from that point — with an option to also undo file changes made since. The agent keeps the earlier context.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/main/HistoryManager.ts
+++ b/packages/electron/src/main/HistoryManager.ts
@@ -1287,6 +1287,43 @@ export class HistoryManager {
     }
   }
 
+  /**
+   * Fetch a file's content as of a point in time within a session: the newest
+   * snapshot for (filePath, sessionId) whose timestamp is <= `timestampMs`.
+   * Used by the edit/rewind file-revert to restore a file to its as-of-message-N
+   * state. Best-effort -- bounded by snapshot retention. Returns null when no
+   * in-session snapshot at or before the cutoff exists.
+   */
+  async getSnapshotContentAsOf(
+    filePath: string,
+    sessionId: string,
+    timestampMs: number,
+  ): Promise<string | null> {
+    try {
+      if (!database.isInitialized()) {
+        await database.initialize();
+      }
+      const result = await database.query<{ content: Buffer }>(
+        `
+          SELECT content
+          FROM document_history
+          WHERE file_path = $1
+            AND metadata->>'sessionId' = $2
+            AND timestamp <= $3
+          ORDER BY timestamp DESC
+          LIMIT 1
+        `,
+        [filePath, sessionId, timestampMs],
+      );
+      if (result.rows.length === 0) return null;
+      const decompressed = await gunzip(result.rows[0].content);
+      return decompressed.toString('utf-8');
+    } catch (error) {
+      logger.main.error('[HistoryManager] getSnapshotContentAsOf failed:', error);
+      return null;
+    }
+  }
+
   async getDiffBaseline(filePath: string): Promise<{ content: string; tagType: 'pre-edit' | 'incremental-approval' } | null> {
     try {
       // SIMPLIFIED: With the unique constraint, there's only ONE pending tag per file

--- a/packages/electron/src/main/services/PGLiteAgentMessagesStore.ts
+++ b/packages/electron/src/main/services/PGLiteAgentMessagesStore.ts
@@ -200,5 +200,98 @@ export function createPGLiteAgentMessagesStore(db: PGliteLike, ensureDbReady?: E
         };
       });
     },
+
+    async getMessageById(sessionId: string, messageId: number): Promise<AgentMessage | null> {
+      await ensureReady();
+      const { rows } = await db.query<any>(
+        `SELECT id, session_id, created_at, source, direction, content, metadata, hidden, provider_message_id
+           FROM ai_agent_messages
+          WHERE session_id = $1 AND id = $2
+          LIMIT 1`,
+        [sessionId, messageId]
+      );
+      if (rows.length === 0) return null;
+      const row = rows[0];
+      let metadata = row.metadata;
+      if (typeof metadata === 'string') {
+        try {
+          metadata = JSON.parse(metadata);
+        } catch {
+          // Keep as string if parsing fails
+        }
+      }
+      return {
+        id: Number(row.id),
+        sessionId: row.session_id,
+        createdAt: row.created_at ? new Date(row.created_at) : undefined,
+        source: row.source,
+        direction: row.direction,
+        content: row.content,
+        metadata: metadata ?? undefined,
+        hidden: row.hidden ?? false,
+        providerMessageId: row.provider_message_id ?? undefined,
+      };
+    },
+
+    async getLastUserMessageId(sessionId: string): Promise<number | null> {
+      await ensureReady();
+      const { rows } = await db.query<any>(
+        `SELECT id FROM ai_agent_messages
+          WHERE session_id = $1 AND message_kind = 'user'
+          ORDER BY id DESC
+          LIMIT 1`,
+        [sessionId]
+      );
+      return rows.length > 0 ? Number(rows[0].id) : null;
+    },
+
+    async deleteMessagesAfter(sessionId: string, afterId: number): Promise<{ deletedIds: number[] }> {
+      await ensureReady();
+
+      // SELECT-then-DELETE (rather than DELETE ... RETURNING) so the result is
+      // identical on both backends -- the SQLite shim routes writes through the
+      // WriteCoordinator, which does not surface RETURNING rows. Both statements
+      // land in one transaction (PGLite) / one batch tick (SQLite), so they are
+      // atomic. FK CASCADE on ai_tool_call_file_edits.message_id and the FTS
+      // delete trigger clean up dependents automatically.
+      await db.query('BEGIN', []);
+      try {
+        const { rows } = await db.query<any>(
+          `SELECT id FROM ai_agent_messages
+            WHERE session_id = $1 AND id > $2
+            ORDER BY id ASC`,
+          [sessionId, afterId]
+        );
+        const deletedIds = rows.map((r) => Number(r.id));
+
+        if (deletedIds.length > 0) {
+          await db.query(
+            `DELETE FROM ai_agent_messages WHERE session_id = $1 AND id > $2`,
+            [sessionId, afterId]
+          );
+        }
+
+        await db.query('COMMIT', []);
+        return { deletedIds };
+      } catch (error) {
+        await db.query('ROLLBACK', []);
+        throw error;
+      }
+    },
+
+    async updateMessageContent(
+      sessionId: string,
+      messageId: number,
+      content: string,
+      searchableText: string | null
+    ): Promise<void> {
+      await ensureReady();
+      await db.query(
+        `UPDATE ai_agent_messages
+            SET content = $3, searchable_text = $4
+          WHERE session_id = $1 AND id = $2`,
+        [sessionId, messageId, content, searchableText]
+      );
+    },
   };
 }

--- a/packages/electron/src/main/services/SyncedAgentMessagesStore.ts
+++ b/packages/electron/src/main/services/SyncedAgentMessagesStore.ts
@@ -136,5 +136,61 @@ export function createSyncedAgentMessagesStore(
       }
       return counts;
     },
+
+    async getMessageById(sessionId: string, messageId: number): Promise<AgentMessage | null> {
+      if (!baseStore.getMessageById) {
+        const messages = await baseStore.list(sessionId, { includeHidden: true });
+        return messages.find((m) => m.id === messageId) ?? null;
+      }
+      return baseStore.getMessageById(sessionId, messageId);
+    },
+
+    async getLastUserMessageId(sessionId: string): Promise<number | null> {
+      if (!baseStore.getLastUserMessageId) {
+        throw new Error('Base agent messages store does not support getLastUserMessageId');
+      }
+      return baseStore.getLastUserMessageId(sessionId);
+    },
+
+    async deleteMessagesAfter(sessionId: string, afterId: number): Promise<{ deletedIds: number[] }> {
+      if (!baseStore.deleteMessagesAfter) {
+        throw new Error('Base agent messages store does not support deleteMessagesAfter');
+      }
+      const result = await baseStore.deleteMessagesAfter(sessionId, afterId);
+      // Best-effort: notify the cross-device propagation hook. The desktop's
+      // local delete above is the source of truth and keeps this device
+      // consistent immediately.
+      notifyMessagesTruncated(sessionId, afterId, result.deletedIds);
+      return result;
+    },
+
+    async updateMessageContent(
+      sessionId: string,
+      messageId: number,
+      content: string,
+      searchableText: string | null
+    ): Promise<void> {
+      if (!baseStore.updateMessageContent) {
+        throw new Error('Base agent messages store does not support updateMessageContent');
+      }
+      await baseStore.updateMessageContent(sessionId, messageId, content, searchableText);
+    },
   };
+}
+
+/**
+ * Notify other devices that a session's tail was truncated by an edit/rewind.
+ *
+ * Deliberately a no-op in v1. The personal-sync `message_added` path has no
+ * delete/truncate counterpart (`packages/collab-protocol/src/personal.ts`), so
+ * propagating a truncation cross-device would require a new protocol change
+ * type plus matching CollabV3-server and iOS-client handling. Until that lands,
+ * the desktop truncation is local-first and authoritative; a mobile mirror that
+ * had the discarded tail reconciles on its next full index/session sync. This
+ * is the single, documented integration point when the protocol gains a
+ * truncation message.
+ */
+function notifyMessagesTruncated(_sessionId: string, _afterId: number, _deletedIds: number[]): void {
+  // No cross-device truncation message exists yet (see docblock). Local delete
+  // is authoritative.
 }

--- a/packages/electron/src/main/services/__tests__/AgentMessagesRewind.test.ts
+++ b/packages/electron/src/main/services/__tests__/AgentMessagesRewind.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Truncation primitive for the edit/rewind feature, verified against a REAL
+ * PGLite engine so the FK CASCADE (ai_tool_call_file_edits.message_id ->
+ * ai_agent_messages.id) and in-place content update are exercised for real --
+ * not asserted against a fake SQL adapter.
+ *
+ * Covers the store methods added in Stage 2:
+ *   deleteMessagesAfter / updateMessageContent / getLastUserMessageId / getMessageById
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import { createPGLiteAgentMessagesStore } from '../PGLiteAgentMessagesStore';
+
+interface Pg {
+  exec(sql: string): Promise<unknown>;
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
+  close(): Promise<void>;
+}
+
+const SESSION = 'sess-rewind-1';
+
+async function seedMessage(
+  db: Pg,
+  opts: {
+    direction: 'input' | 'output';
+    content: string;
+    searchableText?: string | null;
+    messageKind?: 'user' | 'assistant' | 'tool' | 'system' | 'meta' | null;
+    source?: string;
+  },
+): Promise<number> {
+  const { rows } = await db.query<{ id: number }>(
+    `INSERT INTO ai_agent_messages
+       (session_id, source, direction, content, hidden, searchable, searchable_text, message_kind, created_at)
+     VALUES ($1, $2, $3, $4, FALSE, FALSE, $5, $6, NOW())
+     RETURNING id`,
+    [SESSION, opts.source ?? 'claude-code', opts.direction, opts.content, opts.searchableText ?? null, opts.messageKind ?? null],
+  );
+  return Number(rows[0].id);
+}
+
+describe('AgentMessages rewind/truncation primitive (real PGLite)', () => {
+  let db: Pg;
+  let dataDir: string;
+  let store: ReturnType<typeof createPGLiteAgentMessagesStore>;
+
+  beforeEach(async () => {
+    dataDir = path.join(os.tmpdir(), `pglite-rewind-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    db = new PGlite({ dataDir }) as unknown as Pg;
+    await (db as unknown as { waitReady: Promise<void> }).waitReady;
+
+    await db.exec(`
+      CREATE TABLE ai_sessions (
+        id TEXT PRIMARY KEY,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        is_archived BOOLEAN NOT NULL DEFAULT FALSE
+      );
+      CREATE TABLE ai_agent_messages (
+        id BIGSERIAL PRIMARY KEY,
+        session_id TEXT NOT NULL REFERENCES ai_sessions(id) ON DELETE CASCADE,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        source TEXT NOT NULL,
+        direction TEXT NOT NULL,
+        content TEXT NOT NULL,
+        metadata TEXT,
+        hidden BOOLEAN NOT NULL DEFAULT FALSE,
+        provider_message_id TEXT,
+        searchable BOOLEAN NOT NULL DEFAULT FALSE,
+        searchable_text TEXT,
+        message_kind TEXT
+      );
+      CREATE TABLE session_files (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        workspace_id TEXT NOT NULL DEFAULT 'default',
+        file_path TEXT NOT NULL,
+        link_type TEXT NOT NULL DEFAULT 'edited',
+        timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        metadata TEXT NOT NULL DEFAULT '{}'
+      );
+      CREATE TABLE ai_tool_call_file_edits (
+        id BIGSERIAL PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        session_file_id TEXT NOT NULL REFERENCES session_files(id) ON DELETE CASCADE,
+        message_id BIGINT NOT NULL REFERENCES ai_agent_messages(id) ON DELETE CASCADE,
+        tool_use_id TEXT
+      );
+    `);
+    await db.query(`INSERT INTO ai_sessions (id) VALUES ($1)`, [SESSION]);
+    store = createPGLiteAgentMessagesStore(db as unknown as Parameters<typeof createPGLiteAgentMessagesStore>[0]);
+  });
+
+  afterEach(async () => {
+    if (db) await db.close();
+    if (dataDir && fs.existsSync(dataDir)) fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('deletes every message after N and cascades the file-edit link', async () => {
+    const u1 = await seedMessage(db, { direction: 'input', content: JSON.stringify({ prompt: 'first' }), searchableText: 'first', messageKind: 'user' });
+    const a2 = await seedMessage(db, { direction: 'output', content: 'assistant reply', searchableText: 'assistant reply', messageKind: 'assistant' });
+    const t3 = await seedMessage(db, { direction: 'output', content: JSON.stringify({ tool: 'Edit' }), messageKind: 'tool' });
+    await db.query(`INSERT INTO session_files (id, session_id, file_path) VALUES ($1, $2, $3)`, ['sf-1', SESSION, 'src/foo.ts']);
+    await db.query(`INSERT INTO ai_tool_call_file_edits (session_id, session_file_id, message_id) VALUES ($1, $2, $3)`, [SESSION, 'sf-1', t3]);
+    const u4 = await seedMessage(db, { direction: 'input', content: JSON.stringify({ prompt: 'second' }), searchableText: 'second', messageKind: 'user' });
+    const a5 = await seedMessage(db, { direction: 'output', content: 'second reply', searchableText: 'second reply', messageKind: 'assistant' });
+
+    const result = await store.deleteMessagesAfter!(SESSION, u1);
+
+    expect(result.deletedIds.slice().sort((x, y) => x - y)).toEqual([a2, t3, u4, a5].slice().sort((x, y) => x - y));
+
+    const remaining = await db.query<{ id: number }>(`SELECT id FROM ai_agent_messages WHERE session_id = $1 ORDER BY id`, [SESSION]);
+    expect(remaining.rows.map((r) => Number(r.id))).toEqual([u1]);
+
+    // FK CASCADE removed the tool-call-file-edit link that pointed at message t3.
+    const links = await db.query<{ c: number }>(`SELECT COUNT(*)::int AS c FROM ai_tool_call_file_edits`);
+    expect(Number(links.rows[0].c)).toBe(0);
+    // session_files itself is NOT cascade-deleted (no FK to messages); rewind
+    // service cleans those separately. Confirm the row survives here.
+    const files = await db.query<{ c: number }>(`SELECT COUNT(*)::int AS c FROM session_files`);
+    expect(Number(files.rows[0].c)).toBe(1);
+  });
+
+  it('is a no-op (empty deletedIds) when nothing follows N', async () => {
+    const u1 = await seedMessage(db, { direction: 'input', content: JSON.stringify({ prompt: 'only' }), searchableText: 'only', messageKind: 'user' });
+    const result = await store.deleteMessagesAfter!(SESSION, u1);
+    expect(result.deletedIds).toEqual([]);
+    const remaining = await db.query<{ id: number }>(`SELECT id FROM ai_agent_messages WHERE session_id = $1`, [SESSION]);
+    expect(remaining.rows.map((r) => Number(r.id))).toEqual([u1]);
+  });
+
+  it('updates content and searchable_text in place', async () => {
+    const u1 = await seedMessage(db, { direction: 'input', content: JSON.stringify({ prompt: 'first' }), searchableText: 'first', messageKind: 'user' });
+
+    await store.updateMessageContent!(SESSION, u1, JSON.stringify({ prompt: 'edited prompt' }), 'edited prompt');
+
+    const row = await store.getMessageById!(SESSION, u1);
+    expect(row?.content).toBe(JSON.stringify({ prompt: 'edited prompt' }));
+    const raw = await db.query<{ searchable_text: string }>(`SELECT searchable_text FROM ai_agent_messages WHERE id = $1`, [u1]);
+    expect(raw.rows[0].searchable_text).toBe('edited prompt');
+  });
+
+  it('getLastUserMessageId tracks the most recent user row through truncation', async () => {
+    const u1 = await seedMessage(db, { direction: 'input', content: JSON.stringify({ prompt: 'first' }), searchableText: 'first', messageKind: 'user' });
+    await seedMessage(db, { direction: 'output', content: 'reply', searchableText: 'reply', messageKind: 'assistant' });
+    const u3 = await seedMessage(db, { direction: 'input', content: JSON.stringify({ prompt: 'second' }), searchableText: 'second', messageKind: 'user' });
+
+    expect(await store.getLastUserMessageId!(SESSION)).toBe(u3);
+
+    await store.deleteMessagesAfter!(SESSION, u1);
+    expect(await store.getLastUserMessageId!(SESSION)).toBe(u1);
+  });
+
+  it('getMessageById returns null for a missing id', async () => {
+    expect(await store.getMessageById!(SESSION, 999999)).toBeNull();
+  });
+});

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -6,6 +6,8 @@ import { BrowserWindow, ipcMain } from 'electron';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { safeHandle } from '../../utils/ipcRegistry';
+import { RewindSessionService } from './RewindSessionService';
+import { FileRevertService } from './FileRevertService';
 import Store from 'electron-store';
 import {
   isExtensionAgentProvider,
@@ -153,6 +155,11 @@ export class AIService {
   // each claiming a different prompt and sending both to the AI concurrently.
   private sessionsProcessingQueue = new Set<string>();
 
+  // One-shot, per-session context prefix staged by a rewind and consumed by the
+  // next send (MessageStreamingHandler), so a freshly-reset agent provider keeps
+  // the conversational thread after its session is reset.
+  public pendingRewindContext = new Map<string, string>();
+
   // Track mobile session creation requests to prevent duplicate processing
   // (can happen if the same request is delivered multiple times)
   private processingMobileSessionRequests = new Set<string>();
@@ -163,10 +170,19 @@ export class AIService {
   // Owns the streaming send-message lifecycle (extracted from setupIpcHandlers).
   private streamingHandler: MessageStreamingHandler;
 
+  // Owns the edit-a-previous-message + rewind truncation primitive.
+  private rewindService: RewindSessionService;
+
   constructor(sessionStore: SessionStore) {
     logger.main.info('[AIService] Constructor called');
     this.sessionManager = new SessionManager(sessionStore);
     this.streamingHandler = new MessageStreamingHandler(this);
+    this.rewindService = new RewindSessionService({
+      sessionManager: this.sessionManager,
+      sessionsProcessingQueue: this.sessionsProcessingQueue,
+      pendingRewindContext: this.pendingRewindContext,
+    });
+    this.rewindService.setFileRevertService(new FileRevertService());
 
     // Set up persistence callback for DocumentContextService
     // Use AISessionsRepository directly since SessionManager doesn't have a generic updateMetadata
@@ -1997,6 +2013,46 @@ export class AIService {
       }
 
       return { success: true };
+    });
+
+    // Edit a previously-sent user message and rewind: destructively discard
+    // everything after the target message, optionally revert files, reset the
+    // provider session, and rebuild the transcript. The renderer then re-sends
+    // the edited message via the normal ai:sendMessage path.
+    safeHandle('ai:rewindSession', async (
+      _event,
+      sessionId: string,
+      targetRawMessageId: number,
+      options?: { revertFiles?: boolean; workspacePath?: string }
+    ) => {
+      if (!sessionId) {
+        throw new Error('sessionId is required to rewind');
+      }
+      if (typeof targetRawMessageId !== 'number') {
+        throw new Error('targetRawMessageId is required to rewind');
+      }
+      return await this.rewindService.rewindSession({
+        sessionId,
+        targetRawMessageId,
+        revertFiles: options?.revertFiles ?? false,
+        workspacePath: options?.workspacePath,
+      });
+    });
+
+    // Read-only preview of a rewind's blast radius (message + file counts) for
+    // the confirm dialog.
+    safeHandle('ai:getRewindImpact', async (
+      _event,
+      sessionId: string,
+      targetRawMessageId: number
+    ) => {
+      if (!sessionId) {
+        throw new Error('sessionId is required');
+      }
+      if (typeof targetRawMessageId !== 'number') {
+        throw new Error('targetRawMessageId is required');
+      }
+      return await this.rewindService.getRewindImpact(sessionId, targetRawMessageId);
     });
 
     // Update session messages

--- a/packages/electron/src/main/services/ai/FileRevertService.ts
+++ b/packages/electron/src/main/services/ai/FileRevertService.ts
@@ -1,5 +1,5 @@
 /**
- * FileRevertService -- the "Chat + Dateien zurücksetzen" half of the edit/rewind
+ * FileRevertService -- the "Reset chat + files" half of the edit/rewind
  * feature. Restores files the AI edited after the rewind target back to their
  * as-of-target content, using the bounded per-file snapshot history.
  *

--- a/packages/electron/src/main/services/ai/FileRevertService.ts
+++ b/packages/electron/src/main/services/ai/FileRevertService.ts
@@ -1,0 +1,127 @@
+/**
+ * FileRevertService -- the "Chat + Dateien zurücksetzen" half of the edit/rewind
+ * feature. Restores files the AI edited after the rewind target back to their
+ * as-of-target content, using the bounded per-file snapshot history.
+ *
+ * Safety posture (deliberate): this service NEVER deletes files. Files the AI
+ * created after the target (no recoverable prior snapshot) are reported in
+ * `unrevertableFiles` for the user to remove manually, rather than auto-deleted
+ * -- file deletion is the highest-blast-radius operation and the repo's
+ * file-safety rules favour conservatism. Reverts overwrite through a plain write
+ * and let the file watcher propagate the change to open editors (the same path
+ * the app uses for any external file change).
+ *
+ * Precision is best-effort: snapshot retention is bounded, so a file edited long
+ * before the target (with its pre-target snapshot already pruned) may fall back
+ * to its pre-AI baseline.
+ */
+
+import * as fs from 'fs/promises';
+import { database } from '../../database/PGLiteDatabaseWorker';
+import { historyManager } from '../../HistoryManager';
+import { logger } from '../../utils/logger';
+import type { FileRevertCollaborator } from './RewindSessionService';
+
+export class FileRevertService implements FileRevertCollaborator {
+  async countFilesAfter(sessionId: string, afterMessageId: number): Promise<number> {
+    const files = await this.queryFilesEditedAfter(sessionId, afterMessageId);
+    return files.length;
+  }
+
+  async revertFilesAfter(params: {
+    sessionId: string;
+    workspacePath?: string;
+    afterMessageId: number;
+  }): Promise<{ revertedFiles: string[]; unrevertableFiles: string[] }> {
+    const { sessionId, afterMessageId } = params;
+    const revertedFiles: string[] = [];
+    const unrevertableFiles: string[] = [];
+
+    const files = await this.queryFilesEditedAfter(sessionId, afterMessageId);
+    if (files.length === 0) {
+      return { revertedFiles, unrevertableFiles };
+    }
+
+    const targetCreatedAtMs = await this.getMessageCreatedAtMs(sessionId, afterMessageId);
+
+    for (const filePath of files) {
+      try {
+        let asOf: string | null = null;
+
+        // Primary: newest in-session snapshot at or before the target's time =
+        // the file's content as of message N (keeps pre-N edits, drops post-N).
+        if (targetCreatedAtMs != null) {
+          asOf = await historyManager.getSnapshotContentAsOf(filePath, sessionId, targetCreatedAtMs);
+        }
+
+        // Fallback: the file was first edited AFTER the target (its only snapshot
+        // is later than N), so its as-of-N state is its pre-AI baseline.
+        if (asOf == null) {
+          asOf = await historyManager.getLatestSnapshotContent(filePath, sessionId, 'pre-edit');
+        }
+
+        if (asOf == null) {
+          // No recoverable baseline -- the AI created this file after the target.
+          // We do NOT delete it (file-safety); report it instead.
+          unrevertableFiles.push(filePath);
+          continue;
+        }
+
+        // Overwrite (or recreate, if deleted after N). The file watcher picks
+        // this up as an external change and refreshes any open editor.
+        await fs.writeFile(filePath, asOf, 'utf-8');
+        revertedFiles.push(filePath);
+      } catch (err) {
+        logger.main.error(`[FileRevertService] failed to revert ${filePath}:`, err);
+        unrevertableFiles.push(filePath);
+      }
+    }
+
+    logger.main.info(
+      `[FileRevertService] session ${sessionId}: reverted ${revertedFiles.length}, unrevertable ${unrevertableFiles.length}`,
+    );
+    return { revertedFiles, unrevertableFiles };
+  }
+
+  /** Distinct files edited by tool calls attributed to messages after N. */
+  private async queryFilesEditedAfter(sessionId: string, afterMessageId: number): Promise<string[]> {
+    if (!database.isInitialized()) {
+      await database.initialize();
+    }
+    const { rows } = await database.query<{ file_path: string }>(
+      `
+        SELECT DISTINCT sf.file_path
+        FROM ai_tool_call_file_edits atcfe
+        JOIN session_files sf ON atcfe.session_file_id = sf.id
+        WHERE atcfe.session_id = $1
+          AND atcfe.message_id > $2
+      `,
+      [sessionId, afterMessageId],
+    );
+    return rows.map((r) => r.file_path).filter((p): p is string => Boolean(p));
+  }
+
+  private async getMessageCreatedAtMs(sessionId: string, messageId: number): Promise<number | null> {
+    if (!database.isInitialized()) {
+      await database.initialize();
+    }
+    const { rows } = await database.query<{ created_at: unknown }>(
+      `SELECT created_at FROM ai_agent_messages WHERE session_id = $1 AND id = $2 LIMIT 1`,
+      [sessionId, messageId],
+    );
+    if (rows.length === 0) return null;
+    return toMillis(rows[0].created_at);
+  }
+}
+
+/** Coerce a created_at value (Date | ISO string | epoch ms) to epoch ms. */
+function toMillis(value: unknown): number | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string') {
+    const ms = Date.parse(value);
+    return Number.isFinite(ms) ? ms : null;
+  }
+  return null;
+}

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -132,6 +132,8 @@ interface AIServiceInternal {
   processingQueuedPromptIds: Set<string>;
   matchDebounceTimers: Map<string, ReturnType<typeof setTimeout>>;
   sessionsProcessingQueue: Set<string>;
+  /** One-shot per-session context prefix staged by a rewind, consumed on next send. */
+  pendingRewindContext: Map<string, string>;
   documentContextService: DocumentContextService;
   hooklessWatcher: HooklessAgentFileWatcher;
 
@@ -1147,7 +1149,19 @@ export class MessageStreamingHandler {
 
       // Attach @ mentioned files for non-agent providers
       const { enhancedMessage, attachedFiles } = await attachMentionedFiles(message, workspacePath, provider);
-      const messageToSend = enhancedMessage;
+      let messageToSend = enhancedMessage;
+
+      // Edit/rewind context replay: a rewind reset this agent provider's session,
+      // so it has no memory of the earlier conversation. Prepend the one-shot
+      // reconstructed prefix to the provider-bound message ONLY -- the user
+      // message logged above stays clean so the prefix never shows in the UI.
+      // Chat providers replay their full message array each turn and skip this.
+      const rewindPrefix = this.svc.pendingRewindContext.get(session.id);
+      if (rewindPrefix && isAgentProvider(session.provider)) {
+        messageToSend = `${rewindPrefix}${messageToSend}`;
+        this.svc.pendingRewindContext.delete(session.id);
+        logger.main.info(`[AIService] Injected rewind context prefix (${rewindPrefix.length} chars) for session ${session.id}`);
+      }
 
       if (attachedFiles.length > 0) {
         logger.main.info(`[AIService] Attached ${attachedFiles.length} files via @ mentions`, {

--- a/packages/electron/src/main/services/ai/RewindSessionService.ts
+++ b/packages/electron/src/main/services/ai/RewindSessionService.ts
@@ -1,0 +1,315 @@
+/**
+ * RewindSessionService -- the single backend primitive behind the
+ * "edit a previously-sent message + rewind" feature.
+ *
+ * Given a target user message, it destructively discards that message and
+ * everything after it in the SAME session, (optionally) reverts workspace file
+ * changes, resets the provider so the next turn starts cleanly, rebuilds the
+ * canonical transcript, and stages a one-shot context prefix so agent providers
+ * keep the conversational thread after their session is reset.
+ *
+ * The renderer then re-sends the edited message text through the normal
+ * `ai:sendMessage` path, which becomes the new turn at the rewound position.
+ *
+ * Covers both user scenarios with one path:
+ *  - "stop & fix the last message" (target = last user message, a turn may be running)
+ *  - "rewind N turns back and re-run" (target = an earlier user message)
+ */
+
+import { BrowserWindow } from 'electron';
+import type { SessionManager } from '@nimbalyst/runtime';
+import { logger } from '../../utils/logger';
+
+export interface RewindSessionParams {
+  sessionId: string;
+  /** Raw `ai_agent_messages.id` of the user message to rewind to. */
+  targetRawMessageId: number;
+  /** When true, also revert workspace file changes made after the target. */
+  revertFiles: boolean;
+  workspacePath?: string;
+}
+
+export interface RewindSessionResult {
+  success: boolean;
+  /** Number of raw messages discarded at and after the target. */
+  deletedCount: number;
+  /** Files restored to their as-of-target state (when revertFiles). */
+  revertedFiles?: string[];
+  /** Files that could not be reverted (no recoverable snapshot). */
+  unrevertableFiles?: string[];
+  error?: string;
+}
+
+export interface RewindImpact {
+  /** Messages that would be discarded AFTER the target (the target itself is edited, not discarded). */
+  messageCount: number;
+  /** Distinct files edited after the target (0 until the file-revert service is wired). */
+  fileCount: number;
+}
+
+/**
+ * File-revert collaborator (implemented in Stage 4). Kept as an interface so the
+ * truncation primitive has zero hard dependency on the file machinery and stays
+ * unit-testable in isolation.
+ */
+export interface FileRevertCollaborator {
+  revertFilesAfter(params: {
+    sessionId: string;
+    workspacePath?: string;
+    afterMessageId: number;
+  }): Promise<{ revertedFiles: string[]; unrevertableFiles: string[] }>;
+  countFilesAfter(sessionId: string, afterMessageId: number): Promise<number>;
+}
+
+/**
+ * Build a bounded, plain-text prefix replaying the earlier conversation so a
+ * freshly-reset agent provider keeps the thread. Pure and exported for tests.
+ * Returns null when there is no meaningful prior text.
+ */
+export function buildRewindContextPrefix(
+  turns: Array<{ role: 'user' | 'assistant'; text: string }>,
+  maxTurns = 12,
+): string | null {
+  const clean = turns.filter((t) => t.text && t.text.trim().length > 0);
+  if (clean.length === 0) {
+    return null;
+  }
+  const truncated = clean.length > maxTurns;
+  const bounded = clean.slice(-maxTurns);
+  const lines = bounded.map((t) => `${t.role === 'user' ? 'User' : 'Assistant'}: ${t.text.trim()}`);
+  const header =
+    'For context, here is the earlier conversation in this session. The user rewound to edit ' +
+    'a previous message; continue naturally from this history and do not repeat it back.\n\n';
+  const omitted = truncated ? '[earlier turns omitted]\n\n' : '';
+  return `${header}${omitted}${lines.join('\n\n')}\n\n---\n\n`;
+}
+
+export class RewindSessionService {
+  private fileRevertService?: FileRevertCollaborator;
+
+  constructor(
+    private deps: {
+      sessionManager: SessionManager;
+      /** AIService's in-memory set of sessions with an in-flight turn. */
+      sessionsProcessingQueue: Set<string>;
+      /**
+       * One-shot, per-session context prefix consumed by MessageStreamingHandler
+       * on the next send (shared by reference with AIService).
+       */
+      pendingRewindContext: Map<string, string>;
+    },
+  ) {}
+
+  /** Inject the file-revert collaborator (Stage 4). */
+  setFileRevertService(service: FileRevertCollaborator): void {
+    this.fileRevertService = service;
+  }
+
+  /**
+   * Read-only preview of how much a rewind to `targetRawMessageId` would discard,
+   * so the confirm dialog can show counts before the destructive action. Counts
+   * messages strictly AFTER the target -- the target itself is edited, not lost.
+   */
+  async getRewindImpact(sessionId: string, targetRawMessageId: number): Promise<RewindImpact> {
+    const { AgentMessagesRepository } = await import('@nimbalyst/runtime/storage/repositories/AgentMessagesRepository');
+    const messages = await AgentMessagesRepository.list(sessionId, { includeHidden: true });
+    const messageCount = messages.filter((m) => (m.id ?? 0) > targetRawMessageId).length;
+
+    let fileCount = 0;
+    if (this.fileRevertService) {
+      try {
+        fileCount = await this.fileRevertService.countFilesAfter(sessionId, targetRawMessageId);
+      } catch (err) {
+        logger.main.warn('[RewindSessionService] countFilesAfter failed:', err);
+      }
+    }
+
+    return { messageCount, fileCount };
+  }
+
+  async rewindSession(params: RewindSessionParams): Promise<RewindSessionResult> {
+    const { sessionId, targetRawMessageId, revertFiles } = params;
+
+    const { AISessionsRepository } = await import('@nimbalyst/runtime/storage/repositories/AISessionsRepository');
+    const { AgentMessagesRepository } = await import('@nimbalyst/runtime/storage/repositories/AgentMessagesRepository');
+    const { ProviderFactory } = await import('@nimbalyst/runtime/ai/server/ProviderFactory');
+    const { getSessionStateManager } = await import('@nimbalyst/runtime/ai/server/SessionStateManager');
+    const { isAgentProvider } = await import('@nimbalyst/runtime/ai/server/types');
+    const { TranscriptMigrationRepository } = await import('@nimbalyst/runtime');
+
+    const session = await AISessionsRepository.get(sessionId);
+    if (!session) {
+      return { success: false, deletedCount: 0, error: `Session ${sessionId} not found` };
+    }
+    const provider = session.provider as string;
+    const workspacePath = params.workspacePath ?? session.workspacePath;
+
+    // 1. Stop any in-flight turn -- we are discarding it. Hard abort (not the
+    //    graceful interrupt) because the turn's output is being thrown away.
+    await this.stopInFlightTurn(sessionId, provider, ProviderFactory, getSessionStateManager);
+
+    // 2. File revert (optional) runs BEFORE truncation: it relies on the
+    //    ai_tool_call_file_edits.message_id > N links that the truncation's FK
+    //    cascade will destroy. Files were edited by the assistant/tool turns
+    //    AFTER the target user message, so the boundary stays strictly > target.
+    let revertedFiles: string[] | undefined;
+    let unrevertableFiles: string[] | undefined;
+    if (revertFiles) {
+      if (this.fileRevertService) {
+        try {
+          const res = await this.fileRevertService.revertFilesAfter({ sessionId, workspacePath, afterMessageId: targetRawMessageId });
+          revertedFiles = res.revertedFiles;
+          unrevertableFiles = res.unrevertableFiles;
+        } catch (err) {
+          logger.main.error('[RewindSessionService] file revert failed:', err);
+          unrevertableFiles = ['<file revert failed>'];
+        }
+      } else {
+        logger.main.warn('[RewindSessionService] revertFiles requested but no file-revert service is wired');
+      }
+    }
+
+    // 3. Destructive truncation, INCLUSIVE of the target. The renderer re-sends
+    //    the edited text as a fresh turn that lands at the rewound position, so
+    //    the target row is removed (not edited in place). For integer primary
+    //    keys, `id > target - 1` is exactly `id >= target`. FK CASCADE clears
+    //    ai_tool_call_file_edits and the FTS delete trigger clears the mirror.
+    const { deletedIds } = await AgentMessagesRepository.deleteMessagesAfter(sessionId, targetRawMessageId - 1);
+
+    // 4. Reset the provider session. Agent providers (claude-code, codex) own
+    //    their conversation history internally and cannot truncate it, so the
+    //    next turn must start a FRESH provider session (no stale resume). Clear
+    //    BOTH the in-memory provider AND the DB provider_session_id, in that
+    //    order, before any next send.
+    if (isAgentProvider(provider)) {
+      try {
+        ProviderFactory.destroyProvider(sessionId);
+        await this.deps.sessionManager.updateProviderSessionData(sessionId, undefined);
+      } catch (err) {
+        logger.main.warn('[RewindSessionService] provider session reset failed:', err);
+      }
+    }
+
+    // 5. Rebuild the canonical transcript from the now-truncated raw log and
+    //    nudge any open renderer view to reload (reusing the existing reparse
+    //    signal the renderer already listens for).
+    try {
+      if (TranscriptMigrationRepository.hasService()) {
+        await TranscriptMigrationRepository.getService().forceReparseSession(sessionId, provider);
+      }
+    } catch (err) {
+      logger.main.error('[RewindSessionService] forceReparseSession failed:', err);
+    }
+
+    // 6. Stage the one-shot context prefix so the fresh agent session keeps the
+    //    thread when the renderer re-sends the edited message. Chat providers
+    //    replay their full message array each turn and need no prefix.
+    this.deps.pendingRewindContext.delete(sessionId);
+    if (isAgentProvider(provider)) {
+      await this.buildAndStoreContextPrefix(sessionId, provider);
+    }
+
+    this.broadcastReparsed(sessionId, workspacePath);
+
+    logger.main.info(
+      `[RewindSessionService] rewound session ${sessionId} to message ${targetRawMessageId}: ${deletedIds.length} messages discarded` +
+        (revertFiles ? `, ${revertedFiles?.length ?? 0} files reverted` : ''),
+    );
+
+    return {
+      success: true,
+      deletedCount: deletedIds.length,
+      revertedFiles,
+      unrevertableFiles,
+    };
+  }
+
+  /**
+   * Reconstruct a bounded context prefix from the surviving (pre-target)
+   * conversation and stash it for the next send. Uses the same client-side
+   * projection the mobile transcript uses, so the replayed text matches what
+   * the user saw.
+   */
+  private async buildAndStoreContextPrefix(sessionId: string, provider: string): Promise<void> {
+    try {
+      const { AgentMessagesRepository } = await import('@nimbalyst/runtime/storage/repositories/AgentMessagesRepository');
+      const { projectRawMessagesToViewMessages } = await import('@nimbalyst/runtime/ai/server/transcript/projectRawMessages');
+
+      const msgs = await AgentMessagesRepository.list(sessionId, { includeHidden: false });
+      if (msgs.length === 0) {
+        return;
+      }
+      const raw = msgs.map((m) => ({
+        id: m.id ?? 0,
+        sessionId,
+        source: m.source,
+        direction: m.direction,
+        content: m.content,
+        createdAt: m.createdAt ?? new Date(),
+        metadata: m.metadata,
+        hidden: m.hidden,
+      }));
+      const view = await projectRawMessagesToViewMessages(raw, provider);
+      const turns = view
+        .filter((v) => v.type === 'user_message' || v.type === 'assistant_message')
+        .map((v) => ({
+          role: (v.type === 'user_message' ? 'user' : 'assistant') as 'user' | 'assistant',
+          text: v.text ?? '',
+        }));
+
+      const prefix = buildRewindContextPrefix(turns);
+      if (prefix) {
+        this.deps.pendingRewindContext.set(sessionId, prefix);
+      }
+    } catch (err) {
+      logger.main.warn('[RewindSessionService] context prefix build failed:', err);
+    }
+  }
+
+  private async stopInFlightTurn(
+    sessionId: string,
+    provider: string,
+    ProviderFactory: typeof import('@nimbalyst/runtime/ai/server/ProviderFactory')['ProviderFactory'],
+    getSessionStateManager: typeof import('@nimbalyst/runtime/ai/server/SessionStateManager')['getSessionStateManager'],
+  ): Promise<void> {
+    this.deps.sessionsProcessingQueue.delete(sessionId);
+
+    try {
+      const { getQueuedPromptsStore } = await import('../RepositoryManager');
+      const queueStore = getQueuedPromptsStore();
+      // Resolve any executing queued prompt cleanly...
+      await queueStore.sweepExecutingForSession(sessionId);
+      // ...then drop pending/executing prompts -- they were queued against the
+      // conversation tail we are discarding.
+      const pending = await queueStore.listForSession(sessionId, { includeCompleted: false });
+      for (const p of pending) {
+        if (p.status === 'pending' || p.status === 'executing') {
+          await queueStore.delete(p.id);
+        }
+      }
+    } catch (err) {
+      logger.main.warn('[RewindSessionService] queued-prompt cleanup failed:', err);
+    }
+
+    try {
+      const providerInstance = ProviderFactory.getProvider(provider as Parameters<typeof ProviderFactory.getProvider>[0], sessionId);
+      providerInstance?.abort();
+    } catch (err) {
+      logger.main.warn('[RewindSessionService] provider abort failed:', err);
+    }
+
+    try {
+      await getSessionStateManager().endSession(sessionId);
+    } catch {
+      // Session may not be active -- fine.
+    }
+  }
+
+  private broadcastReparsed(sessionId: string, workspacePath?: string): void {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) {
+        window.webContents.send('transcript:session-reparsed', { sessionId, workspacePath });
+      }
+    }
+  }
+}

--- a/packages/electron/src/main/services/ai/__tests__/RewindSessionService.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/RewindSessionService.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// RewindSessionService imports `electron` at module load (BrowserWindow for the
+// reparse broadcast). Stub it so the module loads in the node test env.
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+import { buildRewindContextPrefix } from '../RewindSessionService';
+
+describe('buildRewindContextPrefix', () => {
+  it('returns null when there are no turns', () => {
+    expect(buildRewindContextPrefix([])).toBeNull();
+  });
+
+  it('returns null when all turns are blank', () => {
+    expect(
+      buildRewindContextPrefix([
+        { role: 'user', text: '   ' },
+        { role: 'assistant', text: '' },
+      ]),
+    ).toBeNull();
+  });
+
+  it('renders user/assistant turns with a header and trailing separator', () => {
+    const prefix = buildRewindContextPrefix([
+      { role: 'user', text: 'build a login form' },
+      { role: 'assistant', text: 'Done, added LoginForm.tsx' },
+    ]);
+    expect(prefix).toContain('User: build a login form');
+    expect(prefix).toContain('Assistant: Done, added LoginForm.tsx');
+    expect(prefix).toMatch(/---\n\n$/);
+    expect(prefix).not.toContain('[earlier turns omitted]');
+  });
+
+  it('omits and marks earlier turns when over the bound', () => {
+    const turns = Array.from({ length: 20 }, (_, i) => ({
+      role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+      text: `turn ${i}`,
+    }));
+    const prefix = buildRewindContextPrefix(turns, 6);
+    expect(prefix).toContain('[earlier turns omitted]');
+    // Only the last 6 turns survive.
+    expect(prefix).toContain('turn 19');
+    expect(prefix).toContain('turn 14');
+    expect(prefix).not.toContain('turn 13');
+    expect(prefix).not.toContain('turn 0');
+  });
+
+  it('skips blank turns but keeps surrounding content', () => {
+    const prefix = buildRewindContextPrefix([
+      { role: 'user', text: 'first' },
+      { role: 'assistant', text: '   ' },
+      { role: 'user', text: 'second' },
+    ]);
+    expect(prefix).toContain('User: first');
+    expect(prefix).toContain('User: second');
+    // The blank assistant turn produces no "Assistant:" line.
+    expect(prefix).not.toContain('Assistant:');
+  });
+});

--- a/packages/electron/src/renderer/components/ConfirmDialog/RewindSessionDialog.tsx
+++ b/packages/electron/src/renderer/components/ConfirmDialog/RewindSessionDialog.tsx
@@ -28,11 +28,11 @@ export const RewindSessionDialog: React.FC<RewindSessionDialogProps> = ({
 
   const messagePart =
     messageCount > 0
-      ? `${messageCount} ${messageCount === 1 ? 'Nachricht' : 'Nachrichten'} nach dieser werden verworfen`
-      : 'Die Unterhaltung wird ab hier neu gestartet';
+      ? `${messageCount} ${messageCount === 1 ? 'message' : 'messages'} after this one will be discarded`
+      : 'The conversation will be restarted from here';
   const filePart =
     fileCount > 0
-      ? `, und ${fileCount} ${fileCount === 1 ? 'Datei wurde' : 'Dateien wurden'} seither geändert.`
+      ? `, and ${fileCount} ${fileCount === 1 ? 'file has' : 'files have'} changed since.`
       : '.';
 
   return (
@@ -42,32 +42,32 @@ export const RewindSessionDialog: React.FC<RewindSessionDialogProps> = ({
         onClick={(e) => e.stopPropagation()}
       >
         <h2 className="rewind-session-dialog-title m-0 mb-3 text-lg font-semibold text-nim">
-          Nachricht bearbeiten &amp; zurücksetzen
+          Edit message &amp; rewind
         </h2>
         <p className="rewind-session-dialog-message m-0 mb-5 text-sm text-nim-muted leading-relaxed">
           {messagePart}
-          {filePart} Was soll passieren?
+          {filePart} What would you like to do?
         </p>
         <div className="rewind-session-dialog-buttons flex flex-col gap-2">
           <button
             className="rewind-session-chat-only nim-btn-primary w-full justify-center"
             onClick={onChatOnly}
           >
-            Nur Chat zurücksetzen
+            Reset chat only
           </button>
           <button
             className={`rewind-session-chat-and-files w-full justify-center ${fileCount > 0 ? 'nim-btn-danger' : 'nim-btn-secondary'}`}
             onClick={onChatAndFiles}
             disabled={fileCount === 0}
-            title={fileCount === 0 ? 'Keine Dateiänderungen nach dieser Nachricht' : undefined}
+            title={fileCount === 0 ? 'No file changes after this message' : undefined}
           >
-            Chat + Dateien zurücksetzen
+            Reset chat + files
           </button>
           <button
             className="rewind-session-cancel nim-btn-secondary w-full justify-center mt-1"
             onClick={onCancel}
           >
-            Abbrechen
+            Cancel
           </button>
         </div>
       </div>

--- a/packages/electron/src/renderer/components/ConfirmDialog/RewindSessionDialog.tsx
+++ b/packages/electron/src/renderer/components/ConfirmDialog/RewindSessionDialog.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+export interface RewindSessionDialogProps {
+  isOpen: boolean;
+  /** Messages that will be discarded after the edited one. */
+  messageCount: number;
+  /** Files changed after the edited message (powers the file-revert option). */
+  fileCount: number;
+  onChatOnly: () => void;
+  onChatAndFiles: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Confirmation shown when editing a previous message would destructively discard
+ * the conversation after it. Offers the Cursor-style choice between resetting
+ * only the chat and also reverting the file changes made since.
+ */
+export const RewindSessionDialog: React.FC<RewindSessionDialogProps> = ({
+  isOpen,
+  messageCount,
+  fileCount,
+  onChatOnly,
+  onChatAndFiles,
+  onCancel,
+}) => {
+  if (!isOpen) return null;
+
+  const messagePart =
+    messageCount > 0
+      ? `${messageCount} ${messageCount === 1 ? 'Nachricht' : 'Nachrichten'} nach dieser werden verworfen`
+      : 'Die Unterhaltung wird ab hier neu gestartet';
+  const filePart =
+    fileCount > 0
+      ? `, und ${fileCount} ${fileCount === 1 ? 'Datei wurde' : 'Dateien wurden'} seither geändert.`
+      : '.';
+
+  return (
+    <div className="rewind-session-dialog-overlay nim-overlay" onClick={onCancel}>
+      <div
+        className="rewind-session-dialog nim-modal min-w-[420px] max-w-[520px] p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="rewind-session-dialog-title m-0 mb-3 text-lg font-semibold text-nim">
+          Nachricht bearbeiten &amp; zurücksetzen
+        </h2>
+        <p className="rewind-session-dialog-message m-0 mb-5 text-sm text-nim-muted leading-relaxed">
+          {messagePart}
+          {filePart} Was soll passieren?
+        </p>
+        <div className="rewind-session-dialog-buttons flex flex-col gap-2">
+          <button
+            className="rewind-session-chat-only nim-btn-primary w-full justify-center"
+            onClick={onChatOnly}
+          >
+            Nur Chat zurücksetzen
+          </button>
+          <button
+            className={`rewind-session-chat-and-files w-full justify-center ${fileCount > 0 ? 'nim-btn-danger' : 'nim-btn-secondary'}`}
+            onClick={onChatAndFiles}
+            disabled={fileCount === 0}
+            title={fileCount === 0 ? 'Keine Dateiänderungen nach dieser Nachricht' : undefined}
+          >
+            Chat + Dateien zurücksetzen
+          </button>
+          <button
+            className="rewind-session-cancel nim-btn-secondary w-full justify-center mt-1"
+            onClick={onCancel}
+          >
+            Abbrechen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -30,6 +30,8 @@ import { TranscriptEmbeddedFileCard } from './TranscriptEmbeddedFileCard';
 import { getDiffPeekSizeForInteractiveWidgetHost } from './interactiveWidgetHostProxy';
 import { customEditorRegistry } from '../CustomEditors/registry';
 import { useDialog } from '../../contexts/DialogContext';
+import { DIALOG_IDS } from '../../dialogs/registry';
+import type { RewindSessionData } from '../../dialogs/dataDialogs';
 import { FileGutter } from '../AIChat/FileGutter';
 import { recordClaudeActivity } from '../../store/listeners/claudeUsageListeners';
 import { recordCodexActivity } from '../../store/listeners/codexUsageListeners';
@@ -861,7 +863,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
   // - ai:tokenUsageUpdated → sessionTranscriptListeners updates sessionStoreAtom
   // - ai:error → sessionTranscriptListeners updates sessionErrorAtom
   // ============================================================
-  const { confirm } = useDialog();
+  const { confirm, open, close } = useDialog();
 
   // Handle errors from centralized atom
   useEffect(() => {
@@ -1437,6 +1439,65 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
       console.error('[SessionTranscript] Failed to send /compact command:', error);
     }
   }, [sessionId, sessionData, messages, getEffectiveDocumentContext, aiMode, workspacePath, updateSessionStore]);
+
+  // Edit a previously-sent user message and rewind: confirm the destructive
+  // truncation (with the file-revert choice when files changed), call the
+  // backend rewind primitive, then re-send the edited text as the new turn at
+  // the rewound position. handleSend reads the draft atom imperatively, so
+  // setting it just before the call is sufficient.
+  const handleEditUserMessage = useCallback(async (
+    rawMessageId: number,
+    newText: string,
+    hasDownstream: boolean,
+  ) => {
+    const text = newText.trim();
+    if (!text) return;
+
+    let revertFiles = false;
+    if (hasDownstream) {
+      let messageCount = 0;
+      let fileCount = 0;
+      try {
+        const impact = (await window.electronAPI.invoke('ai:getRewindImpact', sessionId, rawMessageId)) as
+          | { messageCount?: number; fileCount?: number }
+          | undefined;
+        messageCount = impact?.messageCount ?? 0;
+        fileCount = impact?.fileCount ?? 0;
+      } catch (err) {
+        console.error('[SessionTranscript] getRewindImpact failed:', err);
+      }
+
+      const choice = await new Promise<'chat' | 'files' | null>((resolve) => {
+        const data: RewindSessionData = {
+          messageCount,
+          fileCount,
+          onChatOnly: () => { close(DIALOG_IDS.REWIND_SESSION); resolve('chat'); },
+          onChatAndFiles: () => { close(DIALOG_IDS.REWIND_SESSION); resolve('files'); },
+          onCancel: () => { close(DIALOG_IDS.REWIND_SESSION); resolve(null); },
+        };
+        open(DIALOG_IDS.REWIND_SESSION, data);
+      });
+      if (choice === null) return; // cancelled
+      revertFiles = choice === 'files';
+    }
+
+    try {
+      const result = (await window.electronAPI.invoke('ai:rewindSession', sessionId, rawMessageId, {
+        revertFiles,
+        workspacePath,
+      })) as { success?: boolean; error?: string } | undefined;
+      if (!result?.success) {
+        console.error('[SessionTranscript] ai:rewindSession failed:', result?.error);
+        return;
+      }
+    } catch (err) {
+      console.error('[SessionTranscript] ai:rewindSession error:', err);
+      return;
+    }
+
+    store.set(sessionDraftInputAtom(sessionId), text);
+    await handleSend();
+  }, [sessionId, workspacePath, open, close, handleSend]);
 
   const handleTodoClick = useCallback((todo: TodoItem) => {
     onTodoClick?.(todo);
@@ -2399,6 +2460,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
             onOpenInExternalEditor={hasExternalEditor ? handleOpenInExternalEditor : undefined}
             externalEditorName={externalEditorName}
             onCompact={handleCompact}
+            onEditUserMessage={handleEditUserMessage}
             promptAdditions={showPromptAdditions ? promptAdditions : null}
             currentTeammates={transcriptTeammates}
             waitingForNoun={waitingForNoun}

--- a/packages/electron/src/renderer/dialogs/dataDialogs.tsx
+++ b/packages/electron/src/renderer/dialogs/dataDialogs.tsx
@@ -11,6 +11,7 @@ import type { DialogConfig } from '../contexts/DialogContext.types';
 import { ProjectSelectionDialog } from '../components/ProjectSelectionDialog/ProjectSelectionDialog';
 import { ErrorDialog } from '../components/ErrorDialog/ErrorDialog';
 import { ConfirmDialog } from '../components/ConfirmDialog/ConfirmDialog';
+import { RewindSessionDialog } from '../components/ConfirmDialog/RewindSessionDialog';
 import { SessionImportDialog } from '../components/AgenticCoding/SessionImportDialog';
 import { BlitzDialog } from '../components/BlitzDialog/BlitzDialog';
 import { DIALOG_IDS } from './registry';
@@ -49,6 +50,14 @@ export interface ConfirmDialogData {
   cancelLabel?: string;
   destructive?: boolean;
   onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export interface RewindSessionData {
+  messageCount: number;
+  fileCount: number;
+  onChatOnly: () => void;
+  onChatAndFiles: () => void;
   onCancel: () => void;
 }
 
@@ -118,6 +127,36 @@ function ConfirmDialogWrapper({
       cancelLabel={data.cancelLabel}
       destructive={data.destructive}
       onConfirm={data.onConfirm}
+      onCancel={data.onCancel}
+    />
+  );
+}
+
+function RewindSessionWrapper({
+  isOpen,
+  onClose: _onClose,
+  data,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  data: RewindSessionData;
+}) {
+  // If the dialog is dismissed via ESC / click-outside path that unmounts it
+  // without a button press, resolve the caller's pending choice as a cancel so
+  // its promise never leaks. onCancel is idempotent (resolve fires at most once).
+  React.useEffect(() => {
+    return () => {
+      data.onCancel();
+    };
+  }, [data]);
+
+  return (
+    <RewindSessionDialog
+      isOpen={isOpen}
+      messageCount={data.messageCount}
+      fileCount={data.fileCount}
+      onChatOnly={data.onChatOnly}
+      onChatAndFiles={data.onChatAndFiles}
       onCancel={data.onCancel}
     />
   );
@@ -200,6 +239,13 @@ export function registerDataDialogs() {
     group: 'alert',
     component: ConfirmDialogWrapper as DialogConfig<ConfirmDialogData>['component'],
     priority: 350, // Confirmations are high priority but below errors
+  });
+
+  registerDialog<RewindSessionData>({
+    id: DIALOG_IDS.REWIND_SESSION,
+    group: 'alert',
+    component: RewindSessionWrapper as DialogConfig<RewindSessionData>['component'],
+    priority: 350,
   });
 
   registerDialog<SessionImportData>({

--- a/packages/electron/src/renderer/dialogs/registry.ts
+++ b/packages/electron/src/renderer/dialogs/registry.ts
@@ -23,6 +23,7 @@ export const DIALOG_IDS = {
   // Alert group
   CONFIRM: 'confirm-dialog',
   ERROR: 'error-dialog',
+  REWIND_SESSION: 'rewind-session',
 
   // System group
   PROJECT_SELECTION: 'project-selection',

--- a/packages/runtime/src/ai/server/transcript/TranscriptProjector.ts
+++ b/packages/runtime/src/ai/server/transcript/TranscriptProjector.ts
@@ -43,6 +43,13 @@ export interface TranscriptViewMessage {
   type: TranscriptEventType;
   text?: string;
   mode?: 'agent' | 'planning' | 'auto';
+  /**
+   * Raw `ai_agent_messages.id` for user messages, threaded from the canonical
+   * `user_message` payload. The UI uses this to target the exact raw row when
+   * editing/rewinding. Undefined for non-user events and for stale in-memory
+   * events written before a reparse.
+   */
+  rawMessageId?: number;
   attachments?: UserMessagePayload['attachments'];
   toolCall?: {
     toolName: string;
@@ -219,6 +226,9 @@ function projectEvent(
       const p = event.payload as unknown as UserMessagePayload;
       base.text = event.searchableText ?? undefined;
       base.mode = p.mode;
+      if (p.rawMessageId != null) {
+        base.rawMessageId = p.rawMessageId;
+      }
       if (p.attachments) {
         base.attachments = p.attachments;
       }

--- a/packages/runtime/src/ai/server/transcript/TranscriptTransformer.ts
+++ b/packages/runtime/src/ai/server/transcript/TranscriptTransformer.ts
@@ -30,7 +30,7 @@ import type {
   ParseContext,
   CanonicalEventDescriptor,
 } from './parsers/IRawMessageParser';
-import { processDescriptor as processDescriptorShared } from './processDescriptor';
+import { processDescriptor as processDescriptorShared, stampUserMessageRawId } from './processDescriptor';
 
 // ---------------------------------------------------------------------------
 // Dependencies (injected via interfaces)
@@ -289,6 +289,7 @@ export class TranscriptTransformer {
     for (const msg of messages) {
       try {
         const descriptors = await parser.parseMessage(msg, context);
+        stampUserMessageRawId(descriptors, msg.id);
         for (const desc of descriptors) {
           const event = await this.processDescriptorWithNotify(
             writer,
@@ -537,6 +538,7 @@ export class TranscriptTransformer {
     for (const msg of messages) {
       try {
         const descriptors = await parser.parseMessage(msg, context);
+        stampUserMessageRawId(descriptors, msg.id);
         for (const desc of descriptors) {
           const event = suppressNotify
             ? await this.processDescriptor(writer, sessionId, desc, toolEventIds, subagentEventIds, targetStore)

--- a/packages/runtime/src/ai/server/transcript/TranscriptWriter.ts
+++ b/packages/runtime/src/ai/server/transcript/TranscriptWriter.ts
@@ -55,11 +55,13 @@ export class TranscriptWriter {
       inputType?: 'user' | 'system_message';
       attachments?: UserMessagePayload['attachments'];
       createdAt?: Date;
+      rawMessageId?: number;
     },
   ): Promise<TranscriptEvent> {
     const payload: UserMessagePayload = {
       mode: options?.mode ?? 'agent',
       inputType: options?.inputType ?? 'user',
+      ...(options?.rawMessageId != null ? { rawMessageId: options.rawMessageId } : {}),
       ...(options?.attachments ? { attachments: options.attachments } : {}),
     };
 

--- a/packages/runtime/src/ai/server/transcript/__tests__/RawMessageIdThreading.test.ts
+++ b/packages/runtime/src/ai/server/transcript/__tests__/RawMessageIdThreading.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { projectRawMessagesToViewMessages } from '../projectRawMessages';
+import type { RawMessage } from '../TranscriptTransformer';
+
+/**
+ * The edit/rewind feature targets a user message by its raw ai_agent_messages.id.
+ * The canonical event `id` is an in-memory sequence, NOT the raw row id, so the
+ * raw id is threaded onto the user_message payload and surfaced on the view
+ * model. This pins that wiring through the full parse -> project pipeline.
+ */
+describe('rawMessageId threading (raw -> view message)', () => {
+  it('surfaces the raw ai_agent_messages.id on projected user messages', async () => {
+    const raw: RawMessage[] = [
+      {
+        id: 101,
+        sessionId: 's1',
+        source: 'claude-code',
+        direction: 'input',
+        content: JSON.stringify({ prompt: 'first user message', options: {} }),
+        createdAt: new Date(1000),
+        hidden: false,
+      },
+      {
+        id: 102,
+        sessionId: 's1',
+        source: 'claude-code',
+        direction: 'input',
+        content: JSON.stringify({ prompt: 'second user message', options: {} }),
+        createdAt: new Date(3000),
+        hidden: false,
+      },
+    ];
+
+    const view = await projectRawMessagesToViewMessages(raw, 'claude-code');
+
+    const userMessages = view.filter((m) => m.type === 'user_message');
+    expect(userMessages).toHaveLength(2);
+
+    // Each projected user message carries the raw id of the row it came from --
+    // and the canonical (in-memory) id is a DIFFERENT, sequence-based number.
+    const first = userMessages.find((m) => m.text?.includes('first user message'));
+    const second = userMessages.find((m) => m.text?.includes('second user message'));
+    expect(first?.rawMessageId).toBe(101);
+    expect(second?.rawMessageId).toBe(102);
+    expect(first?.id).not.toBe(first?.rawMessageId);
+  });
+
+  it('leaves rawMessageId undefined on non-user messages', async () => {
+    const raw: RawMessage[] = [
+      {
+        id: 201,
+        sessionId: 's2',
+        source: 'claude-code',
+        direction: 'input',
+        content: JSON.stringify({ prompt: 'hi', options: {} }),
+        createdAt: new Date(1000),
+        hidden: false,
+      },
+      {
+        id: 202,
+        sessionId: 's2',
+        source: 'claude-code',
+        direction: 'output',
+        content: JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'hello back' }] },
+        }),
+        createdAt: new Date(2000),
+        hidden: false,
+      },
+    ];
+
+    const view = await projectRawMessagesToViewMessages(raw, 'claude-code');
+    const assistant = view.find((m) => m.type === 'assistant_message');
+    if (assistant) {
+      expect(assistant.rawMessageId).toBeUndefined();
+    }
+    const user = view.find((m) => m.type === 'user_message');
+    expect(user?.rawMessageId).toBe(201);
+  });
+});

--- a/packages/runtime/src/ai/server/transcript/parsers/IRawMessageParser.ts
+++ b/packages/runtime/src/ai/server/transcript/parsers/IRawMessageParser.ts
@@ -52,6 +52,10 @@ export interface UserMessageDescriptor {
   inputType?: 'user' | 'system_message';
   attachments?: UserMessagePayload['attachments'];
   createdAt?: Date;
+  /** Raw `ai_agent_messages.id` this descriptor was parsed from. Stamped by the
+   * transformer/projector loop (not the parser) so edit/rewind can target the
+   * exact raw row. */
+  rawMessageId?: number;
 }
 
 export interface AssistantMessageDescriptor {

--- a/packages/runtime/src/ai/server/transcript/processDescriptor.ts
+++ b/packages/runtime/src/ai/server/transcript/processDescriptor.ts
@@ -40,6 +40,24 @@ function isSyntheticCodexLookupId(id: string): boolean {
   return id.startsWith('nimtc|');
 }
 
+/**
+ * Stamp the raw `ai_agent_messages.id` onto every user_message descriptor
+ * parsed from a single raw row. Called by the transformer/projector loops
+ * (which have `msg.id` in scope) so the edit/rewind feature can map a rendered
+ * user message back to its exact raw row. Provider-agnostic — keeps the parsers
+ * unaware of raw ids.
+ */
+export function stampUserMessageRawId(
+  descriptors: CanonicalEventDescriptor[],
+  rawMessageId: number,
+): void {
+  for (const desc of descriptors) {
+    if (desc.type === 'user_message') {
+      desc.rawMessageId = rawMessageId;
+    }
+  }
+}
+
 export async function processDescriptor(
   writer: TranscriptWriter,
   store: ITranscriptEventStore,
@@ -54,6 +72,7 @@ export async function processDescriptor(
         mode: desc.mode,
         attachments: desc.attachments,
         createdAt: desc.createdAt,
+        rawMessageId: desc.rawMessageId,
       });
     }
 

--- a/packages/runtime/src/ai/server/transcript/projectRawMessages.ts
+++ b/packages/runtime/src/ai/server/transcript/projectRawMessages.ts
@@ -24,7 +24,7 @@ import { VoiceRawParser } from './parsers/VoiceRawParser';
 import type { IRawMessageParser, ParseContext } from './parsers/IRawMessageParser';
 import type { RawMessage } from './TranscriptTransformer';
 import type { TranscriptEvent } from './types';
-import { processDescriptor, selectRawParser } from './processDescriptor';
+import { processDescriptor, selectRawParser, stampUserMessageRawId } from './processDescriptor';
 
 function createParser(provider: string): IRawMessageParser {
   const kind = selectRawParser(provider);
@@ -73,6 +73,7 @@ export async function rawMessagesToCanonicalEvents(
   for (const msg of rawMessages) {
     try {
       const descriptors = await parser.parseMessage(msg, context);
+      stampUserMessageRawId(descriptors, msg.id);
       for (const desc of descriptors) {
         await processDescriptor(
           writer,

--- a/packages/runtime/src/ai/server/transcript/types.ts
+++ b/packages/runtime/src/ai/server/transcript/types.ts
@@ -27,6 +27,13 @@ export type TranscriptEventType =
 export interface UserMessagePayload {
   mode: 'agent' | 'planning' | 'auto';
   inputType: 'user' | 'system_message';
+  /**
+   * Raw `ai_agent_messages.id` this user_message was projected from. Threaded
+   * through so the UI can target the exact raw row for edit/rewind (the
+   * canonical event `id` is an in-memory sequence, NOT the raw row id). Absent
+   * on old in-memory events until the session is reparsed.
+   */
+  rawMessageId?: number;
   attachments?: Array<{
     id: string;
     filename: string;

--- a/packages/runtime/src/storage/repositories/AgentMessagesRepository.ts
+++ b/packages/runtime/src/storage/repositories/AgentMessagesRepository.ts
@@ -11,6 +11,23 @@ export interface AgentMessagesStore {
   list(sessionId: string, options?: { limit?: number; offset?: number; includeHidden?: boolean }): Promise<AgentMessage[]>;
   /** Get message counts for multiple sessions in a single query */
   getMessageCounts?(sessionIds: string[]): Promise<Map<string, number>>;
+  /** Get a single raw message by its id, scoped to the session. Null if absent. */
+  getMessageById?(sessionId: string, messageId: number): Promise<AgentMessage | null>;
+  /** Id of the most recent user-input message (`message_kind = 'user'`), or null. */
+  getLastUserMessageId?(sessionId: string): Promise<number | null>;
+  /**
+   * Edit/rewind truncation primitive: delete every raw message with `id > afterId`
+   * for the session. The `ai_tool_call_file_edits.message_id` FK cascade removes
+   * matching file-edit links and the FTS delete trigger clears the search mirror.
+   * Returns the deleted raw ids (ascending) so callers can clean up dependents.
+   */
+  deleteMessagesAfter?(sessionId: string, afterId: number): Promise<{ deletedIds: number[] }>;
+  /**
+   * Overwrite a message's `content` and `searchable_text` in place (used when a
+   * user edits a previously-sent message). The FTS update trigger reindexes the
+   * row. Does NOT touch `message_kind` (an edited user message stays 'user').
+   */
+  updateMessageContent?(sessionId: string, messageId: number, content: string, searchableText: string | null): Promise<void>;
 }
 
 let storeInstance: AgentMessagesStore | null = null;
@@ -73,5 +90,44 @@ export const AgentMessagesRepository = {
       counts.set(sessionId, messages.length);
     }
     return counts;
+  },
+
+  async getMessageById(sessionId: string, messageId: number): Promise<AgentMessage | null> {
+    const store = requireStore();
+    if (store.getMessageById) {
+      return await store.getMessageById(sessionId, messageId);
+    }
+    // Fallback for stores without a targeted lookup.
+    const messages = await store.list(sessionId, { includeHidden: true });
+    return messages.find((m) => m.id === messageId) ?? null;
+  },
+
+  async getLastUserMessageId(sessionId: string): Promise<number | null> {
+    const store = requireStore();
+    if (!store.getLastUserMessageId) {
+      throw new Error('Agent messages store does not support getLastUserMessageId');
+    }
+    return await store.getLastUserMessageId(sessionId);
+  },
+
+  async deleteMessagesAfter(sessionId: string, afterId: number): Promise<{ deletedIds: number[] }> {
+    const store = requireStore();
+    if (!store.deleteMessagesAfter) {
+      throw new Error('Agent messages store does not support deleteMessagesAfter');
+    }
+    return await store.deleteMessagesAfter(sessionId, afterId);
+  },
+
+  async updateMessageContent(
+    sessionId: string,
+    messageId: number,
+    content: string,
+    searchableText: string | null,
+  ): Promise<void> {
+    const store = requireStore();
+    if (!store.updateMessageContent) {
+      throw new Error('Agent messages store does not support updateMessageContent');
+    }
+    await store.updateMessageContent(sessionId, messageId, content, searchableText);
   },
 };

--- a/packages/runtime/src/ui/AgentTranscript/components/AgentTranscriptPanel.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/AgentTranscriptPanel.tsx
@@ -86,6 +86,8 @@ interface AgentTranscriptPanelProps {
   externalEditorName?: string;
   /** Optional: Callback to trigger /compact command */
   onCompact?: () => void;
+  /** Optional: Edit a previously-sent user message and rewind to it. */
+  onEditUserMessage?: (rawMessageId: number, currentText: string, hasDownstream: boolean) => void;
   /** Optional: Prompt additions for debugging (system prompt, user message, and attachments) */
   promptAdditions?: {
     systemPromptAddition: string | null;
@@ -144,6 +146,7 @@ const AgentTranscriptPanelComponent = React.forwardRef<
   onOpenInExternalEditor,
   externalEditorName,
   onCompact,
+  onEditUserMessage,
   promptAdditions,
   appStartTime,
   renderEmbeddedFile,
@@ -383,6 +386,7 @@ const AgentTranscriptPanelComponent = React.forwardRef<
           onOpenFile={onFileClick}
           onOpenSession={onOpenSession}
           onCompact={onCompact}
+          onEditUserMessage={onEditUserMessage}
           promptAdditions={promptAdditions}
           currentTeammates={currentTeammates ?? sessionData.metadata?.currentTeammates as Array<{ agentId: string; status: 'running' | 'completed' | 'errored' | 'idle' }> | undefined}
           waitingForNoun={waitingForNoun}

--- a/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
@@ -490,6 +490,10 @@ interface RichTranscriptViewProps {
   onOpenSession?: (sessionId: string) => void;
   /** Optional: Callback to trigger /compact command */
   onCompact?: () => void;
+  /** Optional: Edit a previously-sent user message and rewind the conversation to it.
+   * `hasDownstream` is true when messages follow the edited one (so the host can
+   * confirm the destructive truncation). */
+  onEditUserMessage?: (rawMessageId: number, currentText: string, hasDownstream: boolean) => void;
   /** Optional: Prompt additions for debugging (system prompt, user message, and attachments) */
   promptAdditions?: {
     systemPromptAddition: string | null;
@@ -1082,11 +1086,14 @@ export const extractEditsFromToolMessage = (message: TranscriptViewMessage): any
 export const RichTranscriptView = React.forwardRef<
   { scrollToMessage: (index: number) => void; scrollToTop: () => void },
   RichTranscriptViewProps
->(({ sessionId, sessionStatus, isProcessing, hasPendingInteractivePrompt, messages, provider, settings: propsSettings, onSettingsChange, showSettings, documentContext, workspacePath, renderEmptyExtra, hideEmptyHelp, readFile, onOpenFile, onOpenSession, onCompact, promptAdditions, currentTeammates, waitingForNoun, appStartTime, renderEmbeddedFile, canEmbedFile, onSearchBarVisibilityChange, persistScrollState = true }, ref) => {
+>(({ sessionId, sessionStatus, isProcessing, hasPendingInteractivePrompt, messages, provider, settings: propsSettings, onSettingsChange, showSettings, documentContext, workspacePath, renderEmptyExtra, hideEmptyHelp, readFile, onOpenFile, onOpenSession, onCompact, onEditUserMessage, promptAdditions, currentTeammates, waitingForNoun, appStartTime, renderEmbeddedFile, canEmbedFile, onSearchBarVisibilityChange, persistScrollState = true }, ref) => {
   const [collapsedMessages, setCollapsedMessages] = useState<Set<number>>(new Set());
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const scrollButtonRef = useRef<HTMLDivElement>(null);
   const [copiedMessageIndex, setCopiedMessageIndex] = useState<number | null>(null);
+  // Edit/rewind: which user message (by raw id) is being edited inline, plus its draft.
+  const [editingRawMessageId, setEditingRawMessageId] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState('');
   const [showSearchBar, setShowSearchBar] = useState(false);
 
   // Subscribe to the transcript tool-widget registry so extension
@@ -1519,6 +1526,20 @@ export const RichTranscriptView = React.forwardRef<
       return next;
     });
   };
+
+  const cancelMessageEdit = useCallback(() => {
+    setEditingRawMessageId(null);
+    setEditDraft('');
+  }, []);
+
+  const submitMessageEdit = useCallback((rawMessageId: number, indexInList: number) => {
+    if (!onEditUserMessage) return;
+    const text = editDraft;
+    const hasDownstream = indexInList < messages.length - 1;
+    setEditingRawMessageId(null);
+    setEditDraft('');
+    onEditUserMessage(rawMessageId, text, hasDownstream);
+  }, [onEditUserMessage, editDraft, messages.length]);
 
   const toggleToolExpand = useCallback((toolId: string) => {
     setExpandedTools(prev => {
@@ -2245,8 +2266,17 @@ export const RichTranscriptView = React.forwardRef<
         })()}
 
         <div className={`rich-transcript-message-content relative ${isNewGroup ? 'ml-6' : 'no-indent ml-0'}`}>
-          {/* Copy button - shows on hover */}
-          <div className="rich-transcript-message-copy-action absolute -top-1 right-0 z-[1]">
+          {/* Edit (user messages) + Copy buttons - show on hover */}
+          <div className="rich-transcript-message-copy-action absolute -top-1 right-0 z-[1] flex items-center gap-1">
+            {isUser && message.rawMessageId != null && onEditUserMessage && editingRawMessageId == null && (
+              <button
+                onClick={() => { setEditingRawMessageId(message.rawMessageId!); setEditDraft(message.text ?? ''); }}
+                className="rich-transcript-edit-button p-1.5 rounded-md bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] cursor-pointer transition-all flex items-center justify-center hover:bg-[var(--nim-bg-hover)]"
+                title="Edit message & rewind"
+              >
+                <MaterialSymbol icon="edit" size={16} className="text-[var(--nim-text-faint)]" />
+              </button>
+            )}
             <button
               onClick={() => copyTranscriptViewMessageContent(message, index)}
               className={`rich-transcript-copy-button p-1.5 rounded-md bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] cursor-pointer transition-all flex items-center justify-center hover:bg-[var(--nim-bg-hover)] ${copiedMessageIndex === index ? 'copied' : ''}`}
@@ -2259,23 +2289,59 @@ export const RichTranscriptView = React.forwardRef<
               )}
             </button>
           </div>
-          <MessageSegment
-            message={message}
-            isUser={isUser}
-            isCollapsed={isCollapsed}
-            showToolCalls={false}
-            showThinking={settings.showThinking}
-            expandedTools={expandedTools}
-            onToggleToolExpand={toggleToolExpand}
-            documentContext={documentContext}
-            shouldShowLoginWidget={shouldShowLoginWidgetForIndex(index)}
-            sessionId={sessionId}
-            isLastMessage={index === messages.length - 1}
-            onOpenFile={onOpenFile}
-            onOpenSession={onOpenSession}
-            onCompact={onCompact}
-            provider={provider}
-          />
+          {editingRawMessageId != null && message.rawMessageId === editingRawMessageId ? (
+            <div className="rich-transcript-edit-form flex flex-col gap-2 select-text">
+              <textarea
+                className="w-full min-h-[3rem] rounded-md border border-[var(--nim-border)] bg-[var(--nim-bg-secondary)] p-2 text-sm text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)] resize-y"
+                value={editDraft}
+                onChange={(e) => setEditDraft(e.target.value)}
+                autoFocus
+                rows={Math.min(12, Math.max(2, editDraft.split('\n').length + 1))}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                    e.preventDefault();
+                    if (editDraft.trim()) submitMessageEdit(message.rawMessageId!, index);
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    cancelMessageEdit();
+                  }
+                }}
+              />
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  onClick={cancelMessageEdit}
+                  className="px-2.5 py-1 rounded-md text-xs bg-transparent border border-[var(--nim-border)] text-[var(--nim-text-muted)] cursor-pointer hover:bg-[var(--nim-bg-secondary)]"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={() => submitMessageEdit(message.rawMessageId!, index)}
+                  disabled={!editDraft.trim()}
+                  className="rich-transcript-edit-save px-2.5 py-1 rounded-md text-xs bg-[var(--nim-primary)] border-none text-white cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Save &amp; rewind
+                </button>
+              </div>
+            </div>
+          ) : (
+            <MessageSegment
+              message={message}
+              isUser={isUser}
+              isCollapsed={isCollapsed}
+              showToolCalls={false}
+              showThinking={settings.showThinking}
+              expandedTools={expandedTools}
+              onToggleToolExpand={toggleToolExpand}
+              documentContext={documentContext}
+              shouldShowLoginWidget={shouldShowLoginWidgetForIndex(index)}
+              sessionId={sessionId}
+              isLastMessage={index === messages.length - 1}
+              onOpenFile={onOpenFile}
+              onOpenSession={onOpenSession}
+              onCompact={onCompact}
+              provider={provider}
+            />
+          )}
         </div>
 
         {/* Show elapsed time at the end of a completed assistant turn */}


### PR DESCRIPTION
## What

Adds Cursor-style **"edit a previously-sent message + rewind"** to the AI chat. Two user scenarios, one backend primitive (`ai:rewindSession`):

1. **Stop & fix the last message** — interrupt a running turn, edit the message you just sent, continue.
2. **Rewind several turns back** — edit an earlier message, destructively discard everything after it in the same session, and re-run from that point.

## How it works

Hover a user message → **pencil** → inline editor (⌘/Ctrl+Enter saves, Esc cancels). On save, if there is downstream history, a dialog asks **"Nur Chat zurücksetzen" / "Chat + Dateien zurücksetzen" / Abbrechen** (with counts of affected messages/files). Then:

`ai:rewindSession` → stop the in-flight turn + drop queued prompts → (optional) revert files → truncate the session at the target (inclusive) → reset the provider session → reparse the transcript → re-send the edited text as the new turn at the rewound position.

## Key decisions

- **Destructive** truncation in the same session; the edited message replaces the old one at its position.
- **Context kept for agent providers:** Claude Code / Codex own their conversation history internally and their SDKs can't truncate mid-conversation, so rewind starts a fresh provider session and injects a bounded, reconstructed prior-conversation prefix into the *provider-bound* message only (never shown in the UI). Chat providers replay their full message array and need no prefix.
- The canonical transcript event id is an in-memory sequence, **not** the raw `ai_agent_messages` id — so a new `rawMessageId` is threaded onto user messages, giving the UI a stable anchor for the row to truncate.

## Tested

- Both `runtime` and `electron` packages: `tsc --noEmit` clean.
- Truncation primitive against a **real PGLite engine** (FK CASCADE on `ai_tool_call_file_edits` + in-place content/searchable update).
- `rawMessageId` threading through the real parse → project pipeline.
- 547 runtime + 12 electron rewind-related tests green; no regressions in existing transcript tests.

## Not yet verified end-to-end

The full in-app UI flow (pencil → dialog → rewind → re-send) has **not** been exercised in a running app yet — needs manual / Playwright E2E verification.

## Known v1 limitations

- **File revert** is best-effort (snapshot-retention-bounded) and **never deletes files** — AI-created files with no recoverable baseline are reported (`unrevertableFiles`), not removed, for file-safety.
- **Cross-device (mobile) truncation sync is deferred** — the personal sync protocol has no delete/truncate message; desktop is local-authoritative and mobile reconciles on the next full index sync.

## Commits

7 granular commits, one per layer: raw-id threading → store truncation/edit → `RewindSessionService` → file revert → IPC + replay wiring → transcript edit UI → confirm dialog + orchestration.
