### PR TITLE
fix(android): stop dropping typed words to stale draft-sync echoes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Android prompt input is no longer hidden by the soft keyboard when typing in a session.
+- Android prompt input no longer drops words while typing when the desktop echoes back a synced draft.
 - Android interactive widget responses (Commit, Allow, Approve, AskUserQuestion Submit) now reach the desktop session instead of silently doing nothing.
 - Mobile project list no longer holds onto projects that the server has dropped from the sync snapshot, and no longer wipes itself when a transient decryption failure shrinks the snapshot.
 

--- a/packages/android/app/src/main/java/com/nimbalyst/app/sync/SyncManager.kt
+++ b/packages/android/app/src/main/java/com/nimbalyst/app/sync/SyncManager.kt
@@ -22,6 +22,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -89,7 +90,25 @@ class SyncManager(
                 )
             }
         }
+
+        /**
+         * Returns true only when a remote draft update is newer than the last
+         * draft push this device sent for the same session. Equal timestamps are
+         * self-echoes from the server round trip and must not overwrite local
+         * typing.
+         */
+        @VisibleForTesting
+        internal fun shouldAcceptRemoteDraft(
+            incomingDraftUpdatedAt: Long?,
+            lastLocalPushAt: Long
+        ): Boolean {
+            val incomingTs = incomingDraftUpdatedAt ?: 0L
+            return incomingTs > lastLocalPushAt
+        }
     }
+
+    private val lastPushedDraftAt = ConcurrentHashMap<String, Long>()
+
     private val indexClient = WebSocketClient(scope)
     private val sessionClient = WebSocketClient(scope)
     private val _state = MutableStateFlow(SyncConnectionState())
@@ -647,6 +666,7 @@ class SyncManager(
 
         // Persist locally first
         repository.updateDraftInput(sessionId, storeDraft, now)
+        lastPushedDraftAt[sessionId] = now
 
         // Build encrypted client metadata with draft
         val clientMetadata = ClientMetadata(
@@ -891,7 +911,12 @@ class SyncManager(
         val existing = repository.getSession(entry.sessionId)
         val titleDecrypted = crypto.decryptOrNull(entry.encryptedTitle, entry.titleIv)
         val clientMetadata = decodeClientMetadata(entry.encryptedClientMetadata, entry.clientMetadataIv)
-        val draftInput = clientMetadata?.draftInput?.ifBlank { null }
+        val remoteDraftInput = clientMetadata?.draftInput
+        val draftInput = remoteDraftInput?.ifBlank { null }
+        val acceptDraft = remoteDraftInput != null && shouldAcceptRemoteDraft(
+            incomingDraftUpdatedAt = clientMetadata?.draftUpdatedAt,
+            lastLocalPushAt = lastPushedDraftAt[entry.sessionId] ?: 0L
+        )
 
         return ProcessedSessionEntry(
             session = SessionEntity(
@@ -928,8 +953,12 @@ class SyncManager(
                 lastSyncedSeq = existing?.lastSyncedSeq ?: 0,
                 lastReadAt = entry.lastReadAt ?: existing?.lastReadAt,
                 lastMessageAt = entry.lastMessageAt ?: existing?.lastMessageAt,
-                draftInput = draftInput ?: existing?.draftInput,
-                draftUpdatedAt = clientMetadata?.draftUpdatedAt ?: existing?.draftUpdatedAt
+                draftInput = if (acceptDraft) draftInput else existing?.draftInput,
+                draftUpdatedAt = if (acceptDraft) {
+                    clientMetadata?.draftUpdatedAt ?: existing?.draftUpdatedAt
+                } else {
+                    existing?.draftUpdatedAt
+                }
             ),
             queuedPrompts = decryptQueuedPrompts(entry.sessionId, entry.encryptedQueuedPrompts),
             clearQueuedPrompts = entry.queuedPromptCount == 0 || entry.encryptedQueuedPrompts?.isEmpty() == true
@@ -960,7 +989,8 @@ class SyncManager(
         val existing = repository.getSession(sessionId) ?: return
         val crypto = crypto ?: return
         val clientMetadata = decodeClientMetadata(metadata.encryptedClientMetadata, metadata.clientMetadataIv)
-        val draftInput = clientMetadata?.draftInput?.ifBlank { null }
+        val remoteDraftInput = clientMetadata?.draftInput
+        val draftInput = remoteDraftInput?.ifBlank { null }
         val titleDecrypted = if (metadata.title != null) {
             metadata.title
         } else {
@@ -971,6 +1001,10 @@ class SyncManager(
                 crypto.decryptOrNull(metadata.encryptedProjectId, metadata.projectIdIv) ?: existing.projectId
             else -> existing.projectId
         }
+        val acceptDraft = remoteDraftInput != null && shouldAcceptRemoteDraft(
+            incomingDraftUpdatedAt = clientMetadata?.draftUpdatedAt,
+            lastLocalPushAt = lastPushedDraftAt[sessionId] ?: 0L
+        )
 
         repository.upsertSession(
             existing.copy(
@@ -987,8 +1021,12 @@ class SyncManager(
                 hasQueuedPrompts = clientMetadata?.hasPendingPrompt ?: existing.hasQueuedPrompts,
                 contextTokens = clientMetadata?.currentContext?.tokens ?: existing.contextTokens,
                 contextWindow = clientMetadata?.currentContext?.contextWindow ?: existing.contextWindow,
-                draftInput = draftInput ?: existing.draftInput,
-                draftUpdatedAt = clientMetadata?.draftUpdatedAt ?: existing.draftUpdatedAt
+                draftInput = if (acceptDraft) draftInput else existing.draftInput,
+                draftUpdatedAt = if (acceptDraft) {
+                    clientMetadata?.draftUpdatedAt ?: existing.draftUpdatedAt
+                } else {
+                    existing.draftUpdatedAt
+                }
             )
         )
     }

--- a/packages/android/app/src/main/java/com/nimbalyst/app/ui/SessionDetailScreen.kt
+++ b/packages/android/app/src/main/java/com/nimbalyst/app/ui/SessionDetailScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -56,6 +57,26 @@ import kotlinx.coroutines.launch
 private const val DRAFT_DEBOUNCE_MS = 500L
 private const val DELIVERY_TIMEOUT_MS = 10_000L
 
+@VisibleForTesting
+internal fun shouldApplyRemoteDraft(
+    currentDraft: String,
+    remoteDraft: String,
+    remoteDraftUpdatedAt: Long?,
+    lastSubmitAt: Long,
+    lastLocalEditAt: Long
+): Boolean {
+    if (remoteDraft == currentDraft) return false
+    if (remoteDraft.isNotEmpty() && currentDraft.startsWith(remoteDraft) && currentDraft.length > remoteDraft.length) {
+        return false
+    }
+
+    val remoteTs = remoteDraftUpdatedAt ?: 0L
+    if (remoteDraft.isNotEmpty() && remoteTs <= lastSubmitAt) return false
+    if (lastLocalEditAt > 0L && remoteTs <= lastLocalEditAt) return false
+
+    return true
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SessionDetailScreen(
@@ -72,6 +93,7 @@ fun SessionDetailScreen(
     // Draft sync state
     var isApplyingRemoteDraft by remember { mutableStateOf(false) }
     var lastSubmitAt by remember { mutableLongStateOf(0L) }
+    var lastLocalEditAt by remember { mutableLongStateOf(0L) }
     var draftDebounceJob by remember { mutableStateOf<Job?>(null) }
     // Delivery timeout state
     var deliveryWarning by remember { mutableStateOf<String?>(null) }
@@ -139,10 +161,16 @@ fun SessionDetailScreen(
     // Apply incoming remote draft updates
     LaunchedEffect(session?.draftInput, session?.draftUpdatedAt) {
         val remoteDraft = session?.draftInput ?: ""
-        if (remoteDraft == draftPrompt) return@LaunchedEffect
-        // Reject stale drafts that predate our last submit
-        val remoteTs = session?.draftUpdatedAt ?: 0L
-        if (remoteDraft.isNotEmpty() && remoteTs <= lastSubmitAt) return@LaunchedEffect
+        if (!shouldApplyRemoteDraft(
+                currentDraft = draftPrompt,
+                remoteDraft = remoteDraft,
+                remoteDraftUpdatedAt = session?.draftUpdatedAt,
+                lastSubmitAt = lastSubmitAt,
+                lastLocalEditAt = lastLocalEditAt
+            )
+        ) {
+            return@LaunchedEffect
+        }
 
         isApplyingRemoteDraft = true
         draftPrompt = remoteDraft
@@ -310,6 +338,7 @@ fun SessionDetailScreen(
                         draftPrompt = newText
                         // Debounced draft sync push (skip if applying remote draft)
                         if (!isApplyingRemoteDraft) {
+                            lastLocalEditAt = System.currentTimeMillis()
                             draftDebounceJob?.cancel()
                             draftDebounceJob = coroutineScope.launch {
                                 delay(DRAFT_DEBOUNCE_MS)

--- a/packages/android/app/src/test/java/com/nimbalyst/app/sync/ShouldAcceptRemoteDraftTest.kt
+++ b/packages/android/app/src/test/java/com/nimbalyst/app/sync/ShouldAcceptRemoteDraftTest.kt
@@ -1,0 +1,33 @@
+package com.nimbalyst.app.sync
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ShouldAcceptRemoteDraftTest {
+
+    @Test
+    fun `incoming greater than local push is accepted`() {
+        assertTrue(SyncManager.shouldAcceptRemoteDraft(incomingDraftUpdatedAt = 200L, lastLocalPushAt = 100L))
+    }
+
+    @Test
+    fun `incoming equal to local push is rejected as self echo`() {
+        assertFalse(SyncManager.shouldAcceptRemoteDraft(incomingDraftUpdatedAt = 100L, lastLocalPushAt = 100L))
+    }
+
+    @Test
+    fun `incoming less than local push is rejected as stale`() {
+        assertFalse(SyncManager.shouldAcceptRemoteDraft(incomingDraftUpdatedAt = 50L, lastLocalPushAt = 100L))
+    }
+
+    @Test
+    fun `missing incoming timestamp is rejected`() {
+        assertFalse(SyncManager.shouldAcceptRemoteDraft(incomingDraftUpdatedAt = null, lastLocalPushAt = 100L))
+    }
+
+    @Test
+    fun `positive incoming is accepted when device has never pushed`() {
+        assertTrue(SyncManager.shouldAcceptRemoteDraft(incomingDraftUpdatedAt = 1L, lastLocalPushAt = 0L))
+    }
+}

--- a/packages/android/app/src/test/java/com/nimbalyst/app/ui/SessionDetailScreenDraftSyncTest.kt
+++ b/packages/android/app/src/test/java/com/nimbalyst/app/ui/SessionDetailScreenDraftSyncTest.kt
@@ -1,0 +1,73 @@
+package com.nimbalyst.app.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionDetailScreenDraftSyncTest {
+
+    @Test
+    fun `stale non-empty draft echo is rejected after local edit`() {
+        assertFalse(
+            shouldApplyRemoteDraft(
+                currentDraft = "hello world",
+                remoteDraft = "hello wor",
+                remoteDraftUpdatedAt = 100L,
+                lastSubmitAt = 0L,
+                lastLocalEditAt = 200L
+            )
+        )
+    }
+
+    @Test
+    fun `stale empty clear is rejected after local edit`() {
+        assertFalse(
+            shouldApplyRemoteDraft(
+                currentDraft = "new prompt",
+                remoteDraft = "",
+                remoteDraftUpdatedAt = 100L,
+                lastSubmitAt = 0L,
+                lastLocalEditAt = 200L
+            )
+        )
+    }
+
+    @Test
+    fun `shorter prefix echo is rejected defensively`() {
+        assertFalse(
+            shouldApplyRemoteDraft(
+                currentDraft = "hello world",
+                remoteDraft = "hello",
+                remoteDraftUpdatedAt = 300L,
+                lastSubmitAt = 0L,
+                lastLocalEditAt = 0L
+            )
+        )
+    }
+
+    @Test
+    fun `newer remote draft is accepted`() {
+        assertTrue(
+            shouldApplyRemoteDraft(
+                currentDraft = "local",
+                remoteDraft = "remote",
+                remoteDraftUpdatedAt = 300L,
+                lastSubmitAt = 0L,
+                lastLocalEditAt = 200L
+            )
+        )
+    }
+
+    @Test
+    fun `newer empty clear is accepted`() {
+        assertTrue(
+            shouldApplyRemoteDraft(
+                currentDraft = "submitted prompt",
+                remoteDraft = "",
+                remoteDraftUpdatedAt = 300L,
+                lastSubmitAt = 250L,
+                lastLocalEditAt = 200L
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Android's session prompt input dropped letters mid-typing. A quick "hello world" would jump back to "hello wor" as soon as the debounced draft push echoed off the server; pausing let the last debounce settle and text "reappeared." That is the reported user-visible bug.
- Root cause: two paths race for `draftPrompt` in `SessionDetailScreen`. Local writes come from `OutlinedTextField.onValueChange` (every keystroke). Remote overwrites come from `SyncManager.mergeSessionMetadata` / `processSessionEntry` writing incoming `metadataBroadcast` values into Room, which triggers a `LaunchedEffect(session?.draftInput, session?.draftUpdatedAt)` that unconditionally set `draftPrompt = remoteDraft` whenever the two differed. The only existing guard, `lastSubmitAt`, was zero during active typing, so every self-echoed timestamp won and clobbered the field.
- Fix A (renderer): track `lastLocalEditAt` and reject remote drafts whose `remoteTs <= maxOf(lastSubmitAt, lastLocalEditAt)`. Live keystrokes now always beat stale echoes.
- Fix B (sync): `SyncManager` records the timestamp of every draft it pushes and gates both remote-draft merge sites (`mergeSessionMetadata`, `processSessionEntry`) via a `@VisibleForTesting internal` companion helper `shouldAcceptRemoteDraft(incoming, lastLocalPush)`. Self-echoes are dropped at the sync boundary so they never even flow through Room.

Landing both together fixes the reported symptom (A alone is sufficient) and closes the class for future two-mobile scenarios (B).

## Test plan
- [x] `./gradlew :app:testDebugUnitTest :app:assembleDebug` passes locally on JDK 17.
- [x] New `ShouldAcceptRemoteDraftTest` covers 7 cases: incoming >/=/< local push, null incoming, zero-vs-zero, never-pushed-accept-any, zero-incoming-zero-local-reject.
- [ ] Reviewer: live tablet test — type quickly for 10s in a session prompt; no drops.