### PR TITLE
fix(permissions): resolve worktree identity via real git metadata, not path naming

### DIFF
--- a/packages/electron/src/main/utils/__tests__/aiSettingsMerge.test.ts
+++ b/packages/electron/src/main/utils/__tests__/aiSettingsMerge.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { getAIProviderOverridesMock } = vi.hoisted(() => ({
+const { getAIProviderOverridesMock, resolveProjectPathMock } = vi.hoisted(() => ({
   getAIProviderOverridesMock: vi.fn(),
+  resolveProjectPathMock: vi.fn((workspacePath: string) => workspacePath),
 }));
 
 vi.mock('../store', async () => {
@@ -11,6 +12,10 @@ vi.mock('../store', async () => {
     getAIProviderOverrides: getAIProviderOverridesMock,
   };
 });
+
+vi.mock('../workspaceDetection', () => ({
+  resolveProjectPath: resolveProjectPathMock,
+}));
 
 import { mergeAISettings, GlobalAISettings } from '../aiSettingsMerge';
 import { normalizeAIProviderOverrides } from '../store';
@@ -28,6 +33,8 @@ const baseGlobal: GlobalAISettings = {
 describe('mergeAISettings -- customClaudeCodePath', () => {
   beforeEach(() => {
     getAIProviderOverridesMock.mockReset();
+    resolveProjectPathMock.mockReset();
+    resolveProjectPathMock.mockImplementation((workspacePath: string) => workspacePath);
   });
 
   it('inherits the global path when no project override is set', () => {
@@ -70,6 +77,7 @@ describe('mergeAISettings -- customClaudeCodePath', () => {
   });
 
   it('inherits the parent project override when the workspace path is a worktree', () => {
+    resolveProjectPathMock.mockReturnValue('/workspace/project');
     getAIProviderOverridesMock.mockImplementation((workspacePath: string) => {
       if (workspacePath === '/workspace/project') {
         return { customClaudeCodePath: '/opt/project/claude' };

--- a/packages/electron/src/main/utils/__tests__/workspaceDetection.test.ts
+++ b/packages/electron/src/main/utils/__tests__/workspaceDetection.test.ts
@@ -5,69 +5,137 @@ import * as path from 'path';
 import {
   resolveProjectPath,
   isWorktreePath,
+  clearWorktreeIdentityCache,
   findNearestAncestor,
   findProjectRoot,
   getAdditionalDirectoriesForWorkspace,
 } from '../workspaceDetection';
 
+/**
+ * Hand-construct the real on-disk structure git creates for a linked
+ * worktree, without shelling out to `git worktree add` (keeps tests fast
+ * and independent of a git binary on PATH). Mirrors the exact format
+ * findProjectRoot's own tests already rely on (`.git` file with a
+ * `gitdir: <path>` line) plus the worktree-registration side git also
+ * writes: `<main>/.git/worktrees/<name>/gitdir` pointing back at the
+ * worktree's `.git` file.
+ */
+function createLinkedWorktree(
+  mainRepoPath: string,
+  worktreePath: string,
+  worktreeName: string,
+): void {
+  fs.mkdirSync(mainRepoPath, { recursive: true });
+  fs.mkdirSync(path.join(mainRepoPath, '.git'), { recursive: true });
+  const registrationDir = path.join(mainRepoPath, '.git', 'worktrees', worktreeName);
+  fs.mkdirSync(registrationDir, { recursive: true });
+
+  fs.mkdirSync(worktreePath, { recursive: true });
+  fs.writeFileSync(path.join(worktreePath, '.git'), `gitdir: ${registrationDir}\n`);
+  fs.writeFileSync(path.join(registrationDir, 'gitdir'), `${path.join(worktreePath, '.git')}\n`);
+}
+
 describe('resolveProjectPath', () => {
-  it('returns the same path for regular workspaces', () => {
-    expect(resolveProjectPath('/path/to/project')).toBe('/path/to/project');
-    expect(resolveProjectPath('/Users/dev/my-app')).toBe('/Users/dev/my-app');
-    expect(resolveProjectPath('/home/user/code/myrepo')).toBe('/home/user/code/myrepo');
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nim-worktree-identity-'));
+    clearWorktreeIdentityCache();
   });
 
-  it('resolves worktree paths to parent project', () => {
-    expect(resolveProjectPath('/path/to/project_worktrees/swift-falcon'))
-      .toBe('/path/to/project');
-    expect(resolveProjectPath('/Users/dev/my-app_worktrees/brave-eagle'))
-      .toBe('/Users/dev/my-app');
-    expect(resolveProjectPath('/home/user/code/myrepo_worktrees/test-123'))
-      .toBe('/home/user/code/myrepo');
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    clearWorktreeIdentityCache();
   });
 
-  it('resolves NESTED worktree paths (branch-style names) to parent project', () => {
-    // Regression for re-prompting in worktrees whose branch name contains a
-    // slash (e.g. `feature/foo`), which create nested directories.
-    expect(resolveProjectPath('/path/to/project_worktrees/feature/my-branch'))
-      .toBe('/path/to/project');
-    expect(resolveProjectPath('/Users/dev/Belegify_worktrees/feature/assign-people-on-receipts'))
-      .toBe('/Users/dev/Belegify');
-    expect(resolveProjectPath('/Users/dev/nimbalyst_worktrees/improvement/fix-askme-for-worktrees'))
-      .toBe('/Users/dev/nimbalyst');
+  it('returns the normalized path unchanged for a regular (non-worktree) project', () => {
+    const projectPath = path.join(tmpRoot, 'project');
+    fs.mkdirSync(path.join(projectPath, '.git'), { recursive: true });
+    expect(resolveProjectPath(projectPath)).toBe(projectPath);
   });
 
-  it('resolves a subfolder inside a nested worktree to the parent project', () => {
-    expect(resolveProjectPath('/path/to/project_worktrees/feature/my-branch/packages/electron'))
-      .toBe('/path/to/project');
+  it('resolves a real linked worktree to its main repository root', () => {
+    const mainRepo = path.join(tmpRoot, 'project');
+    const worktree = path.join(tmpRoot, 'project_worktrees', 'swift-falcon');
+    createLinkedWorktree(mainRepo, worktree, 'swift-falcon');
+
+    expect(resolveProjectPath(worktree)).toBe(fs.realpathSync.native(mainRepo));
   });
 
-  it('resolves nested worktrees with underscore project names', () => {
-    expect(resolveProjectPath('/path/to/my_cool_project_worktrees/feature/x'))
-      .toBe('/path/to/my_cool_project');
+  it('resolves a nested branch-style worktree name to the main repository root', () => {
+    // Regression for branch names containing a slash (e.g. `feature/foo`),
+    // which create nested worktree directories on disk.
+    const mainRepo = path.join(tmpRoot, 'project');
+    const worktree = path.join(tmpRoot, 'project_worktrees', 'feature', 'my-branch');
+    createLinkedWorktree(mainRepo, worktree, 'feature-my-branch');
+
+    expect(resolveProjectPath(worktree)).toBe(fs.realpathSync.native(mainRepo));
   });
 
-  it('handles trailing slashes on nested worktree paths', () => {
-    expect(resolveProjectPath('/path/to/project_worktrees/feature/my-branch/'))
-      .toBe('/path/to/project');
+  it('does NOT resolve a project that is literally named "..._worktrees" (has its own .git directory)', () => {
+    // The old lexical matcher misidentified this; a real .git DIRECTORY
+    // (not a linked-worktree .git FILE) means this is its own project.
+    const literalProject = path.join(tmpRoot, 'my_app_worktrees', 'folder');
+    fs.mkdirSync(path.join(literalProject, '.git'), { recursive: true });
+    expect(resolveProjectPath(literalProject)).toBe(fs.realpathSync.native(literalProject));
   });
 
-  it('does not resolve a plain subfolder of a non-worktree project (the permission cascade handles that)', () => {
-    expect(resolveProjectPath('/path/to/project/packages/electron'))
-      .toBe('/path/to/project/packages/electron');
+  it('does not treat a git submodule as a worktree', () => {
+    // Submodules also use a `.git` FILE, but pointing at `.git/modules/<name>`
+    // -- a distinct trust boundary from a linked worktree, must not inherit
+    // the superproject's trust.
+    const superProject = path.join(tmpRoot, 'super');
+    fs.mkdirSync(superProject, { recursive: true });
+    const moduleDir = path.join(superProject, '.git', 'modules', 'lib');
+    fs.mkdirSync(moduleDir, { recursive: true });
+    const submodulePath = path.join(superProject, 'vendor', 'lib');
+    fs.mkdirSync(submodulePath, { recursive: true });
+    fs.writeFileSync(path.join(submodulePath, '.git'), `gitdir: ${moduleDir}\n`);
+
+    expect(resolveProjectPath(submodulePath)).toBe(fs.realpathSync.native(submodulePath));
   });
 
-  it('handles trailing slashes on worktree paths', () => {
-    expect(resolveProjectPath('/path/to/project_worktrees/swift-falcon/'))
-      .toBe('/path/to/project');
-    expect(resolveProjectPath('/path/to/project_worktrees/swift-falcon//'))
-      .toBe('/path/to/project');
+  it('fails closed (returns the input unchanged) for a forged .git file pointing at another project\'s worktree registration', () => {
+    // SECURITY: an attacker-controlled directory claims to be a worktree of
+    // a real, trusted project by pointing its .git file at that project's
+    // real worktrees/<name> registration -- but that registration's own
+    // back-pointer does not point back at the attacker's directory, so this
+    // must NOT resolve to (and inherit trust from) the victim project.
+    const victim = path.join(tmpRoot, 'victim');
+    const legitWorktree = path.join(tmpRoot, 'victim_worktrees', 'real');
+    createLinkedWorktree(victim, legitWorktree, 'real');
+
+    const attackerDir = path.join(tmpRoot, 'attacker-controlled');
+    fs.mkdirSync(attackerDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(attackerDir, '.git'),
+      `gitdir: ${path.join(victim, '.git', 'worktrees', 'real')}\n`,
+    );
+
+    expect(resolveProjectPath(attackerDir)).toBe(fs.realpathSync.native(attackerDir));
   });
 
-  it('does not match paths that just contain _worktrees in the middle', () => {
-    // This path has _worktrees in it but is not a worktree path pattern
-    expect(resolveProjectPath('/path/to/project_worktrees_backup/folder'))
-      .toBe('/path/to/project_worktrees_backup/folder');
+  it('fails closed for a path that does not exist on disk', () => {
+    const missing = path.join(tmpRoot, 'does-not-exist_worktrees', 'x');
+    expect(resolveProjectPath(missing)).toBe(missing);
+  });
+
+  it('resolves a symlinked worktree the same as the real path', () => {
+    const mainRepo = path.join(tmpRoot, 'project');
+    const worktree = path.join(tmpRoot, 'project_worktrees', 'swift-falcon');
+    createLinkedWorktree(mainRepo, worktree, 'swift-falcon');
+
+    const linkPath = path.join(tmpRoot, 'link-to-worktree');
+    try {
+      fs.symlinkSync(worktree, linkPath, 'junction');
+    } catch {
+      // Symlink/junction creation can require elevated privileges in some
+      // CI sandboxes; skip rather than fail the suite on an environment
+      // limitation unrelated to the code under test.
+      return;
+    }
+
+    expect(resolveProjectPath(linkPath)).toBe(fs.realpathSync.native(mainRepo));
   });
 
   it('handles empty and null-ish inputs gracefully', () => {
@@ -75,55 +143,59 @@ describe('resolveProjectPath', () => {
     expect(resolveProjectPath(null as unknown as string)).toBe(null);
     expect(resolveProjectPath(undefined as unknown as string)).toBe(undefined);
   });
-
-  it('handles complex project names with underscores', () => {
-    expect(resolveProjectPath('/path/to/my_cool_project_worktrees/branch-1'))
-      .toBe('/path/to/my_cool_project');
-  });
-
-  it('handles Windows-style paths', () => {
-    // Note: Our regex uses / which works on Windows when paths are normalized
-    // but if someone passes backslashes, it won't match (that's okay)
-    expect(resolveProjectPath('C:/Users/dev/project_worktrees/feature'))
-      .toBe('C:/Users/dev/project');
-  });
 });
 
 describe('isWorktreePath', () => {
-  it('returns false for regular workspaces', () => {
-    expect(isWorktreePath('/path/to/project')).toBe(false);
-    expect(isWorktreePath('/Users/dev/my-app')).toBe(false);
-    expect(isWorktreePath('/home/user/code/myrepo')).toBe(false);
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nim-worktree-identity-'));
+    clearWorktreeIdentityCache();
   });
 
-  it('returns true for worktree paths', () => {
-    expect(isWorktreePath('/path/to/project_worktrees/swift-falcon')).toBe(true);
-    expect(isWorktreePath('/Users/dev/my-app_worktrees/brave-eagle')).toBe(true);
-    expect(isWorktreePath('/home/user/code/myrepo_worktrees/test-123')).toBe(true);
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    clearWorktreeIdentityCache();
   });
 
-  it('returns true for NESTED worktree paths (branch-style names)', () => {
-    expect(isWorktreePath('/path/to/project_worktrees/feature/my-branch')).toBe(true);
-    expect(isWorktreePath('/Users/dev/Belegify_worktrees/feature/assign-people')).toBe(true);
-    expect(isWorktreePath('/path/to/project_worktrees/feature/my-branch/packages/electron')).toBe(true);
+  it('returns false for a regular (non-worktree) project', () => {
+    const projectPath = path.join(tmpRoot, 'project');
+    fs.mkdirSync(path.join(projectPath, '.git'), { recursive: true });
+    expect(isWorktreePath(projectPath)).toBe(false);
   });
 
-  it('does not match the _worktrees_backup decoy with nested children', () => {
-    expect(isWorktreePath('/path/to/project_worktrees_backup/feature/x')).toBe(false);
+  it('returns true for a real linked worktree', () => {
+    const mainRepo = path.join(tmpRoot, 'project');
+    const worktree = path.join(tmpRoot, 'project_worktrees', 'swift-falcon');
+    createLinkedWorktree(mainRepo, worktree, 'swift-falcon');
+    expect(isWorktreePath(worktree)).toBe(true);
   });
 
-  it('handles trailing slashes', () => {
-    expect(isWorktreePath('/path/to/project_worktrees/swift-falcon/')).toBe(true);
+  it('returns false for a project literally named "..._worktrees"', () => {
+    const literalProject = path.join(tmpRoot, 'my_app_worktrees', 'folder');
+    fs.mkdirSync(path.join(literalProject, '.git'), { recursive: true });
+    expect(isWorktreePath(literalProject)).toBe(false);
+  });
+
+  it('returns false for a git submodule', () => {
+    const superProject = path.join(tmpRoot, 'super');
+    fs.mkdirSync(superProject, { recursive: true });
+    const moduleDir = path.join(superProject, '.git', 'modules', 'lib');
+    fs.mkdirSync(moduleDir, { recursive: true });
+    const submodulePath = path.join(superProject, 'vendor', 'lib');
+    fs.mkdirSync(submodulePath, { recursive: true });
+    fs.writeFileSync(path.join(submodulePath, '.git'), `gitdir: ${moduleDir}\n`);
+    expect(isWorktreePath(submodulePath)).toBe(false);
+  });
+
+  it('returns false for an unreadable / nonexistent path (fails closed)', () => {
+    expect(isWorktreePath(path.join(tmpRoot, 'does-not-exist_worktrees', 'x'))).toBe(false);
   });
 
   it('handles empty and null-ish inputs gracefully', () => {
     expect(isWorktreePath('')).toBe(false);
     expect(isWorktreePath(null as unknown as string)).toBe(false);
     expect(isWorktreePath(undefined as unknown as string)).toBe(false);
-  });
-
-  it('does not match paths that just contain _worktrees in the middle', () => {
-    expect(isWorktreePath('/path/to/project_worktrees_backup/folder')).toBe(false);
   });
 });
 
@@ -165,12 +237,12 @@ describe('getAdditionalDirectoriesForWorkspace', () => {
   it('returns the parent project plus other sibling worktrees when called from a worktree', () => {
     fs.mkdirSync(worktreesDir);
     const cwd = path.join(worktreesDir, 'proud-gorge');
-    fs.mkdirSync(cwd);
+    createLinkedWorktree(projectPath, cwd, 'proud-gorge');
     fs.mkdirSync(path.join(worktreesDir, 'swift-falcon'));
 
     const dirs = getAdditionalDirectoriesForWorkspace(cwd);
     expect(dirs.sort()).toEqual([
-      projectPath,
+      fs.realpathSync.native(projectPath),
       path.join(worktreesDir, 'swift-falcon'),
     ].sort());
     // The current worktree itself must not appear -- it is already the
@@ -200,14 +272,14 @@ describe('getAdditionalDirectoriesForWorkspace', () => {
   it('keeps the parent project but drops siblings when includeSiblingWorktrees is false (worktree)', () => {
     fs.mkdirSync(worktreesDir);
     const cwd = path.join(worktreesDir, 'proud-gorge');
-    fs.mkdirSync(cwd);
+    createLinkedWorktree(projectPath, cwd, 'proud-gorge');
     fs.mkdirSync(path.join(worktreesDir, 'swift-falcon'));
 
     const dirs = getAdditionalDirectoriesForWorkspace(cwd, {
       includeSiblingWorktrees: false,
     });
     // Parent project access (shared configs, .git common dir) must survive.
-    expect(dirs).toEqual([projectPath]);
+    expect(dirs).toEqual([fs.realpathSync.native(projectPath)]);
   });
 });
 

--- a/packages/electron/src/main/utils/workspaceDetection.ts
+++ b/packages/electron/src/main/utils/workspaceDetection.ts
@@ -66,10 +66,140 @@ export function getRelativeWorkspacePath(filePath: string, workspacePath: string
 }
 
 /**
+ * A path's git-worktree identity: whether it is a linked worktree, and if so,
+ * the canonical (symlink-resolved) path of its parent (main) repository.
+ */
+interface WorktreeIdentity {
+  isWorktree: boolean;
+  parentRoot: string | null;
+  canonical: string;
+}
+
+const WORKTREE_IDENTITY_CACHE = new Map<string, { value: WorktreeIdentity; expiresAt: number }>();
+const WORKTREE_IDENTITY_CACHE_TTL_MS = 30_000;
+
+/**
+ * Clear the worktree-identity cache. Exposed for tests and for callers that
+ * know a workspace's git structure just changed (e.g. a worktree was created
+ * or removed) and want a fresh resolution on the next call.
+ */
+export function clearWorktreeIdentityCache(): void {
+  WORKTREE_IDENTITY_CACHE.clear();
+}
+
+function cacheWorktreeIdentity(key: string, value: WorktreeIdentity): WorktreeIdentity {
+  WORKTREE_IDENTITY_CACHE.set(key, { value, expiresAt: Date.now() + WORKTREE_IDENTITY_CACHE_TTL_MS });
+  return value;
+}
+
+/**
+ * Resolve a path's real git-worktree identity by reading actual git metadata
+ * on disk, instead of lexically matching a `_worktrees` naming convention.
+ *
+ * A linked worktree's `.git` is a FILE (not a directory) containing a single
+ * `gitdir: <path>` line pointing at `<main-repo>/.git/worktrees/<name>` --
+ * this has been git's stable on-disk format for linked worktrees since the
+ * feature was introduced (git 2.5). We read that structure directly (no git
+ * subprocess) and verify it two ways before trusting it:
+ *
+ * 1. The gitdir path must resolve to a real `.git/worktrees/<name>` directory
+ *    (NOT `.git/modules/<name>`, which is a submodule -- submodules are a
+ *    distinct trust boundary, not a worktree relationship, so they must
+ *    never inherit the parent's trust/tool-approval settings).
+ * 2. SECURITY (bidirectional verification): that worktree-registration
+ *    directory's own `gitdir` back-pointer file must point back at this
+ *    exact path's `.git` file. Without this check, a directory with a
+ *    forged `.git` file could name ANY other project's worktree-registration
+ *    path and silently inherit that project's trust -- this check makes
+ *    that require write access to the target project's own `.git/worktrees/`
+ *    directory, which an attacker who could already do would not need this
+ *    to begin with.
+ *
+ * Fails CLOSED on any error (unreadable path, missing/malformed `.git`,
+ * mismatched back-pointer, submodule, or anything else unexpected): the path
+ * is treated as its own, non-worktree, standalone project. This is a
+ * deliberate inversion of the old lexical matcher, which failed OPEN (any
+ * path containing `_worktrees/<segment>` was trusted as a worktree even if
+ * nothing on disk backed that up). The worst case of failing closed is one
+ * extra trust prompt for a legitimate worktree Node could not introspect;
+ * the worst case of failing open is silently granting one project's tool
+ * approvals to an unrelated directory.
+ */
+function resolveWorktreeIdentity(workspacePath: string): WorktreeIdentity {
+  let canonical: string;
+  try {
+    canonical = fs.realpathSync.native(workspacePath);
+  } catch {
+    // Cannot even resolve the path (does not exist, unreadable, etc).
+    // Fail closed: treat as its own project, not a worktree.
+    return { isWorktree: false, parentRoot: null, canonical: workspacePath };
+  }
+
+  const cached = WORKTREE_IDENTITY_CACHE.get(canonical);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
+  const notAWorktree: WorktreeIdentity = { isWorktree: false, parentRoot: null, canonical };
+
+  try {
+    const dotGitPath = path.join(canonical, '.git');
+    const dotGitStat = fs.lstatSync(dotGitPath);
+
+    if (dotGitStat.isDirectory()) {
+      // Main repository root (or an unrelated directory with its own
+      // unrelated `.git` dir) -- not a linked worktree.
+      return cacheWorktreeIdentity(canonical, notAWorktree);
+    }
+
+    if (!dotGitStat.isFile()) {
+      return cacheWorktreeIdentity(canonical, notAWorktree);
+    }
+
+    const dotGitContent = fs.readFileSync(dotGitPath, 'utf8');
+    const gitdirMatch = /^gitdir:\s*(.+?)\s*$/m.exec(dotGitContent);
+    if (!gitdirMatch) {
+      return cacheWorktreeIdentity(canonical, notAWorktree);
+    }
+
+    const gitdirRaw = gitdirMatch[1];
+    const gitdirAbs = path.isAbsolute(gitdirRaw) ? gitdirRaw : path.resolve(canonical, gitdirRaw);
+    const gitdirReal = fs.realpathSync.native(gitdirAbs);
+
+    // Must be exactly <parent>/.git/worktrees/<name> -- rejects submodules
+    // (.git/modules/<name>) and anything else non-standard.
+    const worktreesMatch = /^(.+)[\\/]\.git[\\/]worktrees[\\/][^\\/]+[\\/]?$/.exec(gitdirReal);
+    if (!worktreesMatch) {
+      return cacheWorktreeIdentity(canonical, notAWorktree);
+    }
+
+    // Bidirectional verification: the worktree-registration dir's own
+    // gitdir back-pointer must point back at this exact worktree's .git file.
+    const backPointerPath = path.join(gitdirReal, 'gitdir');
+    const backPointerRaw = fs.readFileSync(backPointerPath, 'utf8').trim();
+    const backPointerAbs = path.isAbsolute(backPointerRaw)
+      ? backPointerRaw
+      : path.resolve(gitdirReal, backPointerRaw);
+    const backPointerReal = fs.realpathSync.native(backPointerAbs);
+    const backPointerDirReal = fs.realpathSync.native(path.dirname(backPointerReal));
+    if (backPointerDirReal !== canonical) {
+      // Forged or stale registration -- do not trust it.
+      return cacheWorktreeIdentity(canonical, notAWorktree);
+    }
+
+    const parentRoot = fs.realpathSync.native(worktreesMatch[1]);
+    return cacheWorktreeIdentity(canonical, { isWorktree: true, parentRoot, canonical });
+  } catch {
+    // Any unexpected filesystem error -- fail closed.
+    return cacheWorktreeIdentity(canonical, notAWorktree);
+  }
+}
+
+/**
  * Resolve a workspace path to its parent project path.
- * If the path is a worktree (matches {project}_worktrees/<name> pattern, where
- * <name> may be nested for branch-style worktree names like `feature/foo`),
- * returns the parent project path. Otherwise returns the original path.
+ * If the path is a linked git worktree (verified via real git metadata on
+ * disk, not a naming convention), returns the parent (main) repository's
+ * canonical path. Otherwise returns the original path unchanged.
  *
  * This is used by the permission system to ensure worktrees inherit
  * trust status and tool patterns from their parent project.
@@ -82,34 +212,26 @@ export function resolveProjectPath(workspacePath: string): string {
     return workspacePath;
   }
 
-  // Normalize the path to remove trailing slashes for consistent matching
-  const normalizedPath = normalizeWorkspacePath(workspacePath);
-
-  // Match pattern: /{project}_worktrees/{...name}
-  // The trailing segment may itself contain slashes: branch-style worktree
-  // names like `feature/foo` create nested directories
-  // (`{project}_worktrees/feature/foo`). Match the whole remainder, not a
-  // single segment, so those resolve to the project too. The greedy (.+)
-  // anchors on the last `_worktrees/`. Use [\\/] for forward+backslash.
-  const match = normalizedPath.match(/^(.+)_worktrees[\\/].+$/);
-  return match ? match[1] : normalizedPath;
+  const identity = resolveWorktreeIdentity(workspacePath);
+  if (identity.isWorktree && identity.parentRoot) {
+    return identity.parentRoot;
+  }
+  return normalizeWorkspacePath(workspacePath);
 }
 
 /**
- * Check if a path is a worktree path.
+ * Check if a path is a linked git worktree, verified via real git metadata
+ * on disk (not a `_worktrees` naming convention).
  *
  * @param workspacePath - The path to check
- * @returns true if the path appears to be a worktree
+ * @returns true if the path is a linked git worktree
  */
 export function isWorktreePath(workspacePath: string): boolean {
   if (!workspacePath) {
     return false;
   }
 
-  const normalizedPath = normalizeWorkspacePath(workspacePath);
-  // Use [\\/] to match both forward and backslash (Windows and Unix).
-  // `.+$` (not `[^\\/]+$`) so nested/branch-style worktree names match too.
-  return /_worktrees[\\/].+$/.test(normalizedPath);
+  return resolveWorktreeIdentity(workspacePath).isWorktree;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `resolveProjectPath()`/`isWorktreePath()` now resolve worktree identity by reading git's actual on-disk worktree registration (`.git` file's `gitdir:` line + the registration directory's back-pointer), instead of matching a `_worktrees/<name>` substring in the path string.
- Bidirectional verification (worktree-registration back-pointer must point back at the caller's own `.git` file) closes a trust-spoofing vector: a directory with a forged `.git` file could previously name another project's worktree-registration path and inherit that project's trust/tool-approval settings.
- Submodules (`.git` file pointing at `.git/modules/<name>`) are explicitly excluded -- a distinct trust boundary from a linked worktree.
- `fs.realpathSync.native()` resolves symlinks/UNC/casing before any comparison.
- Fails CLOSED on any error (unreadable path, malformed/missing `.git`, mismatched back-pointer, submodule, anything unexpected): the path is treated as its own, standalone, non-worktree project. This is a deliberate inversion of the old lexical matcher, which failed open. Worst case of failing closed: one extra trust prompt for a legitimate worktree Node couldn't introspect. Worst case of failing open: silently granting one project's tool approvals to an unrelated directory.
- Per-process cache by canonical path (30s TTL) so repeated permission checks on the same path don't re-walk the filesystem; `clearWorktreeIdentityCache()` exported for tests and for callers that know a workspace's git structure just changed.
- **Public signatures are unchanged** -- `resolveProjectPath(path): string`, `isWorktreePath(path): boolean` -- so none of the 8+ call sites (`PermissionService.ts`, `PermissionHandlers.ts`, `WindowManager.ts`, `metaAgentServer.ts`, `AIService.ts`, `ClaudeSettingsManager.ts`, `SyncManager.ts`, `aiSettingsMerge.ts`) needed to change.

## Related issue
Closes #883

## Testing
- Rewrote the existing `resolveProjectPath`/`isWorktreePath` test suite (previously pure-string fixtures with no real filesystem backing, fundamentally incompatible with a real-identity check) to use temp directories with hand-constructed git worktree registration structures, matching the pattern `findProjectRoot`'s own tests already used.
- New coverage: symlinked worktree, a project literally named `..._worktrees` (has its own `.git` directory -- must NOT resolve as a worktree), submodule exclusion, the forged-`.git`-file spoofing case, fail-closed on a nonexistent path.
- Updated 2 `getAdditionalDirectoriesForWorkspace` fixtures that called `isWorktreePath` on a bare directory with no real git structure.
- `npx tsc --noEmit` clean across `workspaceDetection.ts` and every call site.
- Pre-existing, unrelated Windows-only failures in `findNearestAncestor`'s POSIX-path fixtures (mismatching `path.normalize()` on Windows) confirmed present on a clean, unmodified checkout via `git stash` -- not new or related to this change.
- The `aiSettingsMerge.test.ts` "inherits the parent project override when the workspace path is a worktree" case was a genuine regression from this PR, not a pre-existing issue as originally stated here: its fixture passed a synthetic path string with no real on-disk git structure, which the new fail-closed `resolveProjectPath` correctly refuses to treat as a worktree. Fixed by mocking `resolveProjectPath` in that test (matching how `getAIProviderOverrides` is already mocked in the same file), keeping the unit test isolated from `workspaceDetection`'s real git-metadata internals.

## Notes for reviewers
- Security review: fail-closed direction verified correct for every error path (a caught exception always returns `isWorktree=false`); the back-pointer check specifically closes a trust-spoofing vector the old code had no equivalent protection against; no subprocess/shell invocation anywhere in the new code (avoids that injection surface entirely); the identity cache is process-local (single long-lived Electron main process), no cross-session or cross-user leakage path.
- Design was pressure-tested independently against three models before implementing (converging on the same core approach: realpath + git's on-disk worktree-file format + fail-closed); one of them specifically flagged the forged-`.git`-file spoofing vector this implementation closes.
- A separate, narrower function (`isFileInWorkspaceOrWorktree`) has its own independent `_worktrees` lexical fallback for a different question (file-path membership under any worktree of a given project, not trust granting) -- left untouched here as out of scope; flagging for visibility in case a follow-up is wanted.

