### PR TITLE
Add read-only list_queued_prompts MCP tool

### DIFF
--- a/packages/electron/e2e/ai/meta-agent.spec.ts
+++ b/packages/electron/e2e/ai/meta-agent.spec.ts
@@ -344,6 +344,7 @@ test('creates a meta-agent session that appears in the session list as a group',
 test('surfaces delegated child sessions through the meta-agent MCP tools', async () => {
   const toolNames = await listMcpTools(metaAgentClient);
   expect(toolNames.length).toBeGreaterThan(0);
+  expect(toolNames).toContain('list_queued_prompts');
 
   const created = await createChildSessionWithMetaAgent('Investigate parser edge cases');
   await insertUserPrompt(page, created.sessionId, 'Investigate parser edge cases');
@@ -650,6 +651,37 @@ test('send_prompt queues a follow-up message to a child session', async () => {
     userPrompts: string[];
   }>(metaAgentClient, 'get_session_result', { sessionId: childSessionId });
   expect(result.userPrompts).toContain('Now do the follow-up work');
+});
+
+test('list_queued_prompts exposes bounded queue state for a child session', async () => {
+  const childSessionId = await createLinkedTestSession({
+    title: 'Queued prompt audit task',
+    status: 'running',
+  });
+
+  await callMetaAgentTool(metaAgentClient, 'send_prompt', {
+    sessionId: childSessionId,
+    prompt: 'This prompt should remain queued for inspection',
+  });
+
+  const queue = await callMetaAgentTool<{
+    sessionId: string;
+    count: number;
+    prompts: Array<{
+      id: string;
+      status: string;
+      promptPreview: string;
+      prompt?: string;
+    }>;
+  }>(metaAgentClient, 'list_queued_prompts', {
+    sessionId: childSessionId,
+  });
+
+  expect(queue.sessionId).toBe(childSessionId);
+  expect(queue.count).toBeGreaterThanOrEqual(1);
+  expect(queue.prompts[0].status).toBe('pending');
+  expect(queue.prompts[0].promptPreview).toContain('remain queued');
+  expect(queue.prompts[0].prompt).toBeUndefined();
 });
 
 test('send_prompt rejects empty or missing prompt', async () => {

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -1,7 +1,8 @@
 /**
  * Meta-agent (child-session orchestration) tool surface — `create_session`,
- * `spawn_session`, `send_prompt`, `respond_to_prompt`, `get_session_status`,
- * `get_session_result`, `list_spawned_sessions`, `list_worktrees`.
+ * `spawn_session`, `send_prompt`, `list_queued_prompts`, `respond_to_prompt`,
+ * `get_session_status`, `get_session_result`, `list_spawned_sessions`,
+ * `list_worktrees`.
  *
  * MCP consolidation: these tools are served by the unified internal MCP HTTP
  * server's `/mcp/host` endpoint (`nimbalyst-host`). This module exports the tool
@@ -49,6 +50,20 @@ type RespondToPromptArgs = {
   response: Record<string, unknown>;
 };
 
+type ListQueuedPromptsArgs = {
+  sessionId: string;
+  /**
+   * Include completed and failed queue rows in addition to pending/executing
+   * rows. Defaults to false so the default view answers "what is still stuck?"
+   */
+  includeCompleted?: boolean;
+  /**
+   * Include full prompt text. Defaults to false; the response always includes a
+   * bounded preview so callers can identify rows without dumping huge prompts.
+   */
+  includePromptText?: boolean;
+};
+
 interface MetaAgentToolFns {
   listWorktrees: (
     metaSessionId: string,
@@ -73,6 +88,12 @@ interface MetaAgentToolFns {
     metaSessionId: string,
     workspaceId: string,
     targetSessionId: string
+  ) => Promise<string>;
+  listQueuedPrompts: (
+    metaSessionId: string,
+    workspaceId: string,
+    targetSessionId: string,
+    options?: Pick<ListQueuedPromptsArgs, "includeCompleted" | "includePromptText">
   ) => Promise<string>;
   sendPrompt: (
     metaSessionId: string,
@@ -251,6 +272,31 @@ export const META_AGENT_TOOL_DEFS: Array<{
     },
   },
   {
+    name: "list_queued_prompts",
+    description:
+      "Inspect queued prompts for a session. By default returns only pending/executing rows with bounded prompt previews; set includeCompleted to audit recently consumed rows.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description: "The target session ID.",
+        },
+        includeCompleted: {
+          type: "boolean",
+          description:
+            "Optional. If true, include completed and failed queue rows. Defaults to false.",
+        },
+        includePromptText: {
+          type: "boolean",
+          description:
+            "Optional. If true, include full prompt text. Defaults to false; promptPreview is always included.",
+        },
+      },
+      required: ["sessionId"],
+    },
+  },
+  {
     name: "send_prompt",
     description:
       "Queue a follow-up prompt for a child session. If the session is idle, prompt processing starts immediately.",
@@ -335,6 +381,7 @@ const EXTENSION_META_AGENT_ALLOWED_TOOLS = new Set<string>([
   "create_session",
   "get_session_status",
   "get_session_result",
+  "list_queued_prompts",
   "send_prompt",
   "respond_to_prompt",
   "list_spawned_sessions",
@@ -397,6 +444,16 @@ export async function dispatchMetaAgentTool(
         aiSessionId,
         effectiveWorkspaceId,
         (args?.sessionId as string) ?? ""
+      );
+    case "list_queued_prompts":
+      return toolFns.listQueuedPrompts(
+        aiSessionId,
+        effectiveWorkspaceId,
+        (args?.sessionId as string) ?? "",
+        {
+          includeCompleted: args?.includeCompleted === true,
+          includePromptText: args?.includePromptText === true,
+        }
       );
     case "send_prompt":
       return toolFns.sendPrompt(

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -181,6 +181,8 @@ export class MetaAgentService {
           this.getSessionStatusJson(targetSessionId, workspaceId),
         getSessionResult: (_metaSessionId, workspaceId, targetSessionId) =>
           this.getSessionResultJson(targetSessionId, workspaceId),
+        listQueuedPrompts: (_metaSessionId, workspaceId, targetSessionId, options) =>
+          this.listQueuedPromptsJson(targetSessionId, workspaceId, options),
         sendPrompt: (_metaSessionId, workspaceId, targetSessionId, prompt) =>
           this.sendPromptToSession(targetSessionId, workspaceId, prompt),
         respondToPrompt: (_metaSessionId, workspaceId, args) =>
@@ -828,6 +830,45 @@ export class MetaAgentService {
   private async getSessionResultJson(sessionId: string, workspaceId: string): Promise<string> {
     const data = await this.buildSessionResultData(sessionId, workspaceId);
     return JSON.stringify(data, null, 2);
+  }
+
+  private async listQueuedPromptsJson(
+    sessionId: string,
+    workspaceId: string,
+    options: { includeCompleted?: boolean; includePromptText?: boolean } = {}
+  ): Promise<string> {
+    if (!sessionId) {
+      throw new Error('sessionId is required');
+    }
+
+    const session = await AISessionsRepository.get(sessionId);
+    if (!session || session.workspacePath !== workspaceId) {
+      throw new Error(`Session ${sessionId} not found`);
+    }
+
+    const { getQueuedPromptsStore } = await import('./RepositoryManager');
+    const queueStore = getQueuedPromptsStore();
+    const prompts = await queueStore.listForSession(sessionId, {
+      includeCompleted: options.includeCompleted === true,
+    });
+
+    return JSON.stringify({
+      sessionId,
+      count: prompts.length,
+      includeCompleted: options.includeCompleted === true,
+      prompts: prompts.map((prompt) => ({
+        id: prompt.id,
+        status: prompt.status,
+        createdAt: prompt.createdAt,
+        claimedAt: prompt.claimedAt ?? null,
+        completedAt: prompt.completedAt ?? null,
+        errorMessage: prompt.errorMessage ?? null,
+        promptPreview: prompt.prompt.length > 300
+          ? `${prompt.prompt.slice(0, 300)}...`
+          : prompt.prompt,
+        ...(options.includePromptText === true ? { prompt: prompt.prompt } : {}),
+      })),
+    }, null, 2);
   }
 
   private async sendPromptToSession(sessionId: string, workspaceId: string, prompt: string): Promise<string> {

--- a/packages/runtime/src/ai/server/providers/BaseAgentProvider.ts
+++ b/packages/runtime/src/ai/server/providers/BaseAgentProvider.ts
@@ -39,6 +39,7 @@ export abstract class BaseAgentProvider extends BaseAIProvider {
     'mcp__nimbalyst-host__create_session',
     'mcp__nimbalyst-host__get_session_status',
     'mcp__nimbalyst-host__get_session_result',
+    'mcp__nimbalyst-host__list_queued_prompts',
     'mcp__nimbalyst-host__send_prompt',
     'mcp__nimbalyst-host__respond_to_prompt',
     'mcp__nimbalyst-host__get_session_summary',

--- a/packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts
+++ b/packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts
@@ -53,6 +53,7 @@ describe('Topology descriptor', () => {
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('display_to_user')).toBe(MCP_CORE);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('settings_get_overview')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('spawn_session')).toBe(MCP_HOST);
+    expect(FIRST_PARTY_TOOL_TO_SERVER.get('list_queued_prompts')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('tracker_create')).toBe(MCP_TRACKERS);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('voice_agent_speak')).toBe(MCP_SITUATIONAL);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('renderer_eval')).toBe(MCP_EXTENSION_DEV);

--- a/packages/runtime/src/ai/server/services/mcpTopology.ts
+++ b/packages/runtime/src/ai/server/services/mcpTopology.ts
@@ -154,6 +154,7 @@ export const HOST_TOOLS: readonly string[] = [
   'create_session',
   'spawn_session',
   'send_prompt',
+  'list_queued_prompts',
   'respond_to_prompt',
   'get_session_status',
   'get_session_result',


### PR DESCRIPTION
## Summary

Agents doing long tool-heavy turns have no way to check whether the user (or
another session) queued mid-task steering that hasn't drained yet.
`send_prompt` can enqueue a follow-up prompt, but there was no way to inspect
the queue itself.

This adds `list_queued_prompts`: a read-only MCP tool that returns bounded
prompt previews for a session's queue.

- Defaults to pending/executing rows only (`includeCompleted` opts into
  completed/failed rows for auditing).
- Always returns a bounded `promptPreview`; full prompt text is opt-in via
  `includePromptText`, so callers can identify queue rows without dumping
  large prompts into context.
- Implemented on top of the existing `QueuedPromptsStore.listForSession`, so
  no new storage/plumbing is introduced.

## What's touched

- `packages/electron/src/main/mcp/metaAgentServer.ts` — tool def, dispatch
  case, `MetaAgentToolFns` interface, extension-agent allowed-tools set.
- `packages/electron/src/main/services/MetaAgentService.ts` — the
  `listQueuedPromptsJson` implementation and its `toolFns` wiring.
- `packages/runtime/src/ai/server/services/mcpTopology.ts` — adds
  `list_queued_prompts` to the host MCP topology map so it's actually
  advertised on `/mcp/host`, not just defined in the schema.
- `packages/runtime/src/ai/server/providers/BaseAgentProvider.ts` — adds the
  tool to the built-in-provider meta-agent allowed-tools list.
- `packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts`
  and `packages/electron/e2e/ai/meta-agent.spec.ts` — coverage for the new
  tool.

## Scope note

This is deliberately scoped independently from a larger `send_prompt`
force-delivery / interrupt (`send_prompt_now`) change we've been trying
locally. That part changes turn-interruption semantics and needs its own
test plan; this PR is just the read-only queue-inspection tool, which is
lower-risk and useful on its own.

## Test plan

- [x] `npx vitest run packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts` — passes (20/20)
- [x] Existing `MetaAgentService` unit tests (`cliPortWiring`, `fullResponse`, `parentPromotion`, `providerInheritance`, `workstreamSync`) — passes (23/23), no regressions
- [x] `npm run typecheck --prefix packages/electron` — clean
- [x] `npm run typecheck --prefix packages/runtime` — clean
- [x] `packages/runtime/.../OpenAICodexProvider.test.ts` (asserts `allowedTools` via `arrayContaining`) — passes, confirms no regression from the `BaseAgentProvider` allowed-tools addition
- [ ] `packages/electron/e2e/ai/meta-agent.spec.ts` — new `list_queued_prompts` test added, mirroring the existing `send_prompt` e2e test; not run here (requires the Electron/Vite dev server, matching the same caveat as prior MCP-tool PRs in this repo)