### PR TITLE
feat: add send_prompt_now MCP tool with forced child-update delivery

### DIFF
--- a/packages/electron/e2e/ai/meta-agent.spec.ts
+++ b/packages/electron/e2e/ai/meta-agent.spec.ts
@@ -345,6 +345,7 @@ test('surfaces delegated child sessions through the meta-agent MCP tools', async
   const toolNames = await listMcpTools(metaAgentClient);
   expect(toolNames.length).toBeGreaterThan(0);
   expect(toolNames).toContain('list_queued_prompts');
+  expect(toolNames).toContain('send_prompt_now');
 
   const created = await createChildSessionWithMetaAgent('Investigate parser edge cases');
   await insertUserPrompt(page, created.sessionId, 'Investigate parser edge cases');
@@ -682,6 +683,37 @@ test('list_queued_prompts exposes bounded queue state for a child session', asyn
   expect(queue.prompts[0].status).toBe('pending');
   expect(queue.prompts[0].promptPreview).toContain('remain queued');
   expect(queue.prompts[0].prompt).toBeUndefined();
+});
+
+test('send_prompt_now exposes force-delivery metadata and records the prompt', async () => {
+  const childSessionId = await createLinkedTestSession({
+    title: 'Urgent delegated follow-up task',
+    status: 'running',
+  });
+
+  const sendResult = await callMetaAgentTool<{
+    sessionId: string;
+    prompt: string;
+    interruptCurrentTurnRequested: boolean;
+    interruptAttempted: boolean;
+    processingTriggered: boolean;
+    bypassedExecutionForTest?: boolean;
+  }>(metaAgentClient, 'send_prompt_now', {
+    sessionId: childSessionId,
+    prompt: 'Interrupt with this follow-up',
+  });
+  expect(sendResult.sessionId).toBe(childSessionId);
+  expect(sendResult.prompt).toBe('Interrupt with this follow-up');
+  expect(sendResult.interruptCurrentTurnRequested).toBe(true);
+  expect(sendResult.interruptAttempted).toBe(false);
+  expect(sendResult.processingTriggered).toBe(false);
+  expect(sendResult.bypassedExecutionForTest).toBe(true);
+
+  const result = await callMetaAgentTool<{
+    sessionId: string;
+    userPrompts: string[];
+  }>(metaAgentClient, 'get_session_result', { sessionId: childSessionId });
+  expect(result.userPrompts).toContain('Interrupt with this follow-up');
 });
 
 test('send_prompt rejects empty or missing prompt', async () => {

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -77,6 +77,25 @@ type ListQueuedPromptsArgs = {
   includePromptText?: boolean;
 };
 
+type SendPromptArgs = {
+  sessionId: string;
+  prompt: string;
+  /**
+   * Interrupt the target session's active turn before triggering queued prompt
+   * processing. This is the same intent as the queued-prompt "Interrupt and
+   * send now" action.
+   */
+  interruptCurrentTurn?: boolean;
+  /** Backward-compatible alias for clients that use concise force semantics. */
+  force?: boolean;
+  /**
+   * If true, allow force-delivery to interrupt a session that is currently
+   * waiting for an interactive prompt. Defaults to false; respond_to_prompt is
+   * usually the correct tool for that state.
+   */
+  interruptWaitingForInput?: boolean;
+};
+
 interface MetaAgentToolFns {
   listWorktrees: (
     metaSessionId: string,
@@ -113,7 +132,8 @@ interface MetaAgentToolFns {
     metaSessionId: string,
     workspaceId: string,
     targetSessionId: string,
-    prompt: string
+    prompt: string,
+    options?: Pick<SendPromptArgs, "interruptCurrentTurn" | "force" | "interruptWaitingForInput">
   ) => Promise<string>;
   respondToPrompt: (
     metaSessionId: string,
@@ -318,7 +338,7 @@ export const META_AGENT_TOOL_DEFS: Array<{
   {
     name: "send_prompt",
     description:
-      "Queue a follow-up prompt for a child session. If the session is idle, prompt processing starts immediately.",
+      "Queue a follow-up prompt for a child session. If the session is idle, prompt processing starts immediately. Set interruptCurrentTurn only when you must interrupt an active child turn; for clearer force-delivery semantics, prefer send_prompt_now.",
     inputSchema: {
       type: "object",
       properties: {
@@ -329,6 +349,45 @@ export const META_AGENT_TOOL_DEFS: Array<{
         prompt: {
           type: "string",
           description: "The follow-up prompt to send.",
+        },
+        interruptCurrentTurn: {
+          type: "boolean",
+          description:
+            "Optional. If true, interrupt an active target session before triggering queued prompt processing. Defaults to false.",
+        },
+        force: {
+          type: "boolean",
+          description:
+            "Optional alias for interruptCurrentTurn for clients that use concise force semantics.",
+        },
+        interruptWaitingForInput: {
+          type: "boolean",
+          description:
+            "Optional. If true, allow interrupting a session that is waiting for an interactive prompt. Defaults to false; respond_to_prompt is usually the correct tool for that state.",
+        },
+      },
+      required: ["sessionId", "prompt"],
+    },
+  },
+  {
+    name: "send_prompt_now",
+    description:
+      "Queue a follow-up prompt for a child session, interrupt the child session's active turn when needed, and trigger queue processing immediately. This is the MCP equivalent of the queued-prompt lightning action.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description: "The target child session ID.",
+        },
+        prompt: {
+          type: "string",
+          description: "The urgent follow-up prompt to deliver.",
+        },
+        interruptWaitingForInput: {
+          type: "boolean",
+          description:
+            "Optional. If true, allow interrupting a session that is waiting for an interactive prompt. Defaults to false; respond_to_prompt is usually the correct tool for that state.",
         },
       },
       required: ["sessionId", "prompt"],
@@ -402,6 +461,7 @@ const EXTENSION_META_AGENT_ALLOWED_TOOLS = new Set<string>([
   "get_session_result",
   "list_queued_prompts",
   "send_prompt",
+  "send_prompt_now",
   "respond_to_prompt",
   "list_spawned_sessions",
 ]);
@@ -480,7 +540,23 @@ export async function dispatchMetaAgentTool(
         aiSessionId,
         effectiveWorkspaceId,
         (args?.sessionId as string) ?? "",
-        (args?.prompt as string) ?? ""
+        (args?.prompt as string) ?? "",
+        {
+          interruptCurrentTurn: args?.interruptCurrentTurn === true,
+          force: args?.force === true,
+          interruptWaitingForInput: args?.interruptWaitingForInput === true,
+        }
+      );
+    case "send_prompt_now":
+      return toolFns.sendPrompt(
+        aiSessionId,
+        effectiveWorkspaceId,
+        (args?.sessionId as string) ?? "",
+        (args?.prompt as string) ?? "",
+        {
+          interruptCurrentTurn: true,
+          interruptWaitingForInput: args?.interruptWaitingForInput === true,
+        }
       );
     case "respond_to_prompt":
       return toolFns.respondToPrompt(aiSessionId, effectiveWorkspaceId, (args ?? {}) as RespondToPromptArgs);

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -112,6 +112,12 @@ interface SpawnSessionArgs {
   isolated?: boolean;
 }
 
+interface SendPromptOptions {
+  interruptCurrentTurn?: boolean;
+  force?: boolean;
+  interruptWaitingForInput?: boolean;
+}
+
 export class MetaAgentService {
   private static instance: MetaAgentService | null = null;
   private starting: Promise<void> | null = null;
@@ -183,8 +189,8 @@ export class MetaAgentService {
           this.getSessionResultJson(targetSessionId, workspaceId, options),
         listQueuedPrompts: (_metaSessionId, workspaceId, targetSessionId, options) =>
           this.listQueuedPromptsJson(targetSessionId, workspaceId, options),
-        sendPrompt: (_metaSessionId, workspaceId, targetSessionId, prompt) =>
-          this.sendPromptToSession(targetSessionId, workspaceId, prompt),
+        sendPrompt: (_metaSessionId, workspaceId, targetSessionId, prompt, options) =>
+          this.sendPromptToSession(targetSessionId, workspaceId, prompt, options),
         respondToPrompt: (_metaSessionId, workspaceId, args) =>
           this.respondToPrompt(workspaceId, args),
         listSpawnedSessions: (metaSessionId, workspaceId) =>
@@ -880,7 +886,12 @@ export class MetaAgentService {
     }, null, 2);
   }
 
-  private async sendPromptToSession(sessionId: string, workspaceId: string, prompt: string): Promise<string> {
+  private async sendPromptToSession(
+    sessionId: string,
+    workspaceId: string,
+    prompt: string,
+    options: SendPromptOptions = {}
+  ): Promise<string> {
     if (!this.aiService) {
       throw new Error('AI service not initialized');
     }
@@ -894,6 +905,8 @@ export class MetaAgentService {
     }
 
     const normalizedPrompt = prompt.trim();
+    const interruptCurrentTurnRequested = options.interruptCurrentTurn === true || options.force === true;
+    const interruptWaitingForInput = options.interruptWaitingForInput === true;
     const shouldBypassExecution = this.shouldBypassChildAgentExecutionForTests();
     const statusRow = await this.getSessionStatusRow(sessionId, workspaceId);
     const statusBeforeQueue = (statusRow?.status || 'idle') as SessionStatusValue;
@@ -905,6 +918,9 @@ export class MetaAgentService {
         queuedPromptId: null,
         prompt: normalizedPrompt,
         statusBeforeQueue,
+        interruptCurrentTurnRequested,
+        interruptWaitingForInput,
+        interruptAttempted: false,
         processingTriggered: false,
         bypassedExecutionForTest: true,
       }, null, 2);
@@ -912,21 +928,60 @@ export class MetaAgentService {
 
     const queued = await this.aiService.queuePromptForSession(sessionId, normalizedPrompt);
     const status = (statusRow?.status || 'idle') as SessionStatusValue;
-    const processingTriggered = status === 'idle' || status === 'interrupted' || status === 'error';
+    const waitingForInputBlocked = status === 'waiting_for_input' && !interruptWaitingForInput;
+    const interruptEligible = status === 'running' || (status === 'waiting_for_input' && interruptWaitingForInput);
+    const interruptAttempted = interruptCurrentTurnRequested && interruptEligible;
+    const interruptSkippedReason = interruptCurrentTurnRequested && waitingForInputBlocked
+      ? 'waiting_for_input'
+      : null;
+    let interruptResult: Awaited<ReturnType<AIService['interruptCurrentTurnForSession']>> | null = null;
 
-    if (processingTriggered) {
-      await this.aiService.triggerQueuedPromptProcessingForSession(
-        sessionId,
-        session.worktreePath || session.workspacePath || workspaceId
-      );
+    if (interruptAttempted) {
+      try {
+        interruptResult = await this.aiService.interruptCurrentTurnForSession(sessionId);
+      } catch (error) {
+        interruptResult = {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
     }
 
+    const processingTriggered =
+      status === 'idle' ||
+      status === 'interrupted' ||
+      status === 'error' ||
+      (interruptCurrentTurnRequested && !waitingForInputBlocked);
+    let processingTriggerAccepted: boolean | null = null;
+    let processingTriggerError: string | null = null;
+
+    if (processingTriggered) {
+      try {
+        processingTriggerAccepted = await this.aiService.triggerQueuedPromptProcessingForSession(
+          sessionId,
+          session.worktreePath || session.workspacePath || workspaceId
+        );
+      } catch (error) {
+        processingTriggerAccepted = false;
+        processingTriggerError = error instanceof Error ? error.message : String(error);
+      }
+    }
+
+    const statusAfterQueue = (await this.getSessionStatusRow(sessionId, workspaceId))?.status || status;
     return JSON.stringify({
       sessionId,
       queuedPromptId: queued.id,
       prompt: queued.prompt,
       statusBeforeQueue: status,
+      statusAfterQueue,
+      interruptCurrentTurnRequested,
+      interruptWaitingForInput,
+      interruptAttempted,
+      interruptSkippedReason,
+      interruptResult,
       processingTriggered,
+      processingTriggerAccepted,
+      ...(processingTriggerError ? { processingTriggerError } : {}),
     }, null, 2);
   }
 
@@ -1085,16 +1140,56 @@ export class MetaAgentService {
       }
 
       const notification = this.buildNotificationMessage(eventType, result);
-      await this.aiService.queuePromptForSession(session.createdBySessionId, notification);
+      const shouldForceDeliverNotification = eventType !== 'session:error';
+      if (!shouldForceDeliverNotification) {
+        // Do not auto-re-drive the parent when THIS child settle was an error.
+        // The [Child Session Update] notification is still queued for visibility,
+        // but re-triggering the parent's queue on every error settle spins the
+        // meta-agent wakeup loop with no backoff.
+        await this.aiService.queuePromptForSession(session.createdBySessionId, notification);
+        return;
+      }
 
-      // Do not auto-re-drive the parent when THIS child settle was an error.
-      // The [Child Session Update] notification above is still queued for
-      // visibility, but re-triggering the parent's queue on every error settle
-      // spins the meta-agent wakeup loop with no backoff (an antigravity 429
-      // child settles instantly into 'error' every cycle). Native children
-      // settle 'session:completed', so this gate is a no-op for them.
-      if (eventType !== 'session:error' && (metaStatus === 'idle' || metaStatus === 'interrupted' || metaStatus === 'error')) {
-        await this.aiService.triggerQueuedPromptProcessingForSession(metaSession.id, metaSession.workspacePath);
+      const deliveryResult = await this.sendPromptToSession(
+        session.createdBySessionId,
+        metaSession.workspacePath,
+        notification,
+        {
+          force: shouldForceDeliverNotification,
+          interruptCurrentTurn: shouldForceDeliverNotification,
+          interruptWaitingForInput: false,
+        }
+      );
+
+      if (shouldForceDeliverNotification) {
+        try {
+          const parsed = JSON.parse(deliveryResult) as {
+            processingTriggered?: boolean;
+            processingTriggerAccepted?: boolean | null;
+            interruptAttempted?: boolean;
+            interruptResult?: { success?: boolean; error?: string } | null;
+            interruptSkippedReason?: string | null;
+          };
+          if (
+            parsed.processingTriggered !== true ||
+            parsed.processingTriggerAccepted !== true ||
+            parsed.interruptResult?.success === false
+          ) {
+            console.warn('[MetaAgentService] child notification force delivery was not accepted:', {
+              childSessionId: sessionId,
+              parentSessionId: session.createdBySessionId,
+              eventType,
+              processingTriggered: parsed.processingTriggered,
+              processingTriggerAccepted: parsed.processingTriggerAccepted,
+              interruptAttempted: parsed.interruptAttempted,
+              interruptSkippedReason: parsed.interruptSkippedReason,
+              interruptError: parsed.interruptResult?.error,
+              parentStatusBeforeDelivery: metaStatus,
+            });
+          }
+        } catch (parseError) {
+          console.warn('[MetaAgentService] failed to parse child notification delivery result:', parseError);
+        }
       }
     } catch (error) {
       console.error(`[MetaAgentService] handleChildSessionEvent failed for session ${sessionId} (${eventType}):`, error);

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.forceNotificationDelivery.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.forceNotificationDelivery.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    get: vi.fn(),
+  },
+  AgentMessagesRepository: {
+    list: vi.fn(),
+  },
+  SessionFilesRepository: {
+    getFilesBySession: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  SessionManager: class { async initialize() {} },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: {
+    parse: (id: string) => ({ provider: id.split(':')[0], model: id.split(':')[1], combined: id }),
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn() }),
+}));
+
+vi.mock('../ai/providerResolution', () => ({
+  resolveExtensionAgentRef: () => null,
+  isExtensionAgentProvider: () => false,
+}));
+
+vi.mock('electron', () => ({ BrowserWindow: { getAllWindows: () => [] } }));
+vi.mock('../SyncManager', () => ({ getSyncProvider: () => ({ pushChange: vi.fn() }) }));
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => null }));
+vi.mock('../../utils/timestampUtils', () => ({ toMillis: (v: unknown) => v }));
+vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
+vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({
+  database: { query: vi.fn() },
+}));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => null }));
+vi.mock('../../file/GitRefWatcher', () => ({ gitRefWatcher: {} }));
+vi.mock('./ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({
+  setMetaAgentToolFns: vi.fn(),
+}));
+
+import { AISessionsRepository, AgentMessagesRepository } from '@nimbalyst/runtime';
+import { database as databaseWorker } from '../../database/PGLiteDatabaseWorker';
+import { MetaAgentService } from '../MetaAgentService';
+
+const WORKSPACE = '/workspace';
+
+describe('MetaAgentService child notification force delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const service = MetaAgentService.getInstance() as any;
+    service.notificationSignatures = new Map();
+    service.shouldBypassChildAgentExecutionForTests = () => false;
+  });
+
+  it('force-delivers child completion updates to a running parent session', async () => {
+    vi.mocked(AISessionsRepository.get).mockImplementation(async (sessionId: string) => {
+      if (sessionId === 'child-1') {
+        return {
+          id: 'child-1',
+          title: 'Child worker',
+          provider: 'claude-code',
+          model: 'claude-code:sonnet',
+          status: 'idle',
+          createdAt: 1,
+          updatedAt: 2,
+          workspacePath: WORKSPACE,
+          worktreePath: null,
+          worktreeId: null,
+          agentRole: 'standard',
+          createdBySessionId: 'parent-1',
+          metadata: {},
+        } as never;
+      }
+      if (sessionId === 'parent-1') {
+        return {
+          id: 'parent-1',
+          title: 'Parent orchestrator',
+          provider: 'claude-code',
+          model: 'claude-code:sonnet',
+          status: 'running',
+          createdAt: 1,
+          updatedAt: 2,
+          workspacePath: WORKSPACE,
+          worktreePath: null,
+          worktreeId: null,
+          agentRole: 'meta-agent',
+          createdBySessionId: null,
+          metadata: {},
+        } as never;
+      }
+      return null;
+    });
+
+    vi.mocked(AgentMessagesRepository.list).mockResolvedValue([
+      { direction: 'input', content: 'do the task', metadata: null },
+      { direction: 'output', content: 'task complete', metadata: null },
+    ] as never);
+
+    vi.mocked(databaseWorker.query).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('COUNT(*)::text AS count') && params?.[0] === 'child-1') {
+        return { rows: [{ count: '0' }] };
+      }
+      if (sql.includes('FROM ai_sessions') && params?.[0] === 'parent-1') {
+        return { rows: [{ status: 'running', last_activity: 3, updated_at: 4 }] };
+      }
+      if (sql.includes('FROM ai_sessions') && params?.[0] === 'child-1') {
+        return { rows: [{ status: 'idle', last_activity: 3, updated_at: 4 }] };
+      }
+      return { rows: [] };
+    });
+
+    const aiService = {
+      queuePromptForSession: vi.fn().mockResolvedValue({
+        id: 'queued-notification-1',
+        prompt: '[Child Session Update]\nSession: "Child worker" (child-1)',
+        createdAt: 10,
+      }),
+      interruptCurrentTurnForSession: vi.fn().mockResolvedValue({
+        success: true,
+        method: 'interrupt',
+        completed: 0,
+        rolledBack: 0,
+      }),
+      triggerQueuedPromptProcessingForSession: vi.fn().mockResolvedValue(true),
+    };
+
+    const service = MetaAgentService.getInstance() as any;
+    service.aiService = aiService;
+
+    await service.handleChildSessionEvent('child-1', 'session:completed');
+
+    expect(aiService.queuePromptForSession).toHaveBeenCalledWith(
+      'parent-1',
+      expect.stringContaining('[Child Session Update]')
+    );
+    expect(aiService.interruptCurrentTurnForSession).toHaveBeenCalledWith('parent-1');
+    expect(aiService.triggerQueuedPromptProcessingForSession).toHaveBeenCalledWith('parent-1', WORKSPACE);
+  });
+
+  it('keeps child error notifications queue-only to avoid error-loop churn', async () => {
+    vi.mocked(AISessionsRepository.get).mockImplementation(async (sessionId: string) => {
+      if (sessionId === 'child-err') {
+        return {
+          id: 'child-err',
+          title: 'Failing child',
+          provider: 'claude-code',
+          model: 'claude-code:sonnet',
+          status: 'error',
+          createdAt: 1,
+          updatedAt: 2,
+          workspacePath: WORKSPACE,
+          agentRole: 'standard',
+          createdBySessionId: 'parent-1',
+          metadata: {},
+        } as never;
+      }
+      if (sessionId === 'parent-1') {
+        return {
+          id: 'parent-1',
+          title: 'Parent orchestrator',
+          provider: 'claude-code',
+          model: 'claude-code:sonnet',
+          status: 'running',
+          createdAt: 1,
+          updatedAt: 2,
+          workspacePath: WORKSPACE,
+          agentRole: 'meta-agent',
+          createdBySessionId: null,
+          metadata: {},
+        } as never;
+      }
+      return null;
+    });
+    vi.mocked(AgentMessagesRepository.list).mockResolvedValue([
+      { direction: 'input', content: 'do the task', metadata: null },
+      { direction: 'output', content: 'failed', metadata: null },
+    ] as never);
+    vi.mocked(databaseWorker.query).mockResolvedValue({ rows: [] });
+
+    const aiService = {
+      queuePromptForSession: vi.fn().mockResolvedValue({
+        id: 'queued-error-notification-1',
+        prompt: '[Child Session Update]\nSession: "Failing child" (child-err)',
+        createdAt: 10,
+      }),
+      interruptCurrentTurnForSession: vi.fn(),
+      triggerQueuedPromptProcessingForSession: vi.fn(),
+    };
+
+    const service = MetaAgentService.getInstance() as any;
+    service.aiService = aiService;
+
+    await service.handleChildSessionEvent('child-err', 'session:error');
+
+    expect(aiService.queuePromptForSession).toHaveBeenCalledWith(
+      'parent-1',
+      expect.stringContaining('[Child Session Update]')
+    );
+    expect(aiService.interruptCurrentTurnForSession).not.toHaveBeenCalled();
+    expect(aiService.triggerQueuedPromptProcessingForSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -290,6 +290,60 @@ export class AIService {
     return this.processQueuedPrompt(sessionId, workspacePath, targetWindow);
   }
 
+  public async interruptCurrentTurnForSession(
+    sessionId: string
+  ): Promise<{ success: boolean; method?: 'interrupt' | 'abort' | 'terminal-ctrl-c'; error?: string; completed?: number; failed?: number; rolledBack?: number }> {
+    if (!sessionId) {
+      throw new Error('Session ID is required to interrupt');
+    }
+
+    const { AISessionsRepository } = await import('@nimbalyst/runtime/storage/repositories/AISessionsRepository');
+    const session = await AISessionsRepository.get(sessionId);
+    if (!session) {
+      return { success: false, error: 'Session not found' };
+    }
+
+    if (session.provider === 'claude-code-cli') {
+      const terminalManager = getTerminalSessionManager();
+      if (!terminalManager.isTerminalActive(sessionId)) {
+        return { success: false, error: 'No active terminal for session' };
+      }
+
+      terminalManager.writeToTerminal(sessionId, '\x03');
+      logger.main.info(`[AIService] Interrupted claude-code-cli terminal for session ${sessionId}`);
+      return { success: true, method: 'terminal-ctrl-c' };
+    }
+
+    const provider = ProviderFactory.getProvider(session.provider as AIProviderType, sessionId);
+    if (!provider) {
+      return { success: false, error: 'No active provider for session' };
+    }
+
+    this.sessionsProcessingQueue.delete(sessionId);
+    let completed = 0;
+    let failed = 0;
+    let rolledBack = 0;
+    try {
+      const { getQueuedPromptsStore } = await import('../RepositoryManager');
+      const queueStore = getQueuedPromptsStore();
+      const sweepResult = await queueStore.sweepExecutingForSession(sessionId);
+      completed = sweepResult.completed;
+      failed = sweepResult.failed;
+      rolledBack = sweepResult.rolledBack;
+      if (completed > 0 || failed > 0 || rolledBack > 0) {
+        logger.main.info(
+          `[AIService] interruptCurrentTurn: swept session ${sessionId} -- ${completed} answered marked completed, ${failed} delivered-but-unanswered marked failed, ${rolledBack} undelivered rolled back`
+        );
+      }
+    } catch (sweepErr) {
+      logger.main.error('[AIService] interruptCurrentTurn: sweepExecutingForSession failed:', sweepErr);
+    }
+
+    const result = await provider.interruptCurrentTurn();
+    logger.main.info(`[AIService] Interrupted current turn for session ${sessionId} (method=${result.method})`);
+    return { success: true, method: result.method, completed, failed, rolledBack };
+  }
+
   public async respondToInteractivePrompt(params: {
     sessionId: string;
     promptId: string;
@@ -2875,49 +2929,7 @@ export class AIService {
     // follow-up ai:triggerQueueProcessing doesn't re-send the same input
     // -- NIM-615).
     safeHandle('ai:interruptCurrentTurn', async (_event, sessionId: string) => {
-      if (!sessionId) {
-        throw new Error('Session ID is required to interrupt');
-      }
-
-      const { AISessionsRepository } = await import('@nimbalyst/runtime/storage/repositories/AISessionsRepository');
-      const session = await AISessionsRepository.get(sessionId);
-      if (!session) {
-        return { success: false, error: 'Session not found' };
-      }
-
-      if (session.provider === 'claude-code-cli') {
-        const terminalManager = getTerminalSessionManager();
-        if (!terminalManager.isTerminalActive(sessionId)) {
-          return { success: false, error: 'No active terminal for session' };
-        }
-
-        terminalManager.writeToTerminal(sessionId, '\x03');
-        logger.main.info(`[AIService] Interrupted claude-code-cli terminal for session ${sessionId}`);
-        return { success: true, method: 'terminal-ctrl-c' };
-      }
-
-      const provider = ProviderFactory.getProvider(session.provider as AIProviderType, sessionId);
-      if (!provider) {
-        return { success: false, error: 'No active provider for session' };
-      }
-
-      this.sessionsProcessingQueue.delete(sessionId);
-      try {
-        const { getQueuedPromptsStore } = await import('../RepositoryManager');
-        const queueStore = getQueuedPromptsStore();
-        const { completed, failed, rolledBack } = await queueStore.sweepExecutingForSession(sessionId);
-        if (completed > 0 || failed > 0 || rolledBack > 0) {
-          logger.main.info(
-            `[AIService] interruptCurrentTurn: swept session ${sessionId} -- ${completed} answered marked completed, ${failed} delivered-but-unanswered marked failed, ${rolledBack} undelivered rolled back`
-          );
-        }
-      } catch (sweepErr) {
-        logger.main.error('[AIService] interruptCurrentTurn: sweepExecutingForSession failed:', sweepErr);
-      }
-
-      const result = await provider.interruptCurrentTurn();
-      logger.main.info(`[AIService] Interrupted current turn for session ${sessionId} (method=${result.method})`);
-      return { success: true, method: result.method };
+      return await this.interruptCurrentTurnForSession(sessionId);
     });
 
     // Settings handlers

--- a/packages/runtime/src/ai/server/providers/BaseAgentProvider.ts
+++ b/packages/runtime/src/ai/server/providers/BaseAgentProvider.ts
@@ -41,6 +41,7 @@ export abstract class BaseAgentProvider extends BaseAIProvider {
     'mcp__nimbalyst-host__get_session_result',
     'mcp__nimbalyst-host__list_queued_prompts',
     'mcp__nimbalyst-host__send_prompt',
+    'mcp__nimbalyst-host__send_prompt_now',
     'mcp__nimbalyst-host__respond_to_prompt',
     'mcp__nimbalyst-host__get_session_summary',
     'mcp__nimbalyst-host__get_workstream_overview',

--- a/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
@@ -1236,6 +1236,7 @@ describe('OpenAICodexProvider', () => {
         // update_session_meta onto the eager core `nimbalyst`.
         'mcp__nimbalyst-host__create_session',
         'mcp__nimbalyst-host__get_session_result',
+        'mcp__nimbalyst-host__send_prompt_now',
         'mcp__nimbalyst__update_session_meta',
         'mcp__nimbalyst-host__get_workstream_overview',
         'TaskCreate',

--- a/packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts
+++ b/packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts
@@ -64,6 +64,7 @@ describe('Topology descriptor', () => {
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('settings_get_overview')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('spawn_session')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('list_queued_prompts')).toBe(MCP_HOST);
+    expect(FIRST_PARTY_TOOL_TO_SERVER.get('send_prompt_now')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('tracker_create')).toBe(MCP_TRACKERS);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('voice_agent_speak')).toBe(MCP_SITUATIONAL);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('renderer_eval')).toBe(MCP_EXTENSION_DEV);

--- a/packages/runtime/src/ai/server/services/mcpTopology.ts
+++ b/packages/runtime/src/ai/server/services/mcpTopology.ts
@@ -158,6 +158,7 @@ export const HOST_TOOLS: readonly string[] = [
   'spawn_session',
   'send_prompt',
   'list_queued_prompts',
+  'send_prompt_now',
   'respond_to_prompt',
   'get_session_status',
   'get_session_result',


### PR DESCRIPTION
## Summary

Agents supervising child sessions over MCP had no equivalent of the UI's
"interrupt and send now" lightning action. `send_prompt` could queue a
follow-up, but when the target session was actively running the prompt just
sat in the queue until the user manually intervened. Automatic
`[Child Session Update]` notifications had the same problem: a busy parent
would not see a child's completion/waiting/interrupted update until it
happened to go idle on its own.

## Solution

- Optional `interruptCurrentTurn` / `force` / `interruptWaitingForInput`
  fields on `send_prompt`, plus a new `send_prompt_now` tool that always
  requests the interrupt-and-deliver-now behavior.
- A public `AIService.interruptCurrentTurnForSession` method, extracted from
  the existing `ai:interruptCurrentTurn` IPC handler so MCP and the renderer
  share one implementation instead of duplicating the terminal/provider
  interrupt + queue-sweep logic.
- Structured JSON results (`statusBeforeQueue`/`After`, `interruptAttempted`,
  `interruptResult`, `processingTriggered`, `processingTriggerAccepted`) so
  callers can see whether delivery actually happened instead of assuming a
  queue write means success.
- Routing of child completion/waiting/interrupted notifications through the
  same force-delivery path, so a busy parent is interrupted and re-driven
  immediately. Child `session:error` notifications intentionally stay
  queue-only, to avoid re-driving the parent's queue on every error settle
  with no backoff.

## Scope note

This is deliberately scoped independently from the read-only
`list_queued_prompts` tool proposed in #792. That PR is complementary and can
merge on its own; this one does not touch queue inspection.

## Testing

- `npx vitest run packages/electron/src/main/services/__tests__/MetaAgentService.forceNotificationDelivery.test.ts` (new, 2/2 passing)
- `npx vitest run packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts` (20/20 passing)
- `npx vitest run packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts` (30 passing, 1 skipped, no regressions)
- `npm run typecheck --prefix packages/electron` (clean)
- `npm run typecheck --prefix packages/runtime` (clean)

## Why this is worth merging

Queue-only delivery is insufficient when an authorized controller must steer a session that is already running or waiting. `send_prompt_now` makes that intent explicit, interrupts only through the guarded session path, and returns delivery state so callers can distinguish accepted processing from a message merely parked in FIFO.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
