### PR TITLE
Cache .git existence per directory in findGitRootForFile (#868)

### DIFF
--- a/packages/electron/src/main/services/GitStatusService.ts
+++ b/packages/electron/src/main/services/GitStatusService.ts
@@ -29,6 +29,31 @@ export interface GitStatusResult {
  *
  * Exported for unit testing.
  */
+// Per-directory cache of `.git` existence. findGitRootForFile is called once
+// per file by getFileStatus, walking up the tree with an existsSync at every
+// level; without caching this is an O(files x depth) synchronous FS storm on
+// the main thread under multi-session editing of a large repo (nimbalyst#868).
+// Git roots do not move during a session, so memoizing is safe.
+const gitDirExistsCache = new Map<string, boolean>();
+
+/** Test-only: reset the git-root existence cache. */
+export function __resetGitRootCache(): void {
+  gitDirExistsCache.clear();
+}
+
+function hasGitDir(dir: string): boolean {
+  let cached = gitDirExistsCache.get(dir);
+  if (cached === undefined) {
+    try {
+      cached = existsSync(join(dir, '.git'));
+    } catch {
+      cached = false;
+    }
+    gitDirExistsCache.set(dir, cached);
+  }
+  return cached;
+}
+
 export function findGitRootForFile(filePath: string, boundary: string): string | null {
   const boundaryAbs = resolve(boundary);
   const fileAbs = isAbsolute(filePath) ? filePath : resolve(boundaryAbs, filePath);
@@ -47,7 +72,7 @@ export function findGitRootForFile(filePath: string, boundary: string): string |
   // Walk up until we leave the boundary, hit fs root, or find `.git`.
   while (true) {
     try {
-      if (existsSync(join(dir, '.git'))) {
+      if (hasGitDir(dir)) {
         return dir;
       }
     } catch {

--- a/packages/electron/src/main/services/__tests__/GitStatusService.gitRootCache.test.ts
+++ b/packages/electron/src/main/services/__tests__/GitStatusService.gitRootCache.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the per-directory `.git` existence cache added to
+ * `findGitRootForFile` (nimbalyst#868). The uncached walker re-`existsSync`-ed
+ * the same directory chains on every call, which under multi-session editing of
+ * a large repo turned into a synchronous FS storm that blocked the main thread.
+ *
+ * Uses the real filesystem (matching GitStatusService.findGitRoot.test.ts) and
+ * verifies the result is memoized: once a root is resolved, a later call returns
+ * it without re-reading the filesystem, and clearing the cache re-reads.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { findGitRootForFile, __resetGitRootCache } from '../GitStatusService';
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+  __resetGitRootCache();
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'nim-gitroot-cache-'));
+});
+
+afterEach(async () => {
+  __resetGitRootCache();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('findGitRootForFile caching (#868)', () => {
+  it('memoizes the resolved root and only re-reads after the cache is cleared', async () => {
+    const repo = path.join(tmpRoot, 'repo');
+    const file = path.join(repo, 'src', 'deep', 'a.ts');
+    await fs.mkdir(path.join(repo, '.git'), { recursive: true });
+    await fs.writeFile(path.join(repo, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, '');
+
+    // First resolve finds the repo root.
+    expect(findGitRootForFile(file, tmpRoot)).toBe(repo);
+
+    // Remove the .git marker; a cached lookup must still return the root
+    // (proving the second call did not touch the filesystem).
+    await fs.rm(path.join(repo, '.git'), { recursive: true, force: true });
+    expect(findGitRootForFile(file, tmpRoot)).toBe(repo);
+
+    // After clearing the cache the filesystem is read again -> no root now.
+    __resetGitRootCache();
+    expect(findGitRootForFile(file, tmpRoot)).toBeNull();
+  });
+
+  it('still resolves correct roots for unrelated files (no cross-contamination)', async () => {
+    const repoA = path.join(tmpRoot, 'a');
+    const repoB = path.join(tmpRoot, 'b');
+    for (const r of [repoA, repoB]) {
+      await fs.mkdir(path.join(r, '.git'), { recursive: true });
+      await fs.writeFile(path.join(r, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+      await fs.mkdir(path.join(r, 'src'), { recursive: true });
+      await fs.writeFile(path.join(r, 'src', 'x.ts'), '');
+    }
+    expect(findGitRootForFile(path.join(repoA, 'src', 'x.ts'), tmpRoot)).toBe(repoA);
+    expect(findGitRootForFile(path.join(repoB, 'src', 'x.ts'), tmpRoot)).toBe(repoB);
+  });
+});


### PR DESCRIPTION
## Problem

`GitStatusService.getFileStatus` calls `findGitRootForFile` once per file, and the walker calls `existsSync(join(dir, '.git'))` at every level up the tree — **uncached**. Under heavy multi-session editing of a large monorepo this is an O(files × depth) synchronous FS storm on the main thread. In CPU profiles captured from a frozen app, `existsSync` (via `findGitRootForFile` / `getFileStatus`) was **18–42% of main-process CPU**, blocking the event loop. Part of #868.

## Change

Memoize `.git` existence per directory in a module-level `Map`. Repeated walks over the same directory chains become O(1). Git roots don't move during a session, so the cache is safe. `__resetGitRootCache()` is exported for tests.

## Test

`GitStatusService.gitRootCache.test.ts` (real filesystem, matching the existing `findGitRoot` test): a resolved root is returned from cache even after its `.git` is removed, and re-reads after `__resetGitRootCache()`; unrelated files still resolve to their own roots. Existing `findGitRoot` tests still pass (9 tests green locally).
