### PR TITLE
Fix main-process wedge from blocking showMessageBoxSync on unresponsive renderer

### DIFF
--- a/packages/electron/src/main/window/WindowManager.ts
+++ b/packages/electron/src/main/window/WindowManager.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog, app, nativeImage, ipcMain, screen, nativeTheme, Menu, type IpcMainEvent, type IpcMainInvokeEvent } from 'electron';
+import { BrowserWindow, app, nativeImage, ipcMain, screen, nativeTheme, Menu, type IpcMainEvent, type IpcMainInvokeEvent } from 'electron';
 import { safeHandle, safeOn } from '../utils/ipcRegistry';
 import { join, basename } from 'path';
 import { existsSync } from 'fs';
@@ -13,6 +13,7 @@ import { ElectronDocumentService, setupDocumentServiceHandlers } from '../servic
 import { ElectronFileSystemService } from '../services/ElectronFileSystemService';
 import { isWorktreePath, resolveProjectPath } from '../utils/workspaceDetection';
 import { getPreloadPath } from '../utils/appPaths';
+import { createUnresponsiveHandler } from './unresponsiveHandler';
 import {
   setFileSystemService,
   clearFileSystemService,
@@ -588,20 +589,11 @@ export function createWindow(
         });
 
         // Handle unresponsive renderer
-        window.webContents.on('unresponsive', () => {
-            console.warn('[MAIN] Window became unresponsive');
-            const choice = dialog.showMessageBoxSync(window, {
-                type: 'warning',
-                buttons: ['Reload', 'Keep Waiting'],
-                defaultId: 0,
-                message: 'The window is not responding',
-                detail: 'Would you like to reload the window?'
-            });
-
-            if (choice === 0 && !window.isDestroyed()) {
-                window.reload();
-            }
-        });
+        window.webContents.on('unresponsive', createUnresponsiveHandler({
+            message: 'The window is not responding',
+            logLabel: '[MAIN]',
+            getWindow: () => window
+        }));
 
         // Handle responsive again
         window.webContents.on('responsive', () => {

--- a/packages/electron/src/main/window/WorkspaceManagerWindow.ts
+++ b/packages/electron/src/main/window/WorkspaceManagerWindow.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, dialog, app } from 'electron';
 import { join, basename } from 'path';
 import { getPreloadPath } from '../utils/appPaths';
+import { createUnresponsiveHandler } from './unresponsiveHandler';
 import { existsSync, mkdirSync, statSync } from 'fs';
 import { readdir } from 'fs/promises';
 import { resolveEntryType } from '../utils/FileTree';
@@ -153,20 +154,11 @@ export function createWorkspaceManagerWindow() {
   });
 
   // Handle unresponsive renderer
-  workspaceManagerWindow.webContents.on('unresponsive', () => {
-    console.warn('[WorkspaceManager] Window became unresponsive');
-    const choice = dialog.showMessageBoxSync(workspaceManagerWindow!, {
-      type: 'warning',
-      buttons: ['Reload', 'Keep Waiting'],
-      defaultId: 0,
-      message: 'Project Manager is not responding',
-      detail: 'Would you like to reload the window?'
-    });
-
-    if (choice === 0 && workspaceManagerWindow && !workspaceManagerWindow.isDestroyed()) {
-      workspaceManagerWindow.reload();
-    }
-  });
+  workspaceManagerWindow.webContents.on('unresponsive', createUnresponsiveHandler({
+    message: 'Project Manager is not responding',
+    logLabel: '[WorkspaceManager]',
+    getWindow: () => workspaceManagerWindow
+  }));
 
   // Handle responsive again
   workspaceManagerWindow.webContents.on('responsive', () => {

--- a/packages/electron/src/main/window/__tests__/unresponsiveHandler.test.ts
+++ b/packages/electron/src/main/window/__tests__/unresponsiveHandler.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+
+const showMessageBox = vi.fn();
+const showMessageBoxSync = vi.fn();
+vi.mock('electron', () => ({
+  dialog: {
+    showMessageBox: (...args: unknown[]) => showMessageBox(...args),
+    showMessageBoxSync: (...args: unknown[]) => showMessageBoxSync(...args),
+  },
+}));
+
+import { createUnresponsiveHandler } from '../unresponsiveHandler';
+
+type FakeWindow = { isDestroyed: () => boolean; reload: ReturnType<typeof vi.fn> };
+
+function makeWindow(): FakeWindow {
+  return { isDestroyed: () => false, reload: vi.fn() };
+}
+
+function makeHandler(window: FakeWindow | null) {
+  return createUnresponsiveHandler({
+    message: 'The window is not responding',
+    logLabel: '[Test]',
+    getWindow: () => window as unknown as BrowserWindow | null,
+  });
+}
+
+describe('createUnresponsiveHandler', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    showMessageBox.mockReset();
+    showMessageBoxSync.mockReset();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('uses the async showMessageBox, never the blocking sync variant', async () => {
+    const window = makeWindow();
+    showMessageBox.mockResolvedValue({ response: 1 });
+
+    await makeHandler(window)();
+
+    // The whole point of the fix: showMessageBoxSync blocks the main process.
+    expect(showMessageBox).toHaveBeenCalledTimes(1);
+    expect(showMessageBoxSync).not.toHaveBeenCalled();
+  });
+
+  it('reloads when the user chooses Reload (response 0)', async () => {
+    const window = makeWindow();
+    showMessageBox.mockResolvedValue({ response: 0 });
+
+    await makeHandler(window)();
+
+    expect(window.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload when the user chooses Keep Waiting (response 1)', async () => {
+    const window = makeWindow();
+    showMessageBox.mockResolvedValue({ response: 1 });
+
+    await makeHandler(window)();
+
+    expect(window.reload).not.toHaveBeenCalled();
+  });
+
+  it('does not open a second dialog while one is already open', async () => {
+    const window = makeWindow();
+    let resolveDialog: (value: { response: number }) => void = () => {};
+    showMessageBox.mockImplementation(
+      () => new Promise((resolve) => { resolveDialog = resolve; })
+    );
+
+    const handle = makeHandler(window);
+    const first = handle(); // opens the dialog and stays pending
+    await handle(); // second `unresponsive` while the dialog is open -> ignored
+
+    expect(showMessageBox).toHaveBeenCalledTimes(1);
+
+    resolveDialog({ response: 1 });
+    await first;
+  });
+
+  it('opens again on a later event once the previous dialog has closed', async () => {
+    const window = makeWindow();
+    showMessageBox.mockResolvedValue({ response: 1 });
+
+    const handle = makeHandler(window);
+    await handle();
+    await handle();
+
+    expect(showMessageBox).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing if the window is already gone', async () => {
+    showMessageBox.mockResolvedValue({ response: 0 });
+
+    await makeHandler(null)();
+
+    expect(showMessageBox).not.toHaveBeenCalled();
+  });
+});

--- a/packages/electron/src/main/window/unresponsiveHandler.ts
+++ b/packages/electron/src/main/window/unresponsiveHandler.ts
@@ -1,0 +1,56 @@
+import { dialog, type BrowserWindow } from 'electron';
+
+export interface UnresponsiveHandlerOptions {
+    /** `message` line for the dialog (differs per window). */
+    message: string;
+    /** Log prefix, e.g. '[MAIN]' or '[WorkspaceManager]'. */
+    logLabel: string;
+    /** Resolve the current window; may return null once it has been torn down. */
+    getWindow: () => BrowserWindow | null;
+}
+
+/**
+ * Build the `webContents` `unresponsive` handler.
+ *
+ * Uses the async dialog.showMessageBox, NOT showMessageBoxSync: the sync variant
+ * spins a nested GLib modal loop that blocks the main process, so a dialog that
+ * can't be dismissed (headless/off-screen/WSLg) wedges the whole app and defeats
+ * the render-process-gone -> reload() recovery. The guard prevents stacking a
+ * second dialog while one is already open, since the renderer keeps firing
+ * `unresponsive` every few seconds while it stays hung.
+ */
+export function createUnresponsiveHandler(
+    options: UnresponsiveHandlerOptions
+): () => Promise<void> {
+    const { message, logLabel, getWindow } = options;
+    let dialogOpen = false;
+
+    return async () => {
+        console.warn(`${logLabel} Window became unresponsive`);
+        if (dialogOpen) {
+            return;
+        }
+        const window = getWindow();
+        if (!window || window.isDestroyed()) {
+            return;
+        }
+        dialogOpen = true;
+        try {
+            const { response } = await dialog.showMessageBox(window, {
+                type: 'warning',
+                buttons: ['Reload', 'Keep Waiting'],
+                defaultId: 0,
+                cancelId: 1,
+                message,
+                detail: 'Would you like to reload the window?'
+            });
+
+            const current = getWindow();
+            if (response === 0 && current && !current.isDestroyed()) {
+                current.reload();
+            }
+        } finally {
+            dialogOpen = false;
+        }
+    };
+}


### PR DESCRIPTION
## What

Both `unresponsive` renderer handlers open a modal with `dialog.showMessageBoxSync`, which spins a nested GLib modal loop and **blocks the main process**. When the dialog can't be dismissed — headless, off-screen, or WSLg — the whole app wedges permanently and can no longer service IPC, the `responsive` event, or its own recovery paths. Repeated `unresponsive` events also stack more modals on top.

This extracts the handler into `createUnresponsiveHandler`, switches it to the async `dialog.showMessageBox` (which does **not** block the main event loop), and adds a re-entrancy guard so a second dialog isn't opened while one is already open. Includes unit tests.

Refs #806.

## Scope — please read

This fixes the **main-process wedge**, which is one of two problems in #806. It is **necessary but not sufficient** on its own:

- The reporter confirmed the dialog *was* visible and they clicked **Reload** — and the app **still hung**. That's because `window.reload()` re-hydrates the terminal sessions and replays their saved scrollback back into the ghostty-vt terminal, which re-parses the same hyperlink-dense output and re-hits the root trigger (`StringAllocOutOfMemory`, see #806). So reload can deterministically reproduce the hang.
- Therefore this PR does **not** claim to stop that renderer-side re-hang. What it does: stop a transient renderer hang from escalating into a permanently wedged main process, keep the loop alive so `responsive` / `render-process-gone` can fire, and stop invisible modals from piling up. The renderer-side root trigger and its scrollback-replay mitigation are tracked separately.

## Files

- `packages/electron/src/main/window/unresponsiveHandler.ts` (new — extracted, testable handler)
- `packages/electron/src/main/window/__tests__/unresponsiveHandler.test.ts` (new)
- `packages/electron/src/main/window/WindowManager.ts`
- `packages/electron/src/main/window/WorkspaceManagerWindow.ts`

## Why async fixes the wedge

- `showMessageBoxSync` runs a nested modal loop on the main thread. The process stays alive at the OS level but its JS is starved — observed on a wedged instance: `[PERF] Event loop lag: 179279ms`, `Window became unresponsive` repeating every few minutes, and the main-thread gdb backtrace sitting in `g_main_loop_run`.
- With the async API the main loop keeps running, so IPC, `responsive`, `render-process-gone`, and the remote-debugging port stay serviced. (Confirmed on the same instance: when the hung renderer was killed, the main loop unblocked 5 ms later and processing resumed — the sync modal was the only thing in front of that path.)
- The guard prevents the modal pile-up on repeated `unresponsive` events.

## Behavior change

- The dialog is now non-blocking. Button semantics are unchanged (Reload / Keep Waiting, default Reload). Added `cancelId: 1` so dismissing the dialog via window controls is treated as "Keep Waiting" instead of reloading.
- The handler is extracted into a shared factory used by both windows, so the two previously-duplicated copies stay in sync.

## Tests

`unresponsiveHandler.test.ts` (vitest, `electron` mocked as in `uncaughtException.test.ts`) covers: async `showMessageBox` is used and `showMessageBoxSync` is never called; reload on `response 0`; no reload on `response 1`; the guard blocks a second concurrent dialog; it re-opens on a later event after the first closed; and it no-ops when the window is already gone.

I could not run a full Electron build in my environment, so I validated the handler's logic by executing an equivalent under plain node (all cases pass); the vitest suite / CI is the final check. Happy to adjust style or wording.
