### PR TITLE
Fix mobile interactive prompt response delivery

### DIFF
--- a/packages/electron/src/main/mcp/__tests__/codexToolCallResolver.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/codexToolCallResolver.test.ts
@@ -5,6 +5,7 @@ import {
   extractCodexTurnMetadataFromRequest,
   extractToolUseIdFromMcpRequest,
   findCodexAppServerToolCallId,
+  resolveAskUserQuestionPromptTargets,
   resolveRequestUserInputPromptTargets,
   resolveToolUseIdFromMcpRequest,
 } from "../tools/codexToolCallResolver";
@@ -93,6 +94,21 @@ describe("codexToolCallResolver", () => {
       promptId: "nimtc|call_test|1779232811883|72",
       rawPromptId: "call_test",
       waiterPromptIds: ["nimtc|call_test|1779232811883|72", "call_test"],
+    });
+  });
+
+  it("expands synthetic AskUserQuestion ids into waiter aliases", () => {
+    expect(resolveAskUserQuestionPromptTargets("nimtc|call_question|1779232811883|73")).toEqual({
+      questionId: "nimtc|call_question|1779232811883|73",
+      rawQuestionId: "call_question",
+      waiterQuestionIds: ["nimtc|call_question|1779232811883|73", "call_question"],
+    });
+  });
+
+  it("keeps raw AskUserQuestion ids unchanged", () => {
+    expect(resolveAskUserQuestionPromptTargets("call_question")).toEqual({
+      questionId: "call_question",
+      waiterQuestionIds: ["call_question"],
     });
   });
 });

--- a/packages/electron/src/main/mcp/tools/codexToolCallResolver.ts
+++ b/packages/electron/src/main/mcp/tools/codexToolCallResolver.ts
@@ -13,6 +13,12 @@ export interface RequestUserInputPromptTargets {
   waiterPromptIds: string[];
 }
 
+export interface AskUserQuestionPromptTargets {
+  questionId: string;
+  rawQuestionId?: string;
+  waiterQuestionIds: string[];
+}
+
 export function extractCodexTurnMetadataFromRequest(request: unknown): CodexTurnMetadata | null {
   if (!request || typeof request !== "object") return null;
 
@@ -153,5 +159,18 @@ export function resolveRequestUserInputPromptTargets(
     promptId,
     ...(rawPromptId ? { rawPromptId } : {}),
     waiterPromptIds,
+  };
+}
+
+export function resolveAskUserQuestionPromptTargets(
+  questionId: string,
+): AskUserQuestionPromptTargets {
+  const waiterQuestionIds = getCodexToolLookupAliases(questionId);
+  const rawQuestionId = waiterQuestionIds.find((id) => id !== questionId);
+
+  return {
+    questionId,
+    ...(rawQuestionId ? { rawQuestionId } : {}),
+    waiterQuestionIds,
   };
 }

--- a/packages/electron/src/main/services/ai/MobileSessionControlHandler.ts
+++ b/packages/electron/src/main/services/ai/MobileSessionControlHandler.ts
@@ -7,12 +7,15 @@
  */
 
 import type { SyncProvider, SessionControlMessage } from '@nimbalyst/runtime/sync';
-import { ProviderFactory } from '@nimbalyst/runtime/ai/server';
-import type { BrowserWindow } from 'electron';
+import { ProviderFactory, isAskUserQuestionProvider } from '@nimbalyst/runtime/ai/server';
+import { AgentMessagesRepository, AISessionsRepository, type PermissionScope } from '@nimbalyst/runtime';
+import { ipcMain, type BrowserWindow } from 'electron';
 import { logger } from '../../utils/logger';
-import type { PermissionScope } from '@nimbalyst/runtime';
 import { TrayManager } from '../../tray/TrayManager';
-import { resolveRequestUserInputPromptTargets } from '../../mcp/tools/codexToolCallResolver';
+import {
+  resolveAskUserQuestionPromptTargets,
+  resolveRequestUserInputPromptTargets,
+} from '../../mcp/tools/codexToolCallResolver';
 import {
   getGitCommitProposalResponseChannel,
   resolveGitCommitProposalPromptId,
@@ -152,7 +155,7 @@ function handleControlMessage(
     // Legacy handler - kept for backwards compatibility with older mobile versions
     case 'question_response': {
       const payload = message.payload as unknown as QuestionResponsePayload;
-      handleAskUserQuestionResponse(
+      void handleAskUserQuestionResponse(
         message.sessionId,
         payload.questionId,
         payload.answers,
@@ -242,7 +245,7 @@ function handlePromptResponse(
   switch (payload.promptType) {
     case 'ask_user_question': {
       const response = payload.response as AskUserQuestionResponse;
-      handleAskUserQuestionResponse(
+      void handleAskUserQuestionResponse(
         sessionId,
         payload.promptId,
         response.answers,
@@ -458,91 +461,113 @@ async function handleArchive(sessionId: string, isArchived: boolean): Promise<vo
 /**
  * Handle AskUserQuestion response from mobile
  */
-function handleAskUserQuestionResponse(
+async function handleAskUserQuestionResponse(
   sessionId: string,
   questionId: string,
   answers: Record<string, string>,
   cancelled: boolean,
   _findWindowByWorkspace: (workspacePath: string) => BrowserWindow | null | undefined
-): void {
+): Promise<void> {
   log.info(`[Mobile] AskUserQuestion response: questionId=${questionId}, sessionId=${sessionId}, cancelled=${cancelled}`);
 
   let providerResolved = false;
-  const provider = ProviderFactory.getProvider('claude-code', sessionId);
+  const { waiterQuestionIds, rawQuestionId } = resolveAskUserQuestionPromptTargets(questionId);
+  let provider: ReturnType<typeof ProviderFactory.getProvider> | null = null;
+  let providerType: Parameters<typeof ProviderFactory.getProvider>[0] = 'claude-code';
 
-  if (provider) {
-    if (cancelled) {
-      if ('rejectAskUserQuestion' in provider) {
-        (provider as { rejectAskUserQuestion: (questionId: string, error: Error) => void })
-          .rejectAskUserQuestion(questionId, new Error('Question cancelled from mobile'));
-        providerResolved = true;
-      }
-    } else {
-      if ('resolveAskUserQuestion' in provider) {
-        providerResolved = (provider as { resolveAskUserQuestion: (questionId: string, answers: Record<string, string>, sessionId: string, source: string) => boolean })
-          .resolveAskUserQuestion(questionId, answers, sessionId, 'mobile');
-      }
+  try {
+    const session = await AISessionsRepository.get(sessionId);
+    providerType = (session?.provider as Parameters<typeof ProviderFactory.getProvider>[0]) || providerType;
+    provider = ProviderFactory.getProvider(providerType, sessionId);
+    if (!provider) {
+      log.warn(`[Mobile] No provider found for session: ${sessionId} provider=${providerType}`);
     }
-  } else {
-    log.warn('[Mobile] No provider found for session:', sessionId);
+  } catch (error) {
+    log.warn(`[Mobile] Failed to resolve session provider for AskUserQuestion response: ${error}`);
+    provider = ProviderFactory.getProvider('claude-code', sessionId);
   }
 
-  // When AskUserQuestion comes through MCP, the provider's pendingAskUserQuestions map
-  // is empty, so resolveAskUserQuestion returns false. Fall back to IPC emission +
-  // database write so the MCP server's IPC listeners or database polling can resolve it.
-  if (!providerResolved) {
-    const { ipcMain } = require('electron');
+  if (provider && isAskUserQuestionProvider(provider)) {
+    if (cancelled) {
+      if ('rejectAskUserQuestion' in provider) {
+        for (const waiterQuestionId of waiterQuestionIds) {
+          provider.rejectAskUserQuestion(
+            waiterQuestionId,
+            new Error('Question cancelled from mobile'),
+            'mobile',
+          );
+        }
+      }
+    } else {
+      for (const waiterQuestionId of waiterQuestionIds) {
+        providerResolved = provider.resolveAskUserQuestion(waiterQuestionId, answers, sessionId, 'mobile');
+        if (providerResolved) break;
+      }
+    }
+  }
 
-    // Try MCP-specific IPC channel
-    const mcpChannel = `ask-user-question-response:${sessionId}:${questionId}`;
-    const hasMcpWaiter = ipcMain.listenerCount(mcpChannel) > 0;
-    if (hasMcpWaiter) {
+  // Provider state and MCP delivery are independent. A provider can consume
+  // the response while the MCP-backed tool call is still waiting on IPC.
+  let hasMcpWaiter = false;
+  let notifiedWaiter = false;
+  for (const waiterQuestionId of waiterQuestionIds) {
+    const mcpChannel = `ask-user-question-response:${sessionId}:${waiterQuestionId}`;
+    if (ipcMain.listenerCount(mcpChannel) > 0) {
+      hasMcpWaiter = true;
+      notifiedWaiter = true;
       log.info(`[Mobile] Emitting on MCP channel: ${mcpChannel}`);
       ipcMain.emit(mcpChannel, {}, {
         questionId,
+        ...(rawQuestionId ? { rawQuestionId } : {}),
         answers: cancelled ? {} : answers,
         cancelled,
         respondedBy: 'mobile',
         sessionId,
       });
     }
-
-    // Try session fallback IPC channel
-    const fallbackChannel = `ask-user-question:${sessionId}`;
-    const hasFallbackWaiter = ipcMain.listenerCount(fallbackChannel) > 0;
-    if (hasFallbackWaiter) {
-      log.info(`[Mobile] Emitting on session fallback channel: ${fallbackChannel}`);
-      ipcMain.emit(fallbackChannel, {}, {
-        questionId,
-        answers: cancelled ? {} : answers,
-        cancelled,
-        respondedBy: 'mobile',
-        sessionId,
-      });
-    }
-
-    // Database fallback: write response so MCP server's database polling can find it
-    import('@nimbalyst/runtime/storage/repositories/AgentMessagesRepository').then(({ AgentMessagesRepository }) => {
-      AgentMessagesRepository.create({
-        sessionId,
-        source: 'claude-code',
-        direction: 'output' as const,
-        createdAt: new Date(),
-        content: JSON.stringify({
-          type: 'ask_user_question_response',
-          questionId,
-          answers: cancelled ? {} : answers,
-          cancelled,
-          respondedBy: 'mobile',
-          respondedAt: Date.now()
-        })
-      }).catch(err => {
-        log.warn(`[Mobile] Failed to persist AskUserQuestion response to database: ${err}`);
-      });
-    });
-
-    log.info(`[Mobile] AskUserQuestion fallback resolution: hasMcpWaiter=${hasMcpWaiter}, hasFallbackWaiter=${hasFallbackWaiter}`);
   }
+
+  const fallbackChannel = `ask-user-question:${sessionId}`;
+  const hasFallbackWaiter = !notifiedWaiter && ipcMain.listenerCount(fallbackChannel) > 0;
+  if (hasFallbackWaiter) {
+    notifiedWaiter = true;
+    log.info(`[Mobile] Emitting on session fallback channel: ${fallbackChannel}`);
+    ipcMain.emit(fallbackChannel, {}, {
+      questionId,
+      ...(rawQuestionId ? { rawQuestionId } : {}),
+      answers: cancelled ? {} : answers,
+      cancelled,
+      respondedBy: 'mobile',
+      sessionId,
+    });
+  }
+
+  // Persist independently of provider/IPC delivery. If the response races
+  // waiter registration, database polling remains able to recover it.
+  try {
+    await AgentMessagesRepository.create({
+      sessionId,
+      source: providerType,
+      direction: 'output',
+      createdAt: new Date(),
+      content: JSON.stringify({
+        type: 'ask_user_question_response',
+        questionId,
+        ...(rawQuestionId ? { rawQuestionId } : {}),
+        answers: cancelled ? {} : answers,
+        cancelled,
+        respondedBy: 'mobile',
+        respondedAt: Date.now()
+      })
+    });
+  } catch (err) {
+    log.warn(`[Mobile] Failed to persist AskUserQuestion response to database: ${err}`);
+  }
+
+  log.info(
+    `[Mobile] AskUserQuestion resolution: providerResolved=${providerResolved}, ` +
+    `hasMcpWaiter=${hasMcpWaiter}, hasFallbackWaiter=${hasFallbackWaiter}, notifiedWaiter=${notifiedWaiter}`
+  );
 
   // Notify renderer to clear the pending question UI
   notifyAllWindows('ai:askUserQuestionAnswered', {
@@ -552,6 +577,7 @@ function handleAskUserQuestionResponse(
     answeredBy: 'mobile',
     cancelled,
   });
+  TrayManager.getInstance().onPromptResolved(sessionId);
 }
 
 /**

--- a/packages/electron/src/main/services/ai/__tests__/MobileSessionControlHandler.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/MobileSessionControlHandler.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const provider = {
+    resolveAskUserQuestion: vi.fn(() => true),
+    rejectAskUserQuestion: vi.fn(),
+  };
+
+  return {
+    provider,
+    getProvider: vi.fn(),
+    getSession: vi.fn(),
+    createMessage: vi.fn(),
+    ipcListenerCount: vi.fn((_channel: string) => 0),
+    ipcEmit: vi.fn(),
+    onPromptResolved: vi.fn(),
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    listenerCount: mocks.ipcListenerCount,
+    emit: mocks.ipcEmit,
+  },
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  ProviderFactory: {
+    getProvider: mocks.getProvider,
+  },
+  isAskUserQuestionProvider: (candidate: unknown) =>
+    !!candidate &&
+    typeof (candidate as { resolveAskUserQuestion?: unknown }).resolveAskUserQuestion === 'function',
+}));
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    get: mocks.getSession,
+  },
+  AgentMessagesRepository: {
+    create: mocks.createMessage,
+  },
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  logger: {
+    ai: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../../tray/TrayManager', () => ({
+  TrayManager: {
+    getInstance: () => ({
+      onPromptResolved: mocks.onPromptResolved,
+    }),
+  },
+}));
+
+vi.mock('../../gitEnv', () => ({
+  getGitSubprocessEnv: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../window/WindowManager', () => ({
+  findWindowByWorkspace: vi.fn(),
+}));
+
+import { resolveVoicePromptResponse } from '../MobileSessionControlHandler';
+
+describe('MobileSessionControlHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.provider.resolveAskUserQuestion.mockReturnValue(true);
+    mocks.ipcListenerCount.mockReturnValue(0);
+    mocks.getSession.mockResolvedValue({ provider: 'openai-codex' });
+    mocks.createMessage.mockResolvedValue(undefined);
+    mocks.getProvider.mockImplementation((providerType: string, sessionId: string) =>
+      providerType === 'openai-codex' && sessionId === 'session-1' ? mocks.provider : null,
+    );
+  });
+
+  it('uses the session provider and always persists the mobile response', async () => {
+    resolveVoicePromptResponse('session-1', {
+      promptType: 'ask_user_question',
+      promptId: 'call_question_123',
+      response: {
+        answers: { Scope: 'Everything' },
+        cancelled: false,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.createMessage).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mocks.getProvider).toHaveBeenCalledWith('openai-codex', 'session-1');
+    expect(mocks.provider.resolveAskUserQuestion).toHaveBeenCalledWith(
+      'call_question_123',
+      { Scope: 'Everything' },
+      'session-1',
+      'mobile',
+    );
+    expect(mocks.createMessage).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      source: 'openai-codex',
+      direction: 'output',
+      content: expect.any(String),
+    }));
+    expect(JSON.parse(mocks.createMessage.mock.calls[0][0].content)).toMatchObject({
+      type: 'ask_user_question_response',
+      questionId: 'call_question_123',
+      answers: { Scope: 'Everything' },
+      cancelled: false,
+      respondedBy: 'mobile',
+    });
+    expect(mocks.onPromptResolved).toHaveBeenCalledWith('session-1');
+  });
+
+  it('wakes the MCP waiter even when the provider consumes the response', async () => {
+    mocks.ipcListenerCount.mockImplementation((channel: string) =>
+      channel === 'ask-user-question-response:session-1:call_question_123' ? 1 : 0,
+    );
+
+    resolveVoicePromptResponse('session-1', {
+      promptType: 'ask_user_question',
+      promptId: 'call_question_123',
+      response: {
+        answers: { Scope: 'Everything' },
+        cancelled: false,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.ipcEmit).toHaveBeenCalledWith(
+        'ask-user-question-response:session-1:call_question_123',
+        {},
+        expect.objectContaining({
+          answers: { Scope: 'Everything' },
+          respondedBy: 'mobile',
+          sessionId: 'session-1',
+        }),
+      );
+    });
+    expect(mocks.createMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists the response when no in-process provider is available', async () => {
+    mocks.getProvider.mockReturnValue(null);
+
+    resolveVoicePromptResponse('session-1', {
+      promptType: 'ask_user_question',
+      promptId: 'call_question_123',
+      response: {
+        answers: { Scope: 'Everything' },
+        cancelled: false,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.createMessage).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mocks.provider.resolveAskUserQuestion).not.toHaveBeenCalled();
+    expect(JSON.parse(mocks.createMessage.mock.calls[0][0].content)).toMatchObject({
+      questionId: 'call_question_123',
+      answers: { Scope: 'Everything' },
+      respondedBy: 'mobile',
+    });
+  });
+
+  it('preserves mobile attribution when cancelling a provider question', async () => {
+    resolveVoicePromptResponse('session-1', {
+      promptType: 'ask_user_question',
+      promptId: 'call_question_123',
+      response: {
+        answers: { ignored: 'value' },
+        cancelled: true,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.createMessage).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mocks.provider.rejectAskUserQuestion).toHaveBeenCalledWith(
+      'call_question_123',
+      expect.any(Error),
+      'mobile',
+    );
+    expect(JSON.parse(mocks.createMessage.mock.calls[0][0].content)).toMatchObject({
+      type: 'ask_user_question_response',
+      answers: {},
+      cancelled: true,
+      respondedBy: 'mobile',
+    });
+  });
+});

--- a/packages/runtime/src/ai/server/AIProvider.ts
+++ b/packages/runtime/src/ai/server/AIProvider.ts
@@ -39,7 +39,11 @@ export interface AskUserQuestionProvider {
   /**
    * Reject a pending AskUserQuestion request (e.g., on cancel/abort)
    */
-  rejectAskUserQuestion(questionId: string, error: Error): void;
+  rejectAskUserQuestion(
+    questionId: string,
+    error: Error,
+    respondedBy?: 'desktop' | 'mobile'
+  ): void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- route mobile AskUserQuestion responses through the session's actual provider
- notify provider and MCP waiters independently so one consumer cannot starve the other
- persist every response as a durable polling fallback, including cancellation and Codex raw/synthetic ID aliases
- clear tray prompt state after mobile resolution

This is a focused extraction from #603; it does not include transcript-tail protocol changes or agent-status work.

## Verification
- `vitest run packages/electron/src/main/mcp/__tests__/codexToolCallResolver.test.ts packages/electron/src/main/services/ai/__tests__/MobileSessionControlHandler.test.ts` (11 tests)
- `tsc --noEmit -p packages/runtime/tsconfig.json`
- `tsc --noEmit -p packages/electron/tsconfig.json`
- ESLint on changed Electron files (with the file's pre-existing `no-require-imports` violation excluded)