### PR TITLE
fix: classify Codex usage windows by duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mobile session sync now skips messages the mobile transcript never displays, cutting sync storage and traffic.
 
 ### Fixed
+- Codex usage meters now identify session and weekly limits by duration, so temporary weekly-only limits no longer appear under Session.
 - PR mode now explains when a merge needs the GitHub CLI `workflow` scope and offers the recovery command instead of showing `gh api -X failed`.
 - Importing Mermaid diagrams into Excalidraw works again: flowcharts (including subgraphs) become editable shapes instead of failing or degrading to a broken image, and AI-added arrows no longer lose their labels.
 - Voice mode no longer stops listening while you are still speaking; the mic stays open until you finish or explicitly pause.

--- a/packages/electron/src/main/services/CodexUsageService.ts
+++ b/packages/electron/src/main/services/CodexUsageService.ts
@@ -23,10 +23,12 @@ export interface CodexUsageData {
   fiveHour: {
     utilization: number; // 0-100 percentage
     resetsAt: string | null; // ISO timestamp
+    available: boolean;
   };
   sevenDay: {
     utilization: number;
     resetsAt: string | null;
+    available: boolean;
   };
   credits?: {
     hasCredits: boolean;
@@ -42,18 +44,16 @@ export interface CodexUsageData {
   error?: string;
 }
 
+interface CodexRateLimitWindow {
+  used_percent: number;
+  window_minutes: number;
+  resets_at: number; // Unix seconds
+}
+
 interface CodexRateLimits {
   limit_id?: string;
-  primary?: {
-    used_percent: number;
-    window_minutes: number;
-    resets_at: number; // Unix seconds
-  } | null;
-  secondary?: {
-    used_percent: number;
-    window_minutes: number;
-    resets_at: number; // Unix seconds
-  } | null;
+  primary?: CodexRateLimitWindow | null;
+  secondary?: CodexRateLimitWindow | null;
   credits?: {
     has_credits: boolean;
     unlimited: boolean;
@@ -111,8 +111,8 @@ class CodexUsageServiceImpl {
       );
       if (!snapshot.rateLimits && !snapshot.tokenUsage) {
         const noData: CodexUsageData = {
-          fiveHour: { utilization: 0, resetsAt: null },
-          sevenDay: { utilization: 0, resetsAt: null },
+          fiveHour: { utilization: 0, resetsAt: null, available: false },
+          sevenDay: { utilization: 0, resetsAt: null, available: false },
           lastUpdated: Date.now(),
           error: 'No Codex usage data found. Use Codex CLI with a ChatGPT subscription to see usage.',
         };
@@ -123,8 +123,8 @@ class CodexUsageServiceImpl {
 
       if (!snapshot.rateLimits && snapshot.tokenUsage) {
         const usageData: CodexUsageData = {
-          fiveHour: { utilization: 0, resetsAt: null },
-          sevenDay: { utilization: 0, resetsAt: null },
+          fiveHour: { utilization: 0, resetsAt: null, available: false },
+          sevenDay: { utilization: 0, resetsAt: null, available: false },
           tokenUsage: snapshot.tokenUsage,
           limitsAvailable: false,
           lastUpdated: Date.now(),
@@ -145,8 +145,8 @@ class CodexUsageServiceImpl {
     } catch (error) {
       logger.main.error('[CodexUsageService] Error refreshing usage:', error);
       const errorData: CodexUsageData = {
-        fiveHour: { utilization: 0, resetsAt: null },
-        sevenDay: { utilization: 0, resetsAt: null },
+        fiveHour: { utilization: 0, resetsAt: null, available: false },
+        sevenDay: { utilization: 0, resetsAt: null, available: false },
         lastUpdated: Date.now(),
         error: error instanceof Error ? error.message : 'Unknown error reading Codex session files',
       };
@@ -342,7 +342,7 @@ class CodexUsageServiceImpl {
 
   /**
    * Extract rate_limits from a single JSONL event if it's a token_count event
-   * with non-null primary data. Delegates to the pure `filterRateLimitsByExpiry`
+   * with at least one window. Delegates to the pure `filterRateLimitsByExpiry`
    * helper below so the expiry logic stays unit-testable. See #120.
    */
   private extractRateLimitsFromEvent(event: Record<string, unknown>): CodexRateLimits | null {
@@ -350,7 +350,7 @@ class CodexUsageServiceImpl {
     if (!tokenCountPayload) return null;
 
     const rateLimits = tokenCountPayload.rate_limits as CodexRateLimits | undefined;
-    if (!rateLimits?.primary) return null;
+    if (!rateLimits?.primary && !rateLimits?.secondary) return null;
 
     return filterRateLimitsByExpiry(rateLimits, Date.now() / 1000);
   }
@@ -374,18 +374,21 @@ class CodexUsageServiceImpl {
   }
 
   private convertRateLimits(rateLimits: CodexRateLimits): CodexUsageData {
+    const windows = classifyRateLimitWindows(rateLimits);
     const data: CodexUsageData = {
       fiveHour: {
-        utilization: rateLimits.primary?.used_percent ?? 0,
-        resetsAt: rateLimits.primary?.resets_at
-          ? new Date(rateLimits.primary.resets_at * 1000).toISOString()
+        utilization: windows.fiveHour?.used_percent ?? 0,
+        resetsAt: windows.fiveHour?.resets_at
+          ? new Date(windows.fiveHour.resets_at * 1000).toISOString()
           : null,
+        available: windows.fiveHour !== null,
       },
       sevenDay: {
-        utilization: rateLimits.secondary?.used_percent ?? 0,
-        resetsAt: rateLimits.secondary?.resets_at
-          ? new Date(rateLimits.secondary.resets_at * 1000).toISOString()
+        utilization: windows.sevenDay?.used_percent ?? 0,
+        resetsAt: windows.sevenDay?.resets_at
+          ? new Date(windows.sevenDay.resets_at * 1000).toISOString()
           : null,
+        available: windows.sevenDay !== null,
       },
       lastUpdated: Date.now(),
     };
@@ -414,11 +417,39 @@ class CodexUsageServiceImpl {
 // Singleton instance
 export const codexUsageService = new CodexUsageServiceImpl();
 
+const FIVE_HOUR_WINDOW_MINUTES = 5 * 60;
+const SEVEN_DAY_WINDOW_MINUTES = 7 * 24 * 60;
+
+/**
+ * Classify rate-limit buckets by their declared duration, not their position.
+ * Codex historically emitted 5-hour limits as `primary` and 7-day limits as
+ * `secondary`, but it can put a weekly-only limit in `primary` when the
+ * shorter limit is not active (for example, during temporary limit changes).
+ */
+export function classifyRateLimitWindows(rateLimits: CodexRateLimits): {
+  fiveHour: CodexRateLimitWindow | null;
+  sevenDay: CodexRateLimitWindow | null;
+} {
+  let fiveHour: CodexRateLimitWindow | null = null;
+  let sevenDay: CodexRateLimitWindow | null = null;
+
+  for (const window of [rateLimits.primary, rateLimits.secondary]) {
+    if (!window) continue;
+    if (window.window_minutes === FIVE_HOUR_WINDOW_MINUTES && !fiveHour) {
+      fiveHour = window;
+    } else if (window.window_minutes === SEVEN_DAY_WINDOW_MINUTES && !sevenDay) {
+      sevenDay = window;
+    }
+  }
+
+  return { fiveHour, sevenDay };
+}
+
 /**
  * Drop expired buckets from a CodexRateLimits block.
  *
- * Each window (primary 5h, secondary 7d) carries its own `resets_at` Unix-seconds
- * timestamp. After that moment the window resets and the historical `used_percent`
+ * Each emitted bucket carries its own `resets_at` Unix-seconds timestamp. After
+ * that moment the window resets and the historical `used_percent`
  * no longer matches reality - but the JSONL session file that produced the line is
  * never rewritten, so the same stale value keeps coming back from the
  * scan-backward loop in `extractUsageSnapshotFromFile`. That is the bug behind

--- a/packages/electron/src/main/services/__tests__/CodexUsageService.expiry.test.ts
+++ b/packages/electron/src/main/services/__tests__/CodexUsageService.expiry.test.ts
@@ -14,7 +14,10 @@
  * still-active sibling window.
  */
 import { describe, it, expect } from 'vitest';
-import { filterRateLimitsByExpiry } from '../CodexUsageService';
+import {
+  classifyRateLimitWindows,
+  filterRateLimitsByExpiry,
+} from '../CodexUsageService';
 
 // 2026-05-14T12:00:00Z, in Unix seconds. Each test pins a specific "now"
 // relative to this anchor so resets_at math is human-readable.
@@ -130,5 +133,37 @@ describe('filterRateLimitsByExpiry', () => {
     const out = filterRateLimitsByExpiry(input, NOW_SECONDS);
     expect(out).not.toBeNull();
     expect(out!.limit_id).toBe('usage-bucket-7');
+  });
+});
+
+describe('classifyRateLimitWindows', () => {
+  it('classifies the legacy primary/secondary shape by duration', () => {
+    const windows = classifyRateLimitWindows({
+      primary: primary(42, NOW_SECONDS + FIVE_HOURS),
+      secondary: secondary(18, NOW_SECONDS + SEVEN_DAYS),
+    });
+
+    expect(windows.fiveHour?.used_percent).toBe(42);
+    expect(windows.sevenDay?.used_percent).toBe(18);
+  });
+
+  it('classifies a weekly-only primary bucket as weekly', () => {
+    const windows = classifyRateLimitWindows({
+      primary: secondary(11, NOW_SECONDS + SEVEN_DAYS),
+      secondary: null,
+    });
+
+    expect(windows.fiveHour).toBeNull();
+    expect(windows.sevenDay?.used_percent).toBe(11);
+  });
+
+  it('classifies reordered buckets by duration instead of slot', () => {
+    const windows = classifyRateLimitWindows({
+      primary: secondary(18, NOW_SECONDS + SEVEN_DAYS),
+      secondary: primary(42, NOW_SECONDS + FIVE_HOURS),
+    });
+
+    expect(windows.fiveHour?.used_percent).toBe(42);
+    expect(windows.sevenDay?.used_percent).toBe(18);
   });
 });

--- a/packages/electron/src/renderer/components/CodexUsageIndicator/CodexUsageIndicator.tsx
+++ b/packages/electron/src/renderer/components/CodexUsageIndicator/CodexUsageIndicator.tsx
@@ -50,6 +50,7 @@ export const CodexUsageIndicator: React.FC<CodexUsageIndicatorProps> = ({ classN
   const utilization = hasLoadError ? 0 : usage?.fiveHour?.utilization ?? 0;
   const strokeDashoffset = RING_CIRCUMFERENCE * (1 - utilization / 100);
   const limitsAvailable = !hasLoadError && (usage?.limitsAvailable ?? true);
+  const sessionAvailable = limitsAvailable && (usage?.fiveHour.available ?? true);
 
   const colorClasses: Record<string, string> = {
     green: 'stroke-green-500',
@@ -58,14 +59,16 @@ export const CodexUsageIndicator: React.FC<CodexUsageIndicatorProps> = ({ classN
     muted: 'stroke-nim-muted',
   };
 
-  const effectiveSessionColor = limitsAvailable ? sessionColor : 'muted';
+  const effectiveSessionColor = sessionAvailable ? sessionColor : 'muted';
   const strokeColor = colorClasses[effectiveSessionColor] || colorClasses.muted;
 
   const tooltipContent = usage?.error
     ? `Codex usage unavailable: ${usage.error}`
     : usage
       ? limitsAvailable
-        ? `Codex: ${Math.round(utilization)}% (resets ${formatResetTime(usage.fiveHour.resetsAt)})`
+        ? sessionAvailable
+          ? `Codex: ${Math.round(utilization)}% (resets ${formatResetTime(usage.fiveHour.resetsAt)})`
+          : 'Codex session usage is not currently reported; weekly usage is available in the popover'
         : 'Codex usage (limits unavailable)'
       : 'Codex usage unavailable';
 
@@ -110,7 +113,7 @@ export const CodexUsageIndicator: React.FC<CodexUsageIndicatorProps> = ({ classN
         </svg>
         {/* Percentage text */}
         <span className="absolute inset-0 flex items-center justify-center text-[9px] font-semibold text-nim">
-          {limitsAvailable ? `${Math.round(utilization)}%` : '--'}
+          {sessionAvailable ? `${Math.round(utilization)}%` : '--'}
         </span>
       </button>
 

--- a/packages/electron/src/renderer/components/CodexUsageIndicator/CodexUsagePopover.tsx
+++ b/packages/electron/src/renderer/components/CodexUsageIndicator/CodexUsagePopover.tsx
@@ -27,6 +27,7 @@ interface UsageSectionProps {
   subtitle: string;
   utilization: number;
   resetsAt: string | null;
+  available: boolean;
   color: 'green' | 'yellow' | 'red' | 'muted';
   windowDurationMs: number;
 }
@@ -48,6 +49,7 @@ const UsageSection: React.FC<UsageSectionProps> = ({
   subtitle,
   utilization,
   resetsAt,
+  available,
   color,
   windowDurationMs,
 }) => {
@@ -70,23 +72,25 @@ const UsageSection: React.FC<UsageSectionProps> = ({
           <div className="text-[11px] text-nim-muted">{subtitle}</div>
         </div>
         <div className={`text-[16px] font-semibold ${colors.text}`}>
-          {Math.round(utilization)}%
+          {available ? `${Math.round(utilization)}%` : '--'}
         </div>
       </div>
       <div className="relative h-1.5 bg-nim-tertiary rounded-full overflow-hidden mb-1.5">
         <div
           className={`h-full rounded-full transition-all duration-300 ${colors.bar}`}
-          style={{ width: `${Math.min(utilization, 100)}%` }}
+          style={{ width: available ? `${Math.min(utilization, 100)}%` : '0%' }}
         />
-        <div
-          className={`absolute top-0 h-full w-0.5 transition-all duration-300 ${isOverPacing ? 'bg-red-400' : 'bg-nim-text-muted'}`}
-          style={{ left: `${timeElapsedPercent}%` }}
-          title={`${Math.round(timeElapsedPercent)}% of window elapsed`}
-        />
+        {available && (
+          <div
+            className={`absolute top-0 h-full w-0.5 transition-all duration-300 ${isOverPacing ? 'bg-red-400' : 'bg-nim-text-muted'}`}
+            style={{ left: `${timeElapsedPercent}%` }}
+            title={`${Math.round(timeElapsedPercent)}% of window elapsed`}
+          />
+        )}
       </div>
       <div className="flex items-center gap-1 text-[11px] text-nim-muted">
         <MaterialSymbol icon="schedule" size={12} className="opacity-70" />
-        <span>Resets in {formatResetTime(resetsAt)}</span>
+        <span>{available ? `Resets in ${formatResetTime(resetsAt)}` : 'Not currently reported'}</span>
       </div>
     </div>
   );
@@ -194,6 +198,7 @@ export const CodexUsagePopover: React.FC<CodexUsagePopoverProps> = ({
                 subtitle="5-hour window"
                 utilization={usage.fiveHour.utilization}
                 resetsAt={usage.fiveHour.resetsAt}
+                available={usage.fiveHour.available}
                 color={sessionColor as 'green' | 'yellow' | 'red' | 'muted'}
                 windowDurationMs={sessionWindowMs}
               />
@@ -202,6 +207,7 @@ export const CodexUsagePopover: React.FC<CodexUsagePopoverProps> = ({
                 subtitle="7-day window"
                 utilization={usage.sevenDay.utilization}
                 resetsAt={usage.sevenDay.resetsAt}
+                available={usage.sevenDay.available}
                 color={weeklyColor as 'green' | 'yellow' | 'red' | 'muted'}
                 windowDurationMs={weeklyWindowMs}
               />

--- a/packages/electron/src/renderer/store/atoms/codexUsageAtoms.ts
+++ b/packages/electron/src/renderer/store/atoms/codexUsageAtoms.ts
@@ -15,10 +15,12 @@ export interface CodexUsageData {
   fiveHour: {
     utilization: number; // 0-100 percentage
     resetsAt: string | null; // ISO timestamp
+    available: boolean;
   };
   sevenDay: {
     utilization: number;
     resetsAt: string | null;
+    available: boolean;
   };
   credits?: {
     hasCredits: boolean;
@@ -60,7 +62,7 @@ export const codexUsageAvailableAtom = atom((get) => {
 
 export const codexUsageSessionColorAtom = atom((get) => {
   const usage = get(codexUsageAtom);
-  if (!usage) return 'muted';
+  if (!usage || !usage.fiveHour.available) return 'muted';
   const util = usage.fiveHour.utilization;
   if (util >= 80) return 'red';
   if (util >= 50) return 'yellow';
@@ -69,7 +71,7 @@ export const codexUsageSessionColorAtom = atom((get) => {
 
 export const codexUsageWeeklyColorAtom = atom((get) => {
   const usage = get(codexUsageAtom);
-  if (!usage) return 'muted';
+  if (!usage || !usage.sevenDay.available) return 'muted';
   const util = usage.sevenDay.utilization;
   if (util >= 80) return 'red';
   if (util >= 50) return 'yellow';


### PR DESCRIPTION
## Problem

Codex can emit a weekly-only rate-limit payload while OpenAI's 5-hour restriction is temporarily disabled. In that shape, the 10,080-minute weekly bucket is `primary` and `secondary` is absent.

Nimbalyst assumed `primary` always meant the 5-hour Session window and `secondary` always meant Weekly, so it showed the weekly percentage and six-day reset under Session and rendered an empty Weekly row.

## Solution

- Classify rate-limit buckets by their explicit `window_minutes` value rather than positional slot.
- Accept payloads with either rate-limit bucket present.
- Track per-window availability so an omitted 5-hour window reads "Not currently reported" instead of showing a fabricated 0% / unknown reset.
- Keep legacy and reordered two-window payloads working.
- Add a user-facing changelog entry.

## Testing

- `npx vitest run packages/electron/src/main/services/__tests__/CodexUsageService.expiry.test.ts` — 12 passed
- `npm run typecheck --prefix packages/electron` — passed
- `git diff --check` — passed

The repository-wide clean-worktree gates are not currently green on Windows:
- root `npm run typecheck` fails in unrelated extension workspaces that expect prebuilt runtime/extension SDK/memory-engine outputs
- root `npm run test:prepush` reports 575 files passed and 21 unrelated files failed, including filesystem/migration and Claude runtime fixture tests

Closes #848

## Why this is worth merging

Codex exposes multiple usage windows whose labels are not always enough to identify their scope. Classifying them by measured duration gives the UI stable session-versus-weekly meaning, so users can plan work against the right limit instead of reacting to a percentage attached to the wrong reset horizon.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
