### PR TITLE
fix(codex): reconcile static Codex fallback roster

### DIFF
--- a/packages/electron/src/main/services/ai/__tests__/aiServiceUtils.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/aiServiceUtils.test.ts
@@ -265,6 +265,10 @@ describe('aiServiceUtils', () => {
       expect(extractModelForProvider('openai-codex:default', 'openai-codex')).toBe('gpt-5.6-sol');
     });
 
+    it('normalizes legacy Codex aliases for ACP sessions', () => {
+      expect(extractModelForProvider('openai-codex-acp:default', 'openai-codex-acp')).toBe('gpt-5.6-sol');
+    });
+
     it('returns the full model unchanged for claude-code', () => {
       expect(extractModelForProvider('claude-code:opus-1m', 'claude-code')).toBe('claude-code:opus-1m');
     });

--- a/packages/electron/src/main/services/ai/aiServiceUtils.ts
+++ b/packages/electron/src/main/services/ai/aiServiceUtils.ts
@@ -246,7 +246,7 @@ export function extractModelForProvider(
   fullModel: string,
   provider: AIProviderType
 ): string | null {
-  if (provider === 'openai-codex') {
+  if (provider === 'openai-codex' || provider === 'openai-codex-acp') {
     const parsed = ModelIdentifier.tryParse(fullModel);
     const rawModel = parsed ? parsed.model : fullModel;
     const normalized = OpenAICodexProvider.normalizeModelSelection(rawModel);

--- a/packages/runtime/src/ai/server/providers/OpenAICodexACPProvider.ts
+++ b/packages/runtime/src/ai/server/providers/OpenAICodexACPProvider.ts
@@ -62,11 +62,7 @@ export class OpenAICodexACPProvider extends BaseAgentProvider {
     { id: 'gpt-5.6-luna', name: 'GPT-5.6 Luna', contextWindow: 372000, maxTokens: 128000 },
     { id: 'gpt-5.5', name: 'GPT-5.5', contextWindow: 400000, maxTokens: 128000 },
     { id: 'gpt-5.4', name: 'GPT-5.4', contextWindow: 400000, maxTokens: 128000 },
-    { id: 'gpt-5.3-codex', name: 'GPT-5.3 Codex', contextWindow: 400000, maxTokens: 128000 },
-    { id: 'gpt-5.2-codex', name: 'GPT-5.2 Codex', contextWindow: 400000, maxTokens: 128000 },
-    { id: 'gpt-5.1-codex-max', name: 'GPT-5.1 Codex Max', contextWindow: 400000, maxTokens: 128000 },
-    { id: 'gpt-5.2', name: 'GPT-5.2', contextWindow: 128000, maxTokens: 128000 },
-    { id: 'gpt-5.1-codex-mini', name: 'GPT-5.1 Codex Mini', contextWindow: 400000, maxTokens: 128000 },
+    { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini', contextWindow: 400000, maxTokens: 128000 },
   ];
 
   private readonly protocol: CodexACPProtocol;

--- a/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
+++ b/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
@@ -101,11 +101,7 @@ export class OpenAICodexProvider extends BaseAgentProvider {
     { id: 'gpt-5.6-luna', name: 'GPT-5.6 Luna', contextWindow: 372000, maxTokens: 128000 },
     { id: 'gpt-5.5', name: 'GPT-5.5', contextWindow: 400000, maxTokens: 128000 },
     { id: 'gpt-5.4', name: 'GPT-5.4', contextWindow: 400000, maxTokens: 128000 },
-    { id: 'gpt-5.3-codex', name: 'GPT-5.3 Codex', contextWindow: 400000, maxTokens: 128000 },
-    { id: 'gpt-5.2-codex', name: 'GPT-5.2 Codex', contextWindow: 400000, maxTokens: 128000 },
-    { id: 'gpt-5.1-codex-max', name: 'GPT-5.1 Codex Max', contextWindow: 400000, maxTokens: 128000 },
-    { id: 'gpt-5.2', name: 'GPT-5.2', contextWindow: 128000, maxTokens: 128000 },
-    { id: 'gpt-5.1-codex-mini', name: 'GPT-5.1 Codex Mini', contextWindow: 400000, maxTokens: 128000 },
+    { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini', contextWindow: 400000, maxTokens: 128000 },
   ];
   private static readonly MODEL_FALLBACK_PRIORITY: ReadonlyArray<string> = [
     'gpt-5.6-sol',
@@ -113,11 +109,7 @@ export class OpenAICodexProvider extends BaseAgentProvider {
     'gpt-5.6-luna',
     'gpt-5.5',
     'gpt-5.4',
-    'gpt-5.3-codex',
-    'gpt-5.2-codex',
-    'gpt-5.1-codex-max',
-    'gpt-5.1-codex-mini',
-    'gpt-5.2',
+    'gpt-5.4-mini',
   ];
   private static readonly FALLBACK_MODELS_SET = new Set(
     OpenAICodexProvider.FALLBACK_MODELS.map((model) => model.id)
@@ -437,17 +429,17 @@ export class OpenAICodexProvider extends BaseAgentProvider {
     // Codex (ChatGPT-account auth) rejects the bare `gpt-5.6` alias that the
     // OpenAI API accepts; route it to the flagship Sol tier.
     ['gpt-5.6', 'gpt-5.6-sol'],
-    ['gpt-5', 'gpt-5.2'],
+    ['gpt-5', 'gpt-5.6-terra'],
     ['gpt-5-codex', 'gpt-5.4'],
     ['gpt-5.4-codex', 'gpt-5.4'],
-    ['gpt-5-codex-mini', 'gpt-5.1-codex-mini'],
-    ['gpt-5.2-codex-mini', 'gpt-5.2-codex'],
-    ['gpt-5.2-codex-max', 'gpt-5.2-codex'],
-    ['gpt-5-codex-max', 'gpt-5.1-codex-max'],
-    ['gpt-5.1-codex', 'gpt-5.2-codex'],
-    ['gpt-5.3-codex-mini', 'gpt-5.3-codex'],
-    ['gpt-5.3-codex-max', 'gpt-5.3-codex'],
-    ['codex-mini-latest', 'gpt-5.1-codex-mini'],
+    ['gpt-5-codex-mini', 'gpt-5.4-mini'],
+    ['gpt-5.2-codex-mini', 'gpt-5.4-mini'],
+    ['gpt-5.2-codex-max', 'gpt-5.6-sol'],
+    ['gpt-5-codex-max', 'gpt-5.6-sol'],
+    ['gpt-5.1-codex', 'gpt-5.4'],
+    ['gpt-5.3-codex-mini', 'gpt-5.4-mini'],
+    ['gpt-5.3-codex-max', 'gpt-5.6-sol'],
+    ['codex-mini-latest', 'gpt-5.4-mini'],
   ]);
 
   /**

--- a/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OpenAICodexProvider } from '../OpenAICodexProvider';
+import { OpenAICodexACPProvider } from '../OpenAICodexACPProvider';
 import { configureMcpServers } from '../../services/mcpServerConfig';
 import * as codexBinaryPath from '../codex/codexBinaryPath';
 import * as codexSdkLoader from '../codex/codexSdkLoader';
@@ -109,10 +110,34 @@ describe('OpenAICodexProvider', () => {
         provider: 'openai-codex',
       }),
       expect.objectContaining({
-        id: 'openai-codex:gpt-5.3-codex',
+        id: 'openai-codex:gpt-5.4-mini',
         provider: 'openai-codex',
       }),
     ]));
+  });
+
+  it('keeps the static Codex and ACP fallback rosters in parity', async () => {
+    const expectedModelIds = [
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.5',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+    ];
+    const codexModels = await OpenAICodexProvider.getModels(undefined, {
+      loadSdkModule: async () => {
+        throw new Error('sdk unavailable');
+      },
+    });
+    const acpModels = await OpenAICodexACPProvider.getModels();
+
+    expect(codexModels.map((model) => model.id)).toEqual(
+      expectedModelIds.map((modelId) => `openai-codex:${modelId}`)
+    );
+    expect(acpModels.map((model) => model.id)).toEqual(
+      expectedModelIds.map((modelId) => `openai-codex-acp:${modelId}`)
+    );
   });
 
   it('normalizes legacy codex default aliases to the GPT-5.6 Sol default', () => {
@@ -121,13 +146,29 @@ describe('OpenAICodexProvider', () => {
     expect(OpenAICodexProvider.normalizeModelSelection('cli')).toBe('openai-codex:gpt-5.6-sol');
   });
 
+  it.each([
+    ['gpt-5', 'gpt-5.6-terra'],
+    ['gpt-5-codex-mini', 'gpt-5.4-mini'],
+    ['gpt-5.2-codex-mini', 'gpt-5.4-mini'],
+    ['gpt-5.2-codex-max', 'gpt-5.6-sol'],
+    ['gpt-5-codex-max', 'gpt-5.6-sol'],
+    ['gpt-5.1-codex', 'gpt-5.4'],
+    ['gpt-5.3-codex-mini', 'gpt-5.4-mini'],
+    ['gpt-5.3-codex-max', 'gpt-5.6-sol'],
+    ['codex-mini-latest', 'gpt-5.4-mini'],
+  ])('repoints retired alias %s to %s', (legacyModelId, canonicalModelId) => {
+    expect(OpenAICodexProvider.normalizeModelSelection(legacyModelId)).toBe(
+      `openai-codex:${canonicalModelId}`
+    );
+  });
+
   it('uses SDK-provided model discovery when available', async () => {
     let codexConstructorOptions: Record<string, unknown> | undefined;
     const listModels = vi.fn(async () => ({
       data: [
         {
-          id: 'gpt-5.2-codex',
-          name: 'GPT-5.2 Codex',
+          id: 'gpt-5.4-mini',
+          name: 'GPT-5.4 Mini',
           contextWindow: 400000,
           maxTokens: 128000,
         },
@@ -167,28 +208,12 @@ describe('OpenAICodexProvider', () => {
         provider: 'openai-codex',
       }),
       expect.objectContaining({
-        id: 'openai-codex:gpt-5.3-codex',
-        provider: 'openai-codex',
-      }),
-      expect.objectContaining({
-        id: 'openai-codex:gpt-5.2-codex',
-        name: 'GPT-5.2 Codex',
-        provider: 'openai-codex',
-      }),
-      expect.objectContaining({
-        id: 'openai-codex:gpt-5.1-codex-max',
-        provider: 'openai-codex',
-      }),
-      expect.objectContaining({
-        id: 'openai-codex:gpt-5.2',
-        provider: 'openai-codex',
-      }),
-      expect.objectContaining({
-        id: 'openai-codex:gpt-5.1-codex-mini',
+        id: 'openai-codex:gpt-5.4-mini',
+        name: 'GPT-5.4 Mini',
         provider: 'openai-codex',
       }),
     ]));
-    expect(models).toHaveLength(10);
+    expect(models).toHaveLength(6);
   });
 
   it('preserves CLI auth when initialized without an API key', async () => {
@@ -1499,7 +1524,7 @@ describe('OpenAICodexProvider', () => {
 
     expect(startThread).toHaveBeenCalledTimes(1);
     const startArgs = (startThread.mock.calls as unknown as [Record<string, unknown>][])[0][0];
-    expect(startArgs.model).toBe('gpt-5.1-codex-mini');
+    expect(startArgs.model).toBe('gpt-5.4-mini');
   });
 
   it('maps removed codex max aliases to supported model ids', async () => {
@@ -1542,7 +1567,7 @@ describe('OpenAICodexProvider', () => {
 
     expect(startThread).toHaveBeenCalledTimes(1);
     const startArgs = (startThread.mock.calls as unknown as [Record<string, unknown>][])[0][0];
-    expect(startArgs.model).toBe('gpt-5.2-codex');
+    expect(startArgs.model).toBe('gpt-5.6-sol');
   });
 
   it('supports direct handleToolCall execution through the shared tool handler', async () => {


### PR DESCRIPTION
## Summary

- remove five retired static Codex fallback entries and add GPT-5.4 Mini
- repoint legacy aliases to currently supported Codex model IDs
- keep the ACP fallback catalog and legacy-session normalization in parity
- leave `gpt-5.3-codex-spark` to the separate dependent B4 roster change

Closes #827

## Validation

- `npm ci --no-audit --no-fund` with unchanged `package-lock.json`
- focused Codex provider and AI service utility tests: 142 passed, 1 skipped
- runtime and Electron package typechecks
- `git diff --check`