### PR TITLE
feat: add notify_user MCP tool for agent-initiated OS notifications

### DIFF
--- a/packages/electron/e2e/ai/meta-agent.spec.ts
+++ b/packages/electron/e2e/ai/meta-agent.spec.ts
@@ -345,6 +345,7 @@ test('surfaces delegated child sessions through the meta-agent MCP tools', async
   const toolNames = await listMcpTools(metaAgentClient);
   expect(toolNames.length).toBeGreaterThan(0);
   expect(toolNames).toContain('list_queued_prompts');
+  expect(toolNames).toContain('notify_user');
 
   const created = await createChildSessionWithMetaAgent('Investigate parser edge cases');
   await insertUserPrompt(page, created.sessionId, 'Investigate parser edge cases');

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -77,6 +77,15 @@ type ListQueuedPromptsArgs = {
   includePromptText?: boolean;
 };
 
+type NotifyUserArgs = {
+  title: string;
+  body: string;
+  sessionId?: string;
+  bypassFocusCheck?: boolean;
+  silent?: boolean;
+  urgency?: "normal" | "critical" | "low";
+};
+
 interface MetaAgentToolFns {
   listWorktrees: (
     metaSessionId: string,
@@ -114,6 +123,11 @@ interface MetaAgentToolFns {
     workspaceId: string,
     targetSessionId: string,
     prompt: string
+  ) => Promise<string>;
+  notifyUser: (
+    metaSessionId: string,
+    workspaceId: string,
+    args: NotifyUserArgs
   ) => Promise<string>;
   respondToPrompt: (
     metaSessionId: string,
@@ -335,6 +349,44 @@ export const META_AGENT_TOOL_DEFS: Array<{
     },
   },
   {
+    name: "notify_user",
+    description:
+      "Show a local OS/system notification to get the human's attention. Use this for explicitly authorized asynchronous attention signals when chat may be missed. This is separate from voice mode; it respects the user's OS notification setting and returns JSON explaining whether the notification was shown or skipped.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          description: "Required short notification title.",
+        },
+        body: {
+          type: "string",
+          description: "Required notification body. Keep it concise and action-oriented.",
+        },
+        sessionId: {
+          type: "string",
+          description:
+            "Optional session to open when the user clicks the notification. Defaults to the calling session.",
+        },
+        bypassFocusCheck: {
+          type: "boolean",
+          description:
+            "Optional. If true, bypass in-app focus/session-visible suppression while still respecting the OS notification setting. Use only when the user asked agents to get their attention.",
+        },
+        silent: {
+          type: "boolean",
+          description: "Optional. If true, request a silent OS notification.",
+        },
+        urgency: {
+          type: "string",
+          enum: ["normal", "critical", "low"],
+          description: "Optional OS urgency hint. Defaults to normal.",
+        },
+      },
+      required: ["title", "body"],
+    },
+  },
+  {
     name: "respond_to_prompt",
     description:
       "Answer a child session's interactive prompt such as AskUserQuestion, ExitPlanMode, or ToolPermission.",
@@ -402,6 +454,7 @@ const EXTENSION_META_AGENT_ALLOWED_TOOLS = new Set<string>([
   "get_session_result",
   "list_queued_prompts",
   "send_prompt",
+  "notify_user",
   "respond_to_prompt",
   "list_spawned_sessions",
 ]);
@@ -482,6 +535,8 @@ export async function dispatchMetaAgentTool(
         (args?.sessionId as string) ?? "",
         (args?.prompt as string) ?? ""
       );
+    case "notify_user":
+      return toolFns.notifyUser(aiSessionId, effectiveWorkspaceId, (args ?? {}) as NotifyUserArgs);
     case "respond_to_prompt":
       return toolFns.respondToPrompt(aiSessionId, effectiveWorkspaceId, (args ?? {}) as RespondToPromptArgs);
     case "list_spawned_sessions":

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -16,6 +16,7 @@ import { getDatabase } from '../database/initialize';
 import { gitRefWatcher } from '../file/GitRefWatcher';
 import { AIService } from './ai/AIService';
 import { setMetaAgentToolFns } from '../mcp/metaAgentServer';
+import { notificationService } from './NotificationService';
 import { computeNotificationSignature } from './metaAgentNotificationSignature';
 import { extractMessageText, extractUserPrompts } from './metaAgentMessageText';
 
@@ -112,6 +113,15 @@ interface SpawnSessionArgs {
   isolated?: boolean;
 }
 
+interface NotifyUserArgs {
+  title?: string;
+  body?: string;
+  sessionId?: string;
+  bypassFocusCheck?: boolean;
+  silent?: boolean;
+  urgency?: 'normal' | 'critical' | 'low';
+}
+
 export class MetaAgentService {
   private static instance: MetaAgentService | null = null;
   private starting: Promise<void> | null = null;
@@ -185,6 +195,8 @@ export class MetaAgentService {
           this.listQueuedPromptsJson(targetSessionId, workspaceId, options),
         sendPrompt: (_metaSessionId, workspaceId, targetSessionId, prompt) =>
           this.sendPromptToSession(targetSessionId, workspaceId, prompt),
+        notifyUser: (callerSessionId, workspaceId, args) =>
+          this.notifyUserJson(callerSessionId, workspaceId, args),
         respondToPrompt: (_metaSessionId, workspaceId, args) =>
           this.respondToPrompt(workspaceId, args),
         listSpawnedSessions: (metaSessionId, workspaceId) =>
@@ -927,6 +939,48 @@ export class MetaAgentService {
       prompt: queued.prompt,
       statusBeforeQueue: status,
       processingTriggered,
+    }, null, 2);
+  }
+
+  private async notifyUserJson(
+    callerSessionId: string,
+    workspaceId: string,
+    args: NotifyUserArgs
+  ): Promise<string> {
+    const title = args.title?.trim();
+    const body = args.body?.trim();
+    if (!title) {
+      throw new Error('title is required');
+    }
+    if (!body) {
+      throw new Error('body is required');
+    }
+
+    const targetSessionId = args.sessionId?.trim() || callerSessionId;
+    const session = await AISessionsRepository.get(targetSessionId);
+    if (!session || session.workspacePath !== workspaceId) {
+      throw new Error(`Session ${targetSessionId} not found`);
+    }
+
+    const boundedBody = body.length > 1000 ? `${body.slice(0, 997)}...` : body;
+    const result = await notificationService.showNotificationWithResult({
+      title: title.length > 120 ? `${title.slice(0, 117)}...` : title,
+      body: boundedBody,
+      sessionId: targetSessionId,
+      workspacePath: session.workspacePath,
+      provider: 'agent',
+      bypassFocusCheck: args.bypassFocusCheck === true,
+      silent: args.silent === true,
+      urgency: args.urgency || 'normal',
+    });
+
+    return JSON.stringify({
+      tool: 'notify_user',
+      deliveryChannel: 'os_notification',
+      mobilePushAttempted: false,
+      sessionId: targetSessionId,
+      bypassFocusCheck: args.bypassFocusCheck === true,
+      result,
     }, null, 2);
   }
 

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -16,7 +16,6 @@ import { getDatabase } from '../database/initialize';
 import { gitRefWatcher } from '../file/GitRefWatcher';
 import { AIService } from './ai/AIService';
 import { setMetaAgentToolFns } from '../mcp/metaAgentServer';
-import { notificationService } from './NotificationService';
 import { computeNotificationSignature } from './metaAgentNotificationSignature';
 import { extractMessageText, extractUserPrompts } from './metaAgentMessageText';
 
@@ -963,6 +962,7 @@ export class MetaAgentService {
     }
 
     const boundedBody = body.length > 1000 ? `${body.slice(0, 997)}...` : body;
+    const { notificationService } = await import('./NotificationService');
     const result = await notificationService.showNotificationWithResult({
       title: title.length > 120 ? `${title.slice(0, 117)}...` : title,
       body: boundedBody,

--- a/packages/electron/src/main/services/NotificationService.ts
+++ b/packages/electron/src/main/services/NotificationService.ts
@@ -16,6 +16,33 @@ export interface NotificationOptions {
   sessionId?: string;
   workspacePath: string;  // REQUIRED: stable identifier for routing
   provider?: string;
+  /**
+   * Agent/user-attention notifications can opt out of focus suppression while
+   * still respecting the user's OS notification setting.
+   */
+  bypassFocusCheck?: boolean;
+  silent?: boolean;
+  urgency?: 'normal' | 'critical' | 'low';
+  timeoutType?: 'default' | 'never';
+}
+
+export type NotificationSkippedReason =
+  | 'os_notifications_disabled'
+  | 'unsupported'
+  | 'app_focused'
+  | 'session_visible'
+  | 'error';
+
+export interface NotificationResult {
+  success: boolean;
+  attempted: boolean;
+  shown: boolean;
+  skippedReason: NotificationSkippedReason | null;
+  error?: string;
+  title: string;
+  bodyPreview: string;
+  sessionId?: string;
+  workspacePath: string;
 }
 
 /**
@@ -64,6 +91,21 @@ class NotificationService {
    * 3. System allows notifications (respects Do Not Disturb)
    */
   async showNotification(options: NotificationOptions): Promise<void> {
+    await this.showNotificationWithResult(options);
+  }
+
+  async showNotificationWithResult(options: NotificationOptions): Promise<NotificationResult> {
+    const baseResult = (): NotificationResult => ({
+      success: true,
+      attempted: false,
+      shown: false,
+      skippedReason: null,
+      title: options.title,
+      bodyPreview: NotificationService.truncateBody(options.body, 120),
+      ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+      workspacePath: options.workspacePath,
+    });
+
     // logger.main.info('[NotificationService] showNotification called:', {
     //   title: options.title,
     //   sessionId: options.sessionId,
@@ -74,13 +116,19 @@ class NotificationService {
     // logger.main.info('[NotificationService] OS notifications enabled:', osNotificationsEnabled);
     if (!osNotificationsEnabled) {
       // logger.main.info('[NotificationService] SKIPPED: OS notifications disabled in settings');
-      return;
+      return {
+        ...baseResult(),
+        skippedReason: 'os_notifications_disabled',
+      };
     }
 
     // Check if app has permission to show notifications
     if (!Notification.isSupported()) {
       logger.main.warn('[NotificationService] SKIPPED: Notifications not supported on this platform');
-      return;
+      return {
+        ...baseResult(),
+        skippedReason: 'unsupported',
+      };
     }
 
     // Check if any window is visible and focused
@@ -88,14 +136,17 @@ class NotificationService {
     const focusedWindow = allWindows.find(win => win.isVisible() && win.isFocused());
     // logger.main.info('[NotificationService] Has visible focused window:', !!focusedWindow);
 
-    if (focusedWindow) {
+    if (focusedWindow && !options.bypassFocusCheck) {
       // Window is focused - check if we should still notify
       const notifyWhenFocused = isNotifyWhenFocusedEnabled();
 
       if (!notifyWhenFocused) {
         // Traditional behavior: skip all notifications when app is focused
         // logger.main.info('[NotificationService] SKIPPED: App window is focused (notifications only show when app is in background)');
-        return;
+        return {
+          ...baseResult(),
+          skippedReason: 'app_focused',
+        };
       }
 
       // notifyWhenFocused is enabled - check if viewing this specific session
@@ -103,7 +154,10 @@ class NotificationService {
         const isViewingSession = await this.isWindowViewingSession(focusedWindow, options.sessionId);
         if (isViewingSession) {
           // logger.main.info('[NotificationService] SKIPPED: User is already viewing this session');
-          return;
+          return {
+            ...baseResult(),
+            skippedReason: 'session_visible',
+          };
         }
         // logger.main.info('[NotificationService] User not viewing this session, showing notification');
       }
@@ -115,9 +169,9 @@ class NotificationService {
         title: options.title,
         body: options.body,
         icon: options.icon || this.getAppIcon(),
-        silent: false, // Use system notification sound
-        urgency: 'normal', // macOS notification urgency
-        timeoutType: 'default', // Use system default timeout
+        silent: options.silent === true ? true : false,
+        urgency: options.urgency || 'normal', // macOS notification urgency
+        timeoutType: options.timeoutType || 'default', // Use system default timeout
       });
 
       // Handle notification click - focus window and switch to session
@@ -149,8 +203,20 @@ class NotificationService {
       //   title: options.title,
       //   bodyLength: options.body.length,
       // });
+      return {
+        ...baseResult(),
+        attempted: true,
+        shown: true,
+      };
     } catch (error) {
       logger.main.error('[NotificationService] Error showing notification:', error);
+      return {
+        ...baseResult(),
+        success: false,
+        attempted: true,
+        skippedReason: 'error',
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   }
 

--- a/packages/electron/src/main/services/__tests__/NotificationService.agentNotification.test.ts
+++ b/packages/electron/src/main/services/__tests__/NotificationService.agentNotification.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  browserWindows: [] as Array<{
+    isVisible: () => boolean;
+    isFocused: () => boolean;
+  }>,
+  notificationConstructor: vi.fn(),
+  notificationIsSupported: vi.fn(() => true),
+  notificationShow: vi.fn(),
+  notificationOn: vi.fn(),
+  notificationClose: vi.fn(),
+  osNotificationsEnabled: vi.fn(() => true),
+  notifyWhenFocusedEnabled: vi.fn(() => false),
+  sessionBlockedNotificationsEnabled: vi.fn(() => true),
+}));
+
+vi.mock('electron', () => {
+  class MockNotification {
+    static isSupported = mocks.notificationIsSupported;
+
+    constructor(options: unknown) {
+      mocks.notificationConstructor(options);
+    }
+
+    on = mocks.notificationOn;
+    show = mocks.notificationShow;
+    close = mocks.notificationClose;
+  }
+
+  return {
+    Notification: MockNotification,
+    BrowserWindow: {
+      getAllWindows: () => mocks.browserWindows,
+    },
+    app: {
+      getPath: () => 'C:\\Program Files\\Nimbalyst\\Nimbalyst.exe',
+    },
+    ipcMain: {
+      once: vi.fn(),
+      removeAllListeners: vi.fn(),
+    },
+    shell: {
+      openExternal: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    main: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../utils/store', () => ({
+  isOSNotificationsEnabled: mocks.osNotificationsEnabled,
+  isNotifyWhenFocusedEnabled: mocks.notifyWhenFocusedEnabled,
+  isSessionBlockedNotificationsEnabled: mocks.sessionBlockedNotificationsEnabled,
+}));
+
+vi.mock('../../window/WindowManager', () => ({
+  findWindowByWorkspace: vi.fn(() => null),
+}));
+
+import { notificationService } from '../NotificationService';
+
+describe('NotificationService agent notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.browserWindows = [];
+    mocks.notificationIsSupported.mockReturnValue(true);
+    mocks.osNotificationsEnabled.mockReturnValue(true);
+    mocks.notifyWhenFocusedEnabled.mockReturnValue(false);
+  });
+
+  it('reports a skipped result when OS notifications are disabled', async () => {
+    mocks.osNotificationsEnabled.mockReturnValue(false);
+
+    const result = await notificationService.showNotificationWithResult({
+      title: 'Agent needs attention',
+      body: 'Smoke test',
+      sessionId: 'session-1',
+      workspacePath: '/workspace',
+      provider: 'agent',
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      attempted: false,
+      shown: false,
+      skippedReason: 'os_notifications_disabled',
+      sessionId: 'session-1',
+      workspacePath: '/workspace',
+    });
+    expect(mocks.notificationShow).not.toHaveBeenCalled();
+  });
+
+  it('skips while the app is focused unless bypassFocusCheck is set', async () => {
+    mocks.browserWindows = [
+      {
+        isVisible: () => true,
+        isFocused: () => true,
+      },
+    ];
+
+    const result = await notificationService.showNotificationWithResult({
+      title: 'Agent needs attention',
+      body: 'Smoke test',
+      sessionId: 'session-1',
+      workspacePath: '/workspace',
+      provider: 'agent',
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      attempted: false,
+      shown: false,
+      skippedReason: 'app_focused',
+    });
+    expect(mocks.notificationShow).not.toHaveBeenCalled();
+  });
+
+  it('shows when bypassFocusCheck is set even if the app is focused', async () => {
+    mocks.browserWindows = [
+      {
+        isVisible: () => true,
+        isFocused: () => true,
+      },
+    ];
+
+    const result = await notificationService.showNotificationWithResult({
+      title: 'Agent needs attention',
+      body: 'Smoke test',
+      sessionId: 'session-1',
+      workspacePath: '/workspace',
+      provider: 'agent',
+      bypassFocusCheck: true,
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      attempted: true,
+      shown: true,
+      skippedReason: null,
+    });
+    expect(mocks.notificationConstructor).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Agent needs attention',
+      body: 'Smoke test',
+      urgency: 'normal',
+      timeoutType: 'default',
+    }));
+    expect(mocks.notificationShow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/runtime/src/ai/server/providers/BaseAgentProvider.ts
+++ b/packages/runtime/src/ai/server/providers/BaseAgentProvider.ts
@@ -41,6 +41,7 @@ export abstract class BaseAgentProvider extends BaseAIProvider {
     'mcp__nimbalyst-host__get_session_result',
     'mcp__nimbalyst-host__list_queued_prompts',
     'mcp__nimbalyst-host__send_prompt',
+    'mcp__nimbalyst-host__notify_user',
     'mcp__nimbalyst-host__respond_to_prompt',
     'mcp__nimbalyst-host__get_session_summary',
     'mcp__nimbalyst-host__get_workstream_overview',

--- a/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
@@ -1236,6 +1236,7 @@ describe('OpenAICodexProvider', () => {
         // update_session_meta onto the eager core `nimbalyst`.
         'mcp__nimbalyst-host__create_session',
         'mcp__nimbalyst-host__get_session_result',
+        'mcp__nimbalyst-host__notify_user',
         'mcp__nimbalyst__update_session_meta',
         'mcp__nimbalyst-host__get_workstream_overview',
         'TaskCreate',

--- a/packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts
+++ b/packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts
@@ -64,6 +64,7 @@ describe('Topology descriptor', () => {
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('settings_get_overview')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('spawn_session')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('list_queued_prompts')).toBe(MCP_HOST);
+    expect(FIRST_PARTY_TOOL_TO_SERVER.get('notify_user')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('tracker_create')).toBe(MCP_TRACKERS);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('voice_agent_speak')).toBe(MCP_SITUATIONAL);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('renderer_eval')).toBe(MCP_EXTENSION_DEV);

--- a/packages/runtime/src/ai/server/services/mcpTopology.ts
+++ b/packages/runtime/src/ai/server/services/mcpTopology.ts
@@ -158,6 +158,7 @@ export const HOST_TOOLS: readonly string[] = [
   'spawn_session',
   'send_prompt',
   'list_queued_prompts',
+  'notify_user',
   'respond_to_prompt',
   'get_session_status',
   'get_session_result',


### PR DESCRIPTION
## Summary

Agents have chat and `voice_agent_speak`, but voice mode is a separate runtime
channel that may not be active, and chat alone will not get a human's
attention once they have stepped away. Nimbalyst already has internal
notification infrastructure (`NotificationService`, `NotificationHandlers`,
the `notifications:show` IPC handler) but no agent-callable wrapper around it.

This adds `notify_user`: a safe MCP tool that shows a local OS/system-tray
notification, separate from voice mode, respecting the user's existing "OS
notifications enabled" preference.

## Solution

- `title`/`body` are required; `body` is bounded to 1000 chars and `title` to
  120 chars before being handed to the OS notification API.
- `sessionId` is optional and defaults to the calling session; the target
  session must belong to the caller's workspace.
- `bypassFocusCheck` lets an agent request a notification even while the app
  window is focused, for cases where the user explicitly asked to be
  interrupted -- the underlying OS-notifications-enabled setting is still
  respected either way.
- `silent` and `urgency` are passed through to the OS notification.

`NotificationService.showNotification` is refactored into a thin wrapper
around a new `showNotificationWithResult`, which returns a structured
`NotificationResult` (`success`/`attempted`/`shown`/`skippedReason`/`error`)
instead of a bare `void`, so `notify_user` can tell the caller whether the
notification actually reached the user or was skipped (and why) rather than
assuming a call means delivery.

## Testing

- `npx vitest run packages/electron/src/main/services/__tests__/NotificationService.agentNotification.test.ts` (new, 3/3 passing)
- `npx vitest run packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts` (20/20 passing)
- `npx vitest run packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts` (30 passing, 1 skipped, no regressions)
- `npm run typecheck --prefix packages/electron` (clean)
- `npm run typecheck --prefix packages/runtime` (clean)

## Notes for reviewers

This is scoped to the OS-notification channel only. It intentionally does not
include any mobile-push or "desktop truly away" forcing behavior -- that is a
separate, harder problem (a proper `force`/`reason` field in the sync
protocol plus a server-side push router) better tracked under #704.