### PR TITLE
Debounce the per-edit git-status refresh in session-files:updated

### DIFF
--- a/packages/electron/src/renderer/store/listeners/__tests__/perKeyDebounce.test.ts
+++ b/packages/electron/src/renderer/store/listeners/__tests__/perKeyDebounce.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for createPerKeyDebouncer -- the per-session coalescing used by the
+ * file-state listeners to collapse the git-status refresh that
+ * session-files:updated triggers once per file edit (hundreds/sec during active
+ * AI tool execution) into a single trailing refresh per session.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createPerKeyDebouncer } from '../perKeyDebounce';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('createPerKeyDebouncer', () => {
+  it('collapses a burst of same-key schedules into a single trailing call', () => {
+    const d = createPerKeyDebouncer(250);
+    const fn = vi.fn();
+
+    for (let i = 0; i < 100; i++) d.schedule('s1', fn);
+    expect(fn).not.toHaveBeenCalled(); // nothing runs until the window elapses
+
+    vi.advanceTimersByTime(250);
+    expect(fn).toHaveBeenCalledTimes(1); // 100 edits -> 1 refresh
+  });
+
+  it('runs the most recently scheduled fn for a key', () => {
+    const d = createPerKeyDebouncer(100);
+    const order: string[] = [];
+    d.schedule('s1', () => order.push('stale'));
+    d.schedule('s1', () => order.push('latest'));
+
+    vi.advanceTimersByTime(100);
+    expect(order).toEqual(['latest']);
+  });
+
+  it('debounces keys independently', () => {
+    const d = createPerKeyDebouncer(200);
+    const a = vi.fn();
+    const b = vi.fn();
+
+    d.schedule('a', a);
+    d.schedule('b', b);
+    vi.advanceTimersByTime(200);
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arms after firing (a later edit schedules a fresh refresh)', () => {
+    const d = createPerKeyDebouncer(150);
+    const fn = vi.fn();
+
+    d.schedule('s1', fn);
+    vi.advanceTimersByTime(150);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    d.schedule('s1', fn);
+    vi.advanceTimersByTime(150);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancelAll drops every pending refresh (teardown safety)', () => {
+    const d = createPerKeyDebouncer(300);
+    const fn = vi.fn();
+
+    d.schedule('s1', fn);
+    d.schedule('s2', fn);
+    d.cancelAll();
+
+    vi.advanceTimersByTime(1000);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('cancel(key) drops only that key', () => {
+    const d = createPerKeyDebouncer(300);
+    const a = vi.fn();
+    const b = vi.fn();
+
+    d.schedule('a', a);
+    d.schedule('b', b);
+    d.cancel('a');
+    vi.advanceTimersByTime(300);
+
+    expect(a).not.toHaveBeenCalled();
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/electron/src/renderer/store/listeners/fileStateListeners.ts
+++ b/packages/electron/src/renderer/store/listeners/fileStateListeners.ts
@@ -24,6 +24,7 @@ import {
 } from '../atoms/sessionFiles';
 import { workstreamStagedFilesAtom, setWorkstreamStagedFilesAtom } from '../atoms/workstreamState';
 import { getRelativeWorkspacePath } from '../../../shared/pathUtils';
+import { createPerKeyDebouncer } from './perKeyDebounce';
 
 /**
  * Track which workspace path is currently open.
@@ -214,6 +215,10 @@ export function initFileStateListeners(workspacePath: string): () => void {
   const enrichDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const gitStatusDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const pendingCountDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // session-files:updated fires once per file edit (hundreds/sec during active
+  // AI tool execution); coalesce its per-session git-status refresh so bursts
+  // collapse into a single trailing git:get-file-status call per session.
+  const sessionGitStatusRefresh = createPerKeyDebouncer(250);
   const GIT_STATUS_DEBOUNCE_MS = 300;
   const PENDING_COUNT_DEBOUNCE_MS = 250;
 
@@ -271,8 +276,13 @@ export function initFileStateListeners(workspacePath: string): () => void {
             }
           }, 200));
 
-          // Also refresh git status for these files
-          await refreshSessionGitStatus(sessionId);
+          // Also refresh git status for these files. This handler fires once
+          // per file edit (see the note below on session-files:updated volume),
+          // so coalesce the refresh per session instead of running a full
+          // git:get-file-status over the session's edited-file list every time.
+          sessionGitStatusRefresh.schedule(sessionId, () => {
+            void refreshSessionGitStatus(sessionId);
+          });
 
           // Note: we used to also fetch pending-review files here to keep the
           // atom in sync, but that fired once per session-files:updated event
@@ -401,6 +411,7 @@ export function initFileStateListeners(workspacePath: string): () => void {
     gitStatusDebounceTimers.clear();
     pendingCountDebounceTimers.forEach(timer => clearTimeout(timer));
     pendingCountDebounceTimers.clear();
+    sessionGitStatusRefresh.cancelAll();
   };
 }
 

--- a/packages/electron/src/renderer/store/listeners/perKeyDebounce.ts
+++ b/packages/electron/src/renderer/store/listeners/perKeyDebounce.ts
@@ -1,0 +1,47 @@
+/**
+ * Per-key trailing debouncer.
+ *
+ * Multiple `schedule(key, fn)` calls with the same key within `delayMs` collapse
+ * into a single trailing invocation of the most recently scheduled `fn`. Distinct
+ * keys are independent.
+ *
+ * Extracted as a standalone (dependency-free) unit so the coalescing behaviour of
+ * the file-state listeners can be tested without standing up the whole IPC/store
+ * graph. Used to coalesce the git-status refresh triggered by `session-files:updated`,
+ * which the file-attribution service emits once per file edit -- hundreds per
+ * second during active AI tool execution.
+ */
+export function createPerKeyDebouncer(delayMs: number): {
+  schedule: (key: string, fn: () => void) => void;
+  cancel: (key: string) => void;
+  cancelAll: () => void;
+} {
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  return {
+    schedule(key: string, fn: () => void): void {
+      const existing = timers.get(key);
+      if (existing) clearTimeout(existing);
+      timers.set(
+        key,
+        setTimeout(() => {
+          timers.delete(key);
+          fn();
+        }, delayMs)
+      );
+    },
+
+    cancel(key: string): void {
+      const existing = timers.get(key);
+      if (existing) {
+        clearTimeout(existing);
+        timers.delete(key);
+      }
+    },
+
+    cancelAll(): void {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    },
+  };
+}


### PR DESCRIPTION
## Problem

The `session-files:updated` handler calls `refreshSessionGitStatus(sessionId)` **immediately on every event**:

```ts
// Also refresh git status for these files
await refreshSessionGitStatus(sessionId);
```

The file-attribution service emits **one `session-files:updated` per file edit** — the handler's own comment a few lines down notes this is *"hundreds per second in active sessions"* during AI tool execution. Each refresh runs a `git:get-file-status` IPC over the session's **entire accumulated edited-file list**. With several concurrent active sessions this becomes a sustained storm of synchronous main-process git work that stalls the UI.

Every other refresh in this file is already debounced — enrichment (200ms), the `git:status-changed` fan-out (300ms per workspace), pending-count (250ms). This one path was the exception.

## Change

Coalesce the per-edit refresh with a small **per-session trailing debounce** (250ms), so a burst of edits to a session collapses into a single `git:get-file-status`:

```ts
sessionGitStatusRefresh.schedule(sessionId, () => {
  void refreshSessionGitStatus(sessionId);
});
```

The debouncer is a standalone, dependency-free helper (`perKeyDebounce.ts`) — extracted so its coalescing can be unit-tested without standing up the IPC/store graph — and its pending timers are cancelled on listener teardown. The initial per-session refresh in `loadInitialSessionFileState` (once per session load) is left immediate; only the hot per-edit path is debounced.

Result: git status is still refreshed after edits settle (eventually-consistent, same as the already-debounced `git:status-changed` path), but N rapid edits to a session cost **1** refresh instead of **N**.

## Test

`perKeyDebounce.test.ts` (vitest fake timers): 100 same-key schedules → 1 trailing call; latest fn wins; keys debounce independently; re-arms after firing; `cancelAll`/`cancel(key)` drop pending work. 6 tests green locally.
