### PR TITLE
feat(meta-agent): add optional includeFullResponse param to get_session_result

### DIFF
--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -50,6 +50,19 @@ type RespondToPromptArgs = {
   response: Record<string, unknown>;
 };
 
+type GetSessionResultArgs = {
+  sessionId: string;
+  /**
+   * Include the full last-agent-turn text (capped at 50,000 chars). Defaults
+   * to true for backward compatibility. Pass false for a compact response
+   * (status/prompts/recentMessages/editedFiles only) when the caller doesn't
+   * need the full turn text -- e.g. a supervising session polling many
+   * children, where the full text would otherwise be reinjected into its
+   * context on every poll.
+   */
+  includeFullResponse?: boolean;
+};
+
 type ListQueuedPromptsArgs = {
   sessionId: string;
   /**
@@ -87,7 +100,8 @@ interface MetaAgentToolFns {
   getSessionResult: (
     metaSessionId: string,
     workspaceId: string,
-    targetSessionId: string
+    targetSessionId: string,
+    options?: Pick<GetSessionResultArgs, "includeFullResponse">
   ) => Promise<string>;
   listQueuedPrompts: (
     metaSessionId: string,
@@ -267,6 +281,11 @@ export const META_AGENT_TOOL_DEFS: Array<{
           type: "string",
           description: "The session ID to inspect.",
         },
+        includeFullResponse: {
+          type: "boolean",
+          description:
+            "Optional. Include the full last-agent-turn text (capped at 50,000 chars). Defaults to true. Set to false for a compact response when polling many sessions or when only status/prompts/editedFiles are needed.",
+        },
       },
       required: ["sessionId"],
     },
@@ -443,7 +462,8 @@ export async function dispatchMetaAgentTool(
       return toolFns.getSessionResult(
         aiSessionId,
         effectiveWorkspaceId,
-        (args?.sessionId as string) ?? ""
+        (args?.sessionId as string) ?? "",
+        { includeFullResponse: args?.includeFullResponse !== false }
       );
     case "list_queued_prompts":
       return toolFns.listQueuedPrompts(

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -179,8 +179,8 @@ export class MetaAgentService {
           this.spawnSession(callerSessionId, workspaceId, args),
         getSessionStatus: (_metaSessionId, workspaceId, targetSessionId) =>
           this.getSessionStatusJson(targetSessionId, workspaceId),
-        getSessionResult: (_metaSessionId, workspaceId, targetSessionId) =>
-          this.getSessionResultJson(targetSessionId, workspaceId),
+        getSessionResult: (_metaSessionId, workspaceId, targetSessionId, options) =>
+          this.getSessionResultJson(targetSessionId, workspaceId, options),
         listQueuedPrompts: (_metaSessionId, workspaceId, targetSessionId, options) =>
           this.listQueuedPromptsJson(targetSessionId, workspaceId, options),
         sendPrompt: (_metaSessionId, workspaceId, targetSessionId, prompt) =>
@@ -827,8 +827,17 @@ export class MetaAgentService {
     return JSON.stringify(result, null, 2);
   }
 
-  private async getSessionResultJson(sessionId: string, workspaceId: string): Promise<string> {
-    const data = await this.buildSessionResultData(sessionId, workspaceId);
+  private async getSessionResultJson(
+    sessionId: string,
+    workspaceId: string,
+    options: { includeFullResponse?: boolean } = {}
+  ): Promise<string> {
+    const data = await this.buildSessionResultData(
+      sessionId,
+      workspaceId,
+      undefined,
+      options.includeFullResponse ?? true
+    );
     return JSON.stringify(data, null, 2);
   }
 

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.getSessionResultCompact.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.getSessionResultCompact.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// FIX C: get_session_result gained an optional includeFullResponse param
+// (default true, unchanged behavior). This guards the new wiring from the
+// MCP tool schema down through getSessionResultJson to buildSessionResultData
+// -- the truncation/compaction logic itself already existed and is covered
+// by MetaAgentService.fullResponse.test.ts; this file only covers the new
+// options threading.
+//
+// Mock surface mirrors MetaAgentService.fullResponse.test.ts.
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: { create: vi.fn(), updateMetadata: vi.fn(), get: vi.fn() },
+  AgentMessagesRepository: { list: vi.fn() },
+  SessionFilesRepository: { getFilesBySession: vi.fn().mockResolvedValue([]) },
+}));
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  ClaudeCodeProvider: { setMetaAgentServerPort: vi.fn() },
+  OpenAICodexProvider: { setMetaAgentServerPort: vi.fn() },
+  OpenAICodexACPProvider: { setMetaAgentServerPort: vi.fn() },
+  SessionManager: class { async initialize() {} },
+}));
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: {
+    parse: (id: string) => ({ provider: id.split(':')[0], model: id.split(':')[1], combined: id }),
+    tryParse: (id: string) => {
+      const i = typeof id === 'string' ? id.indexOf(':') : -1;
+      return i > 0 ? { provider: id.slice(0, i), model: id.slice(i + 1) } : null;
+    },
+    getDefaultModelId: (provider: string) => `${provider}:default`,
+  },
+}));
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn() }),
+}));
+vi.mock('../ai/providerResolution', () => ({
+  resolveExtensionAgentRef: () => null,
+  isExtensionAgentProvider: () => false,
+}));
+vi.mock('electron', () => ({ BrowserWindow: { getAllWindows: () => [] } }));
+vi.mock('../SyncManager', () => ({ getSyncProvider: () => ({ pushChange: vi.fn() }) }));
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => null }));
+vi.mock('../../utils/timestampUtils', () => ({ toMillis: (v: unknown) => v }));
+vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
+vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({
+  database: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+}));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => null }));
+vi.mock('../../file/GitRefWatcher', () => ({ gitRefWatcher: {} }));
+vi.mock('./ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({
+  setMetaAgentToolFns: vi.fn(),
+}));
+vi.mock('../metaAgentNotificationSignature', () => ({ computeNotificationSignature: vi.fn() }));
+vi.mock('../metaAgentMessageText', () => ({
+  extractMessageText: (content: unknown) => (typeof content === 'string' ? content : ''),
+  extractUserPrompts: () => ['original task'],
+}));
+vi.mock('../ai/claudeCliLauncherSingleton', () => ({
+  ClaudeCliLauncherConfig: { setMetaAgentServerPort: vi.fn() },
+}));
+
+import { AISessionsRepository, AgentMessagesRepository } from '@nimbalyst/runtime';
+import { MetaAgentService } from '../MetaAgentService';
+
+const SESSION_ROW = {
+  id: 'child-1',
+  title: 'Child: research',
+  provider: 'claude-code',
+  model: 'claude-code:sonnet',
+  workspacePath: '/ws',
+  worktreeId: null,
+  metadata: null,
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+describe('MetaAgentService.getSessionResultJson includeFullResponse (FIX C)', () => {
+  it('includes fullResponse by default (no options passed -- unchanged behavior)', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(SESSION_ROW as never);
+    const longReport = 'R'.repeat(2000);
+    vi.mocked(AgentMessagesRepository.list).mockResolvedValue([
+      { direction: 'output', content: longReport, metadata: null },
+    ] as never);
+
+    const service = MetaAgentService.getInstance();
+    const json = await (service as any).getSessionResultJson('child-1', '/ws');
+    const data = JSON.parse(json);
+
+    expect(data.fullResponse).toBe(longReport);
+  });
+
+  it('omits fullResponse (null) when includeFullResponse is explicitly false', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(SESSION_ROW as never);
+    const longReport = 'R'.repeat(2000);
+    vi.mocked(AgentMessagesRepository.list).mockResolvedValue([
+      { direction: 'output', content: longReport, metadata: null },
+    ] as never);
+
+    const service = MetaAgentService.getInstance();
+    const json = await (service as any).getSessionResultJson('child-1', '/ws', {
+      includeFullResponse: false,
+    });
+    const data = JSON.parse(json);
+
+    expect(data.fullResponse).toBeNull();
+    // Compact mode still returns everything else -- status/prompts/editedFiles,
+    // just not the heavy full-turn text.
+    expect(data.sessionId).toBe('child-1');
+    expect(data.lastResponse).not.toBeNull();
+  });
+
+  it('includes fullResponse when includeFullResponse is explicitly true', async () => {
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(SESSION_ROW as never);
+    const longReport = 'R'.repeat(2000);
+    vi.mocked(AgentMessagesRepository.list).mockResolvedValue([
+      { direction: 'output', content: longReport, metadata: null },
+    ] as never);
+
+    const service = MetaAgentService.getInstance();
+    const json = await (service as any).getSessionResultJson('child-1', '/ws', {
+      includeFullResponse: true,
+    });
+    const data = JSON.parse(json);
+
+    expect(data.fullResponse).toBe(longReport);
+  });
+});


### PR DESCRIPTION
## Summary
- \`buildSessionResultData()\` already supported skipping the heavy full-turn
  text extraction internally (used by the list/notification paths), but
  \`get_session_result\`'s MCP tool surface always requested it — forcing
  every caller to receive the full (up to 50,000-char) last-turn text even
  when only checking status, prompts, or edited files.
- Adds an optional \`includeFullResponse\` boolean param to \`get_session_result\`.
  A supervising session polling several children can now ask for the
  compact shape (status/prompts/recentMessages/editedFiles, no
  fullResponse) without pulling the heavy text into its own context on
  every poll.
- Defaults to \`true\` (identical to current behavior) when omitted — fully
  backward compatible, no existing caller needs to change.

## Related issue
Closes #881

## Testing
- New \`MetaAgentService.getSessionResultCompact.test.ts\` (3 tests) covering
  default-true, explicit-false, and explicit-true.
- \`npx tsc --noEmit\` clean on the 2 changed files (29 pre-existing,
  unrelated errors confirmed present on clean upstream/main via \`git
  stash\`, none touch either changed file).

## Notes for reviewers
- The 50,000-char cap and its truncation logic are untouched — this only
  toggles whether that (already-existing) compact path is reachable from
  the public MCP tool.
- Security: pure boolean toggle that only ever reduces response size
  relative to current default behavior; no new data exposure, no
  authorization-path changes.