### PR TITLE
fix(electron): avoid workspace crawl for git ref watcher

### DIFF
--- a/packages/electron/src/main/file/GitRefWatcher.ts
+++ b/packages/electron/src/main/file/GitRefWatcher.ts
@@ -1,4 +1,3 @@
-import chokidar, { FSWatcher } from 'chokidar';
 import * as path from 'path';
 import * as fs from 'fs';
 import simpleGit, { SimpleGit } from 'simple-git';
@@ -6,9 +5,16 @@ import { BrowserWindow } from 'electron';
 import { logger } from '../utils/logger';
 import { clearGitStatusCache } from '../ipc/GitStatusHandlers';
 
+type NativeFileWatchListener = (curr: fs.Stats, prev: fs.Stats) => void;
+
+interface NativeFileWatcher {
+  filePath: string;
+  listener: NativeFileWatchListener;
+}
+
 interface WatcherEntry {
-  refWatcher: FSWatcher;
-  indexWatcher: FSWatcher;
+  refWatcher: NativeFileWatcher;
+  indexWatcher: NativeFileWatcher;
   lastCommitHash: string;
   currentBranch: string;
   git: SimpleGit;
@@ -33,6 +39,51 @@ interface GitDirInfo {
   gitDir: string;
   /** The common git directory where refs/heads are stored (same as gitDir for regular repos) */
   commonDir: string;
+}
+
+const GIT_FILE_WATCH_INTERVAL_MS = 500;
+
+function statsRepresentExistingFile(stats: fs.Stats): boolean {
+  return stats.nlink > 0 || stats.mtimeMs > 0 || stats.ctimeMs > 0 || stats.size > 0;
+}
+
+function statsChanged(curr: fs.Stats, prev: fs.Stats): boolean {
+  return (
+    curr.mtimeMs !== prev.mtimeMs ||
+    curr.ctimeMs !== prev.ctimeMs ||
+    curr.size !== prev.size ||
+    curr.ino !== prev.ino ||
+    curr.nlink !== prev.nlink
+  );
+}
+
+function watchGitFile(
+  filePath: string,
+  onChange: (created: boolean) => void | Promise<void>,
+  onError: (error: unknown) => void,
+): NativeFileWatcher {
+  const listener: NativeFileWatchListener = (curr, prev) => {
+    try {
+      if (!statsChanged(curr, prev)) return;
+      const currExists = statsRepresentExistingFile(curr);
+      const prevExists = statsRepresentExistingFile(prev);
+      if (!currExists && !prevExists) return;
+      void Promise.resolve(onChange(currExists && !prevExists)).catch(onError);
+    } catch (error) {
+      onError(error);
+    }
+  };
+
+  fs.watchFile(filePath, {
+    interval: GIT_FILE_WATCH_INTERVAL_MS,
+    persistent: false,
+  }, listener);
+
+  return { filePath, listener };
+}
+
+function unwatchGitFile(watcher: NativeFileWatcher): void {
+  fs.unwatchFile(watcher.filePath, watcher.listener);
 }
 
 /**
@@ -183,57 +234,34 @@ export class GitRefWatcher {
       // Watch refs/heads/<current-branch> for commit detection
       // Use commonDir for refs (in worktrees, refs are in the shared parent .git dir)
       const branchRefPath = path.join(commonDir, 'refs/heads', currentBranch);
-      const refWatcher = chokidar.watch(branchRefPath, {
-        ignoreInitial: true,
-        persistent: true,
-        usePolling: false,
-        awaitWriteFinish: {
-          stabilityThreshold: 50,
-          pollInterval: 10,
+      const refWatcher = watchGitFile(
+        branchRefPath,
+        async (created) => {
+          if (created) {
+            logger.main.info('[GitRefWatcher] Ref file added:', {
+              workspace: path.basename(workspacePath),
+              branch: currentBranch,
+            });
+          }
+          await this.handleRefChange(workspacePath);
         },
-      });
-
-      refWatcher.on('change', async () => {
-        // logger.main.info('[GitRefWatcher] Ref file changed:', {
-        //   workspace: path.basename(workspacePath),
-        //   branch: currentBranch,
-        // });
-        await this.handleRefChange(workspacePath);
-      });
-
-      refWatcher.on('add', async () => {
-        // Handle case where ref file is recreated (e.g., after branch switch)
-        logger.main.info('[GitRefWatcher] Ref file added:', {
-          workspace: path.basename(workspacePath),
-          branch: currentBranch,
-        });
-        await this.handleRefChange(workspacePath);
-      });
-
-      refWatcher.on('error', (error) => {
-        logger.main.error('[GitRefWatcher] Ref watcher error:', error);
-      });
+        (error) => {
+          logger.main.error('[GitRefWatcher] Ref watcher error:', error);
+        },
+      );
 
       // Watch index for staging changes
       // Use the resolved gitDir for the actual index file location
       const indexPath = path.join(gitDir, 'index');
-      const indexWatcher = chokidar.watch(indexPath, {
-        ignoreInitial: true,
-        persistent: true,
-        usePolling: false,
-        awaitWriteFinish: {
-          stabilityThreshold: 50,
-          pollInterval: 10,
+      const indexWatcher = watchGitFile(
+        indexPath,
+        () => {
+          this.handleIndexChangeDebounced(workspacePath);
         },
-      });
-
-      indexWatcher.on('change', () => {
-        this.handleIndexChangeDebounced(workspacePath);
-      });
-
-      indexWatcher.on('error', (error) => {
-        logger.main.error('[GitRefWatcher] Index watcher error:', error);
-      });
+        (error) => {
+          logger.main.error('[GitRefWatcher] Index watcher error:', error);
+        },
+      );
 
       this.watchers.set(workspacePath, {
         refWatcher,
@@ -260,8 +288,8 @@ export class GitRefWatcher {
   async stop(workspacePath: string): Promise<void> {
     const entry = this.watchers.get(workspacePath);
     if (entry) {
-      await entry.refWatcher.close();
-      await entry.indexWatcher.close();
+      unwatchGitFile(entry.refWatcher);
+      unwatchGitFile(entry.indexWatcher);
       this.watchers.delete(workspacePath);
 
       // Clear any pending debounce timer

--- a/packages/electron/src/main/file/__tests__/GitRefWatcher.test.ts
+++ b/packages/electron/src/main/file/__tests__/GitRefWatcher.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as path from 'path';
 
 // Hoisted mocks: simple-git fakes that individual tests can wire per scenario,
 // plus logger fakes that the vi.mock factory below references. Hoisting is
@@ -11,6 +12,8 @@ const {
   loggerError,
   loggerWarn,
   loggerDebug,
+  mockWatchFile,
+  mockUnwatchFile,
 } = vi.hoisted(() => ({
   mockStatus: vi.fn(),
   mockLog: vi.fn(),
@@ -18,6 +21,8 @@ const {
   loggerError: vi.fn(),
   loggerWarn: vi.fn(),
   loggerDebug: vi.fn(),
+  mockWatchFile: vi.fn(),
+  mockUnwatchFile: vi.fn(),
 }));
 
 vi.mock('simple-git', () => ({
@@ -27,23 +32,13 @@ vi.mock('simple-git', () => ({
   }),
 }));
 
-// chokidar.watch is invoked at .start() once preflight passes. We never want
-// real file watchers in tests, so return a no-op that satisfies the FSWatcher
-// interface enough for our assertions.
-vi.mock('chokidar', () => ({
-  default: {
-    watch: vi.fn(() => ({
-      on: vi.fn().mockReturnThis(),
-      close: vi.fn().mockResolvedValue(undefined),
-    })),
-  },
-}));
-
 // Pretend `<workspace>/.git` is a regular directory.
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
   return {
     ...actual,
+    watchFile: mockWatchFile,
+    unwatchFile: mockUnwatchFile,
     promises: {
       ...actual.promises,
       stat: vi.fn().mockResolvedValue({
@@ -126,6 +121,26 @@ describe('GitRefWatcher.start - empty repo handling', () => {
       '[GitRefWatcher] Skipping detached HEAD workspace:',
       '/fake/workspace',
     );
+    expect(watcher.getStats().activeWatchers).toBe(0);
+  });
+
+  it('uses native file polling for git ref and index files', async () => {
+    mockStatus.mockResolvedValue({ current: 'master' });
+    mockLog.mockResolvedValue({ latest: { hash: 'abc123', message: 'Initial commit' } });
+
+    const watcher = new GitRefWatcher();
+    await watcher.start('/fake/workspace');
+
+    expect(mockWatchFile).toHaveBeenCalledTimes(2);
+    expect(mockWatchFile.mock.calls[0]?.[0]).toBe(path.join('/fake/workspace', '.git', 'refs', 'heads', 'master'));
+    expect(mockWatchFile.mock.calls[1]?.[0]).toBe(path.join('/fake/workspace', '.git', 'index'));
+    expect(watcher.getStats().activeWatchers).toBe(1);
+
+    await watcher.stop('/fake/workspace');
+
+    expect(mockUnwatchFile).toHaveBeenCalledTimes(2);
+    expect(mockUnwatchFile.mock.calls[0]?.[0]).toBe(path.join('/fake/workspace', '.git', 'refs', 'heads', 'master'));
+    expect(mockUnwatchFile.mock.calls[1]?.[0]).toBe(path.join('/fake/workspace', '.git', 'index'));
     expect(watcher.getStats().activeWatchers).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

This replaces the Git ref/index watcher with native single-file polling.

`GitRefWatcher` only needs to observe two git files per workspace:

- `.git/refs/heads/<current-branch>` for commit detection
- `.git/index` for staging/status changes

Using Chokidar for these two paths can still pull in its directory-walking stack on large workspaces. In a real large workspace slowdown, the Electron main-process CPU profile was dominated by Chokidar/readdirp frames while Nimbalyst was otherwise idle. This PR keeps the same behavior but narrows the watcher implementation to the exact files being observed.

## What Changed

- Removed Chokidar from `GitRefWatcher`.
- Added a small native watcher wrapper around `fs.watchFile` / `fs.unwatchFile`.
- Polls only the resolved branch ref file and git index file.
- Keeps the existing detached-HEAD and empty-repository handling.
- Keeps the existing debounced index-change behavior.
- Handles ref file creation/recreation for branch refs.
- Updated the focused unit test to assert native file watchers are created and removed.

## Why `fs.watchFile`

For this specific use case, native file polling is intentionally simpler and more bounded than a general-purpose directory watcher:

- The watched paths are known single files, not glob patterns.
- Git ref/index changes are low-frequency relative to UI work.
- A 500 ms polling interval is enough for status/commit detection without adding workspace traversal pressure.
- `persistent: false` avoids keeping the process alive just because these watchers exist.

This does not remove Chokidar elsewhere in the app. It only removes it from the Git ref/index watcher path that does not need directory watching.

## Validation

Ran the focused watcher test:

```bash
npx vitest run packages/electron/src/main/file/__tests__/GitRefWatcher.test.ts
```

Result:

- 1 test file passed
- 4 tests passed

Also validated this change in a local packaged Yogi build during performance investigation. After replacing the watcher path, the compiled main process contains the native `watchFile`/`unwatchFile` implementation for `GitRefWatcher`.

## Risk

Low to medium:

- The change is localized to `GitRefWatcher`.
- The watcher now depends on polling interval rather than Chokidar events, so git status/commit UI updates may be delayed by up to roughly 500 ms.
- This should be acceptable for git metadata updates and avoids the broader watcher overhead in large workspaces.

## Notes

This is intended as a performance hardening change for large repositories/workspaces where broad filesystem watcher stacks can become visible in Electron main-process CPU profiles.