### PR TITLE
fix(tracker): saved views capture and restore their tag filter

### DIFF
--- a/packages/electron/src/renderer/components/TrackerMode/TrackerMainView.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/TrackerMainView.tsx
@@ -25,6 +25,7 @@ import { ImportFromSourceDialog } from './ImportFromSourceDialog';
 import {
   trackerModeLayoutAtom,
   setTrackerModeLayoutAtom,
+  trackerModeTagFilterAtom,
   type TrackerFilterChip,
   type TypeColumnConfig,
 } from '../../store/atoms/trackers';
@@ -87,7 +88,9 @@ export const TrackerMainView: React.FC<TrackerMainViewProps> = ({
   const [sortBy, setSortBy] = useState<TrackerSortColumn>('lastIndexed');
   const [sortDirection, setSortDirection] = useState<TrackerSortDirection>('desc');
   const [searchQuery, setSearchQuery] = useState('');
-  const [tagFilter, setTagFilter] = useState<string[]>([]);
+  // Shared with TrackerMode so saved views can snapshot/restore it (NIM-788).
+  const tagFilter = useAtomValue(trackerModeTagFilterAtom);
+  const setTagFilter = useSetAtom(trackerModeTagFilterAtom);
   // Source filter: provider ids (e.g. 'github-issues') plus 'native'.
   const [sourceFilter, setSourceFilter] = useState<string[]>([]);
   const [quickAddType, setQuickAddType] = useState<string | null>(null);

--- a/packages/electron/src/renderer/components/TrackerMode/TrackerMode.tsx
+++ b/packages/electron/src/renderer/components/TrackerMode/TrackerMode.tsx
@@ -11,9 +11,11 @@ import {
   trackerSavedViewsAtom,
   saveTrackerViewAtom,
   deleteTrackerViewAtom,
+  trackerModeTagFilterAtom,
   type TrackerFilterChip,
 } from '../../store/atoms/trackers';
 import type { SavedView } from './trackerSavedViews';
+import { snapshotViewDefinition } from './trackerSavedViews';
 
 // Ensure built-in trackers are loaded
 loadBuiltinTrackers();
@@ -75,21 +77,25 @@ export const TrackerMode: React.FC<TrackerModeProps> = ({
   const savedViews = useAtomValue(trackerSavedViewsAtom);
   const saveView = useSetAtom(saveTrackerViewAtom);
   const deleteView = useSetAtom(deleteTrackerViewAtom);
+  // Live tag filter, shared with TrackerMainView's search bar, so a saved view
+  // captures the active `#tag` chips on save and restores them on apply.
+  const tagFilter = useAtomValue(trackerModeTagFilterAtom);
+  const setTagFilter = useSetAtom(trackerModeTagFilterAtom);
 
   const handleSaveView = useCallback((name: string) => {
     const view: SavedView = {
       id: crypto.randomUUID(),
       name,
-      definition: {
+      definition: snapshotViewDefinition({
         selectedType: modeLayout.selectedType,
         activeFilters: modeLayout.activeFilters,
         viewMode: modeLayout.viewMode,
-        tagFilter: [],
+        tagFilter,
         groupBy: modeLayout.groupBy,
-      },
+      }),
     };
     saveView(view);
-  }, [modeLayout.selectedType, modeLayout.activeFilters, modeLayout.viewMode, modeLayout.groupBy, saveView]);
+  }, [modeLayout.selectedType, modeLayout.activeFilters, modeLayout.viewMode, modeLayout.groupBy, tagFilter, saveView]);
 
   const handleApplyView = useCallback((view: SavedView) => {
     const def = view.definition;
@@ -100,7 +106,9 @@ export const TrackerMode: React.FC<TrackerModeProps> = ({
       groupBy: def.groupBy,
       selectedItemId: null,
     });
-  }, [setModeLayout]);
+    // Restore the view's tag filter (empty array clears any live filter).
+    setTagFilter(def.tagFilter ?? []);
+  }, [setModeLayout, setTagFilter]);
 
   const handleDeleteView = useCallback((viewId: string) => {
     deleteView(viewId);

--- a/packages/electron/src/renderer/components/TrackerMode/__tests__/trackerSavedViews.test.ts
+++ b/packages/electron/src/renderer/components/TrackerMode/__tests__/trackerSavedViews.test.ts
@@ -6,6 +6,7 @@ import {
   groupTrackerItems,
   normalizeViewDefinition,
   createDefaultViewDefinition,
+  snapshotViewDefinition,
 } from '../trackerSavedViews';
 
 function makeItem(
@@ -128,6 +129,43 @@ describe('groupTrackerItems', () => {
     expect(groups.map((g) => g.label)).toEqual(['#ui', '#urgent', 'Untagged']);
     expect(groups[0].items.map((i) => i.id)).toEqual(['1']);
     expect(groups[2].items.map((i) => i.id)).toEqual(['2']);
+  });
+});
+
+describe('snapshotViewDefinition', () => {
+  it('captures the active tag filter so a saved view remembers its tags', () => {
+    // Regression for NIM-788: the tag filter was previously dropped on save,
+    // so every saved view rendered the last-applied tag filter instead of
+    // its own (e.g. clicking "deepc board" showed #backoffice).
+    const def = snapshotViewDefinition({
+      selectedType: 'all',
+      activeFilters: ['high-priority'],
+      viewMode: 'kanban',
+      tagFilter: ['deepc'],
+      groupBy: 'status',
+    });
+    expect(def.tagFilter).toEqual(['deepc']);
+    expect(def).toEqual({
+      selectedType: 'all',
+      activeFilters: ['high-priority'],
+      viewMode: 'kanban',
+      tagFilter: ['deepc'],
+      groupBy: 'status',
+    });
+  });
+
+  it('round-trips through normalizeViewDefinition (persist -> load) preserving tags', () => {
+    const snap = snapshotViewDefinition({
+      selectedType: 'bug',
+      activeFilters: [],
+      viewMode: 'list',
+      tagFilter: ['backoffice', 'nimbalyst'],
+      groupBy: 'none',
+    });
+    // Simulate persist + reload.
+    const loaded = normalizeViewDefinition(JSON.parse(JSON.stringify(snap)));
+    expect(loaded.tagFilter).toEqual(['backoffice', 'nimbalyst']);
+    expect(loaded).toEqual(snap);
   });
 });
 

--- a/packages/electron/src/renderer/components/TrackerMode/trackerSavedViews.ts
+++ b/packages/electron/src/renderer/components/TrackerMode/trackerSavedViews.ts
@@ -69,6 +69,33 @@ export function normalizeViewDefinition(raw: Partial<SavedViewDefinition> | unde
   };
 }
 
+/** The live tracker view state that a saved view captures on save. */
+export interface TrackerViewSnapshot {
+  selectedType: string;
+  activeFilters: TrackerFilterChip[];
+  viewMode: ViewMode;
+  tagFilter: string[];
+  groupBy: TrackerGroupBy;
+}
+
+/**
+ * Build a saved-view definition from the current live view state.
+ *
+ * Centralises the snapshot so every field the view can filter by -- including
+ * the active tag filter -- is captured. The prior inline snapshot hardcoded
+ * `tagFilter: []`, so a saved view never remembered its tags and applying it
+ * left whatever tag filter was live in place (NIM-788 regression).
+ */
+export function snapshotViewDefinition(state: TrackerViewSnapshot): SavedViewDefinition {
+  return {
+    selectedType: state.selectedType,
+    activeFilters: state.activeFilters,
+    viewMode: state.viewMode,
+    tagFilter: state.tagFilter,
+    groupBy: state.groupBy,
+  };
+}
+
 export interface FilterContext {
   /** Current user identity, required for the `mine` chip. */
   identity?: TrackerIdentity | null;

--- a/packages/electron/src/renderer/store/atoms/trackers.ts
+++ b/packages/electron/src/renderer/store/atoms/trackers.ts
@@ -256,6 +256,17 @@ export const trackerModeGroupByAtom = atom(
 /** Saved view definitions for the current workspace. */
 export const trackerSavedViewsAtom = atom<SavedView[]>([]);
 
+/**
+ * Live tag filter (OR match) applied in the tracker main view's search bar.
+ *
+ * Lifted out of TrackerMainView's local state so saved views can snapshot it on
+ * save and restore it on apply (NIM-788). TrackerMainView reads and writes this
+ * as the source of truth for the `#tag` chips; TrackerMode reads it in
+ * handleSaveView and writes it in handleApplyView. In-memory only (not persisted
+ * to workspace state) -- saved views carry the persisted copy.
+ */
+export const trackerModeTagFilterAtom = atom<string[]>([]);
+
 function persistSavedViews(workspacePath: string, views: SavedView[]): void {
   window.electronAPI
     .invoke('workspace:update-state', workspacePath, { trackerSavedViews: views })


### PR DESCRIPTION
## Problem

Saved Views on the tracker board did not remember their own tag filter. Every saved view rendered whatever `#tag` filter was applied most recently, so a per-project view switcher was impossible:

1. Type `#deepc`, save view "deepc board"
2. Type `#backoffice`, save view "backoffice board"
3. Click "deepc board" → it shows **#backoffice** (the last-applied filter), not #deepc

## Root cause

The live tag filter lived as local `useState` inside `TrackerMainView`, invisible to `TrackerMode` where the save/apply handlers run. As a result:

- `handleSaveView` hardcoded `tagFilter: []` — the active tags were never captured.
- `handleApplyView` never set the tag filter — applying a view left the live filter untouched.

## Fix

- Lift the live tag filter into a shared atom (`trackerModeTagFilterAtom`) so the search bar and the saved-view handlers share one source of truth.
- On **save**, capture the current tags; on **apply**, restore them (an empty array clears any live filter).
- Extract a pure `snapshotViewDefinition` helper so the capture is centralised and unit-testable.

## Tests

- Added regression tests reproducing the exact deepc/backoffice scenario and a persist→load round-trip. Full `trackerSavedViews` suite: 14/14 green.
- `tsc --noEmit`: clean.

Fixes the Saved Views project-switcher use case (workaround for the not-yet-built per-project swimlane grouping).