### PR TITLE
Defer agent-triggered compaction until the active turn ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP servers disabled in Settings no longer load in Claude Code (SDK) sessions; the disable toggle now governs both the CLI and SDK paths.
 - Directory grouping now handles Windows paths consistently across session edits, commit proposals, and Git history.
 - Stopping a running Codex session (including from mobile) now interrupts it immediately instead of leaving it stuck showing as running.
+- AI agents can compact their own conversation context reliably without interrupting the active turn.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/mcp/__tests__/metaAgentServer.compactSession.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/metaAgentServer.compactSession.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/workspaceDetection', () => ({
+  resolveProjectPath: vi.fn(() => '/canonical-workspace'),
+}));
+
+import {
+  META_AGENT_TOOL_DEFS,
+  dispatchMetaAgentTool,
+  getMetaAgentOpenAITools,
+  setMetaAgentToolFns,
+} from '../metaAgentServer';
+
+describe('compact_session meta-agent registration', () => {
+  it('advertises the bounded schema and dispatches to the injected service function', async () => {
+    const compactSession = vi.fn().mockResolvedValue('{"scheduled":true}');
+    setMetaAgentToolFns({
+      listWorktrees: vi.fn(),
+      createSession: vi.fn(),
+      spawnSession: vi.fn(),
+      getSessionStatus: vi.fn(),
+      getSessionResult: vi.fn(),
+      sendPrompt: vi.fn(),
+      compactSession,
+      respondToPrompt: vi.fn(),
+      listSpawnedSessions: vi.fn(),
+    });
+
+    const definition = META_AGENT_TOOL_DEFS.find((tool) => tool.name === 'compact_session');
+    expect(definition?.inputSchema.properties.focus).toMatchObject({
+      type: 'string',
+      maxLength: 1000,
+    });
+    expect(getMetaAgentOpenAITools().map((tool) => tool.function.name)).toContain('compact_session');
+
+    await expect(dispatchMetaAgentTool(
+      'mcp__nimbalyst-host__compact_session',
+      'caller-1',
+      '/worktree',
+      { sessionId: 'child-1', focus: 'preserve state' },
+    )).resolves.toBe('{"scheduled":true}');
+    expect(compactSession).toHaveBeenCalledWith(
+      'caller-1',
+      '/canonical-workspace',
+      { sessionId: 'child-1', focus: 'preserve state' },
+    );
+  });
+});

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -1,6 +1,6 @@
 /**
  * Meta-agent (child-session orchestration) tool surface — `create_session`,
- * `spawn_session`, `send_prompt`, `respond_to_prompt`, `get_session_status`,
+ * `spawn_session`, `send_prompt`, `compact_session`, `respond_to_prompt`, `get_session_status`,
  * `get_session_result`, `list_spawned_sessions`, `list_worktrees`.
  *
  * MCP consolidation: these tools are served by the unified internal MCP HTTP
@@ -49,6 +49,11 @@ type RespondToPromptArgs = {
   response: Record<string, unknown>;
 };
 
+type CompactSessionArgs = {
+  sessionId?: string;
+  focus?: string;
+};
+
 interface MetaAgentToolFns {
   listWorktrees: (
     metaSessionId: string,
@@ -79,6 +84,11 @@ interface MetaAgentToolFns {
     workspaceId: string,
     targetSessionId: string,
     prompt: string
+  ) => Promise<string>;
+  compactSession: (
+    callerSessionId: string,
+    workspaceId: string,
+    args: CompactSessionArgs
   ) => Promise<string>;
   respondToPrompt: (
     metaSessionId: string,
@@ -270,6 +280,25 @@ export const META_AGENT_TOOL_DEFS: Array<{
     },
   },
   {
+    name: "compact_session",
+    description:
+      "Schedule compaction for this session or an owned child session after its active turn ends. Codex app-server sessions execute provider-native compaction as a tagged queued action without starting a model turn; Claude Agent and Claude CLI execute a real /compact command. The tool returns compacted:false and scheduled:true; end the current turn before checking queue/session status. Optional focus text is single-line normalized and provider-dependent.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description: "Optional owned target session. Defaults to the calling session.",
+        },
+        focus: {
+          type: "string",
+          maxLength: 1000,
+          description: "Optional focus for providers that support /compact focus text. Newlines are normalized to spaces.",
+        },
+      },
+    },
+  },
+  {
     name: "respond_to_prompt",
     description:
       "Answer a child session's interactive prompt such as AskUserQuestion, ExitPlanMode, or ToolPermission.",
@@ -336,6 +365,7 @@ const EXTENSION_META_AGENT_ALLOWED_TOOLS = new Set<string>([
   "get_session_status",
   "get_session_result",
   "send_prompt",
+  "compact_session",
   "respond_to_prompt",
   "list_spawned_sessions",
 ]);
@@ -404,6 +434,12 @@ export async function dispatchMetaAgentTool(
         effectiveWorkspaceId,
         (args?.sessionId as string) ?? "",
         (args?.prompt as string) ?? ""
+      );
+    case "compact_session":
+      return toolFns.compactSession(
+        aiSessionId,
+        effectiveWorkspaceId,
+        (args ?? {}) as CompactSessionArgs
       );
     case "respond_to_prompt":
       return toolFns.respondToPrompt(aiSessionId, effectiveWorkspaceId, (args ?? {}) as RespondToPromptArgs);

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -15,12 +15,31 @@ import { database as databaseWorker } from '../database/PGLiteDatabaseWorker';
 import { getDatabase } from '../database/initialize';
 import { gitRefWatcher } from '../file/GitRefWatcher';
 import { AIService } from './ai/AIService';
+import { QUEUED_COMPACTION_PROMPT_ORIGIN } from './ai/queuedCompactionAction';
 import { setMetaAgentToolFns } from '../mcp/metaAgentServer';
 import { computeNotificationSignature } from './metaAgentNotificationSignature';
 import { extractMessageText, extractUserPrompts } from './metaAgentMessageText';
 
 type SessionStatusValue = 'idle' | 'running' | 'waiting_for_input' | 'error' | 'interrupted';
 type PromptType = 'permission_request' | 'ask_user_question_request' | 'exit_plan_mode_request';
+const MAX_COMPACTION_FOCUS_LENGTH = 1000;
+
+function normalizeCompactionFocus(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') {
+    throw new Error('focus must be a string');
+  }
+  if (value.length > MAX_COMPACTION_FOCUS_LENGTH) {
+    throw new Error(`focus must be at most ${MAX_COMPACTION_FOCUS_LENGTH} characters`);
+  }
+  // Treat every C0 byte as a separator before collapsing whitespace. This
+  // keeps the focus safe for both SDK-backed prompts and PTY slash-command
+  // tails without accidentally joining words around a stripped control byte.
+  // eslint-disable-next-line no-control-regex
+  const normalized = value.replace(/[\x00-\x1f\x7f]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!normalized) return undefined;
+  return normalized;
+}
 
 interface PendingInteractivePrompt {
   id: string;
@@ -183,6 +202,8 @@ export class MetaAgentService {
           this.getSessionResultJson(targetSessionId, workspaceId),
         sendPrompt: (_metaSessionId, workspaceId, targetSessionId, prompt) =>
           this.sendPromptToSession(targetSessionId, workspaceId, prompt),
+        compactSession: (callerSessionId, workspaceId, args) =>
+          this.compactSessionJson(callerSessionId, workspaceId, args),
         respondToPrompt: (_metaSessionId, workspaceId, args) =>
           this.respondToPrompt(workspaceId, args),
         listSpawnedSessions: (metaSessionId, workspaceId) =>
@@ -877,6 +898,89 @@ export class MetaAgentService {
       prompt: queued.prompt,
       statusBeforeQueue: status,
       processingTriggered,
+    }, null, 2);
+  }
+
+  private async compactSessionJson(
+    callerSessionId: string,
+    workspaceId: string,
+    args: { sessionId?: string; focus?: string },
+  ): Promise<string> {
+    if (!this.aiService) {
+      throw new Error('AI service not initialized');
+    }
+    if (args.sessionId !== undefined && typeof args.sessionId !== 'string') {
+      throw new Error('sessionId must be a string');
+    }
+
+    const targetSessionId = args.sessionId?.trim() || callerSessionId;
+    const focus = normalizeCompactionFocus(args.focus);
+    const session = await AISessionsRepository.get(targetSessionId);
+    if (!session || session.workspacePath !== workspaceId) {
+      throw new Error(`Session ${targetSessionId} not found`);
+    }
+    if (targetSessionId !== callerSessionId && session.createdBySessionId !== callerSessionId) {
+      throw new Error(`Session ${targetSessionId} is not owned by ${callerSessionId}`);
+    }
+
+    const usesCodexNativeQueue = session.provider === 'openai-codex';
+    const usesClaudeSlashQueue = session.provider === 'claude-code'
+      || session.provider === 'claude-code-cli';
+    if (!usesCodexNativeQueue && !usesClaudeSlashQueue) {
+      return JSON.stringify({
+        sessionId: targetSessionId,
+        provider: session.provider,
+        compacted: false,
+        scheduled: false,
+        error: `Provider ${session.provider} does not support compaction`,
+        ...(focus ? { focus, focusApplied: false } : {}),
+      }, null, 2);
+    }
+
+    // Compaction replaces the provider's current task on both Codex and
+    // Claude. Queue it so a self-targeted MCP call returns before the current
+    // turn ends. Codex's tagged exact action is intercepted after normal queue
+    // dispatch and invokes thread/compact/start without starting a model turn;
+    // Claude executes the real slash command through its existing rails.
+    const prompt = usesCodexNativeQueue
+      ? '/compact'
+      : focus
+        ? `/compact focus on ${focus}`
+        : '/compact';
+    const statusRow = await this.getSessionStatusRow(targetSessionId, workspaceId);
+    const status = (statusRow?.status || 'idle') as SessionStatusValue;
+    const queued = usesCodexNativeQueue
+      ? await this.aiService.queuePromptForSession(
+          targetSessionId,
+          prompt,
+          undefined,
+          { promptOrigin: QUEUED_COMPACTION_PROMPT_ORIGIN },
+        )
+      : await this.aiService.queuePromptForSession(targetSessionId, prompt);
+    // A self-targeted MCP call is necessarily running inside the caller's
+    // current turn. Never trust a lagging persisted "idle" status here: an
+    // immediate trigger would re-enter the provider before the tool returns.
+    let processingTriggered = false;
+    const canTriggerProcessing = targetSessionId !== callerSessionId
+      && (status === 'idle' || status === 'interrupted' || status === 'error');
+    if (canTriggerProcessing) {
+      processingTriggered = await this.aiService.triggerQueuedPromptProcessingForSession(
+        targetSessionId,
+        session.worktreePath || session.workspacePath || workspaceId,
+      );
+    }
+
+    return JSON.stringify({
+      sessionId: targetSessionId,
+      provider: session.provider,
+      compacted: false,
+      scheduled: true,
+      method: usesCodexNativeQueue
+        ? 'queued-native-compaction'
+        : 'queued-slash-command',
+      queuedPromptId: queued.id,
+      processingTriggered,
+      ...(focus ? { focus, focusApplied: false } : {}),
     }, null, 2);
   }
 

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.cliPortWiring.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.cliPortWiring.test.ts
@@ -77,6 +77,7 @@ describe('MetaAgentService tool-fn injection (Phase 7: no standalone server)', (
     expect(typeof fns.createSession).toBe('function');
     expect(typeof fns.spawnSession).toBe('function');
     expect(typeof fns.listWorktrees).toBe('function');
+    expect(typeof fns.compactSession).toBe('function');
 
     await service.shutdown();
   });

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.compactSession.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.compactSession.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    get: vi.fn(),
+  },
+  AgentMessagesRepository: {
+    list: vi.fn(),
+  },
+  SessionFilesRepository: {
+    getFilesBySession: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  SessionManager: class { async initialize() {} },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: {
+    parse: (id: string) => ({ provider: id.split(':')[0], model: id.split(':')[1], combined: id }),
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn(() => () => {}) }),
+}));
+
+vi.mock('electron', () => ({ BrowserWindow: { getAllWindows: () => [] } }));
+vi.mock('../SyncManager', () => ({ getSyncProvider: () => ({ pushChange: vi.fn() }) }));
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => null }));
+vi.mock('../../utils/timestampUtils', () => ({ toMillis: (v: unknown) => v }));
+vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
+vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({ database: { query: vi.fn() } }));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => null }));
+vi.mock('../../file/GitRefWatcher', () => ({ gitRefWatcher: {} }));
+vi.mock('./ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({ setMetaAgentToolFns: vi.fn() }));
+vi.mock('../metaAgentNotificationSignature', () => ({ computeNotificationSignature: vi.fn() }));
+vi.mock('../metaAgentMessageText', () => ({
+  extractMessageText: vi.fn(),
+  extractUserPrompts: vi.fn(),
+}));
+
+import { AISessionsRepository } from '@nimbalyst/runtime';
+import { MetaAgentService } from '../MetaAgentService';
+
+const WORKSPACE = '/workspace';
+
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'caller-1',
+    title: 'Session',
+    provider: 'openai-codex',
+    model: 'openai-codex:gpt-5.6-sol',
+    status: 'running',
+    createdAt: 1,
+    updatedAt: 2,
+    workspacePath: WORKSPACE,
+    worktreePath: null,
+    worktreeId: null,
+    agentRole: 'standard',
+    createdBySessionId: null,
+    metadata: {},
+    ...overrides,
+  } as never;
+}
+
+describe('MetaAgentService.compactSessionJson', () => {
+  let service: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = MetaAgentService.getInstance() as any;
+  });
+
+  it('schedules Codex self-compaction without invoking native compaction inside the active turn', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(makeSession());
+    const compactSessionNative = vi.fn();
+    const queuePromptForSession = vi.fn().mockResolvedValue({
+      id: 'queued-codex-1',
+      prompt: '/compact',
+    });
+    const triggerQueuedPromptProcessingForSession = vi.fn();
+    service.getSessionStatusRow = vi.fn().mockResolvedValue({ status: 'idle' });
+    service.aiService = {
+      compactSessionNative,
+      queuePromptForSession,
+      triggerQueuedPromptProcessingForSession,
+    };
+
+    const raw = await service.compactSessionJson('caller-1', WORKSPACE, {});
+
+    expect(compactSessionNative).not.toHaveBeenCalled();
+    expect(queuePromptForSession).toHaveBeenCalledWith(
+      'caller-1',
+      '/compact',
+      undefined,
+      { promptOrigin: 'agent_compaction' },
+    );
+    expect(triggerQueuedPromptProcessingForSession).not.toHaveBeenCalled();
+    expect(JSON.parse(raw)).toEqual({
+      sessionId: 'caller-1',
+      provider: 'openai-codex',
+      compacted: false,
+      scheduled: true,
+      method: 'queued-native-compaction',
+      queuedPromptId: 'queued-codex-1',
+      processingTriggered: false,
+    });
+  });
+
+  it('single-line normalizes focus while reporting that queued Codex native compaction cannot apply it', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(makeSession());
+    const queuePromptForSession = vi.fn().mockResolvedValue({
+      id: 'queued-codex-2',
+      prompt: '/compact',
+    });
+    service.aiService = {
+      compactSessionNative: vi.fn(),
+      queuePromptForSession,
+      triggerQueuedPromptProcessingForSession: vi.fn(),
+    };
+    service.getSessionStatusRow = vi.fn().mockResolvedValue({ status: 'running' });
+
+    const raw = await service.compactSessionJson('caller-1', WORKSPACE, {
+      focus: '  preserve\r\ncurrent\tstate\x00safely  ',
+    });
+
+    expect(JSON.parse(raw)).toEqual({
+      sessionId: 'caller-1',
+      provider: 'openai-codex',
+      compacted: false,
+      scheduled: true,
+      method: 'queued-native-compaction',
+      queuedPromptId: 'queued-codex-2',
+      processingTriggered: false,
+      focus: 'preserve current state safely',
+      focusApplied: false,
+    });
+  });
+
+  it('queues Claude self-compaction for after the active turn and reports scheduling honestly', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(makeSession({
+      provider: 'claude-code',
+      model: 'claude-code:sonnet',
+    }));
+    const queuePromptForSession = vi.fn().mockResolvedValue({
+      id: 'queued-1',
+      prompt: '/compact focus on preserve current state',
+    });
+    const triggerQueuedPromptProcessingForSession = vi.fn();
+    // Persisted status can lag the live turn. Self-targeting must remain
+    // deferred even when the row still says idle.
+    service.getSessionStatusRow = vi.fn().mockResolvedValue({ status: 'idle' });
+    service.aiService = {
+      compactSessionNative: vi.fn().mockResolvedValue({ supported: false, compacted: false }),
+      queuePromptForSession,
+      triggerQueuedPromptProcessingForSession,
+    };
+
+    const raw = await service.compactSessionJson('caller-1', WORKSPACE, {
+      focus: 'preserve\ncurrent state',
+    });
+
+    expect(queuePromptForSession).toHaveBeenCalledWith(
+      'caller-1',
+      '/compact focus on preserve current state',
+    );
+    expect(triggerQueuedPromptProcessingForSession).not.toHaveBeenCalled();
+    expect(JSON.parse(raw)).toEqual({
+      sessionId: 'caller-1',
+      provider: 'claude-code',
+      compacted: false,
+      scheduled: true,
+      method: 'queued-slash-command',
+      queuedPromptId: 'queued-1',
+      processingTriggered: false,
+      focus: 'preserve current state',
+      focusApplied: false,
+    });
+  });
+
+  it('allows an owned child target and triggers its queued Claude compaction when idle', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(makeSession({
+      id: 'child-1',
+      provider: 'claude-code',
+      createdBySessionId: 'caller-1',
+      status: 'idle',
+    }));
+    const queuePromptForSession = vi.fn().mockResolvedValue({ id: 'queued-2', prompt: '/compact' });
+    const triggerQueuedPromptProcessingForSession = vi.fn().mockResolvedValue(true);
+    service.getSessionStatusRow = vi.fn().mockResolvedValue({ status: 'idle' });
+    service.aiService = {
+      compactSessionNative: vi.fn().mockResolvedValue({ supported: false, compacted: false }),
+      queuePromptForSession,
+      triggerQueuedPromptProcessingForSession,
+    };
+
+    const raw = await service.compactSessionJson('caller-1', WORKSPACE, { sessionId: 'child-1' });
+
+    expect(triggerQueuedPromptProcessingForSession).toHaveBeenCalledWith('child-1', WORKSPACE);
+    expect(JSON.parse(raw)).toMatchObject({
+      sessionId: 'child-1',
+      compacted: false,
+      scheduled: true,
+      processingTriggered: true,
+    });
+  });
+
+  it('rejects a same-workspace target that is neither self nor an owned child', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(makeSession({
+      id: 'other-1',
+      createdBySessionId: 'someone-else',
+    }));
+    service.aiService = { compactSessionNative: vi.fn() };
+
+    await expect(
+      service.compactSessionJson('caller-1', WORKSPACE, { sessionId: 'other-1' }),
+    ).rejects.toThrow('not owned by caller-1');
+  });
+
+  it('rejects a target from another workspace without revealing its provider', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(makeSession({
+      id: 'other-workspace-1',
+      workspacePath: '/another-workspace',
+      provider: 'claude-code',
+    }));
+    service.aiService = { compactSessionNative: vi.fn() };
+
+    await expect(
+      service.compactSessionJson('caller-1', WORKSPACE, { sessionId: 'other-workspace-1' }),
+    ).rejects.toThrow('Session other-workspace-1 not found');
+    expect(service.aiService.compactSessionNative).not.toHaveBeenCalled();
+  });
+
+  it('reports an unsupported provider without scheduling a chat turn', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(makeSession({
+      provider: 'fable',
+      model: 'fable:default',
+    }));
+    const queuePromptForSession = vi.fn();
+    const compactSessionNative = vi.fn();
+    service.aiService = { compactSessionNative, queuePromptForSession };
+
+    const raw = await service.compactSessionJson('caller-1', WORKSPACE, {});
+
+    expect(queuePromptForSession).not.toHaveBeenCalled();
+    expect(compactSessionNative).not.toHaveBeenCalled();
+    expect(JSON.parse(raw)).toEqual({
+      sessionId: 'caller-1',
+      provider: 'fable',
+      compacted: false,
+      scheduled: false,
+      error: 'Provider fable does not support compaction',
+    });
+  });
+
+  it('rejects focus text over the supported input bound', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(makeSession());
+    service.aiService = { compactSessionNative: vi.fn() };
+
+    await expect(
+      service.compactSessionJson('caller-1', WORKSPACE, { focus: 'x'.repeat(1001) }),
+    ).rejects.toThrow('focus must be at most 1000 characters');
+  });
+});

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -18,10 +18,12 @@ import {
   ModelRegistry,
   AIProvider,
   isAskUserQuestionProvider,
+  isContextCompactionProvider,
   isAgentProvider,
   isSlashCommandCatalogProvider,
   ClaudeCodeProvider,
   OpenAICodexProvider,
+  type ContextCompactionResult,
 } from '@nimbalyst/runtime/ai/server';
 import { CLAUDE_CODE_SAFE_FALLBACK_MODEL } from '@nimbalyst/runtime/ai/modelConstants';
 import { reconcileClaudeCodeModels } from './claudeCodeModelReconcile';
@@ -122,6 +124,10 @@ import { MessageStreamingHandler } from './MessageStreamingHandler';
 import { HooklessAgentFileWatcher } from './HooklessAgentFileWatcher';
 import { getAgentWorkflowService } from '../AgentWorkflowService';
 import { tryClaimAndDispatchNextQueuedPrompt } from './queuedPromptDispatcher';
+import {
+  dispatchQueuedCompactionAction,
+  isQueuedCompactionAction,
+} from './queuedCompactionAction';
 import { dispatchQueuedPromptToClaudeCli } from './claudeCliQueueDispatch';
 import { ensureClaudeCliSession, claudeCliSessionSupportsPlugins } from './claudeCliLauncherSingleton';
 import { supportsWorkspaceSlashWorkflowProvider } from '../../../shared/agentWorkflowProviders';
@@ -415,6 +421,53 @@ export class AIService {
   }
 
   /**
+   * Invoke provider-native compaction for a tagged queued action after the
+   * requesting turn has ended. The provider/protocol guard still refuses an
+   * active turn so no alternate caller can replace an in-flight Codex task.
+   */
+  public async compactSessionNative(
+    sessionId: string,
+    workspacePath: string,
+  ): Promise<ContextCompactionResult> {
+    const { AISessionsRepository } = await import('@nimbalyst/runtime/storage/repositories/AISessionsRepository');
+    const session = await AISessionsRepository.get(sessionId);
+    if (!session || session.workspacePath !== workspacePath) {
+      return { supported: false, compacted: false, error: `Session ${sessionId} not found` };
+    }
+
+    const provider = ProviderFactory.getProvider(session.provider as AIProviderType, sessionId);
+    if (!isContextCompactionProvider(provider)) {
+      return {
+        supported: false,
+        compacted: false,
+        error: `Provider ${session.provider} does not support native compaction`,
+      };
+    }
+
+    let result: ContextCompactionResult;
+    try {
+      result = await provider.compactSession(sessionId);
+    } catch (error) {
+      return {
+        supported: true,
+        compacted: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+    if (result.compacted && session.tokenUsage) {
+      const tokenUsage = { ...session.tokenUsage, currentContext: undefined };
+      await this.sessionManager.updateSessionTokenUsage(sessionId, tokenUsage);
+
+      const targetWindow = findWindowByWorkspace(workspacePath);
+      if (targetWindow && !targetWindow.isDestroyed()) {
+        targetWindow.webContents.send('ai:tokenUsageUpdated', { sessionId, tokenUsage });
+      }
+    }
+
+    return result;
+  }
+
+  /**
    * Back-fill any claude-code variants that shipped after this user's
    * `providerSettings['claude-code'].models` allow-list was first persisted.
    * Without this, `ai:getModels` filters out newly-introduced variants (they
@@ -703,8 +756,31 @@ export class AIService {
     let settledChildErrored = false;
 
     return tryClaimAndDispatchNextQueuedPrompt({
+      canDispatch: async (pendingPrompt) => {
+        if (!isQueuedCompactionAction(pendingPrompt)) return true;
+        if (!dispatchSession?.provider) return true;
+
+        try {
+          const provider = ProviderFactory.getProvider(
+            dispatchSession.provider as AIProviderType,
+            sessionId,
+          );
+          return !(isContextCompactionProvider(provider)
+            && provider.isSessionActive?.(sessionId) === true);
+        } catch (error) {
+          // Let dispatch claim the row and settle it failed through the normal
+          // observable queue lifecycle instead of breaking the prior turn's
+          // completion handler during a readiness probe.
+          logger.main.warn(`[AIService] ${source}: compaction readiness check failed:`, error);
+          return true;
+        }
+      },
       continueQueuedPromptChain: (nextSessionId, nextWorkspacePath, nextTargetWindow, nextSource) =>
         this.continueQueuedPromptChain(nextSessionId, nextWorkspacePath, nextTargetWindow, nextSource),
+      dispatchClaimedAction: (claimedPrompt) => dispatchQueuedCompactionAction(
+        claimedPrompt,
+        () => this.compactSessionNative(sessionId, workspacePath),
+      ),
       logError: (message, error) => logger.main.error(message, error),
       logInfo: (message) => logger.main.info(message),
       onAfterSettled: async () => {

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliSubmit.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliSubmit.test.ts
@@ -131,14 +131,54 @@ describe('submitClaudeCliPrompt', () => {
       ]);
     });
 
-    it('does NOT add a menu-dismiss space when the slash command already has args (menu closed by its own space) (NIM-851)', async () => {
+    it('resolves the slash-command menu before writing an argument tail', async () => {
       const h = harness();
       await submitClaudeCliPrompt({ sessionId: 's1', workspacePath: '/w', prompt: '/track bug foo' }, h.deps);
       expect(h.writes).toEqual([
         ['s1', '/'],
-        ['s1', 'track bug foo'],
+        ['s1', 'track'],
+        ['s1', ' '],
+        ['s1', 'bug foo'],
         ['s1', '\r'],
       ]);
+    });
+
+    it('single-line normalizes a slash-command argument tail before writing to the PTY', async () => {
+      const h = harness();
+      await submitClaudeCliPrompt(
+        {
+          sessionId: 's1',
+          workspacePath: '/w',
+          prompt: '/compact focus on current state\r\n/clear\tthen continue',
+        },
+        h.deps,
+      );
+      expect(h.writes).toEqual([
+        ['s1', '/'],
+        ['s1', 'compact'],
+        ['s1', ' '],
+        ['s1', 'focus on current state /clear then continue'],
+        ['s1', '\r'],
+      ]);
+      expect(h.writes.slice(0, -1).every(([, data]) => !/[\r\n]/.test(data))).toBe(true);
+    });
+
+    it('strips PTY control bytes from slash-command input', async () => {
+      const h = harness();
+      await submitClaudeCliPrompt(
+        { sessionId: 's1', workspacePath: '/w', prompt: '/compact focus on keep\x1b[31mstate\x07' },
+        h.deps,
+      );
+      expect(h.writes).toEqual([
+        ['s1', '/'],
+        ['s1', 'compact'],
+        ['s1', ' '],
+        ['s1', 'focus on keep[31mstate'],
+        ['s1', '\r'],
+      ]);
+      expect(h.logUserPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({ prompt: '/compact focus on keep[31mstate' }),
+      );
     });
 
     it('does NOT add a menu-dismiss space for # memory notes (NIM-851)', async () => {

--- a/packages/electron/src/main/services/ai/__tests__/queuedCompactionAction.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedCompactionAction.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  dispatchQueuedCompactionAction,
+  isQueuedCompactionAction,
+} from '../queuedCompactionAction';
+
+describe('queuedCompactionAction', () => {
+  it('recognizes only an exact, explicitly tagged internal action', () => {
+    expect(isQueuedCompactionAction({
+      prompt: '/compact',
+      documentContext: { promptOrigin: 'agent_compaction' },
+    })).toBe(true);
+    expect(isQueuedCompactionAction({
+      prompt: '/compact focus on state',
+      documentContext: { promptOrigin: 'agent_compaction' },
+    })).toBe(false);
+    expect(isQueuedCompactionAction({ prompt: '/compact' })).toBe(false);
+  });
+
+  it('runs native compaction for the tagged action and reports it handled', async () => {
+    const compact = vi.fn().mockResolvedValue({
+      supported: true,
+      compacted: true,
+      method: 'thread/compact/start',
+    });
+
+    await expect(dispatchQueuedCompactionAction({
+      prompt: '/compact',
+      documentContext: { promptOrigin: 'agent_compaction' },
+    }, compact)).resolves.toBe(true);
+    expect(compact).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces structured native failures so the queue row settles failed', async () => {
+    await expect(dispatchQueuedCompactionAction({
+      prompt: '/compact',
+      documentContext: { promptOrigin: 'agent_compaction' },
+    }, async () => ({
+      supported: true,
+      compacted: false,
+      error: 'active turn',
+    }))).rejects.toThrow('active turn');
+  });
+});

--- a/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
@@ -180,4 +180,84 @@ describe('queuedPromptDispatcher', () => {
 
     expect(onChainSettled).not.toHaveBeenCalled();
   });
+
+  it('leaves a queued action pending when its provider-boundary guard says it is not dispatchable', async () => {
+    const claimedPrompt: ClaimedQueuedPrompt = {
+      id: 'compact-1',
+      prompt: '/compact',
+      documentContext: { promptOrigin: 'agent_compaction' },
+    };
+    const queueStore: QueuedPromptStoreLike = {
+      listPending: vi.fn(async () => [claimedPrompt]),
+      claim: vi.fn(async () => claimedPrompt),
+      complete: vi.fn(async () => {}),
+      fail: vi.fn(async () => {}),
+    };
+
+    const processed = await tryClaimAndDispatchNextQueuedPrompt({
+      canDispatch: vi.fn(async () => false),
+      continueQueuedPromptChain: vi.fn(),
+      logError: vi.fn(),
+      logInfo: vi.fn(),
+      onPromptClaimed: vi.fn(),
+      processingSet: new Set<string>(),
+      queueStore,
+      sendMessageHandler: vi.fn(),
+      sessionId: 'session-1',
+      source: 'active-turn guard',
+      startSession: vi.fn(),
+      targetWindow: {
+        isDestroyed: () => false,
+        webContents: { send: vi.fn(), mainFrame: {} },
+      } as unknown as Electron.BrowserWindow,
+      workspacePath: '/workspace/project',
+    });
+
+    expect(processed).toBe(false);
+    expect(queueStore.claim).not.toHaveBeenCalled();
+  });
+
+  it('settles a handled internal action without invoking the model-turn handler', async () => {
+    vi.useFakeTimers();
+    const order: string[] = [];
+    const claimedPrompt: ClaimedQueuedPrompt = {
+      id: 'compact-1',
+      prompt: '/compact',
+      documentContext: { promptOrigin: 'agent_compaction' },
+    };
+    const queueStore: QueuedPromptStoreLike = {
+      listPending: vi.fn(async () => [claimedPrompt]),
+      claim: vi.fn(async () => claimedPrompt),
+      complete: vi.fn(async () => { order.push('complete'); }),
+      fail: vi.fn(async () => {}),
+    };
+    const sendMessageHandler = vi.fn();
+
+    await tryClaimAndDispatchNextQueuedPrompt({
+      continueQueuedPromptChain: vi.fn(async () => { order.push('continue'); }),
+      dispatchClaimedAction: vi.fn(async () => {
+        order.push('nativeCompact');
+        return true;
+      }),
+      logError: vi.fn(),
+      logInfo: vi.fn(),
+      onPromptClaimed: vi.fn(),
+      processingSet: new Set<string>(),
+      queueStore,
+      sendMessageHandler,
+      sessionId: 'session-1',
+      source: 'internal action',
+      startSession: vi.fn(async () => { order.push('startSession'); }),
+      targetWindow: {
+        isDestroyed: () => false,
+        webContents: { send: vi.fn(), mainFrame: {} },
+      } as unknown as Electron.BrowserWindow,
+      workspacePath: '/workspace/project',
+    });
+
+    await vi.runAllTimersAsync();
+
+    expect(order).toEqual(['startSession', 'nativeCompact', 'complete', 'continue']);
+    expect(sendMessageHandler).not.toHaveBeenCalled();
+  });
 });

--- a/packages/electron/src/main/services/ai/claudeCliSubmit.ts
+++ b/packages/electron/src/main/services/ai/claudeCliSubmit.ts
@@ -54,6 +54,21 @@ export interface SubmitClaudeCliPromptDeps {
 }
 
 /**
+ * Remove control bytes that can be interpreted by the PTY instead of becoming
+ * ordinary prompt text. Tabs and line breaks remain valid for normal prompts;
+ * slash-command argument tails are normalized separately below.
+ */
+function stripPtyControlBytes(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+}
+
+/** A slash-command tail must never contain an embedded submit keystroke. */
+function normalizeSlashCommandArgs(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Compose + write + log + analytics for one CLI submission. Returns
  * `{ submitted: false }` (a no-op) when there's nothing to send.
  */
@@ -61,7 +76,7 @@ export async function submitClaudeCliPrompt(
   input: SubmitClaudeCliPromptInput,
   deps: SubmitClaudeCliPromptDeps,
 ): Promise<{ submitted: boolean }> {
-  const prompt = (input.prompt ?? '').trim();
+  const prompt = stripPtyControlBytes(input.prompt ?? '').trim();
   const attachments = input.attachments ?? [];
 
   // NIM-819: the claude TUI only opens its slash-command/memory mode when
@@ -76,27 +91,42 @@ export async function submitClaudeCliPrompt(
   if (isTuiTrigger) {
     deps.writeToTerminal(input.sessionId, prompt[0]);
     await deps.delay(SUBMIT_WRITE_GAP_MS);
-    if (prompt.length > 1) {
-      deps.writeToTerminal(input.sessionId, prompt.slice(1));
+
+    const rest = prompt.slice(1);
+    const separatorIndex = prompt.startsWith('/') ? rest.search(/\s/) : -1;
+    const isSlashCommandWithArgs = separatorIndex > 0;
+
+    if (isSlashCommandWithArgs) {
+      const commandName = rest.slice(0, separatorIndex);
+      const args = normalizeSlashCommandArgs(rest.slice(separatorIndex));
+
+      // Resolve the autocomplete menu using only the command token. Writing
+      // the command and its argument tail in one PTY chunk lets the menu keep
+      // fuzzy-matching the entire tail and can submit the wrong highlighted
+      // command (or literal chat text) instead.
+      deps.writeToTerminal(input.sessionId, commandName);
       await deps.delay(SUBMIT_WRITE_GAP_MS);
-    }
-    // NIM-851: writing `/` first opens the claude TUI's slash-command
-    // autocomplete menu, and that menu (a) fuzzy-matches command DESCRIPTIONS
-    // not just names — typing "implement" surfaces `/investigate` ("...before
-    // implementing") and `/session-cleanup` ("...implementing -> validating") —
-    // and (b) hijacks Enter to run the HIGHLIGHTED row instead of the literal
-    // typed text. For a bare command (no args) the menu stays open through
-    // Enter, so a stale/recency-shifted highlight runs the wrong command (real
-    // incident: typed `/implement`, ran `/investigate` with empty args). Type a
-    // trailing space first: it ends the command token and dismisses the menu
-    // (verified on claude 2.1.177), so Enter submits the literal command.
-    // Commands WITH args already closed the menu via their separating space;
-    // bare `/` and `#` memory mode are different UIs and left untouched.
-    const isBareSlashCommand =
-      prompt.startsWith('/') && prompt.length > 1 && !/\s/.test(prompt);
-    if (isBareSlashCommand) {
       deps.writeToTerminal(input.sessionId, ' ');
       await deps.delay(SUBMIT_WRITE_GAP_MS);
+      if (args) {
+        deps.writeToTerminal(input.sessionId, args);
+        await deps.delay(SUBMIT_WRITE_GAP_MS);
+      }
+    } else {
+      if (rest) {
+        deps.writeToTerminal(input.sessionId, rest);
+        await deps.delay(SUBMIT_WRITE_GAP_MS);
+      }
+      // NIM-851: writing `/` first opens the claude TUI's slash-command
+      // autocomplete menu, whose highlighted row can hijack Enter. A trailing
+      // space resolves a bare command token before Enter is sent. Bare `/` and
+      // `#` memory mode are different UIs and remain untouched.
+      const isBareSlashCommand =
+        prompt.startsWith('/') && prompt.length > 1 && !/\s/.test(prompt);
+      if (isBareSlashCommand) {
+        deps.writeToTerminal(input.sessionId, ' ');
+        await deps.delay(SUBMIT_WRITE_GAP_MS);
+      }
     }
     deps.writeToTerminal(input.sessionId, SUBMIT_TERMINATOR);
   } else {

--- a/packages/electron/src/main/services/ai/queuedCompactionAction.ts
+++ b/packages/electron/src/main/services/ai/queuedCompactionAction.ts
@@ -1,0 +1,32 @@
+import type { ContextCompactionResult } from '@nimbalyst/runtime/ai/server';
+import type { DocumentContext } from '@nimbalyst/runtime/ai/server/types';
+
+export const QUEUED_COMPACTION_PROMPT_ORIGIN = 'agent_compaction';
+
+export interface QueuedCompactionPromptLike {
+  prompt: string;
+  documentContext?: DocumentContext | null;
+}
+
+/** Only an explicitly tagged, exact action can bypass the normal model turn. */
+export function isQueuedCompactionAction(prompt: QueuedCompactionPromptLike): boolean {
+  return prompt.prompt === '/compact'
+    && prompt.documentContext?.promptOrigin === QUEUED_COMPACTION_PROMPT_ORIGIN;
+}
+
+/**
+ * Execute a tagged compaction action through the provider-native path. Returns
+ * false for ordinary prompts so the queue dispatcher can send them normally.
+ */
+export async function dispatchQueuedCompactionAction(
+  prompt: QueuedCompactionPromptLike,
+  compact: () => Promise<ContextCompactionResult>,
+): Promise<boolean> {
+  if (!isQueuedCompactionAction(prompt)) return false;
+
+  const result = await compact();
+  if (!result.supported || !result.compacted) {
+    throw new Error(result.error || 'Provider-native compaction did not complete');
+  }
+  return true;
+}

--- a/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
+++ b/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
@@ -23,6 +23,7 @@ interface DispatchClaimedQueuedPromptOptions {
     source: string,
   ) => Promise<void>;
   logError: (message: string, error: unknown) => void;
+  dispatchClaimedAction?: (claimed: ClaimedQueuedPrompt) => Promise<boolean>;
   onAfterSettled?: () => Promise<void>;
   onChainSettled?: (payload: { sessionId: string; workspacePath: string; source: string }) => Promise<void>;
   onPromptClaimed: (payload: { sessionId: string; promptId: string }) => void;
@@ -48,6 +49,7 @@ export async function dispatchClaimedQueuedPrompt(
   const {
     claimed,
     continueQueuedPromptChain,
+    dispatchClaimedAction,
     logError,
     onAfterSettled,
     onChainSettled,
@@ -86,7 +88,12 @@ export async function dispatchClaimedQueuedPrompt(
         senderFrame: targetWindow.webContents.mainFrame,
       } as Electron.IpcMainInvokeEvent;
 
-      await sendMessageHandler(mockEvent, claimed.prompt, docContext, sessionId, workspacePath);
+      const handledAction = dispatchClaimedAction
+        ? await dispatchClaimedAction(claimed)
+        : false;
+      if (!handledAction) {
+        await sendMessageHandler(mockEvent, claimed.prompt, docContext, sessionId, workspacePath);
+      }
       await queueStore.complete(claimed.id);
     } catch (queueError) {
       logError(`[AIService] Failed to process queued prompt ${claimed.id}:`, queueError);
@@ -129,7 +136,9 @@ export async function dispatchClaimedQueuedPrompt(
 }
 
 interface TryClaimAndDispatchNextQueuedPromptOptions {
+  canDispatch?: (prompt: ClaimedQueuedPrompt) => Promise<boolean>;
   continueQueuedPromptChain: DispatchClaimedQueuedPromptOptions['continueQueuedPromptChain'];
+  dispatchClaimedAction?: DispatchClaimedQueuedPromptOptions['dispatchClaimedAction'];
   logError: DispatchClaimedQueuedPromptOptions['logError'];
   logInfo: (message: string) => void;
   onAfterSettled?: DispatchClaimedQueuedPromptOptions['onAfterSettled'];
@@ -149,7 +158,9 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
   options: TryClaimAndDispatchNextQueuedPromptOptions,
 ): Promise<boolean> {
   const {
+    canDispatch,
     continueQueuedPromptChain,
+    dispatchClaimedAction,
     logError,
     logInfo,
     onAfterSettled,
@@ -184,6 +195,11 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
   const nextPrompt = pendingPrompts[0];
   logInfo(`[AIService] ${source}: processing prompt ${nextPrompt.id} for session ${sessionId}`);
 
+  if (canDispatch && !(await canDispatch(nextPrompt))) {
+    logInfo(`[AIService] ${source}: prompt ${nextPrompt.id} deferred by provider-boundary guard`);
+    return false;
+  }
+
   const claimed = await queueStore.claim(nextPrompt.id);
   if (!claimed) {
     logInfo(`[AIService] ${source}: prompt ${nextPrompt.id} already claimed`);
@@ -199,6 +215,7 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
   await dispatchClaimedQueuedPrompt({
     claimed,
     continueQueuedPromptChain,
+    dispatchClaimedAction,
     logError,
     onAfterSettled,
     onChainSettled,

--- a/packages/runtime/src/ai/server/AIProvider.ts
+++ b/packages/runtime/src/ai/server/AIProvider.ts
@@ -63,6 +63,29 @@ export function isSlashCommandCatalogProvider(
   );
 }
 
+export interface ContextCompactionResult {
+  /** Whether this provider exposes a native, structured compaction operation. */
+  supported: boolean;
+  /** True only after the provider confirms that compaction completed. */
+  compacted: boolean;
+  /** Provider operation used for compaction. */
+  method?: string;
+  /** Structured failure detail when compaction did not complete. */
+  error?: string;
+}
+
+export interface ContextCompactionProvider {
+  compactSession(sessionId: string): Promise<ContextCompactionResult>;
+  /** True while provider-native compaction would replace an in-flight turn. */
+  isSessionActive?(sessionId: string): boolean;
+}
+
+export function isContextCompactionProvider(
+  provider: AIProvider | null | undefined
+): provider is AIProvider & ContextCompactionProvider {
+  return !!provider && typeof (provider as Partial<ContextCompactionProvider>).compactSession === 'function';
+}
+
 export interface AIProvider extends EventEmitter {
   /**
    * Initialize the provider with configuration

--- a/packages/runtime/src/ai/server/protocols/CodexAppServerProtocol.ts
+++ b/packages/runtime/src/ai/server/protocols/CodexAppServerProtocol.ts
@@ -120,6 +120,10 @@ interface AppServerSessionRaw {
   dynamicTools: DynamicToolSpec[];
   /** Snapshot of any uncompleted turn for abort handling. */
   activeTurnId: string | null;
+  /** True from before turn/start until a terminal turn notification. */
+  turnInProgress: boolean;
+  /** True while provider-native compaction owns the Codex core task slot. */
+  compactionInProgress: boolean;
   /** stderr buffer for diagnostic surface on failure. */
   stderrTail: string[];
 }
@@ -277,6 +281,17 @@ export class CodexAppServerProtocol implements AgentProtocol {
       ?? (raw.options as unknown as { abortSignal?: AbortSignal })?.abortSignal
       ?? (session.raw as { options?: { abortSignal?: AbortSignal } })?.options?.abortSignal;
 
+    // Model turns and CompactTask both replace any active Codex core task.
+    // Refuse before subscribing or issuing turn/start so concurrent operations
+    // cannot replace each other behind Nimbalyst's lifecycle tracking.
+    if (raw.turnInProgress || raw.compactionInProgress) {
+      yield {
+        type: 'error',
+        error: '[CodexAppServer] thread already has an active turn or compaction',
+      };
+      return;
+    }
+
     // Drain queue: notifications and one terminating turn event are pushed by
     // the JsonRpcClient handler; the generator below awaits them.
     const queue: Array<{ kind: 'event'; event: ProtocolEvent } | { kind: 'end' } | { kind: 'fail'; error: Error } | { kind: 'abort' }> = [];
@@ -334,10 +349,12 @@ export class CodexAppServerProtocol implements AgentProtocol {
       }
     }
 
-    // Start the turn. Errors from the request itself are surfaced as fail.
-    const turnInput = await this.buildInput(message);
+    // Start the turn. Errors from input construction or the request itself are
+    // surfaced as fail while releasing the operation slot.
     let turnStartResultId: string | null = null;
+    raw.turnInProgress = true;
     try {
+      const turnInput = await this.buildInput(message);
       const turnStart = await raw.client.request<{ turn?: { id?: string } }>('turn/start', {
         threadId: raw.threadId,
         input: turnInput,
@@ -345,6 +362,10 @@ export class CodexAppServerProtocol implements AgentProtocol {
       turnStartResultId = turnStart?.turn?.id ?? null;
       raw.activeTurnId = turnStartResultId;
     } catch (err) {
+      raw.turnInProgress = false;
+      for (const unsub of unsubscribers) {
+        try { unsub(); } catch { /* noop */ }
+      }
       const baseMsg = err instanceof Error ? err.message : String(err);
       yield {
         type: 'error',
@@ -390,6 +411,117 @@ export class CodexAppServerProtocol implements AgentProtocol {
         try { unsub(); } catch { /* noop */ }
       }
       raw.activeTurnId = null;
+      raw.turnInProgress = false;
+    }
+  }
+
+  /**
+   * Report whether a model turn or native compaction currently owns the Codex
+   * core task slot for this thread.
+   */
+  isSessionActive(session: ProtocolSession): boolean {
+    const raw = this.assertRaw(session);
+    return raw.turnInProgress || raw.compactionInProgress;
+  }
+
+  /**
+   * Compact an idle Codex thread through the app-server's provider-native RPC.
+   * Codex core implements CompactTask by replacing any current task, so the
+   * active-operation guard is a correctness boundary, not an optimization.
+   * Success is based only on structured notifications, never response text.
+   */
+  async compactSession(session: ProtocolSession): Promise<void> {
+    const raw = this.assertRaw(session);
+    const threadId = raw.threadId;
+    if (!threadId) {
+      throw new Error('[CodexAppServer] cannot compact a session without a thread id');
+    }
+    if (this.isSessionActive(session)) {
+      throw new Error('[CodexAppServer] cannot compact a thread with an active turn');
+    }
+    raw.compactionInProgress = true;
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let unsubscribe = () => {};
+    try {
+      let resolveCompletion!: () => void;
+      let rejectCompletion!: (error: Error) => void;
+      const completion = new Promise<void>((resolve, reject) => {
+        resolveCompletion = resolve;
+        rejectCompletion = reject;
+      });
+      let sawCompactionItem = false;
+      let sawTerminalTurn = false;
+      const resolveWhenFullySettled = () => {
+        if (sawCompactionItem && sawTerminalTurn) resolveCompletion();
+      };
+      timeout = setTimeout(() => {
+        rejectCompletion(new Error(`[CodexAppServer] timed out waiting for thread ${threadId} to compact`));
+      }, 60_000);
+
+      unsubscribe = raw.client.onNotification((method, paramsUnknown) => {
+        const params = paramsUnknown && typeof paramsUnknown === 'object'
+          ? paramsUnknown as Record<string, unknown>
+          : null;
+        if (!params || params.threadId !== threadId) return;
+
+        if (method === 'thread/compacted') {
+          sawCompactionItem = true;
+          resolveWhenFullySettled();
+          return;
+        }
+
+        if (method === 'item/completed') {
+          const item = params.item && typeof params.item === 'object'
+            ? params.item as Record<string, unknown>
+            : null;
+          if (item?.type === 'contextCompaction' || item?.type === 'context_compaction') {
+            sawCompactionItem = true;
+            resolveWhenFullySettled();
+          }
+          return;
+        }
+
+        if (method === 'turn/completed') {
+          const turn = params.turn && typeof params.turn === 'object'
+            ? params.turn as Record<string, unknown>
+            : null;
+          if (turn?.status === 'failed') {
+            const error = turn.error && typeof turn.error === 'object'
+              ? turn.error as Record<string, unknown>
+              : null;
+            rejectCompletion(new Error(
+              typeof error?.message === 'string'
+                ? error.message
+                : '[CodexAppServer] compaction turn failed',
+            ));
+            return;
+          }
+          sawTerminalTurn = true;
+          resolveWhenFullySettled();
+          return;
+        }
+
+        if (method === 'turn/failed' || method === 'error') {
+          const error = params.error && typeof params.error === 'object'
+            ? params.error as Record<string, unknown>
+            : null;
+          rejectCompletion(new Error(
+            typeof error?.message === 'string'
+              ? error.message
+              : '[CodexAppServer] compaction turn failed',
+          ));
+        }
+      });
+
+      await Promise.all([
+        raw.client.request('thread/compact/start', { threadId }, 60_000),
+        completion,
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      unsubscribe();
+      raw.compactionInProgress = false;
     }
   }
 
@@ -478,6 +610,8 @@ export class CodexAppServerProtocol implements AgentProtocol {
       initResponse,
       dynamicTools: this.extractDynamicTools(options),
       activeTurnId: null,
+      turnInProgress: false,
+      compactionInProgress: false,
       stderrTail,
     };
   }
@@ -707,6 +841,11 @@ export class CodexAppServerProtocol implements AgentProtocol {
       }
       case 'turn/completed': {
         const n = params as unknown as TurnCompletedNotification;
+        // The core task is finished before the completion event is exposed to
+        // MessageStreamingHandler. This lets its normal queue continuation
+        // safely start a post-turn compaction action.
+        raw.activeTurnId = null;
+        raw.turnInProgress = false;
         const usage = normalizeUsage(n.usage);
         if (usage) setUsage(usage);
         if (n.turn?.status === 'failed') {
@@ -720,6 +859,8 @@ export class CodexAppServerProtocol implements AgentProtocol {
       case 'turn/failed':
       case 'error': {
         const n = params as unknown as ErrorNotification;
+        raw.activeTurnId = null;
+        raw.turnInProgress = false;
         const msg = n?.error?.message ?? 'codex app-server error';
         push({ kind: 'fail', error: new Error(msg) });
         return;
@@ -1011,6 +1152,8 @@ export class CodexAppServerProtocol implements AgentProtocol {
       'fileChange',
       'mcpToolCall',
       'commandExecution',
+      'contextCompaction',
+      'context_compaction',
     ]).has(item.type);
   }
 

--- a/packages/runtime/src/ai/server/protocols/__tests__/CodexAppServerProtocol.test.ts
+++ b/packages/runtime/src/ai/server/protocols/__tests__/CodexAppServerProtocol.test.ts
@@ -191,6 +191,90 @@ describe('CodexAppServerProtocol', () => {
     protocol.cleanupSession(session);
   });
 
+  it('refuses active-turn compaction, then compacts post-turn without starting a model turn', async () => {
+    const protocol = new CodexAppServerProtocol();
+    const sessionPromise = protocol.createSession({ workspacePath: '/tmp/ws' });
+    const initReq = await nextWrittenMatching(child, 'initialize');
+    child.emitLine({ id: initReq.id, result: { codexHome: '/fake', platformFamily: 'unix', platformOs: 'macos', userAgent: 'fake/0' } });
+    const startReq = await nextWrittenMatching(child, 'thread/start');
+    child.emitLine({ id: startReq.id, result: { thread: { id: 'thread-abc' } } });
+    const session = await sessionPromise;
+
+    const events: ProtocolEvent[] = [];
+    const collector = (async () => {
+      for await (const event of protocol.sendMessage(session, { content: 'call compact_session' })) {
+        events.push(event);
+      }
+    })();
+    const turnReq = await nextWrittenMatching(child, 'turn/start');
+
+    const activeOutcome = protocol.compactSession(session).then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const activeCompactReq = child.writtenLines.find(
+      (line) => (line as { method?: string }).method === 'thread/compact/start',
+    ) as Record<string, unknown> | undefined;
+    if (activeCompactReq) {
+      child.emitLine({ id: activeCompactReq.id, result: {} });
+      child.emitLine({
+        method: 'item/completed',
+        params: {
+          threadId: 'thread-abc',
+          turnId: 'compact-active',
+          item: { id: 'compaction-active', type: 'contextCompaction' },
+        },
+      });
+    }
+    const activeResult = await activeOutcome;
+    expect(activeCompactReq).toBeUndefined();
+    expect(activeResult.ok).toBe(false);
+    expect(activeResult).toMatchObject({
+      error: expect.objectContaining({ message: expect.stringContaining('active turn') }),
+    });
+
+    child.emitLine({ id: turnReq.id, result: { turn: { id: 'turn-1', items: [], status: 'inProgress' } } });
+    child.emitLine({ method: 'turn/completed', params: { threadId: 'thread-abc', turn: { id: 'turn-1', status: 'completed' } } });
+    await collector;
+
+    const compactPromise = protocol.compactSession(session);
+    const compactReq = await nextWrittenMatching(child, 'thread/compact/start');
+    expect(compactReq.params).toEqual({ threadId: 'thread-abc' });
+    child.emitLine({ id: compactReq.id, result: {} });
+    child.emitLine({
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-abc',
+        turnId: 'compact-1',
+        item: { id: 'compaction-1', type: 'contextCompaction' },
+      },
+    });
+
+    let compactionSettled = false;
+    void compactPromise.then(
+      () => { compactionSettled = true; },
+      () => { compactionSettled = true; },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(compactionSettled).toBe(false);
+    expect(protocol.isSessionActive(session)).toBe(true);
+
+    child.emitLine({
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-abc',
+        turn: { id: 'compact-1', status: 'completed' },
+      },
+    });
+    await expect(compactPromise).resolves.toBeUndefined();
+    expect(protocol.isSessionActive(session)).toBe(false);
+    expect(child.writtenLines.filter((line) => (line as { method?: string }).method === 'turn/start')).toHaveLength(1);
+    expect(child.writtenLines.some((line) => (line as { method?: string }).method === 'turn/interrupt')).toBe(false);
+    expect(events.some((event) => event.toolCall?.name === 'contextCompaction')).toBe(false);
+    protocol.cleanupSession(session);
+  });
+
   it('translates fileChange item/completed into a tool_call event with diff-based baselines', async () => {
     const protocol = new CodexAppServerProtocol();
     const sessionPromise = protocol.createSession({ workspacePath: '/tmp/ws' });

--- a/packages/runtime/src/ai/server/providers/BaseAgentProvider.ts
+++ b/packages/runtime/src/ai/server/providers/BaseAgentProvider.ts
@@ -40,6 +40,7 @@ export abstract class BaseAgentProvider extends BaseAIProvider {
     'mcp__nimbalyst-host__get_session_status',
     'mcp__nimbalyst-host__get_session_result',
     'mcp__nimbalyst-host__send_prompt',
+    'mcp__nimbalyst-host__compact_session',
     'mcp__nimbalyst-host__respond_to_prompt',
     'mcp__nimbalyst-host__get_session_summary',
     'mcp__nimbalyst-host__get_workstream_overview',

--- a/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
+++ b/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import crypto from 'crypto';
 import OpenAI from 'openai';
 import { BaseAgentProvider } from './BaseAgentProvider';
+import type { ContextCompactionResult } from '../AIProvider';
 import { buildUserMessageAddition } from './documentContextUtils';
 import { buildClaudeCodeSystemPrompt, buildMetaAgentSystemPrompt, type MetaAgentWorkflowPreset } from '../../prompt';
 import { DEFAULT_MODELS } from '../../modelConstants';
@@ -53,6 +54,8 @@ export type CodexTransport = 'sdk' | 'app-server';
  */
 export interface CodexProtocol extends AgentProtocol {
   setApiKey?(apiKey: string): void;
+  compactSession?(session: ProtocolSession): Promise<void>;
+  isSessionActive?(session: ProtocolSession): boolean;
 }
 
 interface OpenAICodexProviderDeps {
@@ -880,6 +883,59 @@ export class OpenAICodexProvider extends BaseAgentProvider {
 
   async cancelStream(_sessionId?: string): Promise<void> {
     this.abort();
+  }
+
+  /** Compact the existing app-server thread without starting another turn. */
+  async compactSession(sessionId: string): Promise<ContextCompactionResult> {
+    const method = 'thread/compact/start';
+    if (this.transport !== 'app-server' || typeof this.protocol.compactSession !== 'function') {
+      return {
+        supported: false,
+        compacted: false,
+        method,
+        error: 'Native compaction requires the Codex app-server transport',
+      };
+    }
+
+    const session = this.liveProtocolSessions.get(sessionId);
+    if (!session) {
+      return {
+        supported: true,
+        compacted: false,
+        method,
+        error: 'No live Codex app-server thread is available for this session',
+      };
+    }
+
+    if (this.isSessionActive(sessionId)) {
+      return {
+        supported: true,
+        compacted: false,
+        method,
+        error: 'Cannot compact a Codex thread while it has an active turn',
+      };
+    }
+
+    try {
+      await this.protocol.compactSession(session);
+      return { supported: true, compacted: true, method };
+    } catch (error) {
+      return {
+        supported: true,
+        compacted: false,
+        method,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /** Provider-boundary guard used before claiming a queued compaction action. */
+  isSessionActive(sessionId: string): boolean {
+    const session = this.liveProtocolSessions.get(sessionId);
+    if (!session) return false;
+    // A protocol implementation without the guard cannot safely prove
+    // inactivity, so treat a live thread as active rather than guessing.
+    return this.protocol.isSessionActive?.(session) ?? true;
   }
 
   async *sendMessage(

--- a/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
@@ -39,6 +39,93 @@ describe('OpenAICodexProvider', () => {
     OpenAICodexProvider.setSecurityLogger(() => {});
   });
 
+  it('delegates compaction to the live app-server thread without sending another message', async () => {
+    const compactSession = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn();
+    const protocol = {
+      platform: 'codex-app-server',
+      compactSession,
+      isSessionActive: vi.fn(() => false),
+      sendMessage,
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      forkSession: vi.fn(),
+      abortSession: vi.fn(),
+      cleanupSession: vi.fn(),
+    } as any;
+    const provider = new OpenAICodexProvider(undefined, {
+      protocol,
+      transport: 'app-server',
+      permissionService: {} as any,
+    });
+    const protocolSession = { id: 'thread-1', platform: 'codex-app-server', raw: {} };
+    (provider as any).liveProtocolSessions.set('session-1', protocolSession);
+
+    await expect(provider.compactSession('session-1')).resolves.toEqual({
+      supported: true,
+      compacted: true,
+      method: 'thread/compact/start',
+    });
+    expect(compactSession).toHaveBeenCalledWith(protocolSession);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('refuses native compaction while the live app-server thread has an active turn', async () => {
+    const compactSession = vi.fn();
+    const protocol = {
+      platform: 'codex-app-server',
+      compactSession,
+      isSessionActive: vi.fn(() => true),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      forkSession: vi.fn(),
+      sendMessage: vi.fn(),
+      abortSession: vi.fn(),
+      cleanupSession: vi.fn(),
+    } as any;
+    const provider = new OpenAICodexProvider(undefined, {
+      protocol,
+      transport: 'app-server',
+      permissionService: {} as any,
+    });
+    (provider as any).liveProtocolSessions.set('session-1', {
+      id: 'thread-1',
+      platform: 'codex-app-server',
+      raw: {},
+    });
+
+    await expect(provider.compactSession('session-1')).resolves.toMatchObject({
+      supported: true,
+      compacted: false,
+      error: expect.stringContaining('active turn'),
+    });
+    expect(compactSession).not.toHaveBeenCalled();
+  });
+
+  it('reports a structured failure when no live app-server thread is available', async () => {
+    const provider = new OpenAICodexProvider(undefined, {
+      protocol: {
+        platform: 'codex-app-server',
+        compactSession: vi.fn(),
+        createSession: vi.fn(),
+        resumeSession: vi.fn(),
+        forkSession: vi.fn(),
+        sendMessage: vi.fn(),
+        abortSession: vi.fn(),
+        cleanupSession: vi.fn(),
+      } as any,
+      transport: 'app-server',
+      permissionService: {} as any,
+    });
+
+    await expect(provider.compactSession('missing-session')).resolves.toEqual({
+      supported: true,
+      compacted: false,
+      method: 'thread/compact/start',
+      error: 'No live Codex app-server thread is available for this session',
+    });
+  });
+
   it('updates currentTodos for app-server todoList raw events', async () => {
     const updateMetadata = vi.fn(async () => {});
     AISessionsRepository.setStore({

--- a/packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts
+++ b/packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts
@@ -53,6 +53,7 @@ describe('Topology descriptor', () => {
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('display_to_user')).toBe(MCP_CORE);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('settings_get_overview')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('spawn_session')).toBe(MCP_HOST);
+    expect(FIRST_PARTY_TOOL_TO_SERVER.get('compact_session')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('tracker_create')).toBe(MCP_TRACKERS);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('voice_agent_speak')).toBe(MCP_SITUATIONAL);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('renderer_eval')).toBe(MCP_EXTENSION_DEV);

--- a/packages/runtime/src/ai/server/services/mcpTopology.ts
+++ b/packages/runtime/src/ai/server/services/mcpTopology.ts
@@ -154,6 +154,7 @@ export const HOST_TOOLS: readonly string[] = [
   'create_session',
   'spawn_session',
   'send_prompt',
+  'compact_session',
   'respond_to_prompt',
   'get_session_status',
   'get_session_result',


### PR DESCRIPTION
## Summary

- Adds a bounded `compact_session` meta-agent tool for a session or directly owned child in the same workspace.
- Defers Codex compaction through the normal queue, then runs `thread/compact/start` only after the active turn ends and without starting a synthetic model turn.
- Makes Codex model turns and native compaction mutually exclusive, waits for structured compaction plus terminal-turn completion, and preserves safe queued Claude `/compact` handling.

## Related issue

Closes #835

## Testing

- `npx vitest run packages/electron/src/main/mcp/__tests__/metaAgentServer.compactSession.test.ts packages/electron/src/main/services/ai/__tests__/claudeCliSubmit.test.ts packages/electron/src/main/services/ai/__tests__/queuedCompactionAction.test.ts packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts packages/electron/src/main/services/__tests__/MetaAgentService.compactSession.test.ts packages/electron/src/main/services/__tests__/MetaAgentService.cliPortWiring.test.ts packages/runtime/src/ai/server/protocols/__tests__/CodexAppServerProtocol.test.ts packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts`
- `npm run typecheck --prefix packages/electron`
- `npm run typecheck --prefix packages/runtime`
- `git diff --check` and new-file whitespace checks
- Fresh isolated packaged self-target E2E after the NIM-1607 reconciliation: same-turn continuation, post-turn queue claim, structured native completion, terminal queue settlement, and same-thread follow-up all passed.

## Notes for reviewers

Codex core compaction replaces an active task, so the MCP tool reports only a scheduled result. The queued action is guarded at the provider/protocol boundary and completes only after the structured compaction signals and terminal compaction turn. The fresh live gate effectively ran on `gpt-5.6-sol` with medium reasoning despite the prepared session advertising Luna/Medium; this is a separate model-resolution/auditability discrepancy, not a Luna run.

## Why this is worth merging

Compaction mutates the context that an active turn is still using. Deferring an agent-triggered compaction until that turn ends removes a race that can discard or reorder in-flight reasoning while preserving the user's ability to request compaction. The change favors a short, predictable delay over corruption of the active conversation.
