### PR TITLE
fix: update tracker status role fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Tracker status changes now work for custom tracker types that rename their workflow status field.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/renderer/components/TrackerMode/KanbanBoard.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/KanbanBoard.tsx
@@ -3,8 +3,8 @@ import { useFloating, offset, flip, shift, FloatingPortal } from '@floating-ui/r
 import { MaterialSymbol } from '@nimbalyst/runtime';
 import type { TrackerRecord } from '@nimbalyst/runtime/core/TrackerRecord';
 import type { TrackerItemType } from '@nimbalyst/runtime/plugins/TrackerPlugin';
-import { globalRegistry, getRoleField } from '@nimbalyst/runtime/plugins/TrackerPlugin/models';
-import { getRecordTitle, getRecordStatus, getRecordPriority, getRecordSortOrder, getFieldByRole, buildKanbanStatusColumns } from '@nimbalyst/runtime/plugins/TrackerPlugin/trackerRecordAccessors';
+import { globalRegistry } from '@nimbalyst/runtime/plugins/TrackerPlugin/models';
+import { getRecordTitle, getRecordStatus, getRecordPriority, getRecordSortOrder, getFieldByRole, buildKanbanStatusColumns, resolveRoleFieldName } from '@nimbalyst/runtime/plugins/TrackerPlugin/trackerRecordAccessors';
 import { generateKeyBetween } from '@nimbalyst/runtime/utils/fractionalIndex';
 import { UserAvatar } from '@nimbalyst/runtime/plugins/TrackerPlugin/components/UserAvatar';
 
@@ -183,7 +183,9 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
 
   /** Convenience wrapper for status-only updates */
   const updateItemStatus = useCallback(async (record: TrackerRecord, newStatus: string) => {
-    return updateItemFields(record, { status: newStatus });
+    // Kanban columns are driven by workflowStatus, so writes must target the resolved field.
+    const statusFieldName = resolveRoleFieldName(record.primaryType, 'workflowStatus');
+    return updateItemFields(record, { [statusFieldName]: newStatus });
   }, [updateItemFields]);
 
   const handleDragStart = useCallback((e: React.DragEvent, item: TrackerRecord) => {
@@ -304,26 +306,11 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
     closeContextMenu();
     const items = allItemsRef.current.filter(i => selectedIds.has(i.id));
     for (const item of items) {
-      try {
-        if (item.source === 'frontmatter' || item.source === 'import' || item.source === 'inline') {
-          await window.electronAPI.documentService.updateTrackerItemInFile({
-            itemId: item.id,
-            updates: { priority: newPriority },
-          });
-        } else if (!item.system.documentPath || item.source === 'native') {
-          const tracker = globalRegistry.get(item.primaryType);
-          const syncMode = tracker?.sync?.mode || 'local';
-          await window.electronAPI.documentService.updateTrackerItem({
-            itemId: item.id,
-            updates: { priority: newPriority },
-            syncMode,
-          });
-        }
-      } catch (err) {
-        console.error('[KanbanBoard] Failed to update priority:', err);
-      }
+      // Custom tracker types can map priority to a non-priority field.
+      const priorityFieldName = resolveRoleFieldName(item.primaryType, 'priority');
+      await updateItemFields(item, { [priorityFieldName]: newPriority });
     }
-  }, [selectedIds, closeContextMenu]);
+  }, [selectedIds, closeContextMenu, updateItemFields]);
 
   // Sort mode for kanban columns
   type KanbanSortMode = 'manual' | 'priority' | 'created' | 'updated';
@@ -429,7 +416,9 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
     if (currentStatus === targetStatus) {
       updateItemFields(item, { kanbanSortOrder: newSortOrder });
     } else {
-      updateItemFields(item, { status: targetStatus, kanbanSortOrder: newSortOrder });
+      // Moving between columns is a workflowStatus update.
+      const statusFieldName = resolveRoleFieldName(item.primaryType, 'workflowStatus');
+      updateItemFields(item, { [statusFieldName]: targetStatus, kanbanSortOrder: newSortOrder });
     }
   }, [updateItemFields]);
 
@@ -528,7 +517,9 @@ export const KanbanBoard: React.FC<KanbanBoardProps> = ({
       if (currentStatus === targetStatus) {
         updateItemFields(item, { kanbanSortOrder: newSortOrder });
       } else {
-        updateItemFields(item, { status: targetStatus, kanbanSortOrder: newSortOrder });
+        // Keep the document-level drop path aligned with the component drop path.
+        const statusFieldName = resolveRoleFieldName(item.primaryType, 'workflowStatus');
+        updateItemFields(item, { [statusFieldName]: targetStatus, kanbanSortOrder: newSortOrder });
       }
     };
 

--- a/packages/runtime/src/plugins/TrackerPlugin/components/__tests__/useTrackerRows.statusUpdate.test.tsx
+++ b/packages/runtime/src/plugins/TrackerPlugin/components/__tests__/useTrackerRows.statusUpdate.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { TrackerRecord } from '../../../../core/TrackerRecord';
+import { globalRegistry, type TrackerDataModel } from '../../models';
+import { useTrackerRows } from '../useTrackerRows';
+
+vi.mock('posthog-js/react', () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
+const customType = 'statusBulkRoleSpec';
+
+function registerCustomType(): void {
+  const model: TrackerDataModel = {
+    type: customType,
+    displayName: 'Spec',
+    displayNamePlural: 'Specs',
+    icon: 'assignment',
+    color: '#000000',
+    modes: { inline: true, fullDocument: false },
+    idPrefix: 'spc',
+    idFormat: 'ulid',
+    fields: [
+      { name: 'title', type: 'string', required: true },
+      {
+        name: 'phase',
+        type: 'select',
+        options: [
+          { value: 'draft', label: 'Draft' },
+          { value: 'reviewing', label: 'Reviewing' },
+        ],
+      },
+    ],
+    roles: { title: 'title', workflowStatus: 'phase' },
+  };
+  globalRegistry.register(model);
+}
+
+function makeRecord(): TrackerRecord {
+  return {
+    id: 'item-1',
+    primaryType: customType,
+    typeTags: [customType],
+    source: 'native',
+    archived: false,
+    syncStatus: 'local',
+    system: {
+      workspace: '/workspace',
+      createdAt: '2026-06-29T00:00:00.000Z',
+      updatedAt: '2026-06-29T00:00:00.000Z',
+    },
+    fields: { title: 'Custom item', phase: 'draft' },
+  };
+}
+
+describe('useTrackerRows bulk status update', () => {
+  afterEach(() => {
+    globalRegistry.unregister(customType);
+    delete (window as any).electronAPI;
+    vi.unstubAllGlobals();
+  });
+
+  it('writes bulk status updates to the field mapped by workflowStatus', async () => {
+    registerCustomType();
+    const updateTrackerItem = vi.fn().mockResolvedValue({ success: true });
+    (window as any).electronAPI = {
+      documentService: { updateTrackerItem },
+    };
+
+    const item = makeRecord();
+    const { result } = renderHook(() => useTrackerRows({
+      items: [item],
+      activeTypeFilter: customType,
+    }));
+
+    await act(async () => {
+      result.current.setSelectedIds(new Set([item.id]));
+    });
+
+    await act(async () => {
+      await result.current.handleBulkStatusUpdate('reviewing');
+    });
+
+    expect(updateTrackerItem).toHaveBeenCalledWith({
+      itemId: item.id,
+      updates: { phase: 'reviewing' },
+      syncMode: 'local',
+    });
+  });
+});

--- a/packages/runtime/src/plugins/TrackerPlugin/components/useTrackerRows.ts
+++ b/packages/runtime/src/plugins/TrackerPlugin/components/useTrackerRows.ts
@@ -221,7 +221,9 @@ export function useTrackerRows({
     const itemsToUpdate = itemsRef.current.filter(i => selectedIds.has(i.id));
     for (const item of itemsToUpdate) {
       if (isItemEditable(item)) {
-        await handleFieldUpdate(item, 'status', newStatus);
+        // The bulk menu is driven by workflowStatus, so writes must use the record's resolved field.
+        const statusFieldName = resolveRoleFieldName(item.primaryType, 'workflowStatus');
+        await handleFieldUpdate(item, statusFieldName, newStatus);
       }
     }
   }, [selectedIds, closeContextMenu, isItemEditable, handleFieldUpdate]);
@@ -232,7 +234,9 @@ export function useTrackerRows({
     const itemsToUpdate = itemsRef.current.filter(i => selectedIds.has(i.id));
     for (const item of itemsToUpdate) {
       if (isItemEditable(item)) {
-        await handleFieldUpdate(item, 'priority', newPriority);
+        // Custom tracker types can map priority to a non-priority field.
+        const priorityFieldName = resolveRoleFieldName(item.primaryType, 'priority');
+        await handleFieldUpdate(item, priorityFieldName, newPriority);
       }
     }
   }, [selectedIds, closeContextMenu, isItemEditable, handleFieldUpdate]);


### PR DESCRIPTION
## Changes
- Fix tracker status and priority updates to write through schema roles instead of hardcoded field names.
- Cover custom workflow status fields with a regression test.
- Add a changelog entry for the tracker status fix.
- Keep implementation comments and test text in English.

Fixes #721

## Validation
- npx vitest --run packages/runtime/src/plugins/TrackerPlugin/components/__tests__/useTrackerRows.statusUpdate.test.tsx
- npx vitest --run packages/runtime/src/plugins/TrackerPlugin/__tests__/trackerKanbanColumns.test.ts packages/runtime/src/plugins/TrackerPlugin/components/__tests__/trackerColumns.test.ts packages/electron/src/renderer/components/TrackerMode/__tests__/trackerDetailFieldSync.test.ts
- npm run typecheck --prefix packages/runtime
- npm run typecheck --prefix packages/electron

## Risk and impact
- Affects tracker list/table bulk updates and kanban status/priority updates.
- Existing tracker types using the conventional status/priority fields keep the same field mapping.
- Browser UI verification was not run because the local Electron dev server was not running.