### PR TITLE
fix: restore Codex Chrome plugin compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Bundled Codex runtime updated to 0.142.5 so the Codex Chrome plugin can start in Nimbalyst with the current Codex plugin protocol.
 
 ### Removed
 <!-- Removed features go here -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -5629,9 +5629,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0.tgz",
-      "integrity": "sha512-yu+diXznSOt8h296/CDOf2CNi55z1raA7aZ6sejjGy1QWPqn72YkBc2ByTzZG6G+1yiUqlm2G5Hid54hm3/kaA==",
+      "version": "0.142.5",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5.tgz",
+      "integrity": "sha512-WQEpD7l3k68eIAP0aq28EdR18ENBAf8DyprzFhzNwCOQJSv4nHzpwT8Fl30IJacprko2ZCmUBZjM2u941l2yLw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -5640,19 +5640,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.136.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.136.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.136.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.136.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.136.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.136.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.5-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.5-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.5-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.142.5-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.5-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.142.5-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.136.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-darwin-arm64.tgz",
-      "integrity": "sha512-9xnEohnUO9l6qtPSDbG0Y2UXX5mBZ9Lsn0VMgjtkREGfWL9TawNC1d7D1ERMSJtHTlVvieoaFyK9LHPLQCO9Vw==",
+      "version": "0.142.5-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-arm64.tgz",
+      "integrity": "sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA==",
       "cpu": [
         "arm64"
       ],
@@ -5667,9 +5667,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.136.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-darwin-x64.tgz",
-      "integrity": "sha512-HD9YLalPg0cv+CiZSmRWOl/8sefuJlxJcAmxyzb8mSaAMchD3V+2yS6M6E1Z2I6NX1irp4Polt1fPsjGdlHYhQ==",
+      "version": "0.142.5-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-x64.tgz",
+      "integrity": "sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg==",
       "cpu": [
         "x64"
       ],
@@ -5684,9 +5684,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.136.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-linux-arm64.tgz",
-      "integrity": "sha512-xDxTOk5ClEX/nzlQseqEoiubjIzVZfcWKn9nmKkHOLKknz+c7n6tbmw7eY4mwt29zTAAoFoecdRnbbsPZUHJ1g==",
+      "version": "0.142.5-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-arm64.tgz",
+      "integrity": "sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA==",
       "cpu": [
         "arm64"
       ],
@@ -5701,9 +5701,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.136.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-linux-x64.tgz",
-      "integrity": "sha512-Q6yZHRtUWD+27B5yAiOYyPAtM0BzW0Mm23YGaXDmfNEO5BYgHuUT80VDofUpjSyo2+ShYoZQUFVQAsNPKqd+Sw==",
+      "version": "0.142.5-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-x64.tgz",
+      "integrity": "sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg==",
       "cpu": [
         "x64"
       ],
@@ -5717,12 +5717,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.136.0.tgz",
-      "integrity": "sha512-qrSirrVxrpVHR1YIQQ4WSouneaQrQrRAAlQWJYRflvMCcruFXorsmIPeIbDqFXOa8A9H9FHHyc+2U4tdbEGGiQ==",
+      "version": "0.142.5",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.142.5.tgz",
+      "integrity": "sha512-MConZ+eoBoZmkc4reezuzOgLtoI1BQBzo/nVYsSjtAIBpwKcgeEm1rfmqfUnTfFaBNHFTxBntcS7ZeQYuDPbWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.136.0"
+        "@openai/codex": "0.142.5"
       },
       "engines": {
         "node": ">=18"
@@ -5730,9 +5730,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.136.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-win32-arm64.tgz",
-      "integrity": "sha512-mAHZXfygQxBg1JjZ9+bAZfBXe6fg8MabJhuDYhj5z0VF++orKSFsC1lMiv6PksQN36ikQefgVjc9EOlaE4lt7g==",
+      "version": "0.142.5-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-arm64.tgz",
+      "integrity": "sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ==",
       "cpu": [
         "arm64"
       ],
@@ -5747,9 +5747,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.136.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-win32-x64.tgz",
-      "integrity": "sha512-zS6DAmvjdWeAB1CL9KTUMkwzTwfXtxHy8GAtePw2a93jIqawoG07fBxAXuyoHZ3QXQkwEgqBx1zEEh33gdIKAw==",
+      "version": "0.142.5-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-x64.tgz",
+      "integrity": "sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A==",
       "cpu": [
         "x64"
       ],
@@ -25467,7 +25467,7 @@
         "@nimbalyst/extension-datamodellm": "*",
         "@nimbalyst/mockuplm": "*",
         "@nimbalyst/runtime": "*",
-        "@openai/codex-sdk": "^0.136.0",
+        "@openai/codex-sdk": "^0.142.5",
         "@types/glob": "^8.1.0",
         "@types/js-yaml": "^4.0.9",
         "@types/marked": "^5.0.2",
@@ -27877,7 +27877,7 @@
         "@nimbalyst/collab-adapters": "*",
         "@nimbalyst/collab-protocol": "*",
         "@nimbalyst/extension-sdk": "*",
-        "@openai/codex-sdk": "^0.136.0",
+        "@openai/codex-sdk": "^0.142.5",
         "@opencode-ai/sdk": "^1.3.0",
         "@types/js-yaml": "^4.0.9",
         "@types/react-syntax-highlighter": "^15.5.13",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -64,7 +64,7 @@
     "@nimbalyst/extension-datamodellm": "*",
     "@nimbalyst/mockuplm": "*",
     "@nimbalyst/runtime": "*",
-    "@openai/codex-sdk": "^0.136.0",
+    "@openai/codex-sdk": "^0.142.5",
     "@types/glob": "^8.1.0",
     "@types/js-yaml": "^4.0.9",
     "@types/marked": "^5.0.2",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -205,7 +205,7 @@
     "@nimbalyst/collab-adapters": "*",
     "@nimbalyst/collab-protocol": "*",
     "@nimbalyst/extension-sdk": "*",
-    "@openai/codex-sdk": "^0.136.0",
+    "@openai/codex-sdk": "^0.142.5",
     "@opencode-ai/sdk": "^1.3.0",
     "@types/js-yaml": "^4.0.9",
     "@types/react-syntax-highlighter": "^15.5.13",


### PR DESCRIPTION
## Summary

- Updates the bundled `@openai/codex-sdk` / `@openai/codex` runtime from 0.136.0 to 0.142.5.
- Keeps Electron and runtime workspace dependencies in sync with the lockfile.
- Adds an Unreleased changelog entry for the Codex Chrome plugin compatibility fix.

## Related issue

None.

## Testing

- `npm ci --ignore-scripts --dry-run`
- `npm test -- --run packages/runtime/src/ai/server/protocols/__tests__/CodexAppServerProtocol.test.ts`
- `npm test -- --run packages/runtime/src/ai/server/providers/codex/__tests__/codexBinaryPath.test.ts`
- `npm run typecheck --prefix packages/runtime`
- `npm run typecheck --prefix packages/electron`
- `npm exec -- codex --version` -> `codex-cli 0.142.5`
- `node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex --version` -> `codex-cli 0.142.5`

## Notes for reviewers

`node packages/electron/build/validate-extra-resources.js` was not a useful local check before a build because it stops on missing generated build outputs (`out/*` and runtime `dist`), before reaching the Codex resource checks. The installed Codex package path and vendored binary were checked directly instead.
