### PR TITLE
fix(sqlite-browser): remove unused hasActiveDatabase import

### DIFF
--- a/packages/extensions/sqlite-browser/src/aiTools.ts
+++ b/packages/extensions/sqlite-browser/src/aiTools.ts
@@ -4,7 +4,7 @@
  * Provides Claude with tools to query and analyze SQLite databases.
  */
 
-import { getActiveDatabase, getAllDatabases, hasActiveDatabase, dispatchDisplayQuery } from './databaseRegistry';
+import { getActiveDatabase, getAllDatabases, dispatchDisplayQuery } from './databaseRegistry';
 
 /**
  * AI tool definitions


### PR DESCRIPTION
## Summary
- Removes unused \`hasActiveDatabase\` import from
  \`packages/extensions/sqlite-browser/src/aiTools.ts\` (TS6133). Every handler
  in the file already guards via \`getActiveDatabase()\` returning null;
  \`hasActiveDatabase\` is never called.

## Related issue
None — trivial dead-code removal, no behavior change.

## Testing
- \`npx tsc --noEmit\` clean.

## Notes for reviewers
- Single-line diff, no behavior change.