### PR TITLE
Add MiniMax chat provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- MiniMax chat support with regional endpoint selection and MiniMax-M3 and MiniMax-M2.7 model presets.
 - In a shared document, typing `@` now suggests other shared documents and inserts a team-styled link that opens the referenced shared document.
 - Settings now separates Application, Personal, Organizations, and Project management, including per-account mobile-sync profiles, organization administration without an open workspace, explicit project access controls, and project-level MCP server configuration.
 - The Git extension now keeps a persistent, live command output history across panel and renderer reloads.

--- a/docs/AI_PROVIDER_TYPES.md
+++ b/docs/AI_PROVIDER_TYPES.md
@@ -29,7 +29,10 @@ These providers still use `BaseAIProvider`, not `BaseAgentProvider`.
 | --- | --- | --- | --- |
 | `claude` | Claude Chat | Direct Anthropic SDK | Standard chat provider with tool calling but no MCP/file-agent loop. |
 | `openai` | OpenAI | Direct OpenAI SDK | Standard chat/completions path. |
+| `minimax` | MiniMax | Direct compatibility SDK selected by endpoint | Fixed MiniMax-M3 and MiniMax-M2.7 catalog with global and China endpoint presets. |
 | `lmstudio` | LM Studio | Local OpenAI-compatible endpoint | Local-only chat provider. |
+
+Chat providers should extend `BaseAIProvider`, register fixed or discovered models through `ModelRegistry`, and expose their settings, API key, endpoint, and session-creation paths in Electron. When a service offers multiple compatibility protocols, keep one provider ID and select the existing SDK adapter from validated endpoint presets instead of adding duplicate provider IDs or persisting protocol-only fields.
 
 ## What Makes An Agent Provider Different
 

--- a/packages/electron/src/main/services/SyncManager.ts
+++ b/packages/electron/src/main/services/SyncManager.ts
@@ -1207,6 +1207,7 @@ async function getAvailableModelsForMobile(): Promise<{ models: Array<{ id: stri
     if (providerSettings['claude']?.enabled === true && !!apiKeys['anthropic']) enabledSet.add('claude');
     if (providerSettings['claude-code']?.enabled !== false) enabledSet.add('claude-code');
     if (providerSettings['openai']?.enabled === true && !!apiKeys['openai']) enabledSet.add('openai');
+    if (providerSettings['minimax']?.enabled === true && !!apiKeys['minimax']) enabledSet.add('minimax');
     if (providerSettings['openai-codex']?.enabled === true) enabledSet.add('openai-codex');
     if (providerSettings['openai-codex-acp']?.enabled === true) enabledSet.add('openai-codex-acp');
     if (providerSettings['lmstudio']?.enabled === true) enabledSet.add('lmstudio');

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -21,6 +21,8 @@ import {
   isAgentProvider,
   isSlashCommandCatalogProvider,
   ClaudeCodeProvider,
+  MiniMaxProvider,
+  MINIMAX_ENDPOINTS,
   OpenAICodexProvider,
 } from '@nimbalyst/runtime/ai/server';
 import { CLAUDE_CODE_SAFE_FALLBACK_MODEL } from '@nimbalyst/runtime/ai/modelConstants';
@@ -487,6 +489,11 @@ export class AIService {
               openai: {
                 enabled: false,
                 testStatus: "idle",
+              },
+              minimax: {
+                enabled: false,
+                testStatus: "idle",
+                baseUrl: MINIMAX_ENDPOINTS.global_en.openai,
               },
               'openai-codex': {
                 enabled: true,
@@ -1686,6 +1693,10 @@ export class AIService {
         if (hasOpenAI) return true;
       }
 
+      if (apiKeys['minimax'] && providerSettings['minimax']?.enabled === true) {
+        return true;
+      }
+
       // Check OpenAI Codex (uses its own auth, doesn't need API key in settings)
       const hasCodex = providerSettings['openai-codex']?.enabled === true;
       if (hasCodex) return true;
@@ -1786,6 +1797,11 @@ export class AIService {
           case 'openai':
             if (!apiKey) {
               throw new Error('OpenAI API key not configured');
+            }
+            break;
+          case 'minimax':
+            if (!apiKey) {
+              throw new Error('MiniMax API key not configured');
             }
             break;
           case 'openai-codex':
@@ -1949,6 +1965,11 @@ export class AIService {
         const lmstudioSettings = this.getSettingsStore().get('providerSettings.lmstudio', {}) as any;
         const storedApiKeys = this.getSettingsStore().get('apiKeys', {}) as Record<string, string>;
         initConfig.baseUrl = lmstudioSettings.baseUrl || storedApiKeys['lmstudio_url'] || 'http://127.0.0.1:8234';
+      }
+
+      if (provider === 'minimax') {
+        const providerSettings = this.getSettingsStore().get('providerSettings', {}) as any;
+        initConfig.baseUrl = providerSettings['minimax']?.baseUrl || MINIMAX_ENDPOINTS.global_en.openai;
       }
 
       // Pass through allowedTools and effort level settings for Claude Code
@@ -3003,6 +3024,7 @@ export class AIService {
         writeApiKey('anthropic', settings.apiKeys.anthropic);
         writeApiKey('claude-code', settings.apiKeys['claude-code']);
         writeApiKey('openai', settings.apiKeys.openai);
+        writeApiKey('minimax', settings.apiKeys.minimax);
         writeApiKey('openai-codex', settings.apiKeys['openai-codex']);
         if (settings.apiKeys.lmstudio_url !== undefined) {
           // lmstudio_url is a regular setting -- no masking, just write it.
@@ -3106,6 +3128,12 @@ export class AIService {
               return { success: false, error: 'OpenAI API key not configured' };
             }
             break;
+          case 'minimax':
+            apiKey = apiKeys['minimax'];
+            if (!apiKey) {
+              return { success: false, error: 'MiniMax API key not configured' };
+            }
+            break;
           case 'openai-codex':
             apiKey = apiKeys['openai-codex'];
             break;
@@ -3140,6 +3168,32 @@ export class AIService {
         if (provider === 'openai') {
           const models = await ModelRegistry.getModelsForProvider('openai', apiKey);
           return { success: models.length > 0, provider };
+        }
+
+        if (provider === 'minimax') {
+          const providerSettings = this.getSettingsStore().get('providerSettings', {}) as any;
+          const baseUrl = providerSettings['minimax']?.baseUrl || MINIMAX_ENDPOINTS.global_en.openai;
+          const testProvider = new MiniMaxProvider();
+          try {
+            await testProvider.initialize({
+              apiKey,
+              baseUrl,
+              model: MiniMaxProvider.getDefaultModel(),
+              maxTokens: 8,
+            });
+            const response = testProvider.sendMessage('Reply with exactly "ok".');
+            for await (const chunk of response) {
+              if (chunk.type === 'error') {
+                throw new Error(chunk.error || 'Unknown MiniMax error');
+              }
+              if (chunk.type === 'text') {
+                break;
+              }
+            }
+            return { success: true, provider };
+          } finally {
+            testProvider.destroy();
+          }
         }
 
         // For OpenAI Codex, run a real SDK request to validate credentials and connectivity
@@ -3316,6 +3370,7 @@ export class AIService {
       // checkboxes in the settings panel even before the user touches the toggle.
       if (providerSettings['claude-code-cli']?.enabled !== false) enabledSet.add('claude-code-cli');
       if (providerSettings['openai']?.enabled === true && !!apiKeys['openai']) enabledSet.add('openai');
+      if (providerSettings['minimax']?.enabled === true && !!apiKeys['minimax']) enabledSet.add('minimax');
       if (providerSettings['openai-codex']?.enabled === true) enabledSet.add('openai-codex');
       if (providerSettings['opencode']?.enabled === true) enabledSet.add('opencode');
       if (providerSettings['lmstudio']?.enabled === true) enabledSet.add('lmstudio');
@@ -3462,6 +3517,11 @@ export class AIService {
           enabled: providerSettings['openai']?.enabled === true && !!apiKeys['openai'],
           models: providerSettings['openai']?.models,
           hiddenModels: providerSettings['openai']?.hiddenModels
+        },
+        'minimax': {
+          enabled: providerSettings['minimax']?.enabled === true && !!apiKeys['minimax'],
+          models: providerSettings['minimax']?.models,
+          hiddenModels: providerSettings['minimax']?.hiddenModels
         },
         'openai-codex': {
           // Codex SDK uses its own auth (codex auth login), API key is optional
@@ -3810,7 +3870,7 @@ export class AIService {
 
     // Extension SDK: List available chat models
     safeHandle('extensions:ai-list-models', async () => {
-      const CHAT_PROVIDERS: AIProviderType[] = ['claude', 'openai', 'lmstudio'];
+      const CHAT_PROVIDERS: AIProviderType[] = ['claude', 'openai', 'minimax', 'lmstudio'];
       const providerSettings = this.getNormalizedProviderSettings() as any;
       const globalApiKeys = this.getSettingsStore().get('apiKeys', {}) as Record<string, string>;
 
@@ -3823,8 +3883,13 @@ export class AIService {
 
         const apiKey = provider === 'claude' ? globalApiKeys['anthropic']
           : provider === 'openai' ? globalApiKeys['openai']
+          : provider === 'minimax' ? globalApiKeys['minimax']
           : undefined;
-        const baseUrl = provider === 'lmstudio' ? (globalApiKeys['lmstudio_url'] || undefined) : undefined;
+        const baseUrl = provider === 'lmstudio'
+          ? (globalApiKeys['lmstudio_url'] || undefined)
+          : provider === 'minimax'
+            ? (providerSettings['minimax']?.baseUrl || MINIMAX_ENDPOINTS.global_en.openai)
+            : undefined;
 
         try {
           const models = await ModelRegistry.getModelsForProvider(provider, apiKey, baseUrl);
@@ -3996,7 +4061,16 @@ export class AIService {
       return this.cachedNormalizedProviderSettings;
     }
     const providerSettings = this.getSettingsStore().get('providerSettings', {}) as Record<string, any>;
-    const normalized = this.normalizeProviderSettings(providerSettings);
+    const normalizedProviders = this.normalizeProviderSettings(providerSettings);
+    const normalized = normalizedProviders.minimax
+      ? normalizedProviders
+      : {
+          ...normalizedProviders,
+          minimax: {
+            enabled: false,
+            baseUrl: MINIMAX_ENDPOINTS.global_en.openai,
+          },
+        };
     if (normalized !== providerSettings) {
       this.getSettingsStore().set('providerSettings', normalized);
     }
@@ -4123,13 +4197,13 @@ export class AIService {
 
   /**
    * Resolve which chat provider and config to use for an extension completion request.
-   * Only chat providers (claude, openai, lmstudio) are supported.
+   * Only built-in chat providers are supported.
    */
   private async resolveExtensionChatProvider(
     event: Electron.IpcMainInvokeEvent,
     options: { model?: string; maxTokens?: number; temperature?: number; responseFormat?: any }
   ): Promise<{ provider: AIProvider; providerConfig: ProviderConfig; providerType: AIProviderType; syntheticSessionId: string }> {
-    const CHAT_PROVIDERS: AIProviderType[] = ['claude', 'openai', 'lmstudio'];
+    const CHAT_PROVIDERS: AIProviderType[] = ['claude', 'openai', 'minimax', 'lmstudio'];
 
     // Determine provider from model ID or find first available
     let providerType: AIProviderType | undefined;
@@ -4164,7 +4238,7 @@ export class AIService {
     }
 
     if (!providerType) {
-      throw new Error('No chat provider available. Enable Claude, OpenAI, or LM Studio in Settings > AI.');
+      throw new Error('No chat provider available. Enable a chat provider in Settings > AI.');
     }
 
     // Get API key
@@ -4193,6 +4267,11 @@ export class AIService {
     if (providerType === 'lmstudio') {
       const globalApiKeys = this.getSettingsStore().get('apiKeys', {}) as Record<string, string>;
       providerConfig.baseUrl = globalApiKeys['lmstudio_url'] || 'http://127.0.0.1:1234';
+    }
+
+    if (providerType === 'minimax') {
+      const providerSettings = this.getNormalizedProviderSettings() as any;
+      providerConfig.baseUrl = providerSettings['minimax']?.baseUrl || MINIMAX_ENDPOINTS.global_en.openai;
     }
 
     const syntheticSessionId = `ext-completion-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -21,6 +21,7 @@ import {
   onAgentMessageBatch,
   buildMetaAgentSystemPrompt,
   buildDevAgentSystemPrompt,
+  MINIMAX_ENDPOINTS,
   type AIProvider,
   type SessionManager,
 } from '@nimbalyst/runtime/ai/server';
@@ -489,6 +490,9 @@ export class MessageStreamingHandler {
           case 'openai':
             errorMessage = 'OpenAI API key not configured';
             break;
+          case 'minimax':
+            errorMessage = 'MiniMax API key not configured';
+            break;
           case 'openai-codex':
             // Codex SDK uses its own auth (codex auth login), API key is optional
             requiresApiKey = false;
@@ -563,6 +567,11 @@ export class MessageStreamingHandler {
       if (session.provider === 'lmstudio') {
         const providerSettings = this.svc.getSettingsStore().get('providerSettings', {}) as any;
         reinitConfig.baseUrl = providerSettings['lmstudio']?.baseUrl || 'http://127.0.0.1:8234';
+      }
+
+      if (session.provider === 'minimax') {
+        const providerSettings = this.svc.getSettingsStore().get('providerSettings', {}) as any;
+        reinitConfig.baseUrl = providerSettings['minimax']?.baseUrl || MINIMAX_ENDPOINTS.global_en.openai;
       }
 
       // Pass model to provider config for all providers including claude-code
@@ -691,7 +700,7 @@ export class MessageStreamingHandler {
     // their runtime config from the persisted session before each send so a
     // cached provider cannot keep an empty or stale model after the picker
     // updates session.model and invalidates the prior instance.
-    if (['claude', 'openai', 'lmstudio'].includes(session.provider)) {
+    if (['claude', 'openai', 'minimax', 'lmstudio'].includes(session.provider)) {
       let expectedModel: string | undefined;
       const fullModel = session.model || session.providerConfig?.model;
       if (fullModel) {
@@ -716,7 +725,12 @@ export class MessageStreamingHandler {
           ? 'not-required'
           : this.svc.getApiKeyForProvider(session.provider, effectiveWorkspacePath);
         if (!apiKey && session.provider !== 'lmstudio') {
-          throw new Error(session.provider === 'openai' ? 'OpenAI API key not configured' : 'Anthropic API key not configured');
+          const errorMessage = session.provider === 'openai'
+            ? 'OpenAI API key not configured'
+            : session.provider === 'minimax'
+              ? 'MiniMax API key not configured'
+              : 'Anthropic API key not configured';
+          throw new Error(errorMessage);
         }
 
         const refreshedConfig: ProviderConfig = {
@@ -729,6 +743,11 @@ export class MessageStreamingHandler {
         if (session.provider === 'lmstudio') {
           const providerSettings = this.svc.getSettingsStore().get('providerSettings', {}) as any;
           refreshedConfig.baseUrl = providerSettings['lmstudio']?.baseUrl || 'http://127.0.0.1:8234';
+        }
+
+        if (session.provider === 'minimax') {
+          const providerSettings = this.svc.getSettingsStore().get('providerSettings', {}) as any;
+          refreshedConfig.baseUrl = providerSettings['minimax']?.baseUrl || MINIMAX_ENDPOINTS.global_en.openai;
         }
 
         await provider.initialize(refreshedConfig);
@@ -1218,6 +1237,10 @@ export class MessageStreamingHandler {
           temperature: (session.providerConfig as any)?.temperature,
           ...(turnEffortLevel && { effortLevel: turnEffortLevel }),
         };
+        if (session.provider === 'minimax') {
+          const providerSettings = this.svc.getSettingsStore().get('providerSettings', {}) as any;
+          turnConfig.baseUrl = providerSettings['minimax']?.baseUrl || MINIMAX_ENDPOINTS.global_en.openai;
+        }
         const fullTurnModel = session.model || session.providerConfig?.model;
         if (fullTurnModel) {
           const modelForProvider = extractModelForProvider(fullTurnModel, session.provider as AIProviderType);
@@ -1921,7 +1944,7 @@ export class MessageStreamingHandler {
               // Agent providers (claude-code, codex, opencode) render tool calls
               // through the canonical transcript pipeline. The legacy addMessage +
               // streamResponse toolCalls path below is only for chat providers
-              // (claude, openai, lmstudio) that don't have canonical transcripts.
+              // that don't have canonical transcripts.
               // Running both paths creates duplicate tool call entries.
               if (!isAgentProvider(session.provider)) {
                 // Save tool call as a separate message in the session

--- a/packages/electron/src/main/services/ai/__tests__/aiServiceUtils.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/aiServiceUtils.test.ts
@@ -33,7 +33,7 @@ vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
     },
   },
   CLAUDE_CODE_VARIANTS: ['opus', 'sonnet', 'haiku'] as const,
-  AI_PROVIDER_TYPES: ['claude', 'claude-code', 'openai', 'openai-codex', 'lmstudio'] as const,
+  AI_PROVIDER_TYPES: ['claude', 'claude-code', 'openai', 'openai-codex', 'minimax', 'lmstudio'] as const,
 }));
 
 vi.mock('../../../utils/logger', () => ({

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -490,7 +490,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // AI operations (new unified interface)
   aiHasApiKey: () => ipcRenderer.invoke('ai:hasApiKey'),
   aiInitialize: (provider?: string, apiKey?: string) => ipcRenderer.invoke('ai:initialize', provider, apiKey),
-  aiCreateSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'opencode' | 'copilot-cli' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) => {
+  aiCreateSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'opencode' | 'copilot-cli' | 'minimax' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) => {
     // console.log('[Preload] aiCreateSession called:', { provider, workspacePath, sessionType, worktreeId });
     return ipcRenderer.invoke('ai:createSession', provider, documentContext, workspacePath, modelId, sessionType, worktreeId);
   },
@@ -519,7 +519,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   getAISettings: () => ipcRenderer.invoke('ai:getSettings'),
   saveAISettings: (settings: any) => ipcRenderer.invoke('ai:saveSettings', settings),
-  testAIConnection: (provider: 'claude' | 'claude-code' | 'openai' | 'lmstudio') => ipcRenderer.invoke('ai:testConnection', provider),
+  testAIConnection: (provider: 'claude' | 'claude-code' | 'openai' | 'minimax' | 'lmstudio') => ipcRenderer.invoke('ai:testConnection', provider),
   getAIModels: () => ipcRenderer.invoke('ai:getModels'),
   // Aliases for consistency with component naming
   aiGetSettings: () => ipcRenderer.invoke('ai:getSettings'),
@@ -708,7 +708,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   ai: {
     hasApiKey: () => ipcRenderer.invoke('ai:hasApiKey'),
     initialize: (provider?: string, apiKey?: string) => ipcRenderer.invoke('ai:initialize', provider, apiKey),
-    createSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) =>
+    createSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'minimax' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) =>
       ipcRenderer.invoke('ai:createSession', provider, documentContext, workspacePath, modelId, sessionType, worktreeId),
     sendMessage: (message: string, documentContext?: any, sessionId?: string, workspacePath?: string) =>
       ipcRenderer.invoke('ai:sendMessage', message, documentContext, sessionId, workspacePath),

--- a/packages/electron/src/renderer/components/GlobalSettings/panels/MiniMaxPanel.tsx
+++ b/packages/electron/src/renderer/components/GlobalSettings/panels/MiniMaxPanel.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { MINIMAX_ENDPOINTS } from '@nimbalyst/runtime/ai/server';
+import { ProviderConfig, Model } from '../../Settings/SettingsView';
+import { SettingsToggle } from '../SettingsToggle';
+
+interface MiniMaxPanelProps {
+  config: ProviderConfig;
+  apiKeys: Record<string, string>;
+  availableModels: Model[];
+  loading: boolean;
+  onToggle: (enabled: boolean) => void;
+  onApiKeyChange: (key: string, value: string) => void;
+  onModelToggle: (modelId: string, enabled: boolean) => void;
+  onSelectAllModels: (selectAll: boolean) => void;
+  onTestConnection: () => Promise<void>;
+  onConfigChange: (updates: Partial<ProviderConfig>) => void;
+}
+
+const ENDPOINT_OPTIONS = [
+  { label: 'Global - OpenAI-compatible', value: MINIMAX_ENDPOINTS.global_en.openai },
+  { label: 'Global - Anthropic-compatible', value: MINIMAX_ENDPOINTS.global_en.anthropic },
+  { label: 'China - OpenAI-compatible', value: MINIMAX_ENDPOINTS.cn_zh.openai },
+  { label: 'China - Anthropic-compatible', value: MINIMAX_ENDPOINTS.cn_zh.anthropic },
+] as const;
+
+export function MiniMaxPanel({
+  config,
+  apiKeys,
+  availableModels,
+  loading,
+  onToggle,
+  onApiKeyChange,
+  onModelToggle,
+  onSelectAllModels,
+  onTestConnection,
+  onConfigChange,
+}: MiniMaxPanelProps) {
+  const selectedEndpoint = config.baseUrl || MINIMAX_ENDPOINTS.global_en.openai;
+
+  return (
+    <div className="provider-panel minimax-provider-panel flex flex-col">
+      <div className="provider-panel-header mb-6 pb-4 border-b border-[var(--nim-border)]">
+        <h3 className="provider-panel-title text-xl font-semibold leading-tight mb-2 text-[var(--nim-text)]">MiniMax</h3>
+        <p className="provider-panel-description text-sm leading-relaxed text-[var(--nim-text-muted)]">
+          Configure MiniMax chat models with a supported regional and compatibility endpoint.
+        </p>
+      </div>
+
+      <SettingsToggle
+        variant="enable"
+        name="Enable MiniMax"
+        checked={config.enabled}
+        onChange={onToggle}
+      />
+
+      {config.enabled && (
+        <>
+          <div className="provider-panel-section py-4 mb-4 border-b border-[var(--nim-border)] last:border-b-0 last:mb-0 last:pb-0">
+            <h4 className="provider-panel-section-title text-base font-semibold mb-3 text-[var(--nim-text)]">API Configuration</h4>
+            <label className="flex flex-col gap-2 mb-4">
+              <span className="text-sm text-[var(--nim-text-muted)]">Endpoint</span>
+              <select
+                value={selectedEndpoint}
+                onChange={(event) => onConfigChange({ baseUrl: event.target.value })}
+                className="py-2 px-3 rounded-md bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] text-[var(--nim-text)] outline-none focus:border-[var(--nim-primary)]"
+              >
+                {ENDPOINT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </label>
+
+            <div className="api-key-row flex gap-2 items-center">
+              <input
+                type="password"
+                value={apiKeys.minimax || ''}
+                onChange={(event) => onApiKeyChange('minimax', event.target.value)}
+                onFocus={(event) => event.target.select()}
+                placeholder="Enter MiniMax API key"
+                className="api-key-input flex-1 py-2 px-3 rounded-md bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] text-[var(--nim-text)] outline-none font-mono focus:border-[var(--nim-primary)]"
+              />
+              <button
+                className={`test-button inline-flex items-center justify-center py-2 px-4 rounded-md text-sm font-medium whitespace-nowrap cursor-pointer transition-all bg-[var(--nim-bg-tertiary)] text-[var(--nim-text)] border border-[var(--nim-border)] hover:bg-[var(--nim-bg-hover)] hover:border-[var(--nim-primary)] ${
+                  config.testStatus === 'testing' ? 'opacity-60 cursor-wait' : ''
+                } ${config.testStatus === 'success' ? 'text-[var(--nim-success)] border-[var(--nim-success)]' : ''} ${
+                  config.testStatus === 'error' ? 'text-[var(--nim-error)] border-[var(--nim-error)]' : ''
+                }`}
+                onClick={onTestConnection}
+                disabled={config.testStatus === 'testing'}
+              >
+                {config.testStatus === 'testing'
+                  ? 'Testing...'
+                  : config.testStatus === 'success'
+                    ? 'Connected'
+                    : config.testStatus === 'error'
+                      ? 'Failed'
+                      : 'Test'}
+              </button>
+            </div>
+            {config.testMessage && config.testStatus === 'error' && (
+              <div className="test-error text-xs mt-2 text-[var(--nim-error)]">{config.testMessage}</div>
+            )}
+          </div>
+
+          <div className="provider-panel-section py-4 mb-4 border-b border-[var(--nim-border)] last:border-b-0 last:mb-0 last:pb-0">
+            <h4 className="provider-panel-section-title text-base font-semibold mb-3 text-[var(--nim-text)]">Available Models</h4>
+            {loading && (
+              <div className="models-loading text-sm text-[var(--nim-text-muted)] py-2">Loading models...</div>
+            )}
+
+            {!loading && availableModels.length > 0 && (
+              <div className="models-section">
+                <div className="models-header flex items-center justify-between mb-3">
+                  <span className="text-sm text-[var(--nim-text-muted)]">Select models to enable:</span>
+                  <div className="models-actions flex gap-2">
+                    <button
+                      className="models-action-btn text-xs py-1 px-2 rounded bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] text-[var(--nim-text-muted)] hover:text-[var(--nim-text)] hover:bg-[var(--nim-bg-hover)] cursor-pointer transition-all"
+                      onClick={() => onSelectAllModels(true)}
+                    >
+                      Select All
+                    </button>
+                    <button
+                      className="models-action-btn text-xs py-1 px-2 rounded bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] text-[var(--nim-text-muted)] hover:text-[var(--nim-text)] hover:bg-[var(--nim-bg-hover)] cursor-pointer transition-all"
+                      onClick={() => onSelectAllModels(false)}
+                    >
+                      Deselect All
+                    </button>
+                  </div>
+                </div>
+                <div className="models-grid flex flex-col gap-2">
+                  {availableModels.map((model) => (
+                    <label key={model.id} className="model-checkbox flex items-center gap-3 py-2 px-3 rounded-md bg-[var(--nim-bg-secondary)] border border-[var(--nim-border)] cursor-pointer hover:bg-[var(--nim-bg-hover)]">
+                      <input
+                        type="checkbox"
+                        checked={config.models?.includes(model.id) ?? false}
+                        onChange={(event) => onModelToggle(model.id, event.target.checked)}
+                        className="w-4 h-4 cursor-pointer accent-[var(--nim-primary)]"
+                      />
+                      <span className="text-sm text-[var(--nim-text)]">{model.name}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {!loading && availableModels.length === 0 && apiKeys.minimax && (
+              <div className="models-loading text-sm text-[var(--nim-text-muted)] py-2">No models available. Check your API key and connection.</div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/components/Settings/SettingsSidebar.tsx
+++ b/packages/electron/src/renderer/components/Settings/SettingsSidebar.tsx
@@ -37,7 +37,7 @@ const GROUP_DESCRIPTIONS: Record<string, string> = {
 };
 
 function routeIcon(route: SettingsRoute): React.ReactNode {
-  if (['claude-code', 'claude', 'openai', 'openai-codex', 'opencode', 'copilot-cli', 'lmstudio'].includes(route.id)) {
+  if (['claude-code', 'claude', 'openai', 'openai-codex', 'minimax', 'opencode', 'copilot-cli', 'lmstudio'].includes(route.id)) {
     const providerId = route.id === 'openai-codex' ? 'openai' : route.id;
     return getProviderIcon(providerId, { size: 16 });
   }

--- a/packages/electron/src/renderer/components/Settings/SettingsView.tsx
+++ b/packages/electron/src/renderer/components/Settings/SettingsView.tsx
@@ -18,6 +18,7 @@ import { pushNavigationEntryAtom, isRestoringNavigationAtom } from '../../store'
 import { ClaudePanel } from '../GlobalSettings/panels/ClaudePanel';
 import { ClaudeCodePanel } from '../GlobalSettings/panels/ClaudeCodePanel';
 import { OpenAIPanel } from '../GlobalSettings/panels/OpenAIPanel';
+import { MiniMaxPanel } from '../GlobalSettings/panels/MiniMaxPanel';
 import { OpenAICodexPanel } from '../GlobalSettings/panels/OpenAICodexPanel';
 import { OpenCodePanel } from '../GlobalSettings/panels/OpenCodePanel';
 import { CopilotCLIPanel } from '../GlobalSettings/panels/CopilotCLIPanel';
@@ -866,6 +867,8 @@ export function SettingsView({
         );
       case 'openai':
         return wrapWithOverride('openai', 'OpenAI', <OpenAIPanel {...commonProps} />);
+      case 'minimax':
+        return wrapWithOverride('minimax', 'MiniMax', <MiniMaxPanel {...commonProps} />);
       case 'openai-codex':
         return wrapWithOverride('openai-codex', 'OpenAI Codex', <OpenAICodexPanel {...commonProps} />);
       case 'opencode':

--- a/packages/electron/src/renderer/components/Settings/panels/ProjectAIProvidersPanel.tsx
+++ b/packages/electron/src/renderer/components/Settings/panels/ProjectAIProvidersPanel.tsx
@@ -46,6 +46,7 @@ const PROVIDERS: ProviderInfo[] = [
   { id: 'claude-code', name: 'Claude Agent', subtitle: 'CLI-based MCP', apiKeyField: 'claude-code' },
   { id: 'claude', name: 'Claude', subtitle: 'Anthropic API', apiKeyField: 'anthropic' },
   { id: 'openai', name: 'OpenAI', subtitle: 'GPT Models', apiKeyField: 'openai' },
+  { id: 'minimax', name: 'MiniMax', subtitle: 'MiniMax Models', apiKeyField: 'minimax' },
   { id: 'lmstudio', name: 'LM Studio', subtitle: 'Local Models' },
 ];
 

--- a/packages/electron/src/renderer/components/Settings/settingsRoutes.ts
+++ b/packages/electron/src/renderer/components/Settings/settingsRoutes.ts
@@ -11,6 +11,7 @@ export type ApplicationSettingsCategory =
   | 'claude-code'
   | 'claude'
   | 'openai'
+  | 'minimax'
   | 'openai-codex'
   | 'opencode'
   | 'copilot-cli'
@@ -105,6 +106,7 @@ export const settingsRoutes: readonly SettingsRoute[] = [
   { id: 'copilot-cli', scope: 'application', group: 'Agent Providers', label: 'GitHub Copilot', icon: 'terminal', isAlpha: true },
   { id: 'claude', scope: 'application', group: 'Chat Providers', label: 'Claude Chat', icon: 'chat' },
   { id: 'openai', scope: 'application', group: 'Chat Providers', label: 'OpenAI', icon: 'chat' },
+  { id: 'minimax', scope: 'application', group: 'Chat Providers', label: 'MiniMax', icon: 'bolt' },
   { id: 'lmstudio', scope: 'application', group: 'Chat Providers', label: 'LM Studio', icon: 'memory' },
   { id: 'marketplace', scope: 'application', group: 'Extensions', label: 'Marketplace', icon: 'storefront' },
   { id: 'installed-extensions', scope: 'application', group: 'Extensions', label: 'Installed', icon: 'extension' },

--- a/packages/electron/src/renderer/components/UnifiedAI/ModelSelector.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/ModelSelector.tsx
@@ -124,6 +124,7 @@ export function ModelSelector({
       case 'claude':
       case 'claude-code':
       case 'openai':
+      case 'minimax':
       case 'openai-codex':
       case 'opencode':
       case 'copilot-cli':
@@ -177,6 +178,7 @@ export function ModelSelector({
       case 'claude-code': return 'Claude Agent (Claude Code Based)';
       case 'claude-code-cli': return 'Claude Code CLI (Subscription)';
       case 'openai': return 'OpenAI';
+      case 'minimax': return 'MiniMax';
       case 'openai-codex': return 'OpenAI Codex';
       case 'openai-codex-acp': return 'OpenAI Codex (ACP)';
       case 'opencode': return 'OpenCode';
@@ -207,7 +209,7 @@ export function ModelSelector({
     return getProviderIcon(provider, { size });
   };
 
-  const CHAT_MODEL_PROVIDERS = new Set(['claude', 'openai', 'lmstudio']);
+  const CHAT_MODEL_PROVIDERS = new Set(['claude', 'openai', 'minimax', 'lmstudio']);
   const getProviderType = (provider: string): ProviderType => {
     if (isAgentProvider(provider)) return 'agent';
     if (CHAT_MODEL_PROVIDERS.has(provider)) return 'model';

--- a/packages/electron/src/renderer/electron.d.ts
+++ b/packages/electron/src/renderer/electron.d.ts
@@ -380,7 +380,7 @@ interface ElectronAPI {
   // AI operations (flat methods)
   aiHasApiKey: () => Promise<boolean>;
   aiInitialize: (provider?: string, apiKey?: string) => Promise<any>;
-  aiCreateSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'opencode' | 'copilot-cli' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) => Promise<any>;
+  aiCreateSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'opencode' | 'copilot-cli' | 'minimax' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) => Promise<any>;
   aiSendMessage: (message: string, documentContext?: any, sessionId?: string, workspacePath?: string) => Promise<any>;
   aiGetSessions: (workspacePath?: string) => Promise<any>;
   aiLoadSession: (sessionId: string, workspacePath?: string, trackAsResume?: boolean) => Promise<any>;
@@ -400,7 +400,7 @@ interface ElectronAPI {
 
   getAISettings: () => Promise<any>;
   saveAISettings: (settings: any) => Promise<void>;
-  testAIConnection: (provider: 'claude' | 'claude-code' | 'openai' | 'lmstudio') => Promise<any>;
+  testAIConnection: (provider: 'claude' | 'claude-code' | 'openai' | 'minimax' | 'lmstudio') => Promise<any>;
   getAIModels: () => Promise<{ success: boolean; models: any[]; grouped: Record<string, any[]> }>;
   aiGetSettings: () => Promise<any>;
   aiSaveSettings: (settings: any) => Promise<void>;
@@ -466,7 +466,7 @@ interface ElectronAPI {
   ai: {
     hasApiKey: () => Promise<boolean>;
     initialize: (provider?: string, apiKey?: string) => Promise<any>;
-    createSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) => Promise<any>;
+    createSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'minimax' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) => Promise<any>;
     sendMessage: (message: string, documentContext?: any, sessionId?: string, workspacePath?: string) => Promise<any>;
     getSessions: (workspacePath?: string) => Promise<any>;
     getSessionList: (workspacePath?: string) => Promise<any>;

--- a/packages/electron/src/renderer/services/aiApi.ts
+++ b/packages/electron/src/renderer/services/aiApi.ts
@@ -337,7 +337,7 @@ class AIApi {
   async createSession(
     documentContext?: DocumentContext,
     workspacePath?: string,
-    provider?: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'lmstudio',
+    provider?: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'minimax' | 'lmstudio',
     modelId?: string,
     sessionType?: string
   ): Promise<SessionData> {
@@ -350,7 +350,7 @@ class AIApi {
 
   // New method specifically for creating session with provider
   async createSessionWithProvider(
-    provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai',
+    provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'minimax',
     documentContext?: DocumentContext,
     workspacePath?: string,
     modelId?: string,

--- a/packages/electron/src/renderer/store/atoms/appSettings.ts
+++ b/packages/electron/src/renderer/store/atoms/appSettings.ts
@@ -1172,6 +1172,7 @@ const defaultProviders: Record<string, ProviderConfig> = {
   // in the correct state.
   'claude-code-cli': { enabled: false, testStatus: 'idle' },
   openai: { enabled: false, testStatus: 'idle' },
+  minimax: { enabled: false, baseUrl: 'https://api.minimax.io/v1', testStatus: 'idle' },
   // Codex app server. On by default.
   'openai-codex': { enabled: true, testStatus: 'idle', installStatus: 'not-installed' },
   'openai-codex-acp': { enabled: false, testStatus: 'idle', installStatus: 'not-installed' },
@@ -1187,6 +1188,7 @@ const defaultApiKeys: Record<string, string> = {
   anthropic: '',
   'claude-code': '',
   openai: '',
+  minimax: '',
   'openai-codex': '',
   opencode: '',
   lmstudio_url: 'http://127.0.0.1:8234',

--- a/packages/electron/src/renderer/utils/modelUtils.ts
+++ b/packages/electron/src/renderer/utils/modelUtils.ts
@@ -161,6 +161,7 @@ export function getProviderDisplayName(provider: string): string {
     case 'claude-code': return 'Claude Agent';
     case 'claude-code-cli': return 'Claude Code CLI';
     case 'openai': return 'OpenAI';
+    case 'minimax': return 'MiniMax';
     case 'lmstudio': return 'LMStudio';
     case 'copilot-cli': return 'GitHub Copilot';
     default: return provider;
@@ -176,6 +177,7 @@ export function getProviderLabel(provider: string): string {
     case 'claude-code': return 'CODE';
     case 'claude-code-cli': return 'CLI';
     case 'openai': return 'GPT';
+    case 'minimax': return 'MINIMAX';
     case 'lmstudio': return 'LOCAL';
     default: return provider.toUpperCase();
   }

--- a/packages/electron/src/shared/settings/keys.ts
+++ b/packages/electron/src/shared/settings/keys.ts
@@ -107,6 +107,11 @@ export const SETTINGS_REGISTRY = {
     { store: 'ai-settings', path: 'providerSettings.openai' },
     { enabled: false, testStatus: 'idle' },
   ),
+  'ai.provider.minimax': setting(
+    ProviderConfigSchema,
+    { store: 'ai-settings', path: 'providerSettings.minimax' },
+    { enabled: false, baseUrl: 'https://api.minimax.io/v1', testStatus: 'idle' },
+  ),
   'ai.provider.openai-codex': setting(
     ProviderConfigSchema,
     { store: 'ai-settings', path: 'providerSettings.openai-codex' },
@@ -147,6 +152,11 @@ export const SETTINGS_REGISTRY = {
   'ai.apiKey.openai': setting(
     z.string(),
     { store: 'ai-settings', path: 'apiKeys.openai' },
+    '',
+  ),
+  'ai.apiKey.minimax': setting(
+    z.string(),
+    { store: 'ai-settings', path: 'apiKeys.minimax' },
     '',
   ),
   'ai.apiKey.openai-codex': setting(

--- a/packages/extension-sdk/src/types/extension.ts
+++ b/packages/extension-sdk/src/types/extension.ts
@@ -1159,7 +1159,7 @@ export interface ExtensionAIService {
     prompt: string;
     sessionName?: string;
     /** AI provider to use. Defaults to 'claude-code'. */
-    provider?: 'claude-code' | 'claude' | 'openai';
+    provider?: 'claude-code' | 'claude' | 'openai' | 'minimax';
     /** Model ID (e.g. 'claude-code:opus', 'claude-code:sonnet'). Uses provider default if omitted. */
     model?: string;
   }): Promise<{
@@ -1169,7 +1169,7 @@ export interface ExtensionAIService {
 
   /**
    * List available chat models.
-   * Returns models from enabled chat providers (Claude, OpenAI, LM Studio),
+   * Returns models from enabled chat providers,
    * filtered to models the user has enabled in settings.
    */
   listModels(): Promise<ExtensionAIModel[]>;
@@ -1196,7 +1196,7 @@ export interface ExtensionAIModel {
   id: string;
   /** Display name (e.g. "Claude Sonnet 4.6") */
   name: string;
-  /** Provider type (e.g. "claude", "openai", "lmstudio") */
+  /** Provider type returned by listModels(). */
   provider: string;
 }
 

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -445,6 +445,7 @@ export const CLAUDE_CODE_SAFE_FALLBACK_MODEL = 'claude-code:opus' as const;
 export const DEFAULT_MODELS = {
   claude: 'claude:claude-opus-4-8',
   openai: 'openai:gpt-5.6-sol',
+  minimax: 'minimax:MiniMax-M3',
   // Plain `opus` (not `opus-1m`): the current CLI runs plain Opus at 1M natively
   // at a flat price, so the `[1m]` suffix is a redundant no-op (GitHub #825).
   'claude-code': 'claude-code:opus',

--- a/packages/runtime/src/ai/server/ModelRegistry.ts
+++ b/packages/runtime/src/ai/server/ModelRegistry.ts
@@ -64,6 +64,10 @@ export class ModelRegistry {
           const { OpenAIProvider } = await import('./providers/OpenAIProvider');
           models = await OpenAIProvider.getModels(apiKey);
           break;
+        case 'minimax':
+          const { MiniMaxProvider } = await import('./providers/MiniMaxProvider');
+          models = MiniMaxProvider.getModels();
+          break;
         case 'openai-codex':
           const { OpenAICodexProvider } = await import('./providers/OpenAICodexProvider');
           models = await OpenAICodexProvider.getModels(apiKey);
@@ -120,6 +124,7 @@ export class ModelRegistry {
     if (shouldFetch('claude-code')) promises.push(this.getModelsForProvider('claude-code'));
     if (shouldFetch('claude-code-cli')) promises.push(this.getModelsForProvider('claude-code-cli'));
     if (shouldFetch('openai')) promises.push(this.getModelsForProvider('openai', apiKeys['openai']));
+    if (shouldFetch('minimax')) promises.push(this.getModelsForProvider('minimax', apiKeys['minimax']));
     if (shouldFetch('openai-codex')) promises.push(this.getModelsForProvider('openai-codex', apiKeys['openai']));
     if (shouldFetch('openai-codex-acp')) promises.push(this.getModelsForProvider('openai-codex-acp', apiKeys['openai']));
     if (shouldFetch('opencode')) promises.push(this.getModelsForProvider('opencode'));
@@ -153,6 +158,9 @@ export class ModelRegistry {
       case 'openai':
         const { OpenAIProvider } = await import('./providers/OpenAIProvider');
         return OpenAIProvider.getDefaultModel();
+      case 'minimax':
+        const { MiniMaxProvider } = await import('./providers/MiniMaxProvider');
+        return MiniMaxProvider.getDefaultModel();
       case 'claude-code':
         const { ClaudeCodeProvider } = await import('./providers/ClaudeCodeProvider');
         return ClaudeCodeProvider.getDefaultModel();

--- a/packages/runtime/src/ai/server/ProviderFactory.ts
+++ b/packages/runtime/src/ai/server/ProviderFactory.ts
@@ -7,6 +7,7 @@ import { ClaudeProvider } from './providers/ClaudeProvider';
 import { ClaudeCodeProvider } from './providers/ClaudeCodeProvider';
 import { ClaudeCodeCliProvider } from './providers/ClaudeCodeCliProvider';
 import { OpenAIProvider } from './providers/OpenAIProvider';
+import { MiniMaxProvider } from './providers/MiniMaxProvider';
 import { OpenAICodexProvider } from './providers/OpenAICodexProvider';
 import { OpenAICodexACPProvider } from './providers/OpenAICodexACPProvider';
 import { LMStudioProvider } from './providers/LMStudioProvider';
@@ -65,6 +66,9 @@ export class ProviderFactory {
         break;
       case 'openai':
         provider = new OpenAIProvider();
+        break;
+      case 'minimax':
+        provider = new MiniMaxProvider();
         break;
       case 'openai-codex':
         provider = new OpenAICodexProvider();

--- a/packages/runtime/src/ai/server/index.ts
+++ b/packages/runtime/src/ai/server/index.ts
@@ -6,6 +6,7 @@ export * from './SessionManager';
 export * from './providers/ClaudeProvider';
 export * from './providers/ClaudeCodeProvider';
 export * from './providers/OpenAIProvider';
+export * from './providers/MiniMaxProvider';
 export * from './providers/OpenAICodexProvider';
 export * from './providers/OpenAICodexACPProvider';
 export * from './providers/ProviderPermissionMixin';

--- a/packages/runtime/src/ai/server/providers/ClaudeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeProvider.ts
@@ -30,6 +30,16 @@ export class ClaudeProvider extends BaseAIProvider {
 
   static readonly DEFAULT_MODEL = DEFAULT_MODELS.claude;
 
+  protected getProviderId(): AIModel['provider'] {
+    return 'claude';
+  }
+
+  protected getClientDefaultHeaders(): Record<string, string> | undefined {
+    return {
+      'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
+    };
+  }
+
   async initialize(config: ProviderConfig): Promise<void> {
     console.log('[ClaudeProvider] initialize called with config:', {
       hasApiKey: !!config.apiKey,
@@ -45,9 +55,8 @@ export class ClaudeProvider extends BaseAIProvider {
 
     this.anthropic = new Anthropic({
       apiKey: config.apiKey,
-      defaultHeaders: {
-        'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14'
-      }
+      baseURL: config.baseUrl,
+      defaultHeaders: this.getClientDefaultHeaders(),
     });
   }
 
@@ -200,7 +209,7 @@ export class ClaudeProvider extends BaseAIProvider {
     // Log the input message
     // CRITICAL: Must await to ensure user message is persisted before proceeding
     if (sessionId) {
-      await this.logAgentMessage(sessionId, 'claude', 'input', message);
+      await this.logAgentMessage(sessionId, this.getProviderId(), 'input', message);
     }
 
     // Check if current message has attachments
@@ -769,7 +778,7 @@ export class ClaudeProvider extends BaseAIProvider {
           if (sessionId) {
             // Log text content if any
             if (fullContent) {
-              this.logAgentMessage(sessionId, 'claude', 'output', JSON.stringify({
+              this.logAgentMessage(sessionId, this.getProviderId(), 'output', JSON.stringify({
                 type: 'text',
                 content: fullContent
               }));
@@ -778,7 +787,7 @@ export class ClaudeProvider extends BaseAIProvider {
             // Log each tool use and result
             for (const toolUse of toolUses) {
               // Log the tool_use block
-              this.logAgentMessage(sessionId, 'claude', 'output', JSON.stringify({
+              this.logAgentMessage(sessionId, this.getProviderId(), 'output', JSON.stringify({
                 type: 'assistant',
                 message: {
                   content: [{
@@ -803,7 +812,7 @@ export class ClaudeProvider extends BaseAIProvider {
                 resultContent = JSON.stringify(result, null, 2);
               }
 
-              this.logAgentMessage(sessionId, 'claude', 'output', JSON.stringify({
+              this.logAgentMessage(sessionId, this.getProviderId(), 'output', JSON.stringify({
                 type: 'assistant',
                 message: {
                   content: [{
@@ -869,7 +878,7 @@ export class ClaudeProvider extends BaseAIProvider {
 
           // Log the output message - await to ensure it's saved before signaling completion
           if (sessionId && fullContent) {
-            await this.logAgentMessage(sessionId, 'claude', 'output', fullContent, {
+            await this.logAgentMessage(sessionId, this.getProviderId(), 'output', fullContent, {
               usage: totalUsageData
             });
           }

--- a/packages/runtime/src/ai/server/providers/MiniMaxProvider.ts
+++ b/packages/runtime/src/ai/server/providers/MiniMaxProvider.ts
@@ -1,0 +1,208 @@
+import type { AIProvider } from '../AIProvider';
+import { BaseAIProvider } from '../AIProvider';
+import type {
+  AgentToolDefinition,
+  AIModel,
+  DocumentContext,
+  ProviderCapabilities,
+  ProviderConfig,
+  StreamChunk,
+  ToolHandler,
+} from '../types';
+import { ModelIdentifier } from '../ModelIdentifier';
+import { ClaudeProvider } from './ClaudeProvider';
+import { OpenAIProvider } from './OpenAIProvider';
+
+export const MINIMAX_ENDPOINTS = {
+  global_en: {
+    openai: 'https://api.minimax.io/v1',
+    anthropic: 'https://api.minimax.io/anthropic',
+  },
+  cn_zh: {
+    openai: 'https://api.minimaxi.com/v1',
+    anthropic: 'https://api.minimaxi.com/anthropic',
+  },
+} as const;
+
+export type MiniMaxProtocol = keyof typeof MINIMAX_ENDPOINTS.global_en;
+export type MiniMaxRegion = keyof typeof MINIMAX_ENDPOINTS;
+
+export interface MiniMaxEndpoint {
+  baseUrl: string;
+  protocol: MiniMaxProtocol;
+  region: MiniMaxRegion;
+}
+
+const MINIMAX_MODELS = [
+  { id: 'MiniMax-M3', contextWindow: 1000000 },
+  { id: 'MiniMax-M2.7', contextWindow: 204800 },
+] as const;
+
+const FORWARDED_EVENTS = [
+  'message:logged',
+  'promptAdditions',
+  'tool:start',
+  'tool:complete',
+  'tool:error',
+] as const;
+
+export function resolveMiniMaxEndpoint(baseUrl?: string): MiniMaxEndpoint {
+  const normalized = (baseUrl || MINIMAX_ENDPOINTS.global_en.openai).replace(/\/+$/, '');
+
+  for (const region of Object.keys(MINIMAX_ENDPOINTS) as MiniMaxRegion[]) {
+    for (const protocol of Object.keys(MINIMAX_ENDPOINTS[region]) as MiniMaxProtocol[]) {
+      if (MINIMAX_ENDPOINTS[region][protocol] === normalized) {
+        return { baseUrl: normalized, protocol, region };
+      }
+    }
+  }
+
+  throw new Error('Unsupported MiniMax endpoint');
+}
+
+class MiniMaxOpenAIAdapter extends OpenAIProvider {
+  protected getProviderId(): AIModel['provider'] {
+    return 'minimax';
+  }
+}
+
+class MiniMaxAnthropicAdapter extends ClaudeProvider {
+  protected getProviderId(): AIModel['provider'] {
+    return 'minimax';
+  }
+
+  protected getClientDefaultHeaders(): undefined {
+    return undefined;
+  }
+}
+
+export class MiniMaxProvider extends BaseAIProvider {
+  static readonly DEFAULT_MODEL = ModelIdentifier.create('minimax', MINIMAX_MODELS[0].id).combined;
+
+  private delegate: AIProvider | null = null;
+  private forwardedListeners: Array<{ event: string; listener: (...args: any[]) => void }> = [];
+
+  async initialize(config: ProviderConfig): Promise<void> {
+    if (!config.apiKey) {
+      throw new Error('API key required for MiniMax provider');
+    }
+
+    const endpoint = resolveMiniMaxEndpoint(config.baseUrl);
+    const parsedModel = config.model ? ModelIdentifier.tryParse(config.model) : null;
+    this.releaseDelegate();
+
+    this.config = {
+      ...config,
+      baseUrl: endpoint.baseUrl,
+      model: parsedModel?.provider === 'minimax'
+        ? parsedModel.model
+        : config.model || MINIMAX_MODELS[0].id,
+    };
+
+    const delegate = endpoint.protocol === 'anthropic'
+      ? new MiniMaxAnthropicAdapter()
+      : new MiniMaxOpenAIAdapter();
+
+    for (const event of FORWARDED_EVENTS) {
+      const listener = (...args: any[]) => this.emit(event, ...args);
+      delegate.on(event, listener);
+      this.forwardedListeners.push({ event, listener });
+    }
+
+    if (this.toolHandler) {
+      delegate.registerToolHandler(this.toolHandler);
+    }
+
+    this.delegate = delegate;
+    try {
+      await delegate.initialize(this.config);
+    } catch (error) {
+      this.releaseDelegate();
+      throw error;
+    }
+  }
+
+  sendMessage(
+    message: string,
+    documentContext?: DocumentContext,
+    sessionId?: string,
+    messages?: any[],
+    workspacePath?: string,
+    attachments?: any[],
+    tools?: AgentToolDefinition[],
+    systemPrompt?: string,
+  ): AsyncIterableIterator<StreamChunk> {
+    if (!this.delegate) {
+      throw new Error('MiniMax provider not initialized');
+    }
+
+    return this.delegate.sendMessage(
+      message,
+      documentContext,
+      sessionId,
+      messages,
+      workspacePath,
+      attachments,
+      tools,
+      systemPrompt,
+    );
+  }
+
+  abort(): void {
+    this.delegate?.abort();
+  }
+
+  getCapabilities(): ProviderCapabilities {
+    return this.delegate?.getCapabilities() ?? {
+      streaming: true,
+      tools: true,
+      mcpSupport: false,
+      edits: true,
+      resumeSession: false,
+      supportsFileTools: false,
+    };
+  }
+
+  registerToolHandler(handler: ToolHandler): void {
+    super.registerToolHandler(handler);
+    this.delegate?.registerToolHandler(handler);
+  }
+
+  destroy(): void {
+    this.releaseDelegate();
+    super.destroy();
+  }
+
+  static getModels(): AIModel[] {
+    return MINIMAX_MODELS.map((model) => ({
+      id: ModelIdentifier.create('minimax', model.id).combined,
+      name: model.id,
+      provider: 'minimax',
+      contextWindow: model.contextWindow,
+    }));
+  }
+
+  static getDefaultModel(): string {
+    return this.DEFAULT_MODEL;
+  }
+
+  static isModelAllowed(modelId: string): boolean {
+    const parsed = ModelIdentifier.tryParse(modelId);
+    const cleanId = parsed ? parsed.model : modelId;
+    return MINIMAX_MODELS.some((model) => model.id === cleanId);
+  }
+
+  private releaseDelegate(): void {
+    if (!this.delegate) {
+      this.forwardedListeners = [];
+      return;
+    }
+
+    for (const { event, listener } of this.forwardedListeners) {
+      this.delegate.off(event, listener);
+    }
+    this.forwardedListeners = [];
+    this.delegate.destroy();
+    this.delegate = null;
+  }
+}

--- a/packages/runtime/src/ai/server/providers/OpenAIProvider.ts
+++ b/packages/runtime/src/ai/server/providers/OpenAIProvider.ts
@@ -24,6 +24,10 @@ export class OpenAIProvider extends BaseAIProvider {
 
   static readonly DEFAULT_MODEL = DEFAULT_MODELS.openai;
 
+  protected getProviderId(): AIModel['provider'] {
+    return 'openai';
+  }
+
   async initialize(config: ProviderConfig): Promise<void> {
     const initStartTime = Date.now();
     console.log(`[OpenAIProvider] Initializing with config:`, {
@@ -47,6 +51,7 @@ export class OpenAIProvider extends BaseAIProvider {
     console.log(`[OpenAIProvider] Creating OpenAI client with timeout: ${timeout}ms, maxRetries: 0`);
     this.openai = new OpenAI({
       apiKey: config.apiKey,
+      baseURL: config.baseUrl,
       timeout,
       maxRetries: 0,  // NO RETRIES - fail fast
       dangerouslyAllowBrowser: false  // We're in Node.js/Electron main process
@@ -217,7 +222,7 @@ export class OpenAIProvider extends BaseAIProvider {
     // Log the input message
     // CRITICAL: Must await to ensure user message is persisted before proceeding
     if (sessionId) {
-      await this.logAgentMessage(sessionId, 'openai', 'input', message);
+      await this.logAgentMessage(sessionId, this.getProviderId(), 'input', message);
     }
 
     try {
@@ -469,7 +474,7 @@ export class OpenAIProvider extends BaseAIProvider {
               // Log tool call to database in format that UI can reconstruct
               if (sessionId) {
                 // Log the tool_use block
-                this.logAgentMessage(sessionId, 'openai', 'output', JSON.stringify({
+                this.logAgentMessage(sessionId, this.getProviderId(), 'output', JSON.stringify({
                   type: 'assistant',
                   message: {
                     content: [{
@@ -485,7 +490,7 @@ export class OpenAIProvider extends BaseAIProvider {
                 const resultContent = executionResult !== undefined
                   ? (typeof executionResult === 'string' ? executionResult : JSON.stringify(executionResult))
                   : 'Tool executed';
-                this.logAgentMessage(sessionId, 'openai', 'output', JSON.stringify({
+                this.logAgentMessage(sessionId, this.getProviderId(), 'output', JSON.stringify({
                   type: 'assistant',
                   message: {
                     content: [{
@@ -539,7 +544,7 @@ export class OpenAIProvider extends BaseAIProvider {
       // Log the text output message if there was any text content
       // Note: Tool calls are logged individually above, so we only log text here
       if (sessionId && fullContent) {
-        await this.logAgentMessage(sessionId, 'openai', 'output', fullContent, {
+        await this.logAgentMessage(sessionId, this.getProviderId(), 'output', fullContent, {
           usage: usageData
         });
       }

--- a/packages/runtime/src/ai/server/providers/__tests__/MiniMaxProvider.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/MiniMaxProvider.test.ts
@@ -1,0 +1,125 @@
+import Anthropic from '@anthropic-ai/sdk';
+import OpenAI from 'openai';
+import { describe, expect, it } from 'vitest';
+import {
+  MINIMAX_ENDPOINTS,
+  MiniMaxProvider,
+  resolveMiniMaxEndpoint,
+} from '../MiniMaxProvider';
+
+describe('MiniMaxProvider', () => {
+  it('registers the configured models without removing either model', () => {
+    expect(MiniMaxProvider.getModels()).toEqual([
+      {
+        id: 'minimax:MiniMax-M3',
+        name: 'MiniMax-M3',
+        provider: 'minimax',
+        contextWindow: 1000000,
+      },
+      {
+        id: 'minimax:MiniMax-M2.7',
+        name: 'MiniMax-M2.7',
+        provider: 'minimax',
+        contextWindow: 204800,
+      },
+    ]);
+  });
+
+  it('resolves both protocols in both regions', () => {
+    expect(resolveMiniMaxEndpoint(MINIMAX_ENDPOINTS.global_en.openai)).toMatchObject({
+      protocol: 'openai',
+      region: 'global_en',
+    });
+    expect(resolveMiniMaxEndpoint(MINIMAX_ENDPOINTS.global_en.anthropic)).toMatchObject({
+      protocol: 'anthropic',
+      region: 'global_en',
+    });
+    expect(resolveMiniMaxEndpoint(MINIMAX_ENDPOINTS.cn_zh.openai)).toMatchObject({
+      protocol: 'openai',
+      region: 'cn_zh',
+    });
+    expect(resolveMiniMaxEndpoint(MINIMAX_ENDPOINTS.cn_zh.anthropic)).toMatchObject({
+      protocol: 'anthropic',
+      region: 'cn_zh',
+    });
+  });
+
+  it('rejects endpoints outside the configured endpoint matrix', () => {
+    expect(() => resolveMiniMaxEndpoint('https://example.com/v1')).toThrow('Unsupported MiniMax endpoint');
+  });
+
+  it('uses the selected endpoint when initializing either adapter', async () => {
+    const openaiProvider = new MiniMaxProvider();
+    await openaiProvider.initialize({
+      apiKey: 'test-key',
+      baseUrl: MINIMAX_ENDPOINTS.cn_zh.openai,
+      model: MiniMaxProvider.getDefaultModel(),
+    });
+    expect((openaiProvider as any).config).toMatchObject({
+      baseUrl: MINIMAX_ENDPOINTS.cn_zh.openai,
+      model: 'MiniMax-M3',
+    });
+    expect((openaiProvider as any).delegate.openai.baseURL).toBe(MINIMAX_ENDPOINTS.cn_zh.openai);
+
+    const anthropicProvider = new MiniMaxProvider();
+    await anthropicProvider.initialize({
+      apiKey: 'test-key',
+      baseUrl: MINIMAX_ENDPOINTS.cn_zh.anthropic,
+    });
+    expect((anthropicProvider as any).config).toMatchObject({
+      baseUrl: MINIMAX_ENDPOINTS.cn_zh.anthropic,
+      model: 'MiniMax-M3',
+    });
+    expect((anthropicProvider as any).delegate.anthropic.baseURL).toBe(MINIMAX_ENDPOINTS.cn_zh.anthropic);
+
+    openaiProvider.destroy();
+    anthropicProvider.destroy();
+  });
+
+  it('captures the SDK request paths derived from the public base URLs', async () => {
+    const requests: string[] = [];
+    const captureFetch = async (input: RequestInfo | URL): Promise<Response> => {
+      requests.push(String(input));
+      return new Response(JSON.stringify({
+        id: 'test',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'MiniMax-M3',
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+        choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop', index: 0 }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+
+    const openai = new OpenAI({
+      apiKey: 'test-key',
+      baseURL: MINIMAX_ENDPOINTS.global_en.openai,
+      fetch: captureFetch,
+    });
+    await openai.chat.completions.create({
+      model: 'MiniMax-M3',
+      messages: [{ role: 'user', content: 'test' }],
+    });
+
+    const anthropic = new Anthropic({
+      apiKey: 'test-key',
+      baseURL: MINIMAX_ENDPOINTS.global_en.anthropic,
+      fetch: captureFetch,
+    });
+    await anthropic.messages.create({
+      model: 'MiniMax-M3',
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'test' }],
+    });
+
+    expect(requests).toEqual([
+      `${MINIMAX_ENDPOINTS.global_en.openai}/chat/completions`,
+      `${MINIMAX_ENDPOINTS.global_en.anthropic}/v1/messages`,
+    ]);
+  });
+});

--- a/packages/runtime/src/ai/server/transcript/searchableTextExtractor.ts
+++ b/packages/runtime/src/ai/server/transcript/searchableTextExtractor.ts
@@ -281,7 +281,7 @@ function extractCodexOutput(parsed: unknown, content: string): ExtractedSearchab
 }
 
 function extractGenericOutput(content: string): ExtractedSearchable {
-  // Chat providers (claude, openai, lmstudio) write one row per semantic block.
+  // Chat providers write one row per semantic block.
   // The content is typically the assistant text directly (not provider-JSON).
   const parsed = safeJsonParse(content);
   if (parsed && typeof parsed === 'object') {

--- a/packages/runtime/src/ai/server/types.ts
+++ b/packages/runtime/src/ai/server/types.ts
@@ -151,7 +151,7 @@ export interface Message {
  * Add new providers here -- the type, runtime array, and exhaustiveness
  * checks all derive from this one definition.
  */
-export const AI_PROVIDER_TYPES = ['claude', 'claude-code', 'claude-code-cli', 'openai', 'openai-codex', 'openai-codex-acp', 'lmstudio', 'opencode', 'copilot-cli'] as const;
+export const AI_PROVIDER_TYPES = ['claude', 'claude-code', 'claude-code-cli', 'openai', 'openai-codex', 'openai-codex-acp', 'minimax', 'lmstudio', 'opencode', 'copilot-cli'] as const;
 
 export type AIProviderType = typeof AI_PROVIDER_TYPES[number];
 

--- a/packages/runtime/src/extensions/ExtensionLoader.ts
+++ b/packages/runtime/src/extensions/ExtensionLoader.ts
@@ -902,7 +902,7 @@ function createExtensionContext(
       sendPrompt: async (options: {
         prompt: string;
         sessionName?: string;
-        provider?: 'claude-code' | 'claude' | 'openai';
+        provider?: 'claude-code' | 'claude' | 'openai' | 'minimax';
         model?: string;
       }): Promise<{ sessionId: string; response: string }> => {
         const electronAPI = (window as any).electronAPI;

--- a/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
@@ -1635,6 +1635,8 @@ export const RichTranscriptView = React.forwardRef<
       case 'openai':
       case 'openai-codex':
         return 'OpenAI';
+      case 'minimax':
+        return 'MiniMax';
       case 'lmstudio':
         return 'LM Studio';
       default:

--- a/packages/runtime/src/ui/icons/ProviderIcons.tsx
+++ b/packages/runtime/src/ui/icons/ProviderIcons.tsx
@@ -8,6 +8,7 @@ interface IconProps {
 
 const PROVIDER_ICON_MAP: Record<string, string> = {
   'copilot-cli': 'terminal',
+  minimax: 'bolt',
   // ACP transport reuses the OpenAI Codex icon (same underlying agent).
   'openai-codex-acp': 'openai-codex',
   'claude-code-cli': 'claude-code',


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary

- Add the MiniMax provider and its two configured chat models.
- Support global and China-compatible endpoint presets for both supported request formats.
- Wire the provider through runtime, Electron, extension SDK, mobile sync, settings, documentation, and tests.

## Validation

- `npm ci --ignore-scripts --fetch-timeout=300000 --fetch-retries=5`
- `npm run check:override-sync`
- `npm run test:prepush -- --maxWorkers=4`
- Affected runtime, Electron, and extension SDK typechecks.
- Affected runtime, extension SDK, and memory engine builds.
- Focused provider and settings tests: 107 tests passed.
- Configured secret scan.
- `git diff --check`
- Repository-wide `npm run typecheck` remains blocked by existing workspace dependency-resolution errors.