### PR TITLE
Persist Codex interactive prompt completion

### DIFF
--- a/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
+++ b/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
@@ -1397,10 +1397,20 @@ export class OpenAICodexProvider extends BaseAgentProvider {
       respondedBy,
       timestamp: Date.now(),
     });
+    this.logAskUserQuestionResultBestEffort({
+      sessionId: sessionId ?? pending.sessionId,
+      questionId,
+      answers,
+      respondedBy,
+    });
     return true;
   }
 
-  public rejectAskUserQuestion(questionId: string, _error: Error): void {
+  public rejectAskUserQuestion(
+    questionId: string,
+    _error: Error,
+    respondedBy: 'desktop' | 'mobile' = 'desktop'
+  ): void {
     const pending = this.pendingAskUserQuestions.get(questionId);
     if (!pending) {
       return;
@@ -1413,8 +1423,44 @@ export class OpenAICodexProvider extends BaseAgentProvider {
       questions: pending.questions,
       answers: {},
       cancelled: true,
+      respondedBy,
       timestamp: Date.now(),
     });
+    this.logAskUserQuestionResultBestEffort({
+      sessionId: pending.sessionId,
+      questionId,
+      answers: {},
+      cancelled: true,
+      respondedBy,
+    });
+  }
+
+  private logAskUserQuestionResultBestEffort(args: {
+    sessionId?: string;
+    questionId: string;
+    answers: Record<string, string>;
+    cancelled?: boolean;
+    respondedBy?: 'desktop' | 'mobile';
+  }): void {
+    if (!args.sessionId || args.sessionId === 'unknown') {
+      return;
+    }
+
+    void this.logAgentMessageBestEffort(
+      args.sessionId,
+      'output',
+      JSON.stringify({
+        type: 'nimbalyst_tool_result',
+        tool_use_id: args.questionId,
+        result: JSON.stringify({
+          answers: args.cancelled ? {} : args.answers,
+          cancelled: args.cancelled === true,
+          respondedAt: Date.now(),
+          ...(args.respondedBy ? { respondedBy: args.respondedBy } : {}),
+        }),
+        is_error: args.cancelled === true,
+      })
+    );
   }
 
   private handleAskUserQuestionToolCall(

--- a/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
@@ -39,6 +39,71 @@ describe('OpenAICodexProvider', () => {
     OpenAICodexProvider.setSecurityLogger(() => {});
   });
 
+  describe('AskUserQuestion completion persistence', () => {
+    function providerWithPendingQuestion(questionId: string, sessionId: string) {
+      const provider = new OpenAICodexProvider({ apiKey: 'test-key' });
+      (provider as any).pendingAskUserQuestions.set(questionId, {
+        sessionId,
+        questions: [{ header: 'Scope', question: 'Commit everything?', options: [] }],
+      });
+      return provider;
+    }
+
+    it('persists answered questions with their response source', async () => {
+      const provider = providerWithPendingQuestion('call_answer', 'session-answer');
+      const logSpy = vi.spyOn(provider as any, 'logAgentMessageBestEffort').mockResolvedValue(undefined);
+
+      expect(provider.resolveAskUserQuestion(
+        'call_answer',
+        { Scope: 'Everything' },
+        'session-answer',
+        'mobile',
+      )).toBe(true);
+
+      await vi.waitFor(() => expect(logSpy).toHaveBeenCalledTimes(1));
+      expect(logSpy).toHaveBeenCalledWith(
+        'session-answer',
+        'output',
+        expect.any(String),
+      );
+      const content = JSON.parse(logSpy.mock.calls[0][2] as string);
+      expect(content).toMatchObject({
+        type: 'nimbalyst_tool_result',
+        tool_use_id: 'call_answer',
+        is_error: false,
+      });
+      expect(JSON.parse(content.result)).toMatchObject({
+        answers: { Scope: 'Everything' },
+        cancelled: false,
+        respondedBy: 'mobile',
+      });
+    });
+
+    it('persists cancelled questions with their response source', async () => {
+      const provider = providerWithPendingQuestion('call_cancel', 'session-cancel');
+      const logSpy = vi.spyOn(provider as any, 'logAgentMessageBestEffort').mockResolvedValue(undefined);
+
+      provider.rejectAskUserQuestion(
+        'call_cancel',
+        new Error('cancelled'),
+        'mobile',
+      );
+
+      await vi.waitFor(() => expect(logSpy).toHaveBeenCalledTimes(1));
+      const content = JSON.parse(logSpy.mock.calls[0][2] as string);
+      expect(content).toMatchObject({
+        type: 'nimbalyst_tool_result',
+        tool_use_id: 'call_cancel',
+        is_error: true,
+      });
+      expect(JSON.parse(content.result)).toMatchObject({
+        answers: {},
+        cancelled: true,
+        respondedBy: 'mobile',
+      });
+    });
+  });
+
   it('updates currentTodos for app-server todoList raw events', async () => {
     const updateMetadata = vi.fn(async () => {});
     AISessionsRepository.setStore({

--- a/packages/runtime/src/ai/server/transcript/__tests__/TranscriptTransformer.test.ts
+++ b/packages/runtime/src/ai/server/transcript/__tests__/TranscriptTransformer.test.ts
@@ -756,6 +756,103 @@ describe('TranscriptTransformer', () => {
       expect(parsedResult.commitHash).toBe('abc1234');
     });
 
+    it('completes one Codex app-server tool across synthetic and native resume batches', async () => {
+      const rawToolUseId = 'call_question_incremental';
+      const started = makeRawMessage({
+        id: 1,
+        sessionId: SESSION_ID,
+        source: 'openai-codex',
+        direction: 'output',
+        metadata: { transport: 'app-server', eventType: 'item/started' },
+        content: JSON.stringify({
+          method: 'item/started',
+          params: {
+            turnId: 'turn-question',
+            item: {
+              id: rawToolUseId,
+              type: 'mcpToolCall',
+              status: 'in_progress',
+              server: 'nimbalyst',
+              tool: 'AskUserQuestion',
+              arguments: { questions: [{ question: 'Commit everything?' }] },
+            },
+          },
+        }),
+      });
+
+      await new TranscriptTransformer(
+        createMockRawStore([started]),
+        transcriptStore,
+        metadataStore,
+      ).processNewMessages(SESSION_ID, 'openai-codex');
+
+      const afterStart = await transcriptStore.getSessionEvents(SESSION_ID);
+      expect(afterStart).toHaveLength(1);
+      const providerToolCallId = afterStart[0].providerToolCallId as string;
+      expect(providerToolCallId).toMatch(/^nimtc\|call_question_incremental\|/);
+
+      const syntheticResult = makeRawMessage({
+        id: 2,
+        sessionId: SESSION_ID,
+        source: 'openai-codex',
+        direction: 'output',
+        content: JSON.stringify({
+          type: 'nimbalyst_tool_result',
+          tool_use_id: rawToolUseId,
+          result: JSON.stringify({ answers: { Scope: 'Everything' }, respondedBy: 'mobile' }),
+          is_error: false,
+        }),
+      });
+
+      await new TranscriptTransformer(
+        createMockRawStore([started, syntheticResult]),
+        transcriptStore,
+        metadataStore,
+      ).processNewMessages(SESSION_ID, 'openai-codex');
+
+      const afterSyntheticResult = await transcriptStore.getSessionEvents(SESSION_ID);
+      expect(afterSyntheticResult).toHaveLength(1);
+      expect((afterSyntheticResult[0].payload as any).status).toBe('completed');
+
+      const nativeCompletion = makeRawMessage({
+        id: 3,
+        sessionId: SESSION_ID,
+        source: 'openai-codex',
+        direction: 'output',
+        metadata: {
+          transport: 'app-server',
+          eventType: 'item/completed',
+          editGroupId: providerToolCallId,
+        },
+        content: JSON.stringify({
+          method: 'item/completed',
+          params: {
+            turnId: 'turn-question',
+            item: {
+              id: rawToolUseId,
+              type: 'mcpToolCall',
+              status: 'completed',
+              server: 'nimbalyst',
+              tool: 'AskUserQuestion',
+              arguments: { questions: [{ question: 'Commit everything?' }] },
+              result: { answers: { Scope: 'Everything' } },
+            },
+          },
+        }),
+      });
+
+      await new TranscriptTransformer(
+        createMockRawStore([started, syntheticResult, nativeCompletion]),
+        transcriptStore,
+        metadataStore,
+      ).processNewMessages(SESSION_ID, 'openai-codex');
+
+      const finalEvents = await transcriptStore.getSessionEvents(SESSION_ID);
+      expect(finalEvents).toHaveLength(1);
+      expect(finalEvents[0].providerToolCallId).toBe(providerToolCallId);
+      expect((finalEvents[0].payload as any).status).toBe('completed');
+    });
+
     it('transforms system messages', async () => {
       const rawStore = createMockRawStore([
         makeRawMessage({

--- a/packages/runtime/src/ai/server/transcript/__tests__/projectRawMessages.test.ts
+++ b/packages/runtime/src/ai/server/transcript/__tests__/projectRawMessages.test.ts
@@ -301,6 +301,63 @@ describe('projectRawMessagesToViewMessages', () => {
       const toolCall = vms.find(m => m.type === 'tool_call');
       expect(toolCall?.toolCall?.toolName).toBe('mcp__nimbalyst-mcp__developer_git_log');
     });
+
+    it('projects synthetic AskUserQuestion result rows onto app-server tool calls', async () => {
+      const messages: RawMessage[] = [
+        raw({
+          id: 1,
+          source: 'openai-codex',
+          metadata: { transport: 'app-server', eventType: 'item/started' },
+          content: JSON.stringify({
+            method: 'item/started',
+            params: {
+              turnId: 'turn-ask',
+              item: {
+                id: 'call_question_123',
+                type: 'mcpToolCall',
+                status: 'in_progress',
+                server: 'nimbalyst',
+                tool: 'AskUserQuestion',
+                arguments: {
+                  questions: [
+                    {
+                      header: 'COMMIT SCOPE',
+                      question: 'Which changes should be committed?',
+                      options: [{ label: 'Everything' }],
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+        }),
+        raw({
+          id: 2,
+          source: 'claude-code',
+          content: JSON.stringify({
+            type: 'nimbalyst_tool_result',
+            tool_use_id: 'call_question_123',
+            result: JSON.stringify({
+              answers: { commit_scope: 'Everything' },
+              cancelled: false,
+              respondedBy: 'mobile',
+            }),
+            is_error: false,
+          }),
+        }),
+      ];
+
+      const vms = await projectRawMessagesToViewMessages(messages, 'openai-codex');
+
+      const toolCall = vms.find(m => m.type === 'tool_call');
+      expect(toolCall?.toolCall?.toolName).toBe('mcp__nimbalyst__AskUserQuestion');
+      expect(toolCall?.toolCall?.providerToolCallId).toMatch(/^nimtc\|call_question_123\|/);
+      expect(toolCall?.toolCall?.status).toBe('completed');
+      expect(JSON.parse(toolCall?.toolCall?.result as string)).toMatchObject({
+        answers: { commit_scope: 'Everything' },
+        respondedBy: 'mobile',
+      });
+    });
   });
 
   describe('Codex ACP provider', () => {

--- a/packages/runtime/src/ai/server/transcript/parsers/CodexRawParserDispatcher.ts
+++ b/packages/runtime/src/ai/server/transcript/parsers/CodexRawParserDispatcher.ts
@@ -24,10 +24,71 @@ export class CodexRawParserDispatcher implements IRawMessageParser {
   private readonly appServerParser = new CodexAppServerRawParser();
 
   async parseMessage(msg: RawMessage, context: ParseContext): Promise<CanonicalEventDescriptor[]> {
+    if (msg.hidden) return [];
+
+    const syntheticToolResult = await this.parseNimbalystToolResult(msg, context);
+    if (syntheticToolResult) {
+      return [syntheticToolResult];
+    }
+
     const transport = msg.metadata?.transport;
     if (transport === 'app-server') {
       return this.appServerParser.parseMessage(msg, context);
     }
     return this.sdkParser.parseMessage(msg, context);
+  }
+
+  private async parseNimbalystToolResult(
+    msg: RawMessage,
+    context: ParseContext,
+  ): Promise<CanonicalEventDescriptor | null> {
+    if (!msg.content.includes('nimbalyst_tool_result')) return null;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(msg.content);
+    } catch {
+      return null;
+    }
+
+    if (!parsed || typeof parsed !== 'object') return null;
+    const record = parsed as Record<string, unknown>;
+    if (record.type !== 'nimbalyst_tool_result') return null;
+
+    const rawToolUseId =
+      typeof record.tool_use_id === 'string'
+        ? record.tool_use_id
+        : typeof record.id === 'string'
+          ? record.id
+          : null;
+    if (!rawToolUseId) return null;
+
+    let providerToolCallId = rawToolUseId;
+    try {
+      const existing = await context.findActiveToolCallByRawProviderId(rawToolUseId);
+      if (existing?.providerToolCallId) {
+        providerToolCallId = existing.providerToolCallId;
+      }
+    } catch {
+      // If alias lookup fails, fall back to the raw id. Existing exact-id
+      // matching still handles SDK-style Codex rows.
+    }
+
+    const result = record.result;
+    const resultText =
+      typeof result === 'string'
+        ? result
+        : result == null
+          ? ''
+          : JSON.stringify(result);
+    const isError = record.is_error === true;
+
+    return {
+      type: 'tool_call_completed',
+      providerToolCallId,
+      status: isError ? 'error' : 'completed',
+      result: resultText,
+      isError,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- persist Codex AskUserQuestion answers and cancellations as canonical tool-result rows
- retain desktop/mobile response attribution
- teach the Codex parser dispatcher to apply synthetic tool results to the active raw provider call
- preserve one completed tool call across incremental start, synthetic-result, and native-completion batches

This is a focused transcript/provider fix with no sync-protocol or Android changes.

## Verification
- focused Vitest suite: 3 files, 84 passed, 1 existing skip
- `tsc --noEmit -p packages/runtime/tsconfig.json`