### PR TITLE
Bound transcript view load to a recent window (fix giant-session OOM #892)

### DIFF
--- a/packages/runtime/src/ai/server/transcript/TranscriptRuntime.ts
+++ b/packages/runtime/src/ai/server/transcript/TranscriptRuntime.ts
@@ -272,8 +272,26 @@ export class TranscriptRuntime {
     return this.routingStore.getSessionEvents(sessionId, options);
   }
 
-  async getViewMessages(sessionId: string, provider: string): Promise<TranscriptViewMessage[]> {
-    const events = await this.getCanonicalEvents(sessionId, provider);
+  /**
+   * Materialize the transcript view for a session.
+   *
+   * By default only the most recent `maxEvents` canonical events are loaded.
+   * Without a bound, opening a very large session loads its entire history
+   * into the renderer's JS heap on open and can exhaust it (nimbalyst#892:
+   * a big session pushed the heap to the ~3.5 GB V8 limit and froze the app).
+   * Older events remain in the store and can be paged in on demand. Pass
+   * `maxEvents: 0` to force loading the full history.
+   */
+  async getViewMessages(
+    sessionId: string,
+    provider: string,
+    opts?: { maxEvents?: number },
+  ): Promise<TranscriptViewMessage[]> {
+    const maxEvents = opts?.maxEvents ?? 5000;
+    const events =
+      maxEvents > 0
+        ? await this.getTailEvents(sessionId, provider, maxEvents)
+        : await this.getCanonicalEvents(sessionId, provider);
     const viewModel = TranscriptProjector.project(events);
     return viewModel.messages;
   }

--- a/packages/runtime/src/ai/server/transcript/__tests__/TranscriptRuntime.test.ts
+++ b/packages/runtime/src/ai/server/transcript/__tests__/TranscriptRuntime.test.ts
@@ -44,6 +44,27 @@ describe('TranscriptRuntime', () => {
     expect(events[0].searchableText).toBe('hello world');
   });
 
+  it('getViewMessages bounds the resident window to the most recent events (nimbalyst#892)', async () => {
+    const N = 30;
+    const raw = makeRawStore(
+      Array.from({ length: N }, (_, i) => userInput(i + 1, 's1', `msg ${i + 1}`)),
+    );
+    const runtime = new TranscriptRuntime(raw);
+
+    // maxEvents: 0 -> full history (opt-out)
+    const full = await runtime.getViewMessages('s1', 'claude-code', { maxEvents: 0 });
+    expect(full.length).toBe(N);
+
+    // default cap (5000) is well above N -> no regression for normal sessions
+    const def = await runtime.getViewMessages('s1', 'claude-code');
+    expect(def.length).toBe(N);
+
+    // an explicit small window only materializes the tail, not the whole history
+    const windowed = await runtime.getViewMessages('s1', 'claude-code', { maxEvents: 5 });
+    expect(windowed.length).toBeLessThan(full.length);
+    expect(windowed.length).toBeLessThanOrEqual(5);
+  });
+
   it('reports needsTransformation = true only for sessions not yet cached', async () => {
     const raw = makeRawStore([userInput(1, 's1', 'hi')]);
     const runtime = new TranscriptRuntime(raw);


### PR DESCRIPTION
## Problem

Switching to a single very large session freezes the whole app. `TranscriptRuntime.getViewMessages` loads the session's **entire** canonical-event history and projects all of it, so a big enough session materializes multi-GB of message content into the renderer's JS heap on open. That pushes V8 to its ~3.5 GB old-space limit → constant GC → the renderer main thread pegs. Filed as #892.

Captured live over the debugging port while it happened:
- JS heap **≈ 3586 MB** (right at the V8 limit), DOM only ~4257 nodes (so it's data, not rendering), RSS ~5.4 GB, eval RTT → 4000 ms (pegged).
- Heap snapshot at the onset: **~59% of the heap is strings** (message content), spread across thousands of sub-0.5 MB strings — i.e. the sheer number of messages, not one runaway buffer.

## Change

`getViewMessages(sessionId, provider, opts?)` now loads only the most recent `opts.maxEvents` events by default (5000), reusing the existing `getTailEvents` tail query instead of `getCanonicalEvents` (full history). Older events stay in the store and can be paged in later. `maxEvents: 0` opts out and loads everything.

- Sessions under the cap are unaffected (tail(5000) of a 200-event session is the same 200 events).
- Turns "switch to the session → whole app hangs" into a normal open.

## Follow-ups (not in this PR)

- A "load earlier messages" affordance / scroll-up paging to reach older history in the UI.
- Lazily hydrating very large individual tool-result contents.

## Test

Added a case to `TranscriptRuntime.test.ts`: with 30 events, `maxEvents: 0` returns all 30, the default returns all 30 (cap ≫ N, no regression), and `maxEvents: 5` returns only the tail (≤ 5).
