### PR TITLE
fix: keep structured prompts visible when tool calls are hidden

### DIFF
--- a/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
@@ -581,9 +581,20 @@ const WRITE_TOOL_NAMES = new Set(['write', 'notebookedit']);
 /**
  * Interactive tool widgets that require the user to act. These render even when
  * `settings.showToolCalls` is false, so the user can still respond to prompts
- * (permission grants, plan-mode exits, AskUserQuestion answers, commit proposals).
+ * (permission grants, plan-mode exits, question answers, structured input
+ * prompts, commit proposals).
  */
-const INTERACTIVE_WIDGET_TOOLS = new Set(['ToolPermission', 'ExitPlanMode', 'AskUserQuestion', 'GitCommitProposal']);
+const INTERACTIVE_WIDGET_TOOLS = new Set([
+  'ToolPermission',
+  'ExitPlanMode',
+  'AskUserQuestion',
+  'PromptForUserInput',
+  'RequestUserInput',
+  'GitCommitProposal',
+  'git_commit_proposal',
+  'developer_git_commit_proposal',
+  'developer.git_commit_proposal',
+]);
 
 /**
  * MCP tools arrive as `mcp__<server>__<toolName>` (server name may contain
@@ -2060,7 +2071,8 @@ export const RichTranscriptView = React.forwardRef<
     // When settings.showToolCalls is false, hide non-interactive tool
     // rows from the chat view but always render interactive widgets
     // (ToolPermission / ExitPlanMode / AskUserQuestion /
-    // GitCommitProposal) so the user can still act on prompts.
+    // PromptForUserInput / RequestUserInput / GitCommitProposal)
+    // so the user can still act on prompts.
     if (isTool && message.toolCall) {
       const isInteractiveWidget = isInteractiveWidgetTool(message.toolCall.toolName);
       if (!settings.showToolCalls && !isInteractiveWidget) {

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.test.ts
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.test.ts
@@ -435,13 +435,18 @@ describe('interactive widget tool name normalization', () => {
     expect(isInteractiveWidgetTool('ExitPlanMode')).toBe(true);
     expect(isInteractiveWidgetTool('ToolPermission')).toBe(true);
     expect(isInteractiveWidgetTool('GitCommitProposal')).toBe(true);
+    expect(isInteractiveWidgetTool('PromptForUserInput')).toBe(true);
+    expect(isInteractiveWidgetTool('RequestUserInput')).toBe(true);
 
     expect(isInteractiveWidgetTool('mcp__nimbalyst-mcp__AskUserQuestion')).toBe(true);
     expect(isInteractiveWidgetTool('mcp__nimbalyst-mcp__ExitPlanMode')).toBe(true);
     expect(isInteractiveWidgetTool('mcp__nimbalyst__GitCommitProposal')).toBe(true);
+    expect(isInteractiveWidgetTool('mcp__nimbalyst-mcp__PromptForUserInput')).toBe(true);
+    expect(isInteractiveWidgetTool('mcp__nimbalyst-mcp__RequestUserInput')).toBe(true);
 
     expect(isInteractiveWidgetTool('Read')).toBe(false);
     expect(isInteractiveWidgetTool('mcp__nimbalyst-mcp__SomeOtherTool')).toBe(false);
+    expect(isInteractiveWidgetTool('mcp__nimbalyst-mcp__capture_editor_screenshot')).toBe(false);
     expect(isInteractiveWidgetTool(undefined)).toBe(false);
     expect(isInteractiveWidgetTool(null)).toBe(false);
     expect(isInteractiveWidgetTool('')).toBe(false);


### PR DESCRIPTION
## Summary
- Keep PromptForUserInput and RequestUserInput widgets visible when tool call rows are hidden.
- Normalize MCP-prefixed interactive tool names before transcript visibility filtering.
- Add regression coverage for structured input prompts and ordinary non-interactive tools.

## Test plan
- pnpm vitest --run packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.test.ts
- pnpm vitest --run packages/runtime/src/ui/AgentTranscript/components/__tests__/TranscriptWidgets.test.tsx
- npm run typecheck --prefix packages/runtime

Fixes #714
Refs NIM-39