### PR TITLE
Collapse intermediate assistant progress in chat

### DIFF
--- a/packages/electron/src/main/services/__tests__/SettingsService.test.ts
+++ b/packages/electron/src/main/services/__tests__/SettingsService.test.ts
@@ -74,6 +74,7 @@ describe('SettingsService', () => {
     expect(svc.get('ai.provider.openai')).toMatchObject({ enabled: false });
     expect(svc.get('ai.defaultProvider')).toBe('claude-code');
     expect(svc.get('ai.chatShowToolCalls')).toBe(true);
+    expect(svc.get('ai.collapseIntermediateProgress')).toBe(false);
     expect(svc.get('ai.apiKey.anthropic')).toBe('');
   });
 

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -492,6 +492,10 @@ export class AIService {
             type: 'boolean',
             default: true  // User-facing chat toggle; defaults true to preserve current UX
           },
+          collapseIntermediateProgress: {
+            type: 'boolean',
+            default: false  // 面向用户的转录折叠开关；默认关闭以保持现有体验
+          },
           aiDebugLogging: {
             type: 'boolean',
             default: false  // Hidden by default, developer mode only
@@ -1738,7 +1742,7 @@ export class AIService {
       }
 
       // Get API key using project-aware helper (considers project overrides)
-      let apiKey = this.getApiKeyForProvider(provider, workspacePath);
+      const apiKey = this.getApiKeyForProvider(provider, workspacePath);
 
       // Validate API key requirement based on provider.
       // Extension-agent providers defer auth to the extension itself, so they
@@ -2890,6 +2894,7 @@ export class AIService {
       const providerSettings = this.getNormalizedProviderSettings();
       const showToolCalls = this.getSettingsStore().get('showToolCalls', false) as boolean;
       const chatShowToolCalls = this.getSettingsStore().get('chatShowToolCalls', true) as boolean;
+      const collapseIntermediateProgress = this.getSettingsStore().get('collapseIntermediateProgress', false) as boolean;
       const aiDebugLogging = this.getSettingsStore().get('aiDebugLogging', false) as boolean;
       const showPromptAdditions = this.getSettingsStore().get('showPromptAdditions', false) as boolean;
       const showUsageIndicator = this.getSettingsStore().get('showUsageIndicator', true) as boolean;
@@ -2914,6 +2919,7 @@ export class AIService {
         providerSettings,
         showToolCalls,
         chatShowToolCalls,
+        collapseIntermediateProgress,
         aiDebugLogging,
         showPromptAdditions,
         showUsageIndicator,
@@ -3009,6 +3015,7 @@ export class AIService {
 
       if (settings.showToolCalls !== undefined)        safeSet('ai.showToolCalls', settings.showToolCalls);
       if (settings.chatShowToolCalls !== undefined)    safeSet('ai.chatShowToolCalls', settings.chatShowToolCalls);
+      if (settings.collapseIntermediateProgress !== undefined) safeSet('ai.collapseIntermediateProgress', settings.collapseIntermediateProgress);
       if (settings.aiDebugLogging !== undefined)       safeSet('ai.aiDebugLogging', settings.aiDebugLogging);
       if (settings.showPromptAdditions !== undefined)  safeSet('ai.showPromptAdditions', settings.showPromptAdditions);
       if (settings.customClaudeCodePath !== undefined) safeSet('ai.customClaudeCodePath', settings.customClaudeCodePath);
@@ -3620,6 +3627,7 @@ export class AIService {
       const providerSettings = this.getSettingsStore().get('providerSettings', {}) as any;
       const showToolCalls = this.getSettingsStore().get('showToolCalls', false) as boolean;
       const chatShowToolCalls = this.getSettingsStore().get('chatShowToolCalls', true) as boolean;
+      const collapseIntermediateProgress = this.getSettingsStore().get('collapseIntermediateProgress', false) as boolean;
       const aiDebugLogging = this.getSettingsStore().get('aiDebugLogging', false) as boolean;
       const showPromptAdditions = this.getSettingsStore().get('showPromptAdditions', false) as boolean;
       const defaultProvider = this.getSettingsStore().get('defaultProvider', 'claude-code') as string;
@@ -3630,6 +3638,7 @@ export class AIService {
         providerSettings,
         showToolCalls,
         chatShowToolCalls,
+        collapseIntermediateProgress,
         aiDebugLogging,
         showPromptAdditions,
       };

--- a/packages/electron/src/main/utils/__tests__/aiSettingsMerge.test.ts
+++ b/packages/electron/src/main/utils/__tests__/aiSettingsMerge.test.ts
@@ -20,6 +20,7 @@ const baseGlobal: GlobalAISettings = {
   apiKeys: {},
   providerSettings: {},
   showToolCalls: false,
+  collapseIntermediateProgress: false,
   aiDebugLogging: false,
   showPromptAdditions: false,
   customClaudeCodePath: '/usr/local/bin/claude-global',

--- a/packages/electron/src/main/utils/aiSettingsMerge.ts
+++ b/packages/electron/src/main/utils/aiSettingsMerge.ts
@@ -17,6 +17,7 @@ export interface GlobalAISettings {
   apiKeys: Record<string, string>;
   providerSettings: Record<string, ProviderSettings>;
   showToolCalls: boolean;
+  collapseIntermediateProgress: boolean;
   aiDebugLogging: boolean;
   showPromptAdditions: boolean;
   /** Path to a custom Claude Code executable. Empty string means "use bundled SDK". */
@@ -51,6 +52,7 @@ export interface EffectiveAISettings {
   apiKeys: Record<string, string>;
   providerSettings: Record<string, EffectiveProviderSettings>;
   showToolCalls: boolean;
+  collapseIntermediateProgress: boolean;
   aiDebugLogging: boolean;
   showPromptAdditions: boolean;
   customClaudeCodePath?: string;
@@ -172,6 +174,7 @@ export function mergeAISettings(
     apiKeys: { ...globalSettings.apiKeys },
     providerSettings: {},
     showToolCalls: globalSettings.showToolCalls,
+    collapseIntermediateProgress: globalSettings.collapseIntermediateProgress,
     aiDebugLogging: globalSettings.aiDebugLogging,
     showPromptAdditions: globalSettings.showPromptAdditions,
     customClaudeCodePath: globalSettings.customClaudeCodePath,

--- a/packages/electron/src/renderer/components/Settings/AgentFeaturesPanel.tsx
+++ b/packages/electron/src/renderer/components/Settings/AgentFeaturesPanel.tsx
@@ -42,7 +42,7 @@ export function AgentFeaturesPanel() {
 
   const [aiDebugSettings] = useAtom(aiDebugSettingsAtom);
   const [, updateAIDebugSettings] = useAtom(setAIDebugSettingsAtom);
-  const { showToolCalls, chatShowToolCalls, aiDebugLogging, showPromptAdditions } = aiDebugSettings;
+  const { showToolCalls, chatShowToolCalls, collapseIntermediateProgress, aiDebugLogging, showPromptAdditions } = aiDebugSettings;
   const [workflowSettingsLoading, setWorkflowSettingsLoading] = useState(false);
   const [preferredAgentLanguage, setPreferredAgentLanguage] = useState<string>('');
   const [workflowSourceSettings, setWorkflowSourceSettings] = useState<WorkflowSourceSettings>({
@@ -271,6 +271,13 @@ export function AgentFeaturesPanel() {
           onChange={(checked) => updateAIDebugSettings({ chatShowToolCalls: checked })}
           name="Show Tool Calls in Chat"
           description="Display tool call rows in the AI chat view. Turn off to hide tool activity and see only the conversational messages."
+        />
+
+        <SettingsToggle
+          checked={collapseIntermediateProgress}
+          onChange={(checked) => updateAIDebugSettings({ collapseIntermediateProgress: checked })}
+          name="Collapse Intermediate Progress"
+          description="Collapse non-final assistant progress updates in each turn while keeping the final answer and required prompts visible."
         />
       </div>
 

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -103,7 +103,7 @@ import {
 } from '../../store/atoms/terminals';
 import { scrollToTeammateAtom, scrollToMessageAtom, requestOpenSessionAtom } from '../../store/atoms/agentMode';
 import { usePostHog } from 'posthog-js/react';
-import { setAgentModeSettingsAtom, showPromptAdditionsAtom, hasExternalEditorAtom, externalEditorNameAtom, openInExternalEditorAtom, defaultAgentModelAtom, defaultEffortLevelAtom, chatShowToolCallsAtom } from '../../store/atoms/appSettings';
+import { setAgentModeSettingsAtom, showPromptAdditionsAtom, hasExternalEditorAtom, externalEditorNameAtom, openInExternalEditorAtom, defaultAgentModelAtom, defaultEffortLevelAtom, chatShowToolCallsAtom, collapseIntermediateProgressAtom } from '../../store/atoms/appSettings';
 import { supportsEffortLevel, parseEffortLevel, type EffortLevel } from '../../utils/modelUtils';
 import { buildPlanImplementationPrompt, resolvePlanFilePath } from '../../utils/pathUtils';
 import { resolveTranscriptClickPath } from '../../utils/resolveTranscriptClickPath';
@@ -445,6 +445,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
   const tokenUsage = useAtomValue(sessionTokenUsageAtom(sessionId));
   const isDataLoading = useAtomValue(sessionLoadingAtom(sessionId));
   const chatShowToolCalls = useAtomValue(chatShowToolCallsAtom);
+  const collapseIntermediateProgress = useAtomValue(collapseIntermediateProgressAtom);
   const [aiMode, setAiMode] = useAtom(sessionModeAtom(sessionId));
   const [currentModel, setCurrentModel] = useAtom(sessionModelAtom(sessionId));
   const [isArchived, setIsArchived] = useAtom(sessionArchivedAtom(sessionId));
@@ -2378,6 +2379,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
               showToolCalls: chatShowToolCalls,
               compactMode: false,
               collapseTools: false,
+              collapseIntermediateProgress,
               showThinking: true,
               showSessionInit: false
             }}

--- a/packages/electron/src/renderer/store/atoms/__tests__/settingsLockstep.test.ts
+++ b/packages/electron/src/renderer/store/atoms/__tests__/settingsLockstep.test.ts
@@ -112,12 +112,14 @@ describe('settings cross-window lockstep (legacy atoms)', () => {
 
     fireBroadcast({ key: 'ai.showToolCalls', value: true });
     fireBroadcast({ key: 'ai.chatShowToolCalls', value: false });
+    fireBroadcast({ key: 'ai.collapseIntermediateProgress', value: true });
     fireBroadcast({ key: 'ai.aiDebugLogging', value: true });
     fireBroadcast({ key: 'ai.showPromptAdditions', value: true });
 
     expect(store.get(aiDebugSettingsAtom)).toMatchObject({
       showToolCalls: true,
       chatShowToolCalls: false,
+      collapseIntermediateProgress: true,
       aiDebugLogging: true,
       showPromptAdditions: true,
     });

--- a/packages/electron/src/renderer/store/atoms/appSettings.ts
+++ b/packages/electron/src/renderer/store/atoms/appSettings.ts
@@ -873,6 +873,7 @@ export async function initSyncConfig(): Promise<SyncConfig> {
 export interface AIDebugSettings {
   showToolCalls: boolean;
   chatShowToolCalls: boolean;
+  collapseIntermediateProgress: boolean;
   aiDebugLogging: boolean;
   showPromptAdditions: boolean;
 }
@@ -883,6 +884,7 @@ export interface AIDebugSettings {
 const defaultAIDebugSettings: AIDebugSettings = {
   showToolCalls: false,
   chatShowToolCalls: true,
+  collapseIntermediateProgress: false,
   aiDebugLogging: false,
   showPromptAdditions: false,
 };
@@ -901,6 +903,9 @@ onSettingChanged('ai.showToolCalls', (v) => {
 });
 onSettingChanged('ai.chatShowToolCalls', (v) => {
   store.set(aiDebugSettingsAtom, { ...store.get(aiDebugSettingsAtom), chatShowToolCalls: v });
+});
+onSettingChanged('ai.collapseIntermediateProgress', (v) => {
+  store.set(aiDebugSettingsAtom, { ...store.get(aiDebugSettingsAtom), collapseIntermediateProgress: v });
 });
 onSettingChanged('ai.aiDebugLogging', (v) => {
   store.set(aiDebugSettingsAtom, { ...store.get(aiDebugSettingsAtom), aiDebugLogging: v });
@@ -931,6 +936,7 @@ function scheduleAIDebugPersist(settings: AIDebugSettings): void {
     const writes = [
       window.electronAPI.settingsSet('ai.showToolCalls', settings.showToolCalls),
       window.electronAPI.settingsSet('ai.chatShowToolCalls', settings.chatShowToolCalls),
+      window.electronAPI.settingsSet('ai.collapseIntermediateProgress', settings.collapseIntermediateProgress),
       window.electronAPI.settingsSet('ai.aiDebugLogging', settings.aiDebugLogging),
       window.electronAPI.settingsSet('ai.showPromptAdditions', settings.showPromptAdditions),
     ];
@@ -956,6 +962,12 @@ export const showToolCallsAtom = atom((get) => get(aiDebugSettingsAtom).showTool
  * tool rows hidden; default-true preserves UX for everyone else.
  */
 export const chatShowToolCallsAtom = atom((get) => get(aiDebugSettingsAtom).chatShowToolCalls);
+
+/**
+ * 面向用户的转录折叠设置。它只影响渲染，原始消息仍保留在会话中，
+ * 并且可以从折叠行展开查看。
+ */
+export const collapseIntermediateProgressAtom = atom((get) => get(aiDebugSettingsAtom).collapseIntermediateProgress);
 
 /**
  * AI debug logging setting.
@@ -997,6 +1009,7 @@ export async function initAIDebugSettings(): Promise<AIDebugSettings> {
     return {
       showToolCalls: settings?.showToolCalls ?? false,
       chatShowToolCalls: settings?.chatShowToolCalls ?? true,
+      collapseIntermediateProgress: settings?.collapseIntermediateProgress ?? false,
       aiDebugLogging: settings?.aiDebugLogging ?? false,
       showPromptAdditions: settings?.showPromptAdditions ?? false,
     };

--- a/packages/electron/src/shared/settings/keys.ts
+++ b/packages/electron/src/shared/settings/keys.ts
@@ -80,8 +80,9 @@ function setting<S extends z.ZodTypeAny>(
  * Domains we have so far:
  *   - ai.provider.<id>  -- per-provider config (enabled, models, baseUrl, ...)
  *   - ai.apiKey.<name>  -- per-provider API key (string, may be empty)
- *   - ai.defaultProvider, ai.showToolCalls, ai.chatShowToolCalls, ai.aiDebugLogging,
- *     ai.showPromptAdditions, ai.customClaudeCodePath, ai.autoCommitEnabled,
+ *   - ai.defaultProvider, ai.showToolCalls, ai.chatShowToolCalls,
+ *     ai.collapseIntermediateProgress, ai.aiDebugLogging, ai.showPromptAdditions,
+ *     ai.customClaudeCodePath, ai.autoCommitEnabled,
  *     ai.trackerAutomation, ai.diffPeekSize
  */
 export const SETTINGS_REGISTRY = {
@@ -177,6 +178,11 @@ export const SETTINGS_REGISTRY = {
     z.boolean(),
     { store: 'ai-settings', path: 'chatShowToolCalls' },
     true,
+  ),
+  'ai.collapseIntermediateProgress': setting(
+    z.boolean(),
+    { store: 'ai-settings', path: 'collapseIntermediateProgress' },
+    false,
   ),
   'ai.aiDebugLogging': setting(
     z.boolean(),

--- a/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
@@ -115,6 +115,16 @@ const injectRichTranscriptStyles = () => {
       transform: rotate(90deg);
     }
 
+    /* 折叠中间进展行使用自定义 chevron，隐藏原生 details marker */
+    .rich-transcript-progress-collapse details > summary::-webkit-details-marker,
+    .rich-transcript-progress-collapse details > summary::marker {
+      display: none;
+      content: '';
+    }
+    .rich-transcript-progress-collapse details[open] .progress-collapse-chevron {
+      transform: rotate(90deg);
+    }
+
     /* VList scrollbar styling */
     .rich-transcript-vlist {
       scrollbar-width: thin;
@@ -535,9 +545,81 @@ const defaultSettings: TranscriptSettings = {
   showToolCalls: true,
   compactMode: false,
   collapseTools: false,
+  collapseIntermediateProgress: false,
   showThinking: true,
   showSessionInit: false,
 };
+
+export interface IntermediateProgressCollapsePlan {
+  collapsedIndices: Set<number>;
+  groupsByStartIndex: Map<number, number[]>;
+}
+
+function isCollapsibleAssistantProgressMessage(message: TranscriptViewMessage): boolean {
+  if (message.type !== 'assistant_message') return false;
+  const text = message.text?.trim();
+  if (!text) return false;
+  if (message.isError || message.isAuthError || message.isCodexAuthRequired) return false;
+  if ((message.metadata?.promptType as string | undefined) === 'system_reminder') return false;
+
+  const lower = text.toLowerCase();
+  if (text.includes('[RATE_LIMIT')) return false;
+  if (lower.includes('api_error') || lower.includes('overloaded_error')) return false;
+  if (lower.includes('api.openai.com') && lower.includes('401')) return false;
+  if (
+    lower.includes('context limit') ||
+    lower.includes('context window') ||
+    lower.includes('prompt is too long') ||
+    lower.includes('maximum context length')
+  ) {
+    return false;
+  }
+  if (
+    lower.includes('session is being continued from') ||
+    lower.includes('context compacted') ||
+    lower.includes('compaction summary')
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function buildIntermediateProgressCollapsePlan(
+  messages: TranscriptViewMessage[],
+  enabled: boolean,
+): IntermediateProgressCollapsePlan {
+  const collapsedIndices = new Set<number>();
+  const groupsByStartIndex = new Map<number, number[]>();
+  if (!enabled) {
+    return { collapsedIndices, groupsByStartIndex };
+  }
+
+  const flushTurnCandidates = (candidateIndices: number[]) => {
+    if (candidateIndices.length <= 1) return;
+    // 同一轮对话中保留最后一条普通 assistant 文本作为最终结论，其余折叠为一个可展开分组。
+    const collapsed = candidateIndices.slice(0, -1);
+    for (const index of collapsed) {
+      collapsedIndices.add(index);
+    }
+    groupsByStartIndex.set(collapsed[0], collapsed);
+  };
+
+  let currentTurnCandidates: number[] = [];
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (message.type === 'user_message') {
+      flushTurnCandidates(currentTurnCandidates);
+      currentTurnCandidates = [];
+      continue;
+    }
+    if (isCollapsibleAssistantProgressMessage(message)) {
+      currentTurnCandidates.push(index);
+    }
+  }
+  flushTurnCandidates(currentTurnCandidates);
+
+  return { collapsedIndices, groupsByStartIndex };
+}
 
 // Lowercased tool names that should render with EditToolResultCard.
 // 'applypatch'/'apply_patch' covers Codex ACP's apply_patch tool, which
@@ -1131,6 +1213,10 @@ export const RichTranscriptView = React.forwardRef<
   const vlistBufferSize = isMobileWebKit ? MOBILE_TRANSCRIPT_BUFFER_PX : DESKTOP_TRANSCRIPT_BUFFER_PX;
 
   const settings = propsSettings || defaultSettings;
+  const intermediateProgressCollapsePlan = useMemo(
+    () => buildIntermediateProgressCollapsePlan(messages, settings.collapseIntermediateProgress === true),
+    [messages, settings.collapseIntermediateProgress]
+  );
   const previousRenderRef = useRef<{
     messagesRef: TranscriptViewMessage[];
     messageCount: number;
@@ -1529,6 +1615,61 @@ export const RichTranscriptView = React.forwardRef<
       }
       return next;
     });
+  };
+
+  const renderCollapsedProgressGroup = (startIndex: number, collapsedIndices: number[], messageKey: string) => {
+    const preview = [...collapsedIndices]
+      .reverse()
+      .map(index => messages[index]?.text?.trim())
+      .find((text): text is string => !!text);
+    const previewText = preview && preview.length > 140 ? `${preview.slice(0, 140)}...` : preview;
+
+    return (
+      <div
+        key={messageKey}
+        data-message-index={startIndex}
+        ref={(el) => {
+          if (el) {
+            messageRefs.current.set(startIndex, el);
+          } else {
+            messageRefs.current.delete(startIndex);
+          }
+        }}
+        className="rich-transcript-message rich-transcript-progress-collapse rounded-md relative max-w-full overflow-x-hidden break-words mb-2 assistant bg-[var(--nim-bg)] p-2"
+      >
+        <details>
+          <summary className="flex items-center gap-2 text-xs text-[var(--nim-text-muted)] cursor-pointer select-none">
+            <MaterialSymbol icon="chevron_right" size={16} className="progress-collapse-chevron text-[var(--nim-text-faint)] shrink-0 transition-transform" />
+            <span className="font-medium">
+              {collapsedIndices.length === 1 ? 'Intermediate progress collapsed' : `${collapsedIndices.length} intermediate updates collapsed`}
+            </span>
+            {previewText && (
+              <span className="min-w-0 flex-1 truncate text-[var(--nim-text-faint)]">
+                {previewText}
+              </span>
+            )}
+          </summary>
+          <div className="mt-2 ml-6 flex flex-col gap-2 border-l border-[var(--nim-border)] pl-3">
+            {collapsedIndices.map((index) => {
+              const collapsedMessage = messages[index];
+              const text = collapsedMessage?.text?.trim();
+              if (!text) return null;
+              return (
+                <div key={`${messageKey}-collapsed-${index}`} className="text-xs text-[var(--nim-text-muted)]">
+                  <MarkdownRenderer
+                    content={text}
+                    isUser={false}
+                    onOpenFile={onOpenFile}
+                    onOpenSession={onOpenSession}
+                    messageId={collapsedMessage.id}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </details>
+      </div>
+    );
   };
 
   const toggleToolExpand = useCallback((toolId: string) => {
@@ -1992,6 +2133,14 @@ export const RichTranscriptView = React.forwardRef<
     const messageKey = getTranscriptMessageKey(sessionId, message, index);
     // Skip tool calls superseded by a later event with the same providerToolCallId
     if (supersededToolIndices.has(index)) {
+      return <div key={messageKey} style={{ display: 'none' }} />;
+    }
+
+    const collapsedProgressGroup = intermediateProgressCollapsePlan.groupsByStartIndex.get(index);
+    if (collapsedProgressGroup) {
+      return renderCollapsedProgressGroup(index, collapsedProgressGroup, messageKey);
+    }
+    if (intermediateProgressCollapsePlan.collapsedIndices.has(index)) {
       return <div key={messageKey} style={{ display: 'none' }} />;
     }
 

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.test.ts
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { TranscriptViewMessage } from '../../../../ai/server/transcript/TranscriptProjector';
 import {
+  buildIntermediateProgressCollapsePlan,
   extractEditsFromToolMessage,
   isInteractiveWidgetTool,
   isTranscriptAtBottom,
@@ -412,6 +413,55 @@ describe('transcript auto-scroll thresholds', () => {
 
   it('still auto-scrolls when the transcript was sticky before the new content arrived', () => {
     expect(shouldAutoScrollTranscript(true, 200)).toBe(true);
+  });
+});
+
+describe('intermediate assistant progress collapse planning', () => {
+  const message = (index: number, type: TranscriptViewMessage['type'], text?: string, extra: Partial<TranscriptViewMessage> = {}): TranscriptViewMessage => ({
+    id: index,
+    sequence: index,
+    createdAt: new Date(index),
+    type,
+    text,
+    subagentId: null,
+    ...extra,
+  });
+
+  it('collapses non-final assistant progress in each user turn', () => {
+    const messages: TranscriptViewMessage[] = [
+      message(1, 'user_message', 'start'),
+      message(2, 'assistant_message', 'checking files'),
+      message(3, 'assistant_message', 'running tests'),
+      message(4, 'assistant_message', 'final answer'),
+      message(5, 'user_message', 'next'),
+      message(6, 'assistant_message', 'only answer'),
+    ];
+
+    const plan = buildIntermediateProgressCollapsePlan(messages, true);
+
+    expect([...plan.collapsedIndices]).toEqual([1, 2]);
+    expect(plan.groupsByStartIndex.get(1)).toEqual([1, 2]);
+    expect(plan.collapsedIndices.has(3)).toBe(false);
+    expect(plan.collapsedIndices.has(5)).toBe(false);
+  });
+
+  it('does not collapse when disabled and preserves special assistant messages', () => {
+    const messages: TranscriptViewMessage[] = [
+      message(1, 'user_message', 'start'),
+      message(2, 'assistant_message', 'This session is being continued from a previous conversation.'),
+      message(3, 'assistant_message', '401 from api.openai.com', { isError: true, isAuthError: true }),
+      message(4, 'assistant_message', 'checking files'),
+      message(5, 'assistant_message', 'final answer'),
+    ];
+
+    const disabled = buildIntermediateProgressCollapsePlan(messages, false);
+    expect(disabled.collapsedIndices.size).toBe(0);
+
+    const enabled = buildIntermediateProgressCollapsePlan(messages, true);
+    expect([...enabled.collapsedIndices]).toEqual([3]);
+    expect(enabled.groupsByStartIndex.get(3)).toEqual([3]);
+    expect(enabled.collapsedIndices.has(1)).toBe(false);
+    expect(enabled.collapsedIndices.has(2)).toBe(false);
   });
 });
 

--- a/packages/runtime/src/ui/AgentTranscript/types/index.ts
+++ b/packages/runtime/src/ui/AgentTranscript/types/index.ts
@@ -17,6 +17,7 @@ export interface TranscriptSettings {
   showThinking: boolean;
   compactMode: boolean;
   collapseTools: boolean;
+  collapseIntermediateProgress?: boolean;
   showSessionInit: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Add an Agent Features toggle, `Collapse Intermediate Progress`, below `Show Tool Calls in Chat`.
- Persist the setting as `ai.collapseIntermediateProgress` and pass it into chat transcript rendering.
- Collapse non-final assistant progress messages per user turn while keeping final answers, errors, auth notices, and prompts visible.

## Tests
- `npm run test:unit -- --run packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.test.ts packages/electron/src/renderer/store/atoms/__tests__/settingsLockstep.test.ts packages/electron/src/main/services/__tests__/SettingsService.test.ts packages/electron/src/main/utils/__tests__/aiSettingsMerge.test.ts`
- `npm run typecheck --prefix packages/runtime`
- `npm run typecheck --prefix packages/electron`
- `npx eslint ...` on the touched Electron files

Note: `npm run lint --prefix packages/electron` still fails on existing repo-wide lint errors outside this change.

Closes #746