### PR TITLE
fix(electron): expose effort controls for current Claude variants

### DIFF
--- a/packages/electron/src/renderer/utils/__tests__/modelUtils.effort.test.ts
+++ b/packages/electron/src/renderer/utils/__tests__/modelUtils.effort.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { supportsEffortLevel } from '../modelUtils';
+
+describe('supportsEffortLevel', () => {
+  it.each([
+    'claude-code:opus',
+    'claude-code:opus-4-6',
+    'claude-code:sonnet',
+    'claude-code:fable',
+    'claude-code-cli:fable-1m',
+    'claude-code:opus-4-7',
+    'claude-code-cli:opus-4-7-1m',
+    'claude-code:sonnet-4-6',
+    'claude-code-cli:sonnet-4-6-1m',
+  ])('supports current Claude Code effort-capable variants: %s', (modelId) => {
+    expect(supportsEffortLevel(modelId)).toBe(true);
+  });
+
+  it.each([
+    'openai-codex:gpt-5.4',
+    'openai-codex-acp:gpt-5.4',
+  ])('supports effort for both Codex providers: %s', (modelId) => {
+    expect(supportsEffortLevel(modelId)).toBe(true);
+  });
+
+  it.each([
+    undefined,
+    'claude-code:haiku',
+    'claude-code:unknown',
+    'claude:claude-fable-5',
+  ])('does not expose effort for unsupported models: %s', (modelId) => {
+    expect(supportsEffortLevel(modelId)).toBe(false);
+  });
+});

--- a/packages/electron/src/renderer/utils/modelUtils.ts
+++ b/packages/electron/src/renderer/utils/modelUtils.ts
@@ -241,13 +241,20 @@ export function getModelShortName(provider: string, modelId: string): string {
 
 /**
  * Check if a model supports effort level configuration.
- * Supported: Claude Code Opus (4.6+) and Sonnet (4.6+) variants including pinned
- * versions, plus OpenAI Codex models.
+ * Supported: Claude Code Fable, Opus, and Sonnet variants, including retained
+ * pinned versions, plus OpenAI Codex models.
  */
 export function supportsEffortLevel(modelId?: string): boolean {
   if (!modelId) return false;
   const variant = extractClaudeCodeVariant(modelId);
-  if (variant === 'opus' || variant === 'opus-4-6' || variant === 'sonnet') return true;
+  if (
+    variant === 'fable' ||
+    variant === 'opus' ||
+    variant === 'opus-4-7' ||
+    variant === 'opus-4-6' ||
+    variant === 'sonnet' ||
+    variant === 'sonnet-4-6'
+  ) return true;
   // OpenAI Codex models support reasoning effort (both SDK and ACP transports)
   const parsed = ModelIdentifier.tryParse(modelId);
   if (parsed?.provider === 'openai-codex' || parsed?.provider === 'openai-codex-acp') return true;


### PR DESCRIPTION
## Summary
- Extends `supportsEffortLevel` to recognize the `fable`, `opus-4-7`, and `sonnet-4-6` Claude Code variants (SDK and CLI 1M forms), which were previously omitted from the effort-selector allowlist.
- Preserves existing behavior for Haiku and non-Claude-Code providers.

Closes #829

## Test plan
- [x] 15 focused tests passed (`modelUtils.effort.test.ts`)
- [x] Electron typecheck passed
- [x] `git diff --check` / `git show --check` passed (no whitespace issues)
- [x] lockfile unchanged