### PR TITLE
fix: unblock new session creation during sync connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- New AI sessions now appear immediately instead of waiting for sync to connect.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/runtime/src/sync/SyncedSessionStore.ts
+++ b/packages/runtime/src/sync/SyncedSessionStore.ts
@@ -135,13 +135,10 @@ export function createSyncedSessionStore(
       // Create in base store first
       await baseStore.create(payload);
 
-      // Then connect sync and push initial metadata. Build the initial payload
-      // from SYNC_RELEVANT_FIELDS so a new session arrives on iOS with every
-      // sync-relevant column populated -- including sessionType, parentSessionId,
-      // and worktreeId, which used to require an explicit follow-up pushChange
-      // from callers (and which several callers historically forgot).
+      // Push initial metadata immediately, but do not wait for the session-room
+      // WebSocket. metadata_updated can travel through the index channel, and
+      // first render for a new empty session should only depend on local persistence.
       if (shouldSync(payload.id, payload.workspaceId)) {
-        await ensureSyncConnected(payload.id);
         const metadata = buildSyncPayload(payload as unknown as Record<string, unknown>, {
           forceUpdatedAt: true,
         });
@@ -155,6 +152,10 @@ export function createSyncedSessionStore(
           type: 'metadata_updated',
           metadata: metadata as unknown as SyncedSessionMetadata,
         });
+
+        // Keep the original per-session auto-connect behavior in the background
+        // so later room-scoped changes such as message_added can reuse it.
+        void ensureSyncConnected(payload.id);
       }
     },
 

--- a/packages/runtime/src/sync/__tests__/sync.test.ts
+++ b/packages/runtime/src/sync/__tests__/sync.test.ts
@@ -75,6 +75,48 @@ describe('SyncedSessionStore', () => {
     }
   });
 
+  it('create() returns after local persistence even when sync connect is slow', async () => {
+    // Regression coverage for GitHub #705: creating a new empty session should
+    // only wait for local persistence, not for the session-room WebSocket.
+    let resolveConnect!: () => void;
+    const connectPromise = new Promise<void>(resolve => {
+      resolveConnect = resolve;
+    });
+    mockSyncProvider.connect = vi.fn().mockReturnValue(connectPromise);
+
+    const syncedStore = createSyncedSessionStore(mockBaseStore, mockSyncProvider, {
+      autoConnect: true,
+    });
+
+    let createResolved = false;
+    const createPromise = syncedStore.create({
+      id: 'slow-sync-session',
+      title: 'Slow Sync Session',
+      provider: 'claude-code',
+      workspaceId: 'workspace-1',
+    } as any).then(() => {
+      createResolved = true;
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(mockBaseStore.create).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'slow-sync-session',
+    }));
+    expect(mockSyncProvider.connect).toHaveBeenCalledWith('slow-sync-session');
+    expect(createResolved).toBe(true);
+    expect(capturedChanges).toHaveLength(1);
+    expect(capturedChanges[0].sessionId).toBe('slow-sync-session');
+
+    resolveConnect();
+    await connectPromise;
+    await Promise.resolve();
+
+    expect(capturedChanges).toHaveLength(1);
+
+    await createPromise;
+  });
+
   it('should pass title when updating metadata', async () => {
     const syncedStore = createSyncedSessionStore(mockBaseStore, mockSyncProvider, {
       autoConnect: true,


### PR DESCRIPTION
## Changes
- Stop new AI session creation from waiting on the per-session sync WebSocket connection.
- Keep initial metadata sync on the existing index-capable path, while the session-room connection continues in the background.
- Add a regression test for slow sync connect during `create()`.
- Update the changelog.

## Verification
- `npx vitest --run packages/runtime/src/sync/__tests__/sync.test.ts`
- `npm run typecheck --prefix packages/runtime`

## Risk and Impact
- Scope is limited to session creation sync scheduling.
- Local persistence still completes before the IPC returns.
- Metadata sync remains fire-and-forget; message sync can still reuse the background session connection.

Fixes #705