### PR TITLE
fix: decode JSON-stringified tracker content on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Changes to existing functionality go here -->
 
 ### Fixed
-<!-- Bug fixes go here -->
+- Tracker item content no longer renders as raw JSON text after closing and reopening the item.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/mcp/tools/__tests__/trackerToolHandlers.test.ts
+++ b/packages/electron/src/main/mcp/tools/__tests__/trackerToolHandlers.test.ts
@@ -216,6 +216,27 @@ describe('rowToTrackerItem typeTags normalization', () => {
   });
 });
 
+describe('rowToTrackerItem content decoding', () => {
+  it('parses the JSON-encoded content column back into a plain markdown string', () => {
+    // `content` is stored as JSON.stringify(markdown) (see updateTrackerItemContent /
+    // tracker_create). Reading it back without JSON.parse leaves literal quotes and
+    // escaped \n sequences, which is what rendered as raw text after close/reopen.
+    const markdown = '**Objetivo**: validar\n\n### Links';
+    const item = rowToTrackerItem(makeRow({ content: JSON.stringify(markdown) }));
+    expect(item.content).toBe(markdown);
+  });
+
+  it('passes through non-JSON content unchanged (legacy/plain rows)', () => {
+    const item = rowToTrackerItem(makeRow({ content: 'plain text' }));
+    expect(item.content).toBe('plain text');
+  });
+
+  it('returns undefined when content is null', () => {
+    const item = rowToTrackerItem(makeRow({ content: null }));
+    expect(item.content).toBeUndefined();
+  });
+});
+
 describe('handleTrackerGet', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/electron/src/main/mcp/tools/trackerToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/trackerToolHandlers.ts
@@ -370,6 +370,19 @@ export function normalizeTypeTags(rawTypeTags: unknown, fallbackType: string): s
   return parsed && parsed.length > 0 ? parsed : [fallbackType];
 }
 
+/**
+ * `content` is stored as JSON.stringify(markdown) (see updateTrackerItemContent /
+ * tracker_create). Undo that encoding on read; legacy/plain rows without JSON
+ * quoting pass through unchanged.
+ */
+export function parseTrackerContent(raw: string): any {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
 /** Convert a raw DB row to a TrackerItem for the renderer */
 export function rowToTrackerItem(row: any): any {
   const data = typeof row.data === 'string' ? JSON.parse(row.data) : row.data || {};
@@ -396,7 +409,7 @@ export function rowToTrackerItem(row: any): any {
     updated: data.updated || row.updated || undefined,
     dueDate: data.dueDate || undefined,
     lastIndexed: new Date(row.last_indexed),
-    content: row.content != null ? row.content : undefined,
+    content: row.content != null ? parseTrackerContent(row.content) : undefined,
     archived: row.archived ?? false,
     archivedAt: row.archived_at ? new Date(row.archived_at).toISOString() : undefined,
     source: row.source || (row.document_path ? 'inline' : 'native'),

--- a/packages/electron/src/main/services/ElectronDocumentService.ts
+++ b/packages/electron/src/main/services/ElectronDocumentService.ts
@@ -133,6 +133,19 @@ function parseJsonColumn<T>(value: unknown): T | undefined {
   }
 }
 
+/**
+ * `tracker_items.content` is stored as JSON.stringify(markdown) (see
+ * updateTrackerItemContent). Undo that encoding; legacy/plain rows without
+ * JSON quoting pass through unchanged rather than becoming undefined.
+ */
+function parseTrackerContentColumn(raw: string): any {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
 function normalizeTrackerTitle(title: string | undefined): string {
   return (title || '').trim().replace(/\s+/g, ' ').toLowerCase();
 }
@@ -1680,8 +1693,9 @@ export class ElectronDocumentService implements DocumentService {
       updated: data.updated || row.updated || undefined,
       dueDate: data.dueDate || undefined,
       lastIndexed: new Date(row.last_indexed),
-      // Rich content (Lexical editor state)
-      content: row.content != null ? row.content : undefined,
+      // Rich content (Lexical editor state). Stored as JSON.stringify(markdown);
+      // undo that on read or the raw JSON-quoted string renders as literal text.
+      content: row.content != null ? parseTrackerContentColumn(row.content) : undefined,
       // Archive state
       archived: row.archived ?? false,
       archivedAt: row.archived_at ? new Date(row.archived_at).toISOString() : undefined,
@@ -2250,7 +2264,8 @@ export class ElectronDocumentService implements DocumentService {
       [row.id]
     );
     if (result.rows.length === 0) return null;
-    return result.rows[0].content ?? null;
+    const raw = result.rows[0].content;
+    return raw != null ? parseTrackerContentColumn(raw) : null;
   }
 
   /**

--- a/packages/electron/src/main/services/__tests__/ElectronDocumentService.trackerSync.test.ts
+++ b/packages/electron/src/main/services/__tests__/ElectronDocumentService.trackerSync.test.ts
@@ -365,3 +365,23 @@ describe('tracker change event watchers', () => {
     expect(events[0].updated[0].id).toBe('bug-001');
   });
 });
+
+// ============================================================================
+// getTrackerItemContent decoding
+// ============================================================================
+
+describe('getTrackerItemContent', () => {
+  it('decodes the JSON-encoded content column back into plain markdown', async () => {
+    // content is persisted as JSON.stringify(markdown) by updateTrackerItemContent.
+    // Reading it back without JSON.parse leaves literal quotes/escaped \n --
+    // this is the bug: markdown rendered fine on create, then as a raw string
+    // after closing and reopening the item (fresh DB read).
+    const markdown = '**Objetivo**: validar\n\n### Links';
+    mockQuery.mockResolvedValueOnce({ rows: [makeTrackerRow({ id: 'bug-001' })] }); // resolve row
+    mockQuery.mockResolvedValueOnce({ rows: [{ content: JSON.stringify(markdown) }] }); // SELECT content
+
+    const content = await service.getTrackerItemContent('bug-001');
+
+    expect(content).toBe(markdown);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes tracker item content rendering as raw JSON after closing and reopening an item in the Trackers panel.

`updateTrackerItemContent` persists the item's rich-text body as `JSON.stringify(markdown)` in the `content` column. Two read paths returned that column value as-is instead of decoding it: `rowToTrackerItem` (used by `trackerToolHandlers.ts`, the MCP tool surface the AI agent uses) and `ElectronDocumentService.getTrackerItemContent` (used by `TrackerItemDetail.tsx` in the renderer). As a result, a tracker item's body rendered correctly right after creation, but showed literal quotes and escaped `\n` sequences instead of formatted markdown once the item was closed and reopened (fresh DB read).

The fix decodes the JSON-encoded value on read in both places, falling back to the raw string when it isn't valid JSON (legacy/plain rows written before this encoding was introduced).

### Before
<img width="601" height="796" alt="before_nymbalist" src="https://github.com/user-attachments/assets/13e7113b-2b85-40c1-8d78-8f21881173a9" />

### After
<img width="594" height="1187" alt="after_nymbalist" src="https://github.com/user-attachments/assets/05c0adcc-4d4a-4fdf-bde2-f7395e7f657f" />

## Related issue

None filed — found while working in the Trackers panel.

## Testing

- Added unit tests covering: JSON-encoded content decodes back to plain markdown, non-JSON content passes through unchanged, and null content stays undefined/null.
- `npm run test:unit` passes for the touched files.

## Notes for reviewers

Two call sites needed the same fix (`trackerToolHandlers.ts` and `ElectronDocumentService.ts`) since they read the same column independently — happy to consolidate into a shared helper if maintainers prefer not to duplicate the decode logic.