### PR TITLE
fix: preserve Codex model on turn refresh

### DIFF
--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -1212,12 +1212,20 @@ export class MessageStreamingHandler {
         // Refresh credentials every turn for all providers so key changes in settings apply immediately.
         const freshApiKey = this.svc.getApiKeyForProvider(session.provider, effectiveWorkspacePath);
         const turnEffortLevel = resolveEffortLevel((session.metadata as any)?.effortLevel, getDefaultEffortLevel());
-        await provider.initialize({
+        const turnConfig: any = {
           apiKey: freshApiKey,
           maxTokens: (session.providerConfig as any)?.maxTokens,
           temperature: (session.providerConfig as any)?.temperature,
           ...(turnEffortLevel && { effortLevel: turnEffortLevel }),
-        });
+        };
+        const fullTurnModel = session.model || session.providerConfig?.model;
+        if (fullTurnModel) {
+          const modelForProvider = extractModelForProvider(fullTurnModel, session.provider as AIProviderType);
+          if (modelForProvider !== null) {
+            turnConfig.model = modelForProvider;
+          }
+        }
+        await provider.initialize(turnConfig);
       }
 
       // Attach @ mentioned files for non-agent providers


### PR DESCRIPTION
## Summary
- Preserve the selected model when `MessageStreamingHandler` refreshes provider config each turn.
- Prevent OpenAI Codex sessions from silently falling back to the provider default when only credentials/effort settings are refreshed.

## Why
Nimbalyst stores the chosen session model correctly, e.g. `openai-codex:gpt-5.6-sol`, but the per-turn refresh path called `provider.initialize(...)` without a `model`. `OpenAICodexProvider.initialize` replaces its config, so the next Codex turn used the default model (`gpt-5.5`) even though the session still displayed the intended model.

## Verification
- `npm run typecheck --prefix packages/electron`
- Local Yogi smoke: fresh `openai-codex:gpt-5.6-sol` probe session called `update_session_meta`; Nimbalyst log `x-codex-turn-metadata.model` changed from previous `gpt-5.5` fallback to `gpt-5.6-sol`.