### PR TITLE
fix(rtl): mirror composer direction onto visible-text overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- RTL text typed in the chat composer now displays on the right again; the detected direction is mirrored onto the composer's visible-text overlay, which a transparent-textarea refactor had left stuck on LTR.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/extensions/rtl-support/src/__tests__/inputRtl.test.ts
+++ b/packages/extensions/rtl-support/src/__tests__/inputRtl.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for input RTL handling.
+ *
+ * Since 0.68 the composer renders visible text in a sibling overlay over a
+ * transparent textarea. These tests verify that detected direction is mirrored
+ * onto that overlay, not just the textarea itself.
+ *
+ * Note: Persian sample strings below are intentional — real RTL text used to
+ * verify the direction is detected correctly.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { startInputRtl, stopInputRtl } from '../inputRtl';
+import type { RtlSettings } from '../settings';
+
+const SETTINGS: RtlSettings = {
+  enabled: true,
+  mode: 'auto',
+  threshold: 0.3,
+  perBlock: true,
+  inputRtl: true,
+  inlineDetect: false,
+  debug: false,
+};
+
+/** Build a DOM structure matching the 0.68 composer. */
+function buildComposer(): HTMLTextAreaElement {
+  document.body.innerHTML = `
+    <div class="ai-chat-input-textarea-wrap">
+      <textarea class="ai-chat-input-field"></textarea>
+      <div class="command-pill-overlay">
+        <span class="command-pill-overlay-text"></span>
+      </div>
+    </div>`;
+  return document.querySelector<HTMLTextAreaElement>('.ai-chat-input-field')!;
+}
+
+function typeAndDispatch(textarea: HTMLTextAreaElement, value: string): void {
+  textarea.value = value;
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('inputRtl overlay mirroring', () => {
+  afterEach(() => {
+    stopInputRtl();
+    document.body.innerHTML = '';
+  });
+
+  it('mirrors RTL direction onto the composer overlay', () => {
+    const textarea = buildComposer();
+    startInputRtl(document.body, SETTINGS);
+
+    typeAndDispatch(textarea, 'سلام دنیا');
+
+    expect(textarea.getAttribute('dir')).toBe('rtl');
+    expect(document.querySelector('.command-pill-overlay')!.getAttribute('dir')).toBe('rtl');
+    expect(document.querySelector('.command-pill-overlay-text')!.getAttribute('dir')).toBe('rtl');
+  });
+
+  it('mirrors LTR direction onto the composer overlay', () => {
+    const textarea = buildComposer();
+    startInputRtl(document.body, SETTINGS);
+
+    typeAndDispatch(textarea, 'Hello world');
+
+    expect(textarea.getAttribute('dir')).toBe('ltr');
+    expect(document.querySelector('.command-pill-overlay')!.getAttribute('dir')).toBe('ltr');
+    expect(document.querySelector('.command-pill-overlay-text')!.getAttribute('dir')).toBe('ltr');
+  });
+
+  it('flips the overlay direction when the input language switches', () => {
+    const textarea = buildComposer();
+    startInputRtl(document.body, SETTINGS);
+
+    typeAndDispatch(textarea, 'سلام دنیا');
+    expect(document.querySelector('.command-pill-overlay')!.getAttribute('dir')).toBe('rtl');
+
+    typeAndDispatch(textarea, 'Hello world');
+    expect(document.querySelector('.command-pill-overlay')!.getAttribute('dir')).toBe('ltr');
+  });
+
+  it('leaves the overlay untouched when inputRtl is disabled', () => {
+    const textarea = buildComposer();
+    startInputRtl(document.body, { ...SETTINGS, inputRtl: false });
+
+    typeAndDispatch(textarea, 'سلام دنیا');
+
+    expect(textarea.getAttribute('dir')).toBeNull();
+    expect(document.querySelector('.command-pill-overlay')!.getAttribute('dir')).toBeNull();
+  });
+});

--- a/packages/extensions/rtl-support/src/inputRtl.ts
+++ b/packages/extensions/rtl-support/src/inputRtl.ts
@@ -26,9 +26,41 @@ const INPUT_SELECTOR = [
   '[role="textbox"]',
 ].join(',');
 
+/**
+ * Selectors for the overlay elements that visually render the composer input.
+ *
+ * Since 0.68, the composer renders its visible text in a sibling overlay
+ * (`.command-pill-overlay` / `.command-pill-overlay-text`) on top of a
+ * transparent textarea, so @mention / @@session / /command tokens can be
+ * highlighted. The textarea's own text is invisible, so setting `dir` only on
+ * it leaves the visible overlay at LTR and RTL text appears on the left.
+ */
+const OVERLAY_SELECTOR = ['.command-pill-overlay', '.command-pill-overlay-text'].join(',');
+
 let observer: MutationObserver | null = null;
 let activeInputs: Set<HTMLElement> = new Set();
 let currentSettings: RtlSettings | null = null;
+
+/** Find the sibling overlays that mirror the input's visible text. */
+function findOverlays(input: HTMLElement): HTMLElement[] {
+  const root = input.closest('.ai-chat-input-textarea-wrap') || input.parentElement;
+  if (!root) return [];
+  return [...root.querySelectorAll<HTMLElement>(OVERLAY_SELECTOR)];
+}
+
+/** Apply the detected direction to the input and its visible-text overlays. */
+function applyDirection(input: HTMLElement, dir: 'rtl' | 'ltr'): void {
+  if (input.getAttribute('dir') !== dir) {
+    input.setAttribute('dir', dir);
+    debug('input direction changed to', dir);
+  }
+  for (const overlay of findOverlays(input)) {
+    if (overlay.getAttribute('dir') !== dir) {
+      overlay.setAttribute('dir', dir);
+      debug('overlay direction changed to', dir);
+    }
+  }
+}
 
 function handleInput(e: Event): void {
   if (!currentSettings?.inputRtl) return;
@@ -38,10 +70,7 @@ function handleInput(e: Event): void {
   if (!text.trim()) return;
 
   const dir = detectDirection(text, currentSettings.threshold);
-  if (target.getAttribute('dir') !== dir) {
-    target.setAttribute('dir', dir);
-    debug('input direction changed to', dir);
-  }
+  applyDirection(target, dir);
 }
 
 function getInputText(el: HTMLElement): string {


### PR DESCRIPTION
Since 0.68 the composer renders visible text in a sibling overlay over a transparent textarea; setting dir only on the textarea left RTL input on the left.

- add OVERLAY_SELECTOR + findOverlays/applyDirection to mirror dir
- add inputRtl overlay-mirroring tests