### PR TITLE
Ignore stale interactive prompt responses

### DIFF
--- a/packages/electron/src/main/mcp/__tests__/interactiveResponsePolling.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/interactiveResponsePolling.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { findFreshInteractiveResponse } from "../tools/interactiveResponsePolling";
+
+describe("interactive response polling", () => {
+  it("ignores a historical AskUserQuestion answer with a reused id", () => {
+    const response = findFreshInteractiveResponse([
+      {
+        createdAt: new Date(1_000),
+        content: JSON.stringify({
+          type: "ask_user_question_response",
+          questionId: "call_reused",
+          answers: { choice: "old" },
+        }),
+      },
+      {
+        createdAt: new Date(3_000),
+        content: JSON.stringify({
+          type: "ask_user_question_response",
+          questionId: "call_other",
+          answers: { choice: "unrelated" },
+        }),
+      },
+    ], {
+      expectedType: "ask_user_question_response",
+      idFields: ["questionId", "rawQuestionId"],
+      acceptedIds: new Set(["call_reused"]),
+      notBefore: 2_000,
+    });
+
+    expect(response).toBeNull();
+  });
+
+  it("returns the newest fresh RequestUserInput response through an id alias", () => {
+    const response = findFreshInteractiveResponse([
+      {
+        createdAt: "1970-01-01T00:00:02.500Z",
+        content: JSON.stringify({
+          type: "request_user_input_response",
+          rawPromptId: "call_prompt",
+          answers: { choice: "first" },
+        }),
+      },
+      {
+        createdAt: new Date(3_000),
+        content: JSON.stringify({
+          type: "request_user_input_response",
+          promptId: "nimtc|call_prompt|2000|1",
+          answers: { choice: "latest" },
+        }),
+      },
+    ], {
+      expectedType: "request_user_input_response",
+      idFields: ["promptId", "rawPromptId"],
+      acceptedIds: new Set(["call_prompt", "nimtc|call_prompt|2000|1"]),
+      notBefore: 2_000,
+    });
+
+    expect(response?.answers).toEqual({ choice: "latest" });
+  });
+
+  it("ignores rows without a trustworthy creation time", () => {
+    const response = findFreshInteractiveResponse([
+      {
+        content: JSON.stringify({
+          type: "ask_user_question_response",
+          questionId: "call_question",
+        }),
+      },
+    ], {
+      expectedType: "ask_user_question_response",
+      idFields: ["questionId"],
+      acceptedIds: new Set(["call_question"]),
+      notBefore: 1,
+    });
+
+    expect(response).toBeNull();
+  });
+});

--- a/packages/electron/src/main/mcp/tools/interactiveResponsePolling.ts
+++ b/packages/electron/src/main/mcp/tools/interactiveResponsePolling.ts
@@ -1,0 +1,37 @@
+type InteractiveResponseMessage = {
+  content: string;
+  createdAt?: Date | string;
+};
+
+export function findFreshInteractiveResponse(
+  messages: InteractiveResponseMessage[],
+  options: {
+    expectedType: string;
+    idFields: readonly string[];
+    acceptedIds: ReadonlySet<string>;
+    notBefore: number;
+  },
+): Record<string, unknown> | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    const createdAt = message.createdAt instanceof Date
+      ? message.createdAt.getTime()
+      : typeof message.createdAt === "string"
+        ? Date.parse(message.createdAt)
+        : Number.NaN;
+    if (!Number.isFinite(createdAt) || createdAt < options.notBefore) continue;
+
+    try {
+      const content = JSON.parse(message.content) as Record<string, unknown>;
+      if (content.type !== options.expectedType) continue;
+      const matches = options.idFields.some((field) => {
+        const value = content[field];
+        return typeof value === "string" && options.acceptedIds.has(value);
+      });
+      if (matches) return content;
+    } catch {
+      // Non-JSON transcript rows are unrelated to interactive responses.
+    }
+  }
+  return null;
+}

--- a/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
@@ -33,6 +33,7 @@ import {
 import { broadcastMessageLogged } from "../../services/ai/claudeCliUserPromptLog";
 import { ClaudeSettingsManager } from "../../services/ClaudeSettingsManager";
 import { getPermissionService } from "../../services/PermissionService";
+import { findFreshInteractiveResponse } from "./interactiveResponsePolling";
 
 export function getInteractiveToolSchemas(sessionId: string | undefined) {
   if (!sessionId) return [];
@@ -245,6 +246,8 @@ export async function handleAskUserQuestion(
   const questionId =
     await resolveToolUseIdFromMcpRequest(request, sessionId, "AskUserQuestion") ||
     `ask-${sessionId || "unknown"}-${Date.now()}`;
+  const questionIdAliasSet = new Set([questionId]);
+  const responseNotBefore = Date.now();
   const questionResponseChannel = `ask-user-question-response:${sessionId || "unknown"}:${questionId}`;
   const fallbackSessionChannel = `ask-user-question:${sessionId || "unknown"}`;
 
@@ -440,21 +443,21 @@ export async function handleAskUserQuestion(
         }
 
         try {
-          const messages = await AgentMessagesRepository.list(sessionId, { limit: 20 });
-          for (const msg of messages) {
-            try {
-              const content = JSON.parse(msg.content);
-              if (content.type === 'ask_user_question_response' && content.questionId === questionId) {
-                if (content.cancelled) {
-                  settle({ cancelled: true, respondedBy: content.respondedBy }, 'db-poll');
-                } else {
-                  settle({ answers: content.answers, respondedBy: content.respondedBy }, 'db-poll');
-                }
-                return;
-              }
-            } catch {
-              // Not valid JSON, skip
-            }
+          const messages = await AgentMessagesRepository.listTail(sessionId, 50);
+          const content = findFreshInteractiveResponse(messages, {
+            expectedType: "ask_user_question_response",
+            idFields: ["questionId", "rawQuestionId"],
+            acceptedIds: questionIdAliasSet,
+            notBefore: responseNotBefore,
+          });
+          if (!content) return;
+          if (content.cancelled) {
+            settle({ cancelled: true, respondedBy: content.respondedBy as "desktop" | "mobile" | undefined }, 'db-poll');
+          } else {
+            settle({
+              answers: content.answers as Record<string, string> | undefined,
+              respondedBy: content.respondedBy as "desktop" | "mobile" | undefined,
+            }, 'db-poll');
           }
         } catch {
           // Database error, continue polling
@@ -1388,6 +1391,7 @@ export async function handleRequestUserInput(
     `rui-${sessionId || "unknown"}-${Date.now()}`;
   const { waiterPromptIds: promptIdAliases } = resolveRequestUserInputPromptTargets(promptId);
   const promptIdAliasSet = new Set(promptIdAliases);
+  const responseNotBefore = Date.now();
   const responseChannel = getRequestUserInputResponseChannel(sessionId || "unknown", promptId);
   const fallbackResponseChannel = getRequestUserInputFallbackResponseChannel(sessionId || "unknown");
 
@@ -1633,29 +1637,21 @@ export async function handleRequestUserInput(
         }
 
         try {
-          const messages = await AgentMessagesRepository.list(sessionId, { limit: 20 });
-          for (const msg of messages) {
-            try {
-              const content = JSON.parse(msg.content);
-              const responsePromptIds = [
-                typeof content.promptId === "string" ? content.promptId : null,
-                typeof content.rawPromptId === "string" ? content.rawPromptId : null,
-              ].filter((value): value is string => typeof value === "string" && value.length > 0);
-
-              if (
-                content.type === "request_user_input_response"
-                && responsePromptIds.some((id) => promptIdAliasSet.has(id))
-              ) {
-                if (content.cancelled) {
-                  settle({ cancelled: true, respondedBy: content.respondedBy }, "db-poll");
-                } else {
-                  settle({ answers: content.answers, respondedBy: content.respondedBy }, "db-poll");
-                }
-                return;
-              }
-            } catch {
-              // Not valid JSON, skip.
-            }
+          const messages = await AgentMessagesRepository.listTail(sessionId, 50);
+          const content = findFreshInteractiveResponse(messages, {
+            expectedType: "request_user_input_response",
+            idFields: ["promptId", "rawPromptId"],
+            acceptedIds: promptIdAliasSet,
+            notBefore: responseNotBefore,
+          });
+          if (!content) return;
+          if (content.cancelled) {
+            settle({ cancelled: true, respondedBy: content.respondedBy as "desktop" | "mobile" | undefined }, "db-poll");
+          } else {
+            settle({
+              answers: content.answers as Record<string, unknown> | undefined,
+              respondedBy: content.respondedBy as "desktop" | "mobile" | undefined,
+            }, "db-poll");
           }
         } catch {
           // Database error, keep polling.

--- a/packages/electron/src/main/services/PGLiteAgentMessagesStore.ts
+++ b/packages/electron/src/main/services/PGLiteAgentMessagesStore.ts
@@ -200,5 +200,47 @@ export function createPGLiteAgentMessagesStore(db: PGliteLike, ensureDbReady?: E
         };
       });
     },
+
+    async listTail(sessionId: string, limit: number, options?: { includeHidden?: boolean }): Promise<AgentMessage[]> {
+      await ensureReady();
+
+      const boundedLimit = Math.max(1, Math.min(limit, 50000));
+      const includeHidden = options?.includeHidden ?? false;
+      const { rows } = await db.query<any>(
+        `SELECT id, session_id, created_at, source, direction, content, metadata, hidden, provider_message_id
+         FROM (
+           SELECT id, session_id, created_at, source, direction, content, metadata, hidden, provider_message_id
+           FROM ai_agent_messages
+           WHERE session_id = $1${includeHidden ? '' : ' AND hidden = FALSE'}
+           ORDER BY id DESC
+           LIMIT $2
+         ) tail
+         ORDER BY id ASC`,
+        [sessionId, boundedLimit],
+      );
+
+      return rows.map(row => {
+        let metadata = row.metadata;
+        if (typeof metadata === 'string') {
+          try {
+            metadata = JSON.parse(metadata);
+          } catch {
+            // Keep as string if parsing fails
+          }
+        }
+
+        return {
+          id: Number(row.id),
+          sessionId: row.session_id,
+          createdAt: row.created_at ? new Date(row.created_at) : undefined,
+          source: row.source,
+          direction: row.direction,
+          content: row.content,
+          metadata: metadata ?? undefined,
+          hidden: row.hidden ?? false,
+          providerMessageId: row.provider_message_id ?? undefined,
+        };
+      });
+    },
   };
 }

--- a/packages/electron/src/main/services/SyncedAgentMessagesStore.ts
+++ b/packages/electron/src/main/services/SyncedAgentMessagesStore.ts
@@ -124,6 +124,16 @@ export function createSyncedAgentMessagesStore(
       return baseStore.list(sessionId, options);
     },
 
+    async listTail(sessionId: string, limit: number, options?: { includeHidden?: boolean }): Promise<AgentMessage[]> {
+      const boundedLimit = Math.max(1, Math.min(limit, 50000));
+      if (baseStore.listTail) {
+        return baseStore.listTail(sessionId, boundedLimit, options);
+      }
+
+      const messages = await baseStore.list(sessionId, { includeHidden: options?.includeHidden });
+      return messages.slice(-boundedLimit);
+    },
+
     async getMessageCounts(sessionIds: string[]): Promise<Map<string, number>> {
       if (baseStore.getMessageCounts) {
         return baseStore.getMessageCounts(sessionIds);

--- a/packages/electron/src/main/services/__tests__/PGLiteAgentMessagesStore.test.ts
+++ b/packages/electron/src/main/services/__tests__/PGLiteAgentMessagesStore.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createPGLiteAgentMessagesStore } from '../PGLiteAgentMessagesStore';
+
+describe('PGLiteAgentMessagesStore.listTail', () => {
+  it('queries the newest rows and returns them in chronological order', async () => {
+    const query = vi.fn(async (_sql: string, _params?: any[]) => ({
+      rows: [
+        {
+          id: 9,
+          session_id: 'session-1',
+          created_at: new Date(9_000),
+          source: 'test',
+          direction: 'output',
+          content: 'message-9',
+          metadata: '{"kind":"answer"}',
+          hidden: false,
+          provider_message_id: null,
+        },
+        {
+          id: 10,
+          session_id: 'session-1',
+          created_at: new Date(10_000),
+          source: 'test',
+          direction: 'output',
+          content: 'message-10',
+          metadata: null,
+          hidden: false,
+          provider_message_id: null,
+        },
+      ],
+    }));
+    const store = createPGLiteAgentMessagesStore({ query: query as any });
+
+    const messages = await store.listTail?.('session-1', 2);
+
+    expect(query).toHaveBeenCalledOnce();
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain('ORDER BY id DESC');
+    expect(sql).toContain(') tail');
+    expect(sql).toContain('ORDER BY id ASC');
+    expect(params).toEqual(['session-1', 2]);
+    expect(messages?.map((message) => message.id)).toEqual([9, 10]);
+    expect(messages?.[0].metadata).toEqual({ kind: 'answer' });
+  });
+});

--- a/packages/runtime/src/storage/repositories/AgentMessagesRepository.ts
+++ b/packages/runtime/src/storage/repositories/AgentMessagesRepository.ts
@@ -9,6 +9,8 @@ export interface AgentMessagesStore {
    */
   createMany?(messages: CreateAgentMessageInput[]): Promise<void>;
   list(sessionId: string, options?: { limit?: number; offset?: number; includeHidden?: boolean }): Promise<AgentMessage[]>;
+  /** Get the newest messages for one session, returned oldest-to-newest. */
+  listTail?(sessionId: string, limit: number, options?: { includeHidden?: boolean }): Promise<AgentMessage[]>;
   /** Get message counts for multiple sessions in a single query */
   getMessageCounts?(sessionIds: string[]): Promise<Map<string, number>>;
 }
@@ -59,6 +61,17 @@ export const AgentMessagesRepository = {
 
   async list(sessionId: string, options?: { limit?: number; offset?: number; includeHidden?: boolean }): Promise<AgentMessage[]> {
     return await requireStore().list(sessionId, options);
+  },
+
+  async listTail(sessionId: string, limit: number, options?: { includeHidden?: boolean }): Promise<AgentMessage[]> {
+    const store = requireStore();
+    const boundedLimit = Math.max(1, Math.min(limit, 50000));
+    if (store.listTail) {
+      return await store.listTail(sessionId, boundedLimit, options);
+    }
+
+    const messages = await store.list(sessionId, { includeHidden: options?.includeHidden });
+    return messages.slice(-boundedLimit);
   },
 
   async getMessageCounts(sessionIds: string[]): Promise<Map<string, number>> {

--- a/packages/runtime/src/storage/repositories/__tests__/AgentMessagesRepository.test.ts
+++ b/packages/runtime/src/storage/repositories/__tests__/AgentMessagesRepository.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentMessagesRepository, type AgentMessagesStore } from '../AgentMessagesRepository';
+
+function message(id: number) {
+  return {
+    id,
+    sessionId: 'session-1',
+    source: 'test',
+    direction: 'output' as const,
+    content: `message-${id}`,
+    createdAt: new Date(id * 1_000),
+  };
+}
+
+describe('AgentMessagesRepository.listTail', () => {
+  afterEach(() => {
+    AgentMessagesRepository.clearStore();
+  });
+
+  it('delegates to a native tail query', async () => {
+    const listTail = vi.fn(async () => [message(3), message(4)]);
+    AgentMessagesRepository.setStore({
+      create: vi.fn(async () => {}),
+      list: vi.fn(async () => []),
+      listTail,
+    });
+
+    await expect(AgentMessagesRepository.listTail('session-1', 2)).resolves.toEqual([
+      message(3),
+      message(4),
+    ]);
+    expect(listTail).toHaveBeenCalledWith('session-1', 2, undefined);
+  });
+
+  it('falls back to slicing the end of an ordered store result', async () => {
+    const list = vi.fn(async () => [message(1), message(2), message(3), message(4)]);
+    AgentMessagesRepository.setStore({
+      create: vi.fn(async () => {}),
+      list,
+    } satisfies AgentMessagesStore);
+
+    await expect(AgentMessagesRepository.listTail('session-1', 2, {
+      includeHidden: true,
+    })).resolves.toEqual([message(3), message(4)]);
+    expect(list).toHaveBeenCalledWith('session-1', { includeHidden: true });
+  });
+});


### PR DESCRIPTION
## Summary
- reject persisted interactive responses created before the current prompt began
- scan newest responses first so reused provider IDs cannot consume historical answers
- add an efficient local `listTail` repository/store capability; no sync-protocol changes
- cover native/fallback tail reads and AskUserQuestion/RequestUserInput freshness filtering

This is independent from #813 and contains no mobile protocol, transcript publishing, or agent-status changes.

## Verification
- focused Vitest suite: 4 files, 9 tests
- `tsc --noEmit -p packages/runtime/tsconfig.json`
- `tsc --noEmit -p packages/electron/tsconfig.json`
- ESLint on all changed Electron files