### PR TITLE
fix: enable tracker display grouping

### DIFF
--- a/packages/electron/src/renderer/components/TrackerMode/trackerSavedViews.ts
+++ b/packages/electron/src/renderer/components/TrackerMode/trackerSavedViews.ts
@@ -13,16 +13,16 @@ import type { TrackerRecord } from '@nimbalyst/runtime/core/TrackerRecord';
 import type { TrackerIdentity } from '@nimbalyst/runtime';
 import {
   getRecordPriority,
-  getRecordStatus,
   getFieldByRole,
   isMyRecord,
 } from '@nimbalyst/runtime/plugins/TrackerPlugin/trackerRecordAccessors';
+import type { TrackerGroupBy } from '@nimbalyst/runtime/plugins/TrackerPlugin';
 import type { TrackerFilterChip } from '../../store/atoms/trackers';
 import type { ViewMode } from './TrackerMainView';
-import { getTrackerItemTags, filterTrackerItemsByTags } from './trackerTagFilterUtils';
+import { filterTrackerItemsByTags } from './trackerTagFilterUtils';
 
-/** How items are grouped in a grouped view. `none` = a single flat group. */
-export type TrackerGroupBy = 'none' | 'status' | 'priority' | 'assignee' | 'type' | 'tag';
+export { groupTrackerItems } from '@nimbalyst/runtime/plugins/TrackerPlugin';
+export type { TrackerGroup, TrackerGroupBy } from '@nimbalyst/runtime/plugins/TrackerPlugin';
 
 export interface SavedViewDefinition {
   /** Selected type filter: `'all'` or a specific tracker type. */
@@ -107,93 +107,4 @@ export function filterTrackerItems(
   out = filterTrackerItemsByTags(out, def.tagFilter);
 
   return out;
-}
-
-export interface TrackerGroup {
-  /** Group key: the field value, or `''` for the empty/none bucket. */
-  key: string;
-  label: string;
-  items: TrackerRecord[];
-}
-
-function titleCase(value: string): string {
-  return value
-    .split('-')
-    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : w))
-    .join(' ');
-}
-
-function singleGroupValue(item: TrackerRecord, groupBy: Exclude<TrackerGroupBy, 'none' | 'tag'>): string {
-  switch (groupBy) {
-    case 'status':
-      return (getRecordStatus(item) || '').toLowerCase();
-    case 'priority':
-      return (getRecordPriority(item) || '').toLowerCase();
-    case 'type':
-      return item.primaryType;
-    case 'assignee':
-      return ((getFieldByRole(item, 'assignee') as string | undefined) || '');
-  }
-}
-
-/**
- * Group items for a grouped rendering. `none` returns a single bucket; `tag`
- * groups by the schema tags role (an item with N tags appears in N groups, with
- * a trailing "Untagged" bucket); the rest group by a single-valued field in
- * first-seen order, collecting empty values into a trailing fallback bucket
- * ("Unassigned" for assignee, "None" otherwise).
- */
-export function groupTrackerItems(items: TrackerRecord[], groupBy: TrackerGroupBy): TrackerGroup[] {
-  if (groupBy === 'none') {
-    return [{ key: '', label: 'All', items }];
-  }
-
-  if (groupBy === 'tag') {
-    const byTag = new Map<string, TrackerRecord[]>();
-    const order: string[] = [];
-    const untagged: TrackerRecord[] = [];
-    for (const item of items) {
-      const tags = Array.from(new Set(getTrackerItemTags(item)));
-      if (tags.length === 0) {
-        untagged.push(item);
-        continue;
-      }
-      for (const tag of tags) {
-        const bucket = byTag.get(tag);
-        if (bucket) bucket.push(item);
-        else {
-          byTag.set(tag, [item]);
-          order.push(tag);
-        }
-      }
-    }
-    const groups: TrackerGroup[] = order.map((tag) => ({ key: tag, label: `#${tag}`, items: byTag.get(tag)! }));
-    if (untagged.length > 0) groups.push({ key: '', label: 'Untagged', items: untagged });
-    return groups;
-  }
-
-  const buckets = new Map<string, TrackerRecord[]>();
-  const order: string[] = [];
-  for (const item of items) {
-    const value = singleGroupValue(item, groupBy);
-    const bucket = buckets.get(value);
-    if (bucket) bucket.push(item);
-    else {
-      buckets.set(value, [item]);
-      order.push(value);
-    }
-  }
-
-  const emptyLabel = groupBy === 'assignee' ? 'Unassigned' : 'None';
-  // Keep non-empty groups in first-seen order; push the empty bucket last.
-  const nonEmpty = order.filter((v) => v !== '');
-  const groups: TrackerGroup[] = nonEmpty.map((value) => ({
-    key: value,
-    label: groupBy === 'type' || groupBy === 'assignee' ? value : titleCase(value),
-    items: buckets.get(value)!,
-  }));
-  if (buckets.has('')) {
-    groups.push({ key: '', label: emptyLabel, items: buckets.get('')! });
-  }
-  return groups;
 }

--- a/packages/runtime/src/plugins/TrackerPlugin/__tests__/trackerGrouping.test.ts
+++ b/packages/runtime/src/plugins/TrackerPlugin/__tests__/trackerGrouping.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { TrackerRecord } from '../../../core/TrackerRecord';
+import { groupTrackerItems, normalizeTrackerGroupBy } from '../trackerGrouping';
+
+function makeItem(
+  id: string,
+  fields: Record<string, unknown>,
+  primaryType = 'task',
+): TrackerRecord {
+  return {
+    id,
+    primaryType,
+    typeTags: [primaryType],
+    source: 'native',
+    archived: false,
+    syncStatus: 'local',
+    system: { workspace: '/ws', createdAt: '', updatedAt: '' },
+    fields,
+  };
+}
+
+describe('trackerGrouping', () => {
+  it('normalizes unknown or empty grouping values to none', () => {
+    expect(normalizeTrackerGroupBy(null)).toBe('none');
+    expect(normalizeTrackerGroupBy('')).toBe('none');
+    expect(normalizeTrackerGroupBy('unknown')).toBe('none');
+  });
+
+  it('groups Display Options owner values through the assignee role', () => {
+    const items = [
+      makeItem('1', { owner: 'alice@example.com' }),
+      makeItem('2', {}),
+    ];
+
+    const groups = groupTrackerItems(items, 'owner');
+
+    expect(groups.map((g) => g.label)).toEqual(['alice@example.com', 'Unassigned']);
+    expect(groups[0].items.map((i) => i.id)).toEqual(['1']);
+    expect(groups[1].items.map((i) => i.id)).toEqual(['2']);
+  });
+});

--- a/packages/runtime/src/plugins/TrackerPlugin/components/TrackerTable.tsx
+++ b/packages/runtime/src/plugins/TrackerPlugin/components/TrackerTable.tsx
@@ -34,6 +34,7 @@ import {
 import { UserAvatar } from './UserAvatar';
 import { DisplayOptionsPanel } from './DisplayOptionsPanel';
 import { useTrackerRows } from './useTrackerRows';
+import { groupTrackerItems, normalizeTrackerGroupBy } from '../trackerGrouping';
 
 export type SortColumn = 'title' | 'type' | 'status' | 'priority' | 'progress' | 'module' | 'lastIndexed' | (string & {});
 export type SortDirection = 'asc' | 'desc';
@@ -68,6 +69,24 @@ interface TrackerTableProps {
   /** Callback when column config changes (from display options panel) */
   onColumnConfigChange?: (config: import('./trackerColumns').TypeColumnConfig) => void;
 }
+
+export const TrackerGroupHeader: React.FC<{
+  label: string;
+  count: number;
+  className?: string;
+  style?: React.CSSProperties;
+}> = ({ label, count, className = '', style }) => (
+  <div
+    data-testid="tracker-table-group-header"
+    className={`tracker-table-group-header flex items-center gap-2 px-3 py-1.5 bg-[var(--nim-bg-secondary)] border-b border-[var(--nim-border)] text-[11px] font-semibold text-[var(--nim-text-muted)] ${className}`}
+    style={style}
+  >
+    <span className="truncate">{label}</span>
+    <span className="text-[10px] font-medium text-[var(--nim-text-faint)]">
+      {count} item{count === 1 ? '' : 's'}
+    </span>
+  </div>
+);
 
 /**
  * Get educational description for each tracker type
@@ -926,6 +945,15 @@ export function TrackerTable({
 
   // console.log('[TrackerTable] Render - items:', items.length, 'filtered:', filteredItems.length, 'typeFilter:', typeFilter);
   const sortedItems = sortItems(filteredItems, currentSortBy, currentSortDirection);
+  const activeGroupBy = normalizeTrackerGroupBy(effectiveColumnConfig.groupBy);
+  const isGrouped = activeGroupBy !== 'none';
+  const groupedItems = useMemo(
+    () => groupTrackerItems(sortedItems, activeGroupBy),
+    [sortedItems, activeGroupBy],
+  );
+  const rowIndexById = useMemo(() => {
+    return new Map(sortedItems.map((item, index) => [item.id, index]));
+  }, [sortedItems]);
 
   // Row interaction model -- shared with TrackerTableGrid via useTrackerRows.
   const rows = useTrackerRows({
@@ -1093,6 +1121,72 @@ export function TrackerTable({
     { value: 'idea', label: 'Ideas', icon: 'lightbulb' },
     { value: 'decision', label: 'Decisions', icon: 'gavel' },
   ];
+
+  const renderTrackerRow = (item: TrackerRecord, index: number) => {
+    const title = getRecordTitle(item);
+
+    return (
+      <div
+        key={item.id || index}
+        className={`tracker-table-row flex items-center gap-3 px-3 py-[7px] border-b border-[var(--nim-border)] cursor-pointer transition-colors duration-100 hover:bg-[var(--nim-bg-secondary)] select-none ${
+          selectedIds.has(item.id) ? 'bg-[var(--nim-bg-secondary)]' : ''
+        } ${
+          selectedItemId && item.id === selectedItemId ? 'bg-[var(--nim-bg-secondary)]' : ''
+        } ${
+          focusedIndex === index ? 'outline outline-1 outline-[var(--nim-primary)] -outline-offset-1' : ''
+        }`}
+        data-testid="tracker-table-row"
+        data-item-id={item.id}
+        data-item-title={item.fields.title as string}
+        onClick={(e) => handleRowClick(item, index, e)}
+        onDoubleClick={() => { if (item.system.documentPath) openItemInEditor(item); }}
+        onContextMenu={(e) => handleContextMenu(e, item, index)}
+      >
+        <span className="shrink-0 w-5 flex items-center justify-center" style={{ color: getTypeColor(item.primaryType), opacity: 0.7 }}>
+          <span className="material-symbols-outlined" style={{ fontSize: '16px', fontVariationSettings: "'wght' 300" }}>{getTypeIcon(item.primaryType)}</span>
+        </span>
+
+        <div className="tracker-table-cell title flex-1 min-w-0">
+          {editingCell?.itemId === item.id && editingCell?.field === 'title' ? (
+            <input
+              ref={titleInputRef}
+              type="text"
+              value={editingTitle}
+              onChange={(e) => setEditingTitle(e.target.value)}
+              onBlur={() => {
+                if (editingTitle.trim() && editingTitle !== (item.fields.title as string)) handleFieldUpdate(item, 'title', editingTitle.trim());
+                else setEditingCell(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') { if (editingTitle.trim() && editingTitle !== title) handleFieldUpdate(item, 'title', editingTitle.trim()); else setEditingCell(null); }
+                else if (e.key === 'Escape') setEditingCell(null);
+              }}
+              onClick={(e) => e.stopPropagation()}
+              className="w-full bg-[var(--nim-bg-secondary)] border border-[var(--nim-primary)] rounded px-1 py-0.5 text-[13px] text-[var(--nim-text)] font-medium outline-none"
+            />
+          ) : (
+            <div className="flex items-baseline gap-2 min-w-0">
+              {item.issueKey && (
+                <span className="shrink-0 text-[10px] font-mono font-medium uppercase tracking-[0.08em] text-[var(--nim-text-faint)]">{item.issueKey}</span>
+              )}
+              <span className="text-[13px] font-medium text-[var(--nim-text)] truncate">{title}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          {visibleColumnDefs.filter(col => col.id !== 'type' && col.id !== 'title').map(col => {
+            const value = getCellValue(item, col.id);
+            return (
+              <div key={col.id} className={`tracker-table-cell ${col.id}`}>
+                {renderCell(col, item, value, editingCell, isItemEditable, setEditingCell, editingTitle, setEditingTitle, titleInputRef, handleFieldUpdate)}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
 
   return (
     <div className="tracker-table-wrapper flex flex-col h-full w-full bg-[var(--nim-bg)]" data-testid="tracker-table">
@@ -1275,80 +1369,15 @@ export function TrackerTable({
               </div>
             )}
           </div>
+        ) : isGrouped ? (
+          groupedItems.map((group) => (
+            <React.Fragment key={`${activeGroupBy}:${group.key || 'empty'}`}>
+              <TrackerGroupHeader label={group.label} count={group.items.length} />
+              {group.items.map((item) => renderTrackerRow(item, rowIndexById.get(item.id) ?? 0))}
+            </React.Fragment>
+          ))
         ) : (
-          sortedItems.map((item, index) => {
-            const title = getRecordTitle(item);
-            const status = getRecordStatus(item);
-            const priority = getRecordPriority(item);
-            const statusColor = getStatusColor(status, item.primaryType);
-            const lastIndexed = item.system.lastIndexed ? new Date(item.system.lastIndexed) : new Date(0);
-            const editable = isItemEditable(item);
-
-            return (
-              <div
-                key={item.id || index}
-                className={`tracker-table-row flex items-center gap-3 px-3 py-[7px] border-b border-[var(--nim-border)] cursor-pointer transition-colors duration-100 hover:bg-[var(--nim-bg-secondary)] select-none ${
-                  selectedIds.has(item.id) ? 'bg-[var(--nim-bg-secondary)]' : ''
-                } ${
-                  selectedItemId && item.id === selectedItemId ? 'bg-[var(--nim-bg-secondary)]' : ''
-                } ${
-                  focusedIndex === index ? 'outline outline-1 outline-[var(--nim-primary)] -outline-offset-1' : ''
-                }`}
-                data-testid="tracker-table-row"
-                data-item-id={item.id}
-                data-item-title={item.fields.title as string}
-                onClick={(e) => handleRowClick(item, index, e)}
-                onDoubleClick={() => { if (item.system.documentPath) openItemInEditor(item); }}
-                onContextMenu={(e) => handleContextMenu(e, item, index)}
-              >
-                {/* Type icon - fixed width for alignment */}
-                <span className="shrink-0 w-5 flex items-center justify-center" style={{ color: getTypeColor(item.primaryType), opacity: 0.7 }}>
-                  <span className="material-symbols-outlined" style={{ fontSize: '16px', fontVariationSettings: "'wght' 300" }}>{getTypeIcon(item.primaryType)}</span>
-                </span>
-
-                {/* Title (takes remaining space) */}
-                <div className="tracker-table-cell title flex-1 min-w-0">
-                  {editingCell?.itemId === item.id && editingCell?.field === 'title' ? (
-                    <input
-                      ref={titleInputRef}
-                      type="text"
-                      value={editingTitle}
-                      onChange={(e) => setEditingTitle(e.target.value)}
-                      onBlur={() => {
-                        if (editingTitle.trim() && editingTitle !== (item.fields.title as string)) handleFieldUpdate(item, 'title', editingTitle.trim());
-                        else setEditingCell(null);
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') { if (editingTitle.trim() && editingTitle !== title) handleFieldUpdate(item, 'title', editingTitle.trim()); else setEditingCell(null); }
-                        else if (e.key === 'Escape') setEditingCell(null);
-                      }}
-                      onClick={(e) => e.stopPropagation()}
-                      className="w-full bg-[var(--nim-bg-secondary)] border border-[var(--nim-primary)] rounded px-1 py-0.5 text-[13px] text-[var(--nim-text)] font-medium outline-none"
-                    />
-                  ) : (
-                    <div className="flex items-baseline gap-2 min-w-0">
-                      {item.issueKey && (
-                        <span className="shrink-0 text-[10px] font-mono font-medium uppercase tracking-[0.08em] text-[var(--nim-text-faint)]">{item.issueKey}</span>
-                      )}
-                      <span className="text-[13px] font-medium text-[var(--nim-text)] truncate">{title}</span>
-                    </div>
-                  )}
-                </div>
-
-                {/* Right-side metadata: render visible columns (except type/title which are already shown) */}
-                <div className="flex items-center gap-2 shrink-0">
-                  {visibleColumnDefs.filter(col => col.id !== 'type' && col.id !== 'title').map(col => {
-                    const value = getCellValue(item, col.id);
-                    return (
-                      <div key={col.id} className={`tracker-table-cell ${col.id}`}>
-                        {renderCell(col, item, value, editingCell, isItemEditable, setEditingCell, editingTitle, setEditingTitle, titleInputRef, handleFieldUpdate)}
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })
+          sortedItems.map((item, index) => renderTrackerRow(item, index))
         )}
       </div>
 

--- a/packages/runtime/src/plugins/TrackerPlugin/components/TrackerTableGrid.tsx
+++ b/packages/runtime/src/plugins/TrackerPlugin/components/TrackerTableGrid.tsx
@@ -37,8 +37,9 @@ import {
 } from './trackerColumns';
 import { DisplayOptionsPanel } from './DisplayOptionsPanel';
 import { useTrackerRows } from './useTrackerRows';
-import { renderCell, ContextSubmenu } from './TrackerTable';
+import { renderCell, ContextSubmenu, TrackerGroupHeader } from './TrackerTable';
 import type { SortColumn, SortDirection } from './TrackerTable';
+import { groupTrackerItems, normalizeTrackerGroupBy } from '../trackerGrouping';
 
 interface TrackerTableGridProps {
   filterType?: TrackerItemType | 'all';
@@ -175,6 +176,15 @@ export function TrackerTableGrid({
     });
     return sorted;
   }, [filteredItems, currentSortBy, currentSortDirection]);
+  const activeGroupBy = normalizeTrackerGroupBy(effectiveColumnConfig.groupBy);
+  const isGrouped = activeGroupBy !== 'none';
+  const groupedItems = useMemo(
+    () => groupTrackerItems(sortedItems, activeGroupBy),
+    [sortedItems, activeGroupBy],
+  );
+  const rowIndexById = useMemo(() => {
+    return new Map(sortedItems.map((item, index) => [item.id, index]));
+  }, [sortedItems]);
 
   // Row interaction (shared with TrackerTable)
   const rows = useTrackerRows({
@@ -412,28 +422,60 @@ export function TrackerTableGrid({
               );
             })}
 
-            {/* Body rows -- each row uses display: contents so its cells join the parent grid */}
-            {sortedItems.map((item, rowIndex) => (
-              <GridRow
-                key={item.id || rowIndex}
-                item={item}
-                rowIndex={rowIndex}
-                columns={visibleColumnDefs}
-                selectedIds={selectedIds}
-                selectedItemId={selectedItemId}
-                focusedIndex={focusedIndex}
-                editingCell={editingCell}
-                setEditingCell={setEditingCell}
-                editingTitle={editingTitle}
-                setEditingTitle={setEditingTitle}
-                titleInputRef={titleInputRef}
-                handleFieldUpdate={handleFieldUpdate}
-                isItemEditable={isItemEditable}
-                handleRowClick={handleRowClick}
-                handleContextMenu={handleContextMenu}
-                openItemInEditor={openItemInEditor}
-              />
-            ))}
+            {isGrouped ? (
+              groupedItems.map((group) => (
+                <React.Fragment key={`${activeGroupBy}:${group.key || 'empty'}`}>
+                  <TrackerGroupHeader
+                    label={group.label}
+                    count={group.items.length}
+                    style={{ gridColumn: '1 / -1' }}
+                  />
+                  {group.items.map((item) => (
+                    <GridRow
+                      key={item.id}
+                      item={item}
+                      rowIndex={rowIndexById.get(item.id) ?? 0}
+                      columns={visibleColumnDefs}
+                      selectedIds={selectedIds}
+                      selectedItemId={selectedItemId}
+                      focusedIndex={focusedIndex}
+                      editingCell={editingCell}
+                      setEditingCell={setEditingCell}
+                      editingTitle={editingTitle}
+                      setEditingTitle={setEditingTitle}
+                      titleInputRef={titleInputRef}
+                      handleFieldUpdate={handleFieldUpdate}
+                      isItemEditable={isItemEditable}
+                      handleRowClick={handleRowClick}
+                      handleContextMenu={handleContextMenu}
+                      openItemInEditor={openItemInEditor}
+                    />
+                  ))}
+                </React.Fragment>
+              ))
+            ) : (
+              sortedItems.map((item, rowIndex) => (
+                <GridRow
+                  key={item.id || rowIndex}
+                  item={item}
+                  rowIndex={rowIndex}
+                  columns={visibleColumnDefs}
+                  selectedIds={selectedIds}
+                  selectedItemId={selectedItemId}
+                  focusedIndex={focusedIndex}
+                  editingCell={editingCell}
+                  setEditingCell={setEditingCell}
+                  editingTitle={editingTitle}
+                  setEditingTitle={setEditingTitle}
+                  titleInputRef={titleInputRef}
+                  handleFieldUpdate={handleFieldUpdate}
+                  isItemEditable={isItemEditable}
+                  handleRowClick={handleRowClick}
+                  handleContextMenu={handleContextMenu}
+                  openItemInEditor={openItemInEditor}
+                />
+              ))
+            )}
           </div>
         )}
       </div>

--- a/packages/runtime/src/plugins/TrackerPlugin/components/__tests__/TrackerTable.grouping.test.tsx
+++ b/packages/runtime/src/plugins/TrackerPlugin/components/__tests__/TrackerTable.grouping.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { TrackerRecord } from '../../../../core/TrackerRecord';
+import { TrackerTable } from '../TrackerTable';
+import { TrackerTableGrid } from '../TrackerTableGrid';
+import type { TypeColumnConfig } from '../trackerColumns';
+
+vi.mock('posthog-js/react', () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
+afterEach(() => cleanup());
+
+function makeItem(id: string, primaryType: string, title: string): TrackerRecord {
+  return {
+    id,
+    primaryType,
+    typeTags: [primaryType],
+    source: 'native',
+    archived: false,
+    syncStatus: 'local',
+    issueKey: id.toUpperCase(),
+    system: {
+      workspace: '/ws',
+      createdAt: '2026-06-29T00:00:00.000Z',
+      updatedAt: '2026-06-29T00:00:00.000Z',
+      lastIndexed: '2026-06-29T00:00:00.000Z',
+    },
+    fields: {
+      title,
+      status: 'to-do',
+      priority: 'medium',
+    },
+  };
+}
+
+const groupedColumnConfig: TypeColumnConfig = {
+  visibleColumns: ['type', 'key', 'title', 'status', 'priority', 'updated'],
+  columnWidths: {},
+  groupBy: 'type',
+};
+
+const items = [
+  makeItem('bug-1', 'bug', 'First bug'),
+  makeItem('task-1', 'task', 'Task work'),
+  makeItem('bug-2', 'bug', 'Second bug'),
+];
+
+describe('TrackerTable grouping', () => {
+  it('renders group headers in the list view when Display Options grouping is set', () => {
+    render(
+      <TrackerTable
+        hideTypeTabs
+        filterType="all"
+        overrideItems={items}
+        columnConfig={groupedColumnConfig}
+        onColumnConfigChange={() => {}}
+      />,
+    );
+
+    const headers = screen.getAllByTestId('tracker-table-group-header');
+    expect(headers.map((header) => header.textContent)).toEqual(['bug2 items', 'task1 item']);
+  });
+
+  it('renders group headers in the grid view when Display Options grouping is set', () => {
+    render(
+      <TrackerTableGrid
+        filterType="all"
+        overrideItems={items}
+        columnConfig={groupedColumnConfig}
+        onColumnConfigChange={() => {}}
+      />,
+    );
+
+    const headers = screen.getAllByTestId('tracker-table-group-header');
+    expect(headers.map((header) => header.textContent)).toEqual(['bug2 items', 'task1 item']);
+  });
+});

--- a/packages/runtime/src/plugins/TrackerPlugin/index.tsx
+++ b/packages/runtime/src/plugins/TrackerPlugin/index.tsx
@@ -1027,6 +1027,8 @@ export { DisplayOptionsPanel } from './components/DisplayOptionsPanel';
 export { getDefaultColumnConfig, resolveColumnsForType, BUILTIN_COLUMNS, DEFAULT_VISIBLE_COLUMNS } from './components/trackerColumns';
 export type { TrackerColumnDef, TypeColumnConfig, ColumnRenderType } from './components/trackerColumns';
 export type { TrackerFieldEditorProps } from './components/TrackerFieldEditor';
+export { groupTrackerItems, normalizeTrackerGroupBy } from './trackerGrouping';
+export type { TrackerGroup, TrackerGroupBy } from './trackerGrouping';
 
 // Export tracker data atoms (cross-platform reactive state)
 export {

--- a/packages/runtime/src/plugins/TrackerPlugin/trackerGrouping.ts
+++ b/packages/runtime/src/plugins/TrackerPlugin/trackerGrouping.ts
@@ -1,0 +1,132 @@
+import type { TrackerRecord } from '../../core/TrackerRecord';
+import {
+  getRecordPriority,
+  getRecordStatus,
+  getFieldByRole,
+} from './trackerRecordAccessors';
+
+export type TrackerGroupBy = 'none' | 'status' | 'priority' | 'assignee' | 'owner' | 'type' | 'tag';
+
+export interface TrackerGroup {
+  /** 分组键：字段值本身；空值桶使用 `''`。 */
+  key: string;
+  label: string;
+  items: TrackerRecord[];
+}
+
+export function normalizeTrackerGroupBy(value: string | null | undefined): TrackerGroupBy {
+  switch (value) {
+    case 'status':
+    case 'priority':
+    case 'assignee':
+    case 'owner':
+    case 'type':
+    case 'tag':
+      return value;
+    default:
+      return 'none';
+  }
+}
+
+function titleCase(value: string): string {
+  return value
+    .split('-')
+    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}
+
+function normalizeTrackerTagList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((tag): tag is string => typeof tag === 'string')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+function getTrackerItemTags(item: TrackerRecord): string[] {
+  return normalizeTrackerTagList(getFieldByRole(item, 'tags'));
+}
+
+function singleGroupValue(item: TrackerRecord, groupBy: Exclude<TrackerGroupBy, 'none' | 'tag'>): string {
+  switch (groupBy) {
+    case 'status':
+      return (getRecordStatus(item) || '').toLowerCase();
+    case 'priority':
+      return (getRecordPriority(item) || '').toLowerCase();
+    case 'type':
+      return item.primaryType;
+    case 'assignee':
+    case 'owner':
+      return ((getFieldByRole(item, 'assignee') as string | undefined) || '');
+  }
+}
+
+/**
+ * Tracker 表格和 saved view 共用的分组语义。
+ * `owner` 是 Display Options 里的文案值，等价于 schema 的 assignee role。
+ */
+export function groupTrackerItems(items: TrackerRecord[], rawGroupBy: string | null | undefined): TrackerGroup[] {
+  const groupBy = normalizeTrackerGroupBy(rawGroupBy);
+
+  if (groupBy === 'none') {
+    return [{ key: '', label: 'All', items }];
+  }
+
+  if (groupBy === 'tag') {
+    const byTag = new Map<string, TrackerRecord[]>();
+    const order: string[] = [];
+    const untagged: TrackerRecord[] = [];
+    for (const item of items) {
+      const tags = Array.from(new Set(getTrackerItemTags(item)));
+      if (tags.length === 0) {
+        untagged.push(item);
+        continue;
+      }
+      for (const tag of tags) {
+        const bucket = byTag.get(tag);
+        if (bucket) bucket.push(item);
+        else {
+          byTag.set(tag, [item]);
+          order.push(tag);
+        }
+      }
+    }
+    const groups: TrackerGroup[] = order.map((tag) => ({ key: tag, label: `#${tag}`, items: byTag.get(tag)! }));
+    if (untagged.length > 0) groups.push({ key: '', label: 'Untagged', items: untagged });
+    return groups;
+  }
+
+  const buckets = new Map<string, TrackerRecord[]>();
+  const order: string[] = [];
+  for (const item of items) {
+    const value = singleGroupValue(item, groupBy);
+    const bucket = buckets.get(value);
+    if (bucket) bucket.push(item);
+    else {
+      buckets.set(value, [item]);
+      order.push(value);
+    }
+  }
+
+  const emptyLabel = groupBy === 'assignee' || groupBy === 'owner' ? 'Unassigned' : 'None';
+  const nonEmpty = order.filter((v) => v !== '');
+  const groups: TrackerGroup[] = nonEmpty.map((value) => ({
+    key: value,
+    label: groupBy === 'type' || groupBy === 'assignee' || groupBy === 'owner' ? value : titleCase(value),
+    items: buckets.get(value)!,
+  }));
+  if (buckets.has('')) {
+    groups.push({ key: '', label: emptyLabel, items: buckets.get('')! });
+  }
+  return groups;
+}


### PR DESCRIPTION
## Summary
- Add a shared tracker grouping helper in runtime and reuse it from saved views.
- Render group headers in tracker list and grid views when Display Options grouping is set.
- Add regression coverage for owner/type grouping and grouped list/grid rendering.

## Verification
- `npx vitest run packages/runtime/src/plugins/TrackerPlugin packages/electron/src/renderer/components/TrackerMode/__tests__/trackerSavedViews.test.ts packages/electron/src/renderer/components/TrackerMode/__tests__/trackerTagBoard.test.ts packages/electron/src/renderer/components/TrackerMode/__tests__/trackerTagFilterUtils.test.ts`
- `npx vitest run packages/runtime/src/plugins/TrackerPlugin/__tests__/trackerGrouping.test.ts packages/runtime/src/plugins/TrackerPlugin/components/__tests__/TrackerTable.grouping.test.tsx packages/electron/src/renderer/components/TrackerMode/__tests__/trackerSavedViews.test.ts`
- `npm run typecheck --prefix packages/runtime`
- `npm run typecheck --prefix packages/electron`
- `git diff --check origin/main..HEAD`

## Risk
- Affects tracker list/table display only.
- No schema, sync, or storage changes.
- Ungrouped rendering keeps the existing flat list/grid path.

Refs NIM-2