### PR TITLE
Scan only the head of streamed content for the stream-edit marker (O(n^2) fix)

### DIFF
--- a/packages/electron/src/renderer/services/__tests__/aiStreamProtocol.detectStreamingIntent.test.ts
+++ b/packages/electron/src/renderer/services/__tests__/aiStreamProtocol.detectStreamingIntent.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for detectStreamingIntent's bounded (head-only) marker scan.
+ *
+ * The caller (aiApi) invokes this on the full, growing accumulated content on
+ * every stream chunk. Scanning the whole string each time is O(n^2) over a
+ * response and froze the renderer on long turns. A STREAM_EDIT / @stream-to-editor
+ * directive only appears at the start, so we scan the head; the clean-content
+ * slice is still derived from the full content.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    protocol: { info: () => {}, warn: () => {} },
+    streaming: { info: () => {} },
+  },
+}));
+
+import { detectStreamingIntent } from '../aiStreamProtocol';
+
+describe('detectStreamingIntent (bounded head scan)', () => {
+  it('returns not-streaming for ordinary content', () => {
+    const r = detectStreamingIntent('hello, this is a normal response');
+    expect(r.isStreaming).toBe(false);
+    expect(r.cleanContent).toBe('hello, this is a normal response');
+  });
+
+  it('detects a STREAM_EDIT marker at the start and returns the full clean content', () => {
+    const body = 'x'.repeat(50000); // clean content far larger than the scan window
+    const r = detectStreamingIntent(`<!-- STREAM_EDIT: {"position":"cursor","mode":"after"} -->\n${body}`);
+    expect(r.isStreaming).toBe(true);
+    expect(r.streamConfig).toEqual({ position: 'cursor', mode: 'after' });
+    // cleanContent is derived from the FULL content, not just the scanned head
+    expect(r.cleanContent).toBe(body);
+    expect(r.cleanContent.length).toBe(50000);
+  });
+
+  it('detects an @stream-to-editor marker at the start', () => {
+    const r = detectStreamingIntent('@stream-to-editor cursor after\nrest of body');
+    expect(r.isStreaming).toBe(true);
+    expect(r.streamConfig?.position).toBe('cursor');
+  });
+
+  it('does not scan the whole body when there is no marker (bounded work on huge content)', () => {
+    const huge = 'y'.repeat(2_000_000);
+    const before = Date.now();
+    const r = detectStreamingIntent(huge);
+    const elapsed = Date.now() - before;
+    expect(r.isStreaming).toBe(false);
+    expect(r.cleanContent).toBe(huge);
+    // head-only scan should be effectively instant even for a 2 MB body
+    expect(elapsed).toBeLessThan(50);
+  });
+});

--- a/packages/electron/src/renderer/services/aiStreamProtocol.ts
+++ b/packages/electron/src/renderer/services/aiStreamProtocol.ts
@@ -30,6 +30,14 @@ export interface StreamingEdit {
 /**
  * Detects if an AI response contains streaming markers
  */
+// A STREAM_EDIT / @stream-to-editor directive is emitted at the start of a
+// streamed response. The caller invokes detectStreamingIntent on the full,
+// growing accumulated content on every stream chunk, so scanning the whole
+// string each time is O(n^2) over a response and froze the renderer on long
+// turns. Only the head can contain the directive, so scan that; the (rare)
+// clean-content slice below is still derived from the full content.
+const STREAM_MARKER_SCAN_LIMIT = 8192;
+
 export function detectStreamingIntent(content: string): {
   isStreaming: boolean;
   streamConfig?: {
@@ -38,18 +46,23 @@ export function detectStreamingIntent(content: string): {
   };
   cleanContent: string;
 } {
+  const head =
+    content.length > STREAM_MARKER_SCAN_LIMIT
+      ? content.slice(0, STREAM_MARKER_SCAN_LIMIT)
+      : content;
+
   logger.protocol.info('Detecting streaming intent in content:', {
     length: content.length,
-    first100: content.substring(0, 100),
-    startsWithHTML: content.startsWith('<!--'),
-    startsWithAt: content.startsWith('@'),
-    hasStreamEdit: content.includes('STREAM_EDIT'),
-    hasStreamToEditor: content.includes('stream-to-editor')
+    first100: head.substring(0, 100),
+    startsWithHTML: head.startsWith('<!--'),
+    startsWithAt: head.startsWith('@'),
+    hasStreamEdit: head.includes('STREAM_EDIT'),
+    hasStreamToEditor: head.includes('stream-to-editor')
   });
 
   // Look for streaming directive anywhere in the response (not just at start)
   const streamingPattern = /<!--\s*STREAM_EDIT:\s*(.+?)\s*-->/;
-  const match = content.match(streamingPattern);
+  const match = head.match(streamingPattern);
 
   if (match) {
     logger.protocol.info('Found STREAM_EDIT marker:', match[0]);
@@ -74,7 +87,7 @@ export function detectStreamingIntent(content: string): {
 
   // Alternative: Check for MCP-style directive
   const mcpPattern = /^@stream-to-editor\s+(.+?)\n/;
-  const mcpMatch = content.match(mcpPattern);
+  const mcpMatch = head.match(mcpPattern);
 
   if (mcpMatch) {
     logger.protocol.info('Found @stream-to-editor marker:', mcpMatch[0]);
@@ -91,7 +104,7 @@ export function detectStreamingIntent(content: string): {
     };
   }
 
-  logger.protocol.info('No streaming markers found', content);
+  logger.protocol.info('No streaming markers found', { length: content.length });
   return {
     isStreaming: false,
     cleanContent: content


### PR DESCRIPTION
## Problem

`aiApi` calls `detectStreamingIntent(this.accumulatedContent)` on **every** stream chunk until a marker is detected. For a normal (non-streaming) response no marker is ever found, so `streamStartDetected` stays false and it re-scans the **entire growing response on every chunk** — `content.includes(...)` ×2 plus a regex `match` each time — which is **O(n²)** over the turn. In a renderer CPU profile captured while the heap climbed, `detectStreamingIntent` was **~35% of CPU**.

## Change

`STREAM_EDIT` / `@stream-to-editor` directives are emitted at the **start** of a response, so scan only the first `STREAM_MARKER_SCAN_LIMIT` (8 KB) — making each call O(1). The clean-content slice is still derived from the full `content` (the marker, when present, is in the head), so its result is unchanged. The no-match debug log no longer serializes the whole body either.

Tradeoff: a directive placed **beyond** the first 8 KB of a response would no longer switch to streaming mode. In practice the directive is a control prefix at the very start.

## Test

`aiStreamProtocol.detectStreamingIntent.test.ts`: ordinary content → not streaming; a `STREAM_EDIT` marker followed by a 50 KB body → detected with the **full** clean content; `@stream-to-editor` → detected; a 2 MB no-marker body returns quickly (bounded scan). 4 tests green locally.
