### PR TITLE
fix(ai-sessions): mark delivered-but-unanswered queued prompts failed instead of completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - PR mode now explains when a merge needs the GitHub CLI `workflow` scope and offers the recovery command instead of showing `gh api -X failed`.
+- Queued prompts that were delivered but never answered (app quit or interrupt mid-turn) now show a visible failed state with a retry hint instead of being silently marked completed (#783, #790).
 - Importing Mermaid diagrams into Excalidraw works again: flowcharts (including subgraphs) become editable shapes instead of failing or degrading to a broken image, and AI-added arrows no longer lose their labels.
 - Voice mode no longer stops listening while you are still speaking; the mic stays open until you finish or explicitly pause.
 - Shared-document comments now live in the text-selection toolbar instead of overlapping it.

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -2162,10 +2162,10 @@ app.whenReady().then(async () => {
     // re-sent on next launch (NIM-615).
     try {
       const { getQueuedPromptsStore } = await import('./services/RepositoryManager');
-      const { completed, rolledBack } = await getQueuedPromptsStore().sweepExecutingOnBoot();
-      if (completed > 0 || rolledBack > 0) {
+      const { completed, failed, rolledBack } = await getQueuedPromptsStore().sweepExecutingOnBoot();
+      if (completed > 0 || failed > 0 || rolledBack > 0) {
         logger.main.info(
-          `[Main] Boot sweep: ${completed} delivered prompt(s) marked completed, ${rolledBack} undelivered prompt(s) rolled back to pending`
+          `[Main] Boot sweep: ${completed} answered prompt(s) marked completed, ${failed} delivered-but-unanswered prompt(s) marked failed, ${rolledBack} undelivered prompt(s) rolled back to pending`
         );
       }
     } catch (sweepErr) {

--- a/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
+++ b/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
@@ -278,9 +278,12 @@ export function createPGLiteQueuedPromptsStore(
     async complete(id: string): Promise<void> {
       await ensureReady();
 
+      // error_message = NULL: a turn that resolves normally after a sweep
+      // provisionally failed the row (buffered output landing late) must
+      // not keep the stale sweep error alongside status 'completed'.
       await db.query(
         `UPDATE queued_prompts
-         SET status = 'completed', completed_at = CURRENT_TIMESTAMP
+         SET status = 'completed', completed_at = CURRENT_TIMESTAMP, error_message = NULL
          WHERE id = $1`,
         [id]
       );
@@ -411,11 +414,13 @@ export function createPGLiteQueuedPromptsStore(
       );
 
       // Pass 2: still-executing rows whose input WAS delivered but that
-      // have no output evidence (pass 1 already consumed the answered
-      // ones). The turn died between delivery and any response. Mark
-      // failed with a visible error, NOT completed (silent fake success,
-      // #783) and NOT pending (a re-claim would re-send the delivered
-      // input, regressing NIM-615).
+      // have no output evidence. The turn died between delivery and any
+      // response. Mark failed with a visible error, NOT completed (silent
+      // fake success, #783) and NOT pending (a re-claim would re-send the
+      // delivered input, regressing NIM-615). The NOT EXISTS makes this
+      // pass independently correct rather than relying on pass 1 having
+      // consumed the answered rows first (an output row committed between
+      // the two statements must not produce a failed-but-answered row).
       const failedResult = await db.query<{ id: string }>(
         `UPDATE queued_prompts
          SET status = 'failed', completed_at = CURRENT_TIMESTAMP, error_message = $1
@@ -424,6 +429,12 @@ export function createPGLiteQueuedPromptsStore(
              SELECT 1 FROM ai_agent_messages m
              WHERE m.session_id = queued_prompts.session_id
                AND m.direction = 'input'
+               AND m.created_at >= queued_prompts.claimed_at
+           )
+           AND NOT EXISTS (
+             SELECT 1 FROM ai_agent_messages m
+             WHERE m.session_id = queued_prompts.session_id
+               AND m.direction = 'output'
                AND m.created_at >= queued_prompts.claimed_at
            )
          RETURNING id`,
@@ -485,7 +496,10 @@ export function createPGLiteQueuedPromptsStore(
       // exact #790 shape ("why did you stop?" was claimed, never
       // answered, and the interrupt sweep marked it completed). Fail it
       // visibly instead; never roll back to pending (re-claim would
-      // re-send the delivered input, NIM-615).
+      // re-send the delivered input, NIM-615). NOT EXISTS keeps this
+      // pass independently correct if an output row commits between the
+      // two statements; and if the turn later resolves normally anyway,
+      // complete() overwrites the provisional failed and clears the error.
       const failedResult = await db.query<{ id: string }>(
         `UPDATE queued_prompts
          SET status = 'failed', completed_at = CURRENT_TIMESTAMP, error_message = $2
@@ -496,6 +510,12 @@ export function createPGLiteQueuedPromptsStore(
              SELECT 1 FROM ai_agent_messages m
              WHERE m.session_id = queued_prompts.session_id
                AND m.direction = 'input'
+               AND m.created_at >= queued_prompts.claimed_at
+           )
+           AND NOT EXISTS (
+             SELECT 1 FROM ai_agent_messages m
+             WHERE m.session_id = queued_prompts.session_id
+               AND m.direction = 'output'
                AND m.created_at >= queued_prompts.claimed_at
            )
          RETURNING id`,

--- a/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
+++ b/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
@@ -95,14 +95,18 @@ export interface QueuedPromptsStore {
    * activation, duplicating the original user input. We instead check
    * whether the prompt was already injected into the conversation by
    * looking for an `ai_agent_messages` input row in the same session
-   * dated at or after `claimed_at`. If delivered -> mark `completed`
-   * (the agent turn is no longer running, but the prompt did its job).
-   * If not delivered -> roll back to `pending` so a retry can pick it
-   * up (genuine crash before send).
+   * dated at or after `claimed_at`, AND whether the agent produced any
+   * output row after the claim. Delivered and answered -> `completed`.
+   * Delivered but never answered (input row only, e.g. the provider was
+   * SIGTERM'd mid-turn at quit, #783) -> `failed` with an error message,
+   * a visible terminal state; never `pending`, because a re-claim would
+   * re-send the already-delivered input (NIM-615). Not delivered ->
+   * roll back to `pending` so a retry can pick it up (genuine crash
+   * before send).
    *
    * Returns the count of rows in each bucket.
    */
-  sweepExecutingOnBoot(): Promise<{ completed: number; rolledBack: number }>;
+  sweepExecutingOnBoot(): Promise<{ completed: number; failed: number; rolledBack: number }>;
 
   /**
    * Delivery-aware single-session variant of the boot sweep. Used by
@@ -111,11 +115,13 @@ export interface QueuedPromptsStore {
    * not undo the user message that has already landed in
    * `ai_agent_messages`. Rolling such a row back to `pending` causes
    * the queue trigger that follows the abort to immediately re-claim
-   * and re-send it, duplicating the input. Mark delivered rows
-   * `completed`; roll back only rows that never made it to the
+   * and re-send it, duplicating the input. Mark answered rows
+   * `completed`, delivered-but-unanswered rows `failed` (#790: an
+   * interrupt sweep used to mark those completed and the session looked
+   * silently answered); roll back only rows that never made it to the
    * conversation.
    */
-  sweepExecutingForSession(sessionId: string): Promise<{ completed: number; rolledBack: number }>;
+  sweepExecutingForSession(sessionId: string): Promise<{ completed: number; failed: number; rolledBack: number }>;
 
   /** Delete all completed/failed prompts older than a certain age */
   cleanup(olderThanMs: number): Promise<number>;
@@ -126,6 +132,15 @@ type PGliteLike = {
 };
 
 type EnsureReadyFn = () => Promise<void>;
+
+/**
+ * error_message written by the sweep passes for prompts that were
+ * delivered (input row logged) but got no agent output before the turn
+ * died (app quit / provider interrupt). Deliberately phrased so a user
+ * reading the row knows the recovery action.
+ */
+const SWEEP_UNANSWERED_ERROR =
+  'Prompt was delivered but the turn was interrupted before a response was recorded. Send it again to retry.';
 
 function rowToQueuedPrompt(row: any): QueuedPrompt {
   // Parse JSONB fields
@@ -330,19 +345,25 @@ export function createPGLiteQueuedPromptsStore(
       return rows.length;
     },
 
-    async sweepExecutingOnBoot(): Promise<{ completed: number; rolledBack: number }> {
+    async sweepExecutingOnBoot(): Promise<{ completed: number; failed: number; rolledBack: number }> {
       await ensureReady();
 
       // Pass 1: rows whose user message was already logged to
-      // ai_agent_messages -- the prompt was delivered and the agent was
-      // just paused (e.g. on AskUserQuestion) when the app quit. Mark
-      // completed so the next session activation doesn't re-claim and
-      // re-send the original prompt.
+      // ai_agent_messages AND that have agent output after the claim --
+      // the prompt was delivered and the agent responded (or was paused
+      // on an interactive prompt, which also persists as an output row)
+      // when the app quit. Mark completed so the next session activation
+      // doesn't re-claim and re-send the original prompt.
       //
       // Three branches join in this update:
       //
-      // (a) `executing` rows whose input arrived after `claimed_at` --
-      //     standard "delivered then paused" case.
+      // (a) `executing` rows whose input arrived after `claimed_at` AND
+      //     that have at least one output row after `claimed_at` --
+      //     "delivered then answered/paused". The input row alone does
+      //     NOT prove the agent ever responded: a provider SIGTERM'd at
+      //     quit leaves the input logged and nothing else, and marking
+      //     that completed makes the session look silently answered
+      //     (#783). Those rows fall through to pass 2 instead.
       // (b) `pending` rows whose prompt text appears in a later input
       //     for the same session -- leftover corruption from older
       //     builds that ran the blanket `rollbackAllExecuting` sweep on
@@ -366,6 +387,12 @@ export function createPGLiteQueuedPromptsStore(
               WHERE m.session_id = queued_prompts.session_id
                 AND m.direction = 'input'
                 AND m.created_at >= queued_prompts.claimed_at
+            )
+            AND EXISTS (
+              SELECT 1 FROM ai_agent_messages m
+              WHERE m.session_id = queued_prompts.session_id
+                AND m.direction = 'output'
+                AND m.created_at >= queued_prompts.claimed_at
             ))
            OR
            (status = 'pending'
@@ -383,7 +410,27 @@ export function createPGLiteQueuedPromptsStore(
          RETURNING id`
       );
 
-      // Pass 2: anything still executing crashed before its input was
+      // Pass 2: still-executing rows whose input WAS delivered but that
+      // have no output evidence (pass 1 already consumed the answered
+      // ones). The turn died between delivery and any response. Mark
+      // failed with a visible error, NOT completed (silent fake success,
+      // #783) and NOT pending (a re-claim would re-send the delivered
+      // input, regressing NIM-615).
+      const failedResult = await db.query<{ id: string }>(
+        `UPDATE queued_prompts
+         SET status = 'failed', completed_at = CURRENT_TIMESTAMP, error_message = $1
+         WHERE status = 'executing' AND claimed_at IS NOT NULL
+           AND EXISTS (
+             SELECT 1 FROM ai_agent_messages m
+             WHERE m.session_id = queued_prompts.session_id
+               AND m.direction = 'input'
+               AND m.created_at >= queued_prompts.claimed_at
+           )
+         RETURNING id`,
+        [SWEEP_UNANSWERED_ERROR]
+      );
+
+      // Pass 3: anything still executing crashed before its input was
       // ever logged. Roll back to pending so it can be retried.
       const rolledBackResult = await db.query<{ id: string }>(
         `UPDATE queued_prompts
@@ -393,24 +440,25 @@ export function createPGLiteQueuedPromptsStore(
       );
 
       const completed = completedResult.rows.length;
+      const failed = failedResult.rows.length;
       const rolledBack = rolledBackResult.rows.length;
 
-      if (completed > 0 || rolledBack > 0) {
+      if (completed > 0 || failed > 0 || rolledBack > 0) {
         console.log(
-          `[QueuedPromptsStore] Boot sweep: marked ${completed} delivered prompt(s) completed, rolled back ${rolledBack} undelivered prompt(s)`
+          `[QueuedPromptsStore] Boot sweep: marked ${completed} answered prompt(s) completed, ${failed} delivered-but-unanswered prompt(s) failed, rolled back ${rolledBack} undelivered prompt(s)`
         );
       }
 
-      return { completed, rolledBack };
+      return { completed, failed, rolledBack };
     },
 
-    async sweepExecutingForSession(sessionId: string): Promise<{ completed: number; rolledBack: number }> {
+    async sweepExecutingForSession(sessionId: string): Promise<{ completed: number; failed: number; rolledBack: number }> {
       await ensureReady();
 
-      // Pass 1: same delivery check as sweepExecutingOnBoot, but scoped
-      // to a single session. Used on cancel/interrupt to avoid the
-      // immediate re-claim that follows when an already-delivered prompt
-      // is rolled back to pending.
+      // Pass 1: same delivery + output-evidence check as
+      // sweepExecutingOnBoot, but scoped to a single session. Used on
+      // cancel/interrupt to avoid the immediate re-claim that follows
+      // when an already-delivered prompt is rolled back to pending.
       const completedResult = await db.query<{ id: string }>(
         `UPDATE queued_prompts
          SET status = 'completed', completed_at = CURRENT_TIMESTAMP
@@ -423,11 +471,38 @@ export function createPGLiteQueuedPromptsStore(
                AND m.direction = 'input'
                AND m.created_at >= queued_prompts.claimed_at
            )
+           AND EXISTS (
+             SELECT 1 FROM ai_agent_messages m
+             WHERE m.session_id = queued_prompts.session_id
+               AND m.direction = 'output'
+               AND m.created_at >= queued_prompts.claimed_at
+           )
          RETURNING id`,
         [sessionId]
       );
 
-      // Pass 2: roll back anything still executing for this session that
+      // Pass 2: delivered but no output before the interrupt -- the
+      // exact #790 shape ("why did you stop?" was claimed, never
+      // answered, and the interrupt sweep marked it completed). Fail it
+      // visibly instead; never roll back to pending (re-claim would
+      // re-send the delivered input, NIM-615).
+      const failedResult = await db.query<{ id: string }>(
+        `UPDATE queued_prompts
+         SET status = 'failed', completed_at = CURRENT_TIMESTAMP, error_message = $2
+         WHERE status = 'executing'
+           AND session_id = $1
+           AND claimed_at IS NOT NULL
+           AND EXISTS (
+             SELECT 1 FROM ai_agent_messages m
+             WHERE m.session_id = queued_prompts.session_id
+               AND m.direction = 'input'
+               AND m.created_at >= queued_prompts.claimed_at
+           )
+         RETURNING id`,
+        [sessionId, SWEEP_UNANSWERED_ERROR]
+      );
+
+      // Pass 3: roll back anything still executing for this session that
       // never made it to the conversation.
       const rolledBackResult = await db.query<{ id: string }>(
         `UPDATE queued_prompts
@@ -438,15 +513,16 @@ export function createPGLiteQueuedPromptsStore(
       );
 
       const completed = completedResult.rows.length;
+      const failed = failedResult.rows.length;
       const rolledBack = rolledBackResult.rows.length;
 
-      if (completed > 0 || rolledBack > 0) {
+      if (completed > 0 || failed > 0 || rolledBack > 0) {
         console.log(
-          `[QueuedPromptsStore] Session sweep (${sessionId}): marked ${completed} delivered prompt(s) completed, rolled back ${rolledBack} undelivered prompt(s)`
+          `[QueuedPromptsStore] Session sweep (${sessionId}): marked ${completed} answered prompt(s) completed, ${failed} delivered-but-unanswered prompt(s) failed, rolled back ${rolledBack} undelivered prompt(s)`
         );
       }
 
-      return { completed, rolledBack };
+      return { completed, failed, rolledBack };
     },
 
     async cleanup(olderThanMs: number): Promise<number> {

--- a/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.test.ts
+++ b/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.test.ts
@@ -120,11 +120,15 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingOnBoot', () => {
     // Second pass: delivered-but-unanswered rows become a VISIBLE terminal
     // state, never 'completed' (silent success) and never 'pending'
     // (re-claim would re-send the delivered input, regressing NIM-615).
+    // The pass re-checks output absence itself (NOT EXISTS) so it stays
+    // correct even if an output row commits between the two statements.
     expect(calls[1].sql).toContain("SET status = 'failed'");
     expect(calls[1].sql).toContain('error_message');
     expect(calls[1].sql).toContain("status = 'executing'");
     expect(calls[1].sql).toContain('claimed_at IS NOT NULL');
     expect(calls[1].sql).toContain("direction = 'input'");
+    expect(calls[1].sql).toContain('NOT EXISTS');
+    expect(calls[1].sql).toContain("direction = 'output'");
 
     // Third pass: rolls back anything still executing (i.e. undelivered)
     expect(calls[2].sql).toContain("SET status = 'pending'");
@@ -224,6 +228,23 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingOnBoot', () => {
   });
 });
 
+describe('PGLiteQueuedPromptsStore.complete', () => {
+  it('clears error_message so a turn resolving after a provisional sweep-fail does not keep the stale error', async () => {
+    const query = vi.fn(async (sql: string, params?: any[]) => {
+      expect(sql).toContain("SET status = 'completed'");
+      expect(sql).toContain('error_message = NULL');
+      expect(params).toEqual(['prompt-1']);
+      return { rows: [] };
+    });
+    const db: DbStub = { query: query as any };
+
+    const store = createPGLiteQueuedPromptsStore(db);
+    await store.complete('prompt-1');
+
+    expect(query).toHaveBeenCalledOnce();
+  });
+});
+
 describe('PGLiteQueuedPromptsStore.sweepExecutingForSession', () => {
   it('scopes all three passes to the given session id', async () => {
     const calls: { sql: string; params?: any[] }[] = [];
@@ -261,10 +282,12 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingForSession', () => {
     expect(calls[0].sql).toContain('m.created_at >= queued_prompts.claimed_at');
     expect(calls[0].params).toEqual(['session-xyz']);
 
-    // Pass 2: delivered-but-unanswered rows go to a visible failed state
+    // Pass 2: delivered-but-unanswered rows go to a visible failed state,
+    // with an independent no-output recheck (NOT EXISTS)
     expect(calls[1].sql).toContain("SET status = 'failed'");
     expect(calls[1].sql).toContain('error_message');
     expect(calls[1].sql).toContain('session_id = $1');
+    expect(calls[1].sql).toContain('NOT EXISTS');
     expect(calls[1].params?.[0]).toBe('session-xyz');
     expect(calls[1].params?.[1]).toContain('interrupted before a response was recorded');
 

--- a/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.test.ts
+++ b/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.test.ts
@@ -75,16 +75,20 @@ describe('PGLiteQueuedPromptsStore.rollbackAllExecuting', () => {
 });
 
 describe('PGLiteQueuedPromptsStore.sweepExecutingOnBoot', () => {
-  it('marks delivered executing rows completed, rolls back undelivered ones', async () => {
+  it('completes answered rows, fails delivered-but-unanswered ones, rolls back undelivered ones', async () => {
     const calls: { sql: string; params?: any[] }[] = [];
     const db: DbStub = {
       query: (async (sql: string, params?: any[]) => {
         calls.push({ sql, params });
-        // Pass 1: completed-update returns rows that were delivered
+        // Pass 1: completed-update returns rows with delivery AND output evidence
         if (sql.includes("SET status = 'completed'")) {
-          return { rows: [{ id: 'delivered-1' }, { id: 'delivered-2' }] };
+          return { rows: [{ id: 'answered-1' }, { id: 'answered-2' }] };
         }
-        // Pass 2: rollback-update returns the remaining stuck rows
+        // Pass 2: failed-update returns delivered rows with no output evidence
+        if (sql.includes("SET status = 'failed'")) {
+          return { rows: [{ id: 'unanswered-1' }] };
+        }
+        // Pass 3: rollback-update returns the remaining stuck rows
         if (sql.includes("SET status = 'pending'") && sql.includes('claimed_at = NULL')) {
           return { rows: [{ id: 'undelivered-1' }] };
         }
@@ -95,32 +99,71 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingOnBoot', () => {
     const store = createPGLiteQueuedPromptsStore(db);
     const result = await store.sweepExecutingOnBoot();
 
-    expect(result).toEqual({ completed: 2, rolledBack: 1 });
-    expect(calls).toHaveLength(2);
+    expect(result).toEqual({ completed: 2, failed: 1, rolledBack: 1 });
+    expect(calls).toHaveLength(3);
 
-    // First pass: covers both executing-with-delivered-claim AND
-    // pending-with-content-match (leftover corruption from old boot sweeps).
+    // First pass: executing rows need BOTH the delivered input row AND
+    // output evidence after claimed_at to count as completed (#783: a
+    // delivered input alone does not prove the agent ever responded).
+    // Pending-with-content-match and 24h-abandoned branches stay.
     expect(calls[0].sql).toContain("SET status = 'completed'");
     expect(calls[0].sql).toContain("status = 'executing'");
     expect(calls[0].sql).toContain("status = 'pending'");
     expect(calls[0].sql).toContain('claimed_at IS NOT NULL');
     expect(calls[0].sql).toContain('ai_agent_messages');
     expect(calls[0].sql).toContain("direction = 'input'");
+    expect(calls[0].sql).toContain("direction = 'output'");
     expect(calls[0].sql).toContain('m.created_at >= queued_prompts.claimed_at');
     expect(calls[0].sql).toContain('m.created_at >= queued_prompts.created_at');
     expect(calls[0].sql).toContain('POSITION(queued_prompts.prompt IN m.content)');
 
-    // Second pass: rolls back anything still executing (i.e. undelivered)
-    expect(calls[1].sql).toContain("SET status = 'pending'");
-    expect(calls[1].sql).toContain('claimed_at = NULL');
+    // Second pass: delivered-but-unanswered rows become a VISIBLE terminal
+    // state, never 'completed' (silent success) and never 'pending'
+    // (re-claim would re-send the delivered input, regressing NIM-615).
+    expect(calls[1].sql).toContain("SET status = 'failed'");
+    expect(calls[1].sql).toContain('error_message');
     expect(calls[1].sql).toContain("status = 'executing'");
+    expect(calls[1].sql).toContain('claimed_at IS NOT NULL');
+    expect(calls[1].sql).toContain("direction = 'input'");
+
+    // Third pass: rolls back anything still executing (i.e. undelivered)
+    expect(calls[2].sql).toContain("SET status = 'pending'");
+    expect(calls[2].sql).toContain('claimed_at = NULL');
+    expect(calls[2].sql).toContain("status = 'executing'");
+  });
+
+  it('fails a delivered executing row with no output after claimed_at instead of completing it (#783)', async () => {
+    // Karl's forensic case: input row logged after claim, app quit
+    // SIGTERM'd the provider, zero output events persisted. The old sweep
+    // marked the row completed and the session looked answered-and-idle.
+    const calls: { sql: string; params?: any[] }[] = [];
+    const db: DbStub = {
+      query: (async (sql: string, params?: any[]) => {
+        calls.push({ sql, params });
+        if (sql.includes("SET status = 'completed'")) {
+          return { rows: [] };
+        }
+        if (sql.includes("SET status = 'failed'")) {
+          return { rows: [{ id: 'local-1783443721220-i0jrwc8' }] };
+        }
+        if (sql.includes("SET status = 'pending'")) {
+          return { rows: [] };
+        }
+        throw new Error(`Unexpected query: ${sql}`);
+      }) as any,
+    };
+
+    const store = createPGLiteQueuedPromptsStore(db);
+    const result = await store.sweepExecutingOnBoot();
+
+    expect(result).toEqual({ completed: 0, failed: 1, rolledBack: 0 });
   });
 
   it('returns zeros when nothing was executing', async () => {
     const db: DbStub = { query: (async () => ({ rows: [] })) as any };
 
     const store = createPGLiteQueuedPromptsStore(db);
-    expect(await store.sweepExecutingOnBoot()).toEqual({ completed: 0, rolledBack: 0 });
+    expect(await store.sweepExecutingOnBoot()).toEqual({ completed: 0, failed: 0, rolledBack: 0 });
   });
 
   it('completes pending rows that match a delivered input message (leftover-corruption cleanup)', async () => {
@@ -135,7 +178,7 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingOnBoot', () => {
           completedSql = sql;
           return { rows: [{ id: 'leftover-1' }, { id: 'leftover-2' }, { id: 'leftover-3' }] };
         }
-        if (sql.includes("SET status = 'pending'")) {
+        if (sql.includes("SET status = 'failed'") || sql.includes("SET status = 'pending'")) {
           return { rows: [] };
         }
         throw new Error(`Unexpected query: ${sql}`);
@@ -145,7 +188,7 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingOnBoot', () => {
     const store = createPGLiteQueuedPromptsStore(db);
     const result = await store.sweepExecutingOnBoot();
 
-    expect(result).toEqual({ completed: 3, rolledBack: 0 });
+    expect(result).toEqual({ completed: 3, failed: 0, rolledBack: 0 });
     // The combined query must contain both branches so an existing
     // pending row whose prompt text already appears in the conversation
     // gets cleaned up alongside the executing-but-delivered case.
@@ -161,7 +204,7 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingOnBoot', () => {
           completedSql = sql;
           return { rows: [{ id: 'abandoned-1' }, { id: 'abandoned-2' }] };
         }
-        if (sql.includes("SET status = 'pending'")) {
+        if (sql.includes("SET status = 'failed'") || sql.includes("SET status = 'pending'")) {
           return { rows: [] };
         }
         throw new Error(`Unexpected query: ${sql}`);
@@ -171,7 +214,7 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingOnBoot', () => {
     const store = createPGLiteQueuedPromptsStore(db);
     const result = await store.sweepExecutingOnBoot();
 
-    expect(result).toEqual({ completed: 2, rolledBack: 0 });
+    expect(result).toEqual({ completed: 2, failed: 0, rolledBack: 0 });
     // Age branch: pending rows older than 24h are completed
     // unconditionally. Handles content-match false negatives caused by
     // JSON escaping (newlines / quotes / attachments) and genuinely
@@ -182,13 +225,16 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingOnBoot', () => {
 });
 
 describe('PGLiteQueuedPromptsStore.sweepExecutingForSession', () => {
-  it('scopes both passes to the given session id', async () => {
+  it('scopes all three passes to the given session id', async () => {
     const calls: { sql: string; params?: any[] }[] = [];
     const db: DbStub = {
       query: (async (sql: string, params?: any[]) => {
         calls.push({ sql, params });
         if (sql.includes("SET status = 'completed'")) {
-          return { rows: [{ id: 'delivered-1' }] };
+          return { rows: [{ id: 'answered-1' }] };
+        }
+        if (sql.includes("SET status = 'failed'")) {
+          return { rows: [{ id: 'unanswered-1' }] };
         }
         if (sql.includes("SET status = 'pending'")) {
           return { rows: [{ id: 'undelivered-1' }, { id: 'undelivered-2' }] };
@@ -200,24 +246,34 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingForSession', () => {
     const store = createPGLiteQueuedPromptsStore(db);
     const result = await store.sweepExecutingForSession('session-xyz');
 
-    expect(result).toEqual({ completed: 1, rolledBack: 2 });
-    expect(calls).toHaveLength(2);
+    expect(result).toEqual({ completed: 1, failed: 1, rolledBack: 2 });
+    expect(calls).toHaveLength(3);
 
-    // Pass 1: delivery check filters by session_id and matches input messages
+    // Pass 1: completion needs input AND output evidence, session-scoped
+    // (#790: an interrupt sweep marked a delivered-but-never-answered
+    // prompt completed on the input row alone).
     expect(calls[0].sql).toContain("SET status = 'completed'");
     expect(calls[0].sql).toContain("session_id = $1");
     expect(calls[0].sql).toContain('claimed_at IS NOT NULL');
     expect(calls[0].sql).toContain('ai_agent_messages');
     expect(calls[0].sql).toContain("direction = 'input'");
+    expect(calls[0].sql).toContain("direction = 'output'");
     expect(calls[0].sql).toContain('m.created_at >= queued_prompts.claimed_at');
     expect(calls[0].params).toEqual(['session-xyz']);
 
-    // Pass 2: roll back undelivered executing rows for the same session
-    expect(calls[1].sql).toContain("SET status = 'pending'");
-    expect(calls[1].sql).toContain('claimed_at = NULL');
-    expect(calls[1].sql).toContain("status = 'executing'");
+    // Pass 2: delivered-but-unanswered rows go to a visible failed state
+    expect(calls[1].sql).toContain("SET status = 'failed'");
+    expect(calls[1].sql).toContain('error_message');
     expect(calls[1].sql).toContain('session_id = $1');
-    expect(calls[1].params).toEqual(['session-xyz']);
+    expect(calls[1].params?.[0]).toBe('session-xyz');
+    expect(calls[1].params?.[1]).toContain('interrupted before a response was recorded');
+
+    // Pass 3: roll back undelivered executing rows for the same session
+    expect(calls[2].sql).toContain("SET status = 'pending'");
+    expect(calls[2].sql).toContain('claimed_at = NULL');
+    expect(calls[2].sql).toContain("status = 'executing'");
+    expect(calls[2].sql).toContain('session_id = $1');
+    expect(calls[2].params).toEqual(['session-xyz']);
   });
 
   it('returns zeros when the session has no executing rows', async () => {
@@ -226,6 +282,7 @@ describe('PGLiteQueuedPromptsStore.sweepExecutingForSession', () => {
     const store = createPGLiteQueuedPromptsStore(db);
     expect(await store.sweepExecutingForSession('session-clean')).toEqual({
       completed: 0,
+      failed: 0,
       rolledBack: 0,
     });
   });

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -2833,10 +2833,10 @@ export class AIService {
         try {
           const { getQueuedPromptsStore } = await import('../RepositoryManager');
           const queueStore = getQueuedPromptsStore();
-          const { completed, rolledBack } = await queueStore.sweepExecutingForSession(sessionId);
-          if (completed > 0 || rolledBack > 0) {
+          const { completed, failed, rolledBack } = await queueStore.sweepExecutingForSession(sessionId);
+          if (completed > 0 || failed > 0 || rolledBack > 0) {
             logger.main.info(
-              `[AIService] cancelRequest: swept session ${sessionId} -- ${completed} delivered marked completed, ${rolledBack} undelivered rolled back`
+              `[AIService] cancelRequest: swept session ${sessionId} -- ${completed} answered marked completed, ${failed} delivered-but-unanswered marked failed, ${rolledBack} undelivered rolled back`
             );
           }
         } catch (sweepErr) {
@@ -2895,10 +2895,10 @@ export class AIService {
       try {
         const { getQueuedPromptsStore } = await import('../RepositoryManager');
         const queueStore = getQueuedPromptsStore();
-        const { completed, rolledBack } = await queueStore.sweepExecutingForSession(sessionId);
-        if (completed > 0 || rolledBack > 0) {
+        const { completed, failed, rolledBack } = await queueStore.sweepExecutingForSession(sessionId);
+        if (completed > 0 || failed > 0 || rolledBack > 0) {
           logger.main.info(
-            `[AIService] interruptCurrentTurn: swept session ${sessionId} -- ${completed} delivered marked completed, ${rolledBack} undelivered rolled back`
+            `[AIService] interruptCurrentTurn: swept session ${sessionId} -- ${completed} answered marked completed, ${failed} delivered-but-unanswered marked failed, ${rolledBack} undelivered rolled back`
           );
         }
       } catch (sweepErr) {


### PR DESCRIPTION
## Summary

Both recovery sweeps (boot and per-session) treated "an input row exists after claimed_at" as proof a claimed queued prompt was handled, and marked it completed. A prompt whose turn died between delivery and any response (app quit SIGTERM'd the provider, or an interrupt killed a stuck turn) was marked completed with no answer anywhere. The session then looked answered-and-idle. That is the exact forensic chain in #783 (boot sweep) and the interrupt-sweep half of #790.

## The fix

Completion now requires output evidence: at least one `direction='output'` ai_agent_messages row at or after `claimed_at`. Assistant text, tool events, and interactive prompts all persist as output rows (interactivePromptTranscript.ts:101, interactiveToolHandlers.ts:762), so the case the sweep was originally built for, paused on AskUserQuestion at quit, still completes.

Delivered-but-unanswered rows now land in `status='failed'` with an error_message: a visible, queryable terminal state. They are deliberately NOT rolled back to pending, since a re-claim would re-send the already-delivered input (the NIM-615 double-send this sweep exists to prevent).

Two hardening details:
- The failed pass re-checks output absence itself (NOT EXISTS), so it stays correct independent of pass ordering if an output row commits between the statements.
- complete() clears error_message, so a turn that resolves normally after a provisional sweep-fail does not keep a stale error next to status completed.

The boot and sweep log lines now report the three buckets separately (answered / delivered-but-unanswered / undelivered), which is the line the #783 forensics walked.

## Tests

13 store tests, including the #783 boot case verbatim (input row after claim, zero output rows: failed, not completed). The new assertions were red before the fix.

## Intended behavior and edge cases

- Answered or paused prompts: unchanged (input + output rows exist, marked completed).
- Delivered, never answered: was silently completed, now failed with a retry hint in error_message.
- Never delivered: unchanged (rolled back to pending).
- Legacy pending-corruption and 24h-abandoned branches of the boot sweep: untouched.
- Both queue sweeps share one store implementation; there is no second backend copy to drift.

## Scope notes (deliberately not bundled, happy to take as follow-ups)

1. Failed rows do not yet render in the queue UI with a retry button; they leave the pending list exactly like completed rows did. The DB state, log lines, and error_message make the outcome diagnosable now; the UI affordance is a separate renderer change.
2. Output evidence is session-scoped, the same granularity as the existing input-delivery check. Correlating evidence to one specific queued prompt would need a per-turn marker (schema change). This heuristic strictly tightens the current behavior, which required no evidence at all.
3. The other half of #790, a prompt stuck executing with no completion event during a live session, is a dispatcher/watchdog question. This PR makes the next sweep classify such a row visibly instead of silently completing it.

Fixes #783. Covers the interrupt-sweep mislabel half of #790.
