### PR TITLE
Add GLM 5.2 OpenCode presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- OpenCode presets now include GLM 5.2 through the Z.AI and Z.AI Coding Plan providers.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -379,6 +379,18 @@ export const OPENCODE_PRESET_MODELS: OpenCodePresetModel[] = [
     providerID: 'google',
     modelID: 'gemini-2.5-pro',
   },
+  {
+    id: 'opencode:zai/glm-5.2',
+    name: 'GLM 5.2 (Z.AI)',
+    providerID: 'zai',
+    modelID: 'glm-5.2',
+  },
+  {
+    id: 'opencode:zai-coding-plan/glm-5.2',
+    name: 'GLM 5.2 (Z.AI Coding Plan)',
+    providerID: 'zai-coding-plan',
+    modelID: 'glm-5.2',
+  },
 ];
 
 /** OpenCode provider id reserved for an LM Studio bridge written into opencode.json. */

--- a/packages/runtime/src/ai/server/providers/__tests__/OpenCodeProvider.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/OpenCodeProvider.test.ts
@@ -93,6 +93,8 @@ describe('OpenCodeProvider', () => {
       expect.objectContaining({ id: 'opencode:anthropic/claude-sonnet-4-5', provider: 'opencode' }),
       expect.objectContaining({ id: 'opencode:openai/gpt-5', provider: 'opencode' }),
       expect.objectContaining({ id: 'opencode:google/gemini-2.5-pro', provider: 'opencode' }),
+      expect.objectContaining({ id: 'opencode:zai/glm-5.2', provider: 'opencode' }),
+      expect.objectContaining({ id: 'opencode:zai-coding-plan/glm-5.2', provider: 'opencode' }),
     ]));
   });
 


### PR DESCRIPTION
## Summary
- add GLM 5.2 to the curated OpenCode preset list for Z.AI direct access
- add GLM 5.2 to the curated OpenCode preset list for the Z.AI Coding Plan provider
- cover both presets in the OpenCode provider model discovery test

## Notes
This is intentionally separate from the Extended Thinking PR (#734). It does not include the local Yogi Claude-brain selector change because official upstream `main` does not currently contain the local `customBackends.ts` brain-list surface.

References used:
- Models.dev Z.AI provider: https://models.dev/providers/zai
- Models.dev Z.AI Coding Plan provider: https://models.dev/providers/zai-coding-plan
- Z.AI OpenCode guide: https://docs.z.ai/scenario-example/develop-tools/opencode
- Z.AI model switch/devpack note: https://docs.z.ai/devpack/latest-model

## Validation
- `npx vitest run packages/runtime/src/ai/server/providers/__tests__/OpenCodeProvider.test.ts` passed (10 tests).