### PR TITLE
Allow child sessions to set Codex reasoning effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Child sessions can request their own Codex reasoning effort.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/main/mcp/__tests__/metaAgentServer.effortLevel.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/metaAgentServer.effortLevel.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EFFORT_LEVELS } from '@nimbalyst/runtime/ai/server/effortLevels';
+
+vi.mock('../../utils/workspaceDetection', () => ({
+  resolveProjectPath: (workspacePath: string) => workspacePath,
+}));
+
+import {
+  META_AGENT_TOOL_DEFS,
+  dispatchMetaAgentTool,
+  setMetaAgentToolFns,
+} from '../metaAgentServer';
+
+const EXPECTED_EFFORT_LEVELS = EFFORT_LEVELS.map(({ key }) => key);
+
+describe('meta-agent child effort tools (#899)', () => {
+  const createSession = vi.fn().mockResolvedValue('{"created":true}');
+  const spawnSession = vi.fn().mockResolvedValue('{"spawned":true}');
+
+  beforeEach(() => {
+    createSession.mockClear();
+    spawnSession.mockClear();
+    setMetaAgentToolFns({
+      listWorktrees: vi.fn().mockResolvedValue('[]'),
+      createSession,
+      spawnSession,
+      getSessionStatus: vi.fn().mockResolvedValue('{}'),
+      getSessionResult: vi.fn().mockResolvedValue('{}'),
+      listQueuedPrompts: vi.fn().mockResolvedValue('[]'),
+      sendPrompt: vi.fn().mockResolvedValue('{}'),
+      respondToPrompt: vi.fn().mockResolvedValue('{}'),
+      listSpawnedSessions: vi.fn().mockResolvedValue('[]'),
+    });
+  });
+
+  it('exposes the same exact effortLevel enum on create_session and spawn_session', () => {
+    for (const toolName of ['create_session', 'spawn_session']) {
+      const tool = META_AGENT_TOOL_DEFS.find((candidate) => candidate.name === toolName);
+      const effortLevel = tool?.inputSchema.properties.effortLevel as { enum?: string[] } | undefined;
+
+      expect(effortLevel?.enum).toEqual(EXPECTED_EFFORT_LEVELS);
+    }
+  });
+
+  it('forwards effortLevel unchanged through both tool dispatch paths', async () => {
+    await dispatchMetaAgentTool('create_session', 'parent-1', '/workspace', {
+      prompt: 'create child',
+      effortLevel: 'max',
+    });
+    await dispatchMetaAgentTool('spawn_session', 'parent-1', '/workspace', {
+      prompt: 'spawn sibling',
+      effortLevel: 'xhigh',
+    });
+
+    expect(createSession).toHaveBeenCalledWith('parent-1', '/workspace', {
+      prompt: 'create child',
+      effortLevel: 'max',
+    });
+    expect(spawnSession).toHaveBeenCalledWith('parent-1', '/workspace', {
+      prompt: 'spawn sibling',
+      effortLevel: 'xhigh',
+    });
+  });
+});

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -13,6 +13,9 @@
  */
 
 import { resolveProjectPath } from "../utils/workspaceDetection";
+import { EFFORT_LEVELS, type EffortLevel } from "@nimbalyst/runtime/ai/server/effortLevels";
+
+const CHILD_EFFORT_LEVELS: EffortLevel[] = EFFORT_LEVELS.map(({ key }) => key);
 
 type CreateSessionArgs = {
   title?: string;
@@ -22,6 +25,7 @@ type CreateSessionArgs = {
   useWorktree?: boolean;
   worktreeId?: string;
   toolScope?: string;
+  effortLevel?: EffortLevel;
 };
 
 type SpawnSessionArgs = {
@@ -29,6 +33,7 @@ type SpawnSessionArgs = {
   prompt: string;
   useWorktree?: boolean;
   model?: string;
+  effortLevel?: EffortLevel;
   notifyOnComplete?: boolean;
   /**
    * When true, the new session is created at the top level — no parent,
@@ -193,6 +198,12 @@ export const META_AGENT_TOOL_DEFS: Array<{
           description:
             "Capability scope for the child. \"read\" = read_file/list_files/search_files only (pure investigation). \"write\" = those plus write_file but NO run_command, so the child can save a file deliverable (e.g. a report) yet cannot build/test/run anything. \"full\" (default) = all tools including run_command. Use read or write for analyze/research tasks so the child physically cannot run a build, and reserve full for tasks that must build/test.",
         },
+        effortLevel: {
+          type: "string",
+          enum: [...CHILD_EFFORT_LEVELS],
+          description:
+            "Optional requested reasoning effort for this child only. Supported only when the resolved provider is openai-codex. Omit to preserve the app-default effort behavior; do not append effort to the model identifier.",
+        },
       },
     },
   },
@@ -226,6 +237,12 @@ export const META_AGENT_TOOL_DEFS: Array<{
           type: "string",
           description:
             "Optional explicit model identifier (e.g. 'claude-code:opus'). When omitted, the new session uses the global default model unless inheritModel=true. Wins over inheritModel when both are set.",
+        },
+        effortLevel: {
+          type: "string",
+          enum: [...CHILD_EFFORT_LEVELS],
+          description:
+            "Optional requested reasoning effort for this child only. Supported only when the resolved provider is openai-codex. Omit to preserve the app-default effort behavior; do not append effort to the model identifier.",
         },
         inheritModel: {
           type: "boolean",

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -5,6 +5,7 @@ import { safeHandle } from '../utils/ipcRegistry';
 import { SessionManager } from '@nimbalyst/runtime/ai/server';
 import type { AIProviderType } from '@nimbalyst/runtime/ai/server/types';
 import { ModelIdentifier } from '@nimbalyst/runtime/ai/server/types';
+import { EFFORT_LEVELS, type EffortLevel } from '@nimbalyst/runtime/ai/server/effortLevels';
 import { AISessionsRepository, AgentMessagesRepository, SessionFilesRepository } from '@nimbalyst/runtime';
 import { getSessionStateManager } from '@nimbalyst/runtime/ai/server/SessionStateManager';
 import { getDefaultAIModel } from '../utils/store';
@@ -54,6 +55,8 @@ interface SessionResultData {
   /** Capability scope the child was granted (read|write|full). The objective
    *  record of what the child COULD do; null/full means all tools. */
   toolScope?: string | null;
+  /** Explicit per-child request. This is not a claim about effective effort. */
+  requestedEffortLevel?: EffortLevel;
 }
 
 interface CreateChildSessionArgs {
@@ -64,6 +67,51 @@ interface CreateChildSessionArgs {
   useWorktree?: boolean;
   worktreeId?: string;
   toolScope?: string;
+  effortLevel?: EffortLevel;
+}
+
+const CHILD_EFFORT_LEVELS: EffortLevel[] = EFFORT_LEVELS.map(({ key }) => key);
+const VALID_CHILD_EFFORT_LEVELS = new Set<string>(CHILD_EFFORT_LEVELS);
+
+function parseRequestedChildEffortLevel(value: unknown): EffortLevel | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string' || !VALID_CHILD_EFFORT_LEVELS.has(value)) {
+    throw new Error(
+      `Invalid effortLevel ${JSON.stringify(value)}. Expected one of: ${CHILD_EFFORT_LEVELS.join(', ')}`
+    );
+  }
+  return value as EffortLevel;
+}
+
+function assertRequestedChildEffortProvider(
+  requestedEffortLevel: EffortLevel | undefined,
+  provider: AIProviderType
+): void {
+  if (requestedEffortLevel && provider !== 'openai-codex') {
+    throw new Error(
+      `effortLevel is supported only for openai-codex child sessions; resolved provider was ${provider}`
+    );
+  }
+}
+
+function readRequestedChildEffortLevel(metadata: unknown): EffortLevel | undefined {
+  let parsedMetadata = metadata;
+  if (typeof parsedMetadata === 'string') {
+    try {
+      parsedMetadata = JSON.parse(parsedMetadata);
+    } catch {
+      return undefined;
+    }
+  }
+  if (!parsedMetadata || typeof parsedMetadata !== 'object' || Array.isArray(parsedMetadata)) {
+    return undefined;
+  }
+  const value = (parsedMetadata as Record<string, unknown>).effortLevel;
+  return typeof value === 'string' && VALID_CHILD_EFFORT_LEVELS.has(value)
+    ? value as EffortLevel
+    : undefined;
 }
 
 function normalizeStoredChildModelIdentifier(
@@ -85,11 +133,71 @@ function normalizeStoredChildModelIdentifier(
   return model;
 }
 
+async function resolveChildSessionModelAndProvider(
+  parentSessionId: string,
+  args: Pick<CreateChildSessionArgs, 'provider' | 'model'>
+): Promise<{ provider: AIProviderType; normalizedModel: string }> {
+  // Inherit the calling session's provider+model as the primary fallback so a
+  // non-Claude parent (Gemini, OpenAI-Codex, LM Studio, etc.) spawning a child
+  // via the meta-agent tools without an explicit model does NOT silently land
+  // on the hardcoded Opus default and bill the user's Anthropic pool. Only fall
+  // through to getDefaultAIModel() / the last-resort default when the parent
+  // session cannot be loaded (orphan call) or carries no usable provider+model.
+  // An explicit args.provider/args.model still wins; that is what they are for.
+  let parentProvider: string | null = null;
+  let parentModel: string | null = null;
+  try {
+    const parentSession = await AISessionsRepository.get(parentSessionId);
+    if (parentSession) {
+      parentProvider = parentSession.provider ?? null;
+      parentModel = normalizeStoredChildModelIdentifier(parentProvider, parentSession.model ?? null);
+    }
+  } catch {
+    // Best-effort lookup; fall through to the hardcoded default below.
+  }
+
+  const defaultModel =
+    parentModel
+    || normalizeStoredChildModelIdentifier(null, getDefaultAIModel())
+    || 'claude-code:opus';
+  // For an explicit model, the model's own "provider:" prefix is
+  // authoritative (e.g. a claude-code parent launching an
+  // "openai-codex:gpt-5.5" action). Only fall back to the parent's provider
+  // for a bare, prefix-less variant; passing the parent provider for a
+  // self-describing identifier wrongly trips the claude-code mismatch guard.
+  const explicitModelProvider =
+    args.provider
+    ?? (args.model?.includes(':') ? ModelIdentifier.tryParse(args.model)?.provider ?? null : null)
+    ?? parentProvider;
+  const explicitModel = normalizeStoredChildModelIdentifier(explicitModelProvider, args.model ?? null);
+  const model = explicitModel || defaultModel;
+  const parsed = ModelIdentifier.tryParse(model);
+  const provider = (args.provider ||
+    parsed?.provider ||
+    parentProvider ||
+    'claude-code') as AIProviderType;
+  // Provider and model MUST agree. Otherwise a child is persisted with, e.g.,
+  // provider=claude-code + an antigravity-gemini model, gets routed to the
+  // Claude Code provider, is rejected ("requires a claude-code:* identifier"),
+  // and dies with no output. Only reuse the parent model when it actually
+  // belongs to the resolved provider; otherwise use that provider default.
+  const parentModelProvider = parentModel
+    ? (ModelIdentifier.tryParse(parentModel)?.provider ?? parentProvider)
+    : null;
+  const normalizedModel =
+    explicitModel
+    || (parentModel && parentModelProvider === provider ? parentModel : null)
+    || ModelIdentifier.getDefaultModelId(provider);
+
+  return { provider, normalizedModel };
+}
+
 interface SpawnSessionArgs {
   title?: string;
   prompt: string;
   useWorktree?: boolean;
   model?: string;
+  effortLevel?: EffortLevel;
   /**
    * When true and `model` is not explicitly set, the new session uses the
    * caller's model instead of the global app default. Ignored if `model` is
@@ -367,6 +475,7 @@ export class MetaAgentService {
     createdBySessionId: string;
     queuedInitialPrompt: boolean;
     parentSessionId: string | null;
+    requestedEffortLevel?: EffortLevel;
   }> {
     if (!this.aiService) {
       throw new Error('AI service not initialized');
@@ -391,57 +500,9 @@ export class MetaAgentService {
       );
     }
 
-    // Inherit the calling session's provider+model as the primary fallback so a
-    // non-Claude parent (Gemini, OpenAI-Codex, LM Studio, etc.) spawning a child
-    // via the meta-agent tools without an explicit model does NOT silently land
-    // on the hardcoded Opus default and bill the user's Anthropic pool. Only fall
-    // through to getDefaultAIModel() / the last-resort default when the parent
-    // session cannot be loaded (orphan call) or carries no usable provider+model.
-    // An explicit args.provider/args.model still wins; that is what they are for.
-    let parentProvider: string | null = null;
-    let parentModel: string | null = null;
-    try {
-      const parentSession = await AISessionsRepository.get(metaSessionId);
-      if (parentSession) {
-        parentProvider = parentSession.provider ?? null;
-        parentModel = normalizeStoredChildModelIdentifier(parentProvider, parentSession.model ?? null);
-      }
-    } catch {
-      // Best-effort lookup; fall through to the hardcoded default below.
-    }
-
-    const defaultModel =
-      parentModel
-      || normalizeStoredChildModelIdentifier(null, getDefaultAIModel())
-      || 'claude-code:opus';
-    // For an explicit model, the model's own "provider:" prefix is
-    // authoritative (e.g. a claude-code parent launching an
-    // "openai-codex:gpt-5.5" action). Only fall back to the parent's provider
-    // for a bare, prefix-less variant; passing the parent provider for a
-    // self-describing identifier wrongly trips the claude-code mismatch guard.
-    const explicitModelProvider =
-      args.provider
-      ?? (args.model?.includes(':') ? ModelIdentifier.tryParse(args.model)?.provider ?? null : null)
-      ?? parentProvider;
-    const explicitModel = normalizeStoredChildModelIdentifier(explicitModelProvider, args.model ?? null);
-    const model = explicitModel || defaultModel;
-    const parsed = ModelIdentifier.tryParse(model);
-    const provider = (args.provider ||
-      parsed?.provider ||
-      parentProvider ||
-      'claude-code') as AIProviderType;
-    // Provider and model MUST agree. Otherwise a child is persisted with, e.g.,
-    // provider=claude-code + an antigravity-gemini model, gets routed to the
-    // Claude Code provider, is rejected ("requires a claude-code:* identifier"),
-    // and dies with no output. Only reuse the parent model when it actually
-    // belongs to the resolved provider; otherwise use that provider default.
-    const parentModelProvider = parentModel
-      ? (ModelIdentifier.tryParse(parentModel)?.provider ?? parentProvider)
-      : null;
-    const normalizedModel =
-      explicitModel
-      || (parentModel && parentModelProvider === provider ? parentModel : null)
-      || ModelIdentifier.getDefaultModelId(provider);
+    const { provider, normalizedModel } = await resolveChildSessionModelAndProvider(metaSessionId, args);
+    const requestedEffortLevel = parseRequestedChildEffortLevel(args.effortLevel);
+    assertRequestedChildEffortProvider(requestedEffortLevel, provider);
 
     const callerProvidedTitle = !!args.title?.trim();
     const title = (args.title || this.deriveTitleFromPrompt(args.prompt) || 'Meta Task').trim();
@@ -580,8 +641,13 @@ export class MetaAgentService {
     // child physically cannot run_command, so it cannot build or claim to).
     const childToolScope =
       args.toolScope === 'read' || args.toolScope === 'write' ? args.toolScope : undefined;
-    if (childToolScope) {
-      await AISessionsRepository.updateMetadata(sessionId, { metadata: { toolScope: childToolScope } });
+    if (childToolScope || requestedEffortLevel) {
+      await AISessionsRepository.updateMetadata(sessionId, {
+        metadata: {
+          ...(childToolScope ? { toolScope: childToolScope } : {}),
+          ...(requestedEffortLevel ? { effortLevel: requestedEffortLevel } : {}),
+        },
+      });
     }
 
     const initialPrompt = args.prompt?.trim();
@@ -635,6 +701,7 @@ export class MetaAgentService {
       createdBySessionId: metaSessionId,
       queuedInitialPrompt: !!initialPrompt,
       parentSessionId: args.parentSessionIdOverride ?? null,
+      ...(requestedEffortLevel ? { requestedEffortLevel } : {}),
     };
   }
 
@@ -650,6 +717,19 @@ export class MetaAgentService {
     const parent = await AISessionsRepository.get(parentSessionId);
     if (!parent || parent.workspacePath !== workspaceId) {
       throw new Error(`Parent session ${parentSessionId} not found in this workspace`);
+    }
+
+    // Validate before resolveOrCreateWorkstream can create a grouping row or
+    // reparent the caller. createChildSessionInternal repeats the same checks as
+    // defense in depth for its other entry points.
+    const effectiveModel =
+      args.model ?? (args.inheritModel ? parent.model ?? undefined : undefined);
+    const requestedEffortLevel = parseRequestedChildEffortLevel(args.effortLevel);
+    if (requestedEffortLevel) {
+      const { provider } = await resolveChildSessionModelAndProvider(parentSessionId, {
+        model: effectiveModel,
+      });
+      assertRequestedChildEffortProvider(requestedEffortLevel, provider);
     }
 
     const isolated = args.isolated === true;
@@ -675,19 +755,13 @@ export class MetaAgentService {
     const inheritedWorktreeId =
       !args.useWorktree && parent.worktreeId ? parent.worktreeId : undefined;
 
-    // Resolve effective model: explicit `model` wins; otherwise `inheritModel`
-    // copies the caller's model so the new session keeps the same provider/model
-    // (e.g. opus stays on opus). Falling through to undefined lets
-    // createChildSessionInternal use the global default.
-    const effectiveModel =
-      args.model ?? (args.inheritModel ? parent.model ?? undefined : undefined);
-
     const childResult = await this.createChildSessionInternal(parentSessionId, workspaceId, {
       title: args.title,
       prompt: args.prompt,
       useWorktree: !!args.useWorktree,
       worktreeId: inheritedWorktreeId,
       model: effectiveModel,
+      effortLevel: args.effortLevel,
       parentSessionIdOverride: workstreamId,
     });
 
@@ -823,6 +897,10 @@ export class MetaAgentService {
       agentRole: row.agent_role || 'standard',
       waitingForInput: status === 'waiting_for_input',
     };
+    const requestedEffortLevel = readRequestedChildEffortLevel(row.metadata);
+    if (requestedEffortLevel) {
+      result.requestedEffortLevel = requestedEffortLevel;
+    }
 
     return JSON.stringify(result, null, 2);
   }
@@ -1185,6 +1263,7 @@ export class MetaAgentService {
     let sessionUpdatedAt: number;
     let sessionWorktreeId: string | null;
     let sessionToolScope: string | null = null;
+    let requestedEffortLevel: EffortLevel | undefined;
 
     if (prefetchedSession) {
       sessionTitle = prefetchedSession.title;
@@ -1211,6 +1290,7 @@ export class MetaAgentService {
       sessionWorktreeId = session.worktreeId || null;
       sessionToolScope =
         ((session.metadata as Record<string, unknown> | undefined)?.toolScope as string | undefined) ?? null;
+      requestedEffortLevel = readRequestedChildEffortLevel(session.metadata);
     }
 
     const messages = await AgentMessagesRepository.list(sessionId, { limit: 500 });
@@ -1245,6 +1325,7 @@ export class MetaAgentService {
       updatedAt: sessionUpdatedAt,
       worktreeId: sessionWorktreeId,
       toolScope: sessionToolScope,
+      ...(requestedEffortLevel ? { requestedEffortLevel } : {}),
     };
   }
 
@@ -1378,7 +1459,7 @@ export class MetaAgentService {
 
   private async getSessionStatusRow(sessionId: string, workspaceId: string): Promise<any | null> {
     const { rows } = await databaseWorker.query<any>(
-      `SELECT id, title, provider, model, status, last_activity, updated_at, created_by_session_id, agent_role
+      `SELECT id, title, provider, model, status, last_activity, updated_at, created_by_session_id, agent_role, metadata
        FROM ai_sessions
        WHERE id = $1 AND workspace_id = $2
        LIMIT 1`,

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.effortLevel.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.effortLevel.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    create: vi.fn(),
+    updateMetadata: vi.fn(),
+    get: vi.fn(),
+  },
+  AgentMessagesRepository: {
+    create: vi.fn(),
+    list: vi.fn(),
+  },
+  SessionFilesRepository: {
+    getFilesBySession: vi.fn(),
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  SessionManager: class {
+    async initialize() {}
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: {
+    parse: (id: string) => {
+      const separator = id.indexOf(':');
+      if (separator <= 0) throw new Error(`invalid model: ${id}`);
+      return {
+        provider: id.slice(0, separator),
+        model: id.slice(separator + 1),
+        combined: id,
+      };
+    },
+    tryParse: (id: string) => {
+      const separator = typeof id === 'string' ? id.indexOf(':') : -1;
+      return separator > 0
+        ? { provider: id.slice(0, separator), model: id.slice(separator + 1) }
+        : null;
+    },
+    getDefaultModelId: (provider: string) => `${provider}:default`,
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn() }),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => null }));
+vi.mock('../../utils/timestampUtils', () => ({ toMillis: (value: unknown) => value }));
+vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
+vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({
+  database: {
+    query: vi.fn(),
+  },
+}));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => null }));
+vi.mock('../../file/GitRefWatcher', () => ({ gitRefWatcher: {} }));
+vi.mock('./ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({ setMetaAgentToolFns: vi.fn() }));
+vi.mock('../metaAgentNotificationSignature', () => ({ computeNotificationSignature: vi.fn() }));
+vi.mock('../metaAgentMessageText', () => ({
+  extractMessageText: (content: unknown) => (typeof content === 'string' ? content : ''),
+  extractUserPrompts: () => [],
+}));
+
+import {
+  AISessionsRepository,
+  AgentMessagesRepository,
+  SessionFilesRepository,
+} from '@nimbalyst/runtime';
+import { database as databaseWorker } from '../../database/PGLiteDatabaseWorker';
+import { MetaAgentService } from '../MetaAgentService';
+
+const WORKSPACE = '/workspace/path';
+
+const CODEX_PARENT = {
+  id: 'parent-codex-session',
+  provider: 'openai-codex',
+  model: 'openai-codex:gpt-5.6-sol',
+  title: 'Codex parent',
+  workspacePath: WORKSPACE,
+  worktreeId: null,
+  parentSessionId: null,
+  sessionType: 'session',
+  metadata: { effortLevel: 'max' },
+};
+
+function installAIService(service: MetaAgentService) {
+  const queuePromptForSession = vi.fn().mockResolvedValue({ id: 'queued-1' });
+  const triggerQueuedPromptProcessingForSession = vi.fn().mockResolvedValue(undefined);
+  (service as any).aiService = {
+    queuePromptForSession,
+    triggerQueuedPromptProcessingForSession,
+  };
+  return { queuePromptForSession, triggerQueuedPromptProcessingForSession };
+}
+
+describe('MetaAgentService per-child requested effort (#899)', () => {
+  beforeEach(() => {
+    vi.mocked(AISessionsRepository.create).mockReset().mockResolvedValue(undefined);
+    vi.mocked(AISessionsRepository.updateMetadata).mockReset().mockResolvedValue(undefined);
+    vi.mocked(AISessionsRepository.get).mockReset();
+    vi.mocked(AgentMessagesRepository.create).mockReset().mockResolvedValue(undefined);
+    vi.mocked(AgentMessagesRepository.list).mockReset().mockResolvedValue([] as never);
+    vi.mocked(SessionFilesRepository.getFilesBySession).mockReset().mockResolvedValue([] as never);
+    vi.mocked(databaseWorker.query)
+      .mockReset()
+      .mockResolvedValue({ rows: [{ in_flight: '0', total: '0' }] } as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists explicit max before queue/trigger and reports it as requested, not effective', async () => {
+    const service = MetaAgentService.getInstance();
+    const { queuePromptForSession, triggerQueuedPromptProcessingForSession } = installAIService(service);
+    vi.spyOn(service as any, 'shouldBypassChildAgentExecutionForTests').mockReturnValue(false);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    const json = await (service as any).createChildSession('parent-codex-session', WORKSPACE, {
+      prompt: 'Implement the focused fix',
+      effortLevel: 'max',
+    });
+    const result = JSON.parse(json);
+
+    expect(result.requestedEffortLevel).toBe('max');
+    expect(result.effectiveEffortLevel).toBeUndefined();
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(result.sessionId, {
+      metadata: { effortLevel: 'max' },
+    });
+
+    const persistOrder = vi.mocked(AISessionsRepository.updateMetadata).mock.invocationCallOrder[0];
+    const queueOrder = queuePromptForSession.mock.invocationCallOrder[0];
+    const triggerOrder = triggerQueuedPromptProcessingForSession.mock.invocationCallOrder[0];
+    expect(persistOrder).toBeLessThan(queueOrder);
+    expect(queueOrder).toBeLessThan(triggerOrder);
+  });
+
+  it('keeps effort metadata absent when omitted and does not inherit the parent effort', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    const result = await (service as any).createChildSessionInternal('parent-codex-session', WORKSPACE, {
+      model: 'openai-codex:gpt-5.6-sol',
+    });
+
+    expect(result.requestedEffortLevel).toBeUndefined();
+    expect(AISessionsRepository.updateMetadata).not.toHaveBeenCalled();
+    const created = vi.mocked(AISessionsRepository.create).mock.calls[0][0] as any;
+    expect(created.model).toBe('openai-codex:gpt-5.6-sol');
+    expect(created).not.toHaveProperty('effortLevel');
+  });
+
+  it('applies explicit effort only to the target child', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    const explicit = await (service as any).createChildSessionInternal('parent-codex-session', WORKSPACE, {
+      effortLevel: 'low',
+    });
+    const omitted = await (service as any).createChildSessionInternal('parent-codex-session', WORKSPACE, {});
+
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledTimes(1);
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(explicit.sessionId, {
+      metadata: { effortLevel: 'low' },
+    });
+    expect(AISessionsRepository.updateMetadata).not.toHaveBeenCalledWith(
+      omitted.sessionId,
+      expect.objectContaining({ metadata: expect.objectContaining({ effortLevel: expect.anything() }) }),
+    );
+  });
+
+  it('rejects invalid effort before creating a session', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    await expect(
+      (service as any).createChildSessionInternal('parent-codex-session', WORKSPACE, {
+        effortLevel: 'ultra',
+      }),
+    ).rejects.toThrow('Invalid effortLevel "ultra". Expected one of: low, medium, high, xhigh, max');
+
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+    expect(AISessionsRepository.updateMetadata).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid spawn_session effort before resolving or mutating an ungrouped parent', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+    const resolveWorkstream = vi.spyOn(service as any, 'resolveOrCreateWorkstream');
+
+    await expect(
+      (service as any).spawnSession('parent-codex-session', WORKSPACE, {
+        prompt: 'Spawn with invalid effort',
+        effortLevel: 'ultra',
+      }),
+    ).rejects.toThrow('Invalid effortLevel "ultra". Expected one of: low, medium, high, xhigh, max');
+
+    expect(resolveWorkstream).not.toHaveBeenCalled();
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+    expect(AISessionsRepository.updateMetadata).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported-provider spawn_session effort before resolving or mutating an ungrouped parent', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      ...CODEX_PARENT,
+      provider: 'openai-codex-acp',
+      model: 'openai-codex-acp:gpt-5.6-sol',
+    } as any);
+    const resolveWorkstream = vi.spyOn(service as any, 'resolveOrCreateWorkstream');
+
+    await expect(
+      (service as any).spawnSession('parent-codex-acp-session', WORKSPACE, {
+        prompt: 'Spawn with unsupported effort',
+        effortLevel: 'max',
+      }),
+    ).rejects.toThrow(
+      'effortLevel is supported only for openai-codex child sessions; resolved provider was openai-codex-acp',
+    );
+
+    expect(resolveWorkstream).not.toHaveBeenCalled();
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+    expect(AISessionsRepository.updateMetadata).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['openai-codex-acp', 'openai-codex-acp:gpt-5.6-sol'],
+    ['claude-code', 'claude-code:opus'],
+    ['opencode', 'opencode:default'],
+  ])('rejects explicit effort for resolved provider %s before creation', async (provider, model) => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      ...CODEX_PARENT,
+      provider,
+      model,
+    } as any);
+
+    await expect(
+      (service as any).createChildSessionInternal('parent-non-codex', WORKSPACE, {
+        effortLevel: 'high',
+      }),
+    ).rejects.toThrow(`effortLevel is supported only for openai-codex child sessions; resolved provider was ${provider}`);
+
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('forwards explicit effort through default spawn_session and leaves completion notification disabled', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    const json = await (service as any).spawnSession('parent-codex-session', WORKSPACE, {
+      prompt: 'Continue in a sibling',
+      effortLevel: 'xhigh',
+      isolated: true,
+    });
+    const result = JSON.parse(json);
+
+    expect(result.requestedEffortLevel).toBe('xhigh');
+    expect(result.effectiveEffortLevel).toBeUndefined();
+    expect(result.notifyOnComplete).toBe(false);
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(result.sessionId, {
+      metadata: { effortLevel: 'xhigh' },
+    });
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(result.sessionId, {
+      metadata: { notifyParent: false },
+    });
+  });
+
+  it('reports requested effort in get_session_status without claiming an effective effort', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(databaseWorker.query).mockResolvedValueOnce({
+      rows: [{
+        id: 'child-1',
+        title: 'Effort child',
+        status: 'idle',
+        last_activity: 10,
+        updated_at: 11,
+        provider: 'openai-codex',
+        model: 'openai-codex:gpt-5.6-sol',
+        created_by_session_id: 'parent-1',
+        agent_role: 'standard',
+        metadata: { effortLevel: 'max' },
+      }],
+    } as any);
+
+    const status = JSON.parse(await (service as any).getSessionStatusJson('child-1', WORKSPACE));
+
+    expect(status.requestedEffortLevel).toBe('max');
+    expect(status.effectiveEffortLevel).toBeUndefined();
+  });
+
+  it('reports requested effort in get_session_result without claiming an effective effort', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      id: 'child-1',
+      title: 'Effort child',
+      provider: 'openai-codex',
+      model: 'openai-codex:gpt-5.6-sol',
+      workspacePath: WORKSPACE,
+      worktreeId: null,
+      createdAt: 1,
+      updatedAt: 2,
+      metadata: { effortLevel: 'max' },
+    } as any);
+    vi.mocked(databaseWorker.query)
+      .mockResolvedValueOnce({ rows: [{ status: 'idle', last_activity: 3 }] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any);
+
+    const result = JSON.parse(await (service as any).getSessionResultJson('child-1', WORKSPACE));
+
+    expect(result.requestedEffortLevel).toBe('max');
+    expect(result.effectiveEffortLevel).toBeUndefined();
+  });
+});

--- a/packages/electron/src/main/services/__tests__/PGLiteSessionStore.test.ts
+++ b/packages/electron/src/main/services/__tests__/PGLiteSessionStore.test.ts
@@ -208,6 +208,33 @@ describe('PGLiteSessionStore JSON-column read normalization', () => {
 });
 
 describe('PGLiteSessionStore.updateMetadata defense-in-depth', () => {
+  it('shallow-merges sequential effort and notification metadata writes', async () => {
+    let storedMetadata: Record<string, unknown> = {};
+    const persistedWrites: Record<string, unknown>[] = [];
+    const db = {
+      query: vi.fn(async (sql: string, values: unknown[] = []) => {
+        if (/SELECT metadata FROM ai_sessions/i.test(sql)) {
+          return { rows: [{ metadata: JSON.stringify(storedMetadata) }] };
+        }
+        if (/UPDATE ai_sessions SET metadata =/i.test(sql)) {
+          storedMetadata = JSON.parse(values[1] as string) as Record<string, unknown>;
+          persistedWrites.push({ ...storedMetadata });
+        }
+        return { rows: [] };
+      }),
+    };
+    const store = createPGLiteSessionStore(db as any);
+
+    await store.updateMetadata('s1', { metadata: { effortLevel: 'xhigh' } });
+    await store.updateMetadata('s1', { metadata: { notifyParent: false } });
+
+    expect(persistedWrites).toEqual([
+      { effortLevel: 'xhigh' },
+      { effortLevel: 'xhigh', notifyParent: false },
+    ]);
+    expect(storedMetadata).toEqual({ effortLevel: 'xhigh', notifyParent: false });
+  });
+
   it('refuses to merge when metadata.metadata is a string and warns', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const db = {

--- a/packages/electron/src/main/services/ai/__tests__/MessageStreamingHandler.codexEffortHandoff.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/MessageStreamingHandler.codexEffortHandoff.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+vi.mock('../../../utils/logger', () => ({
+  logger: { main: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+}));
+
+vi.mock('../../FeatureUsageService.ts', () => ({
+  FEATURES: { AI_PROMPT_SUBMITTED: 'ai_prompt_submitted' },
+  FeatureUsageService: {
+    getInstance: () => ({ recordUsage: vi.fn() }),
+  },
+}));
+
+vi.mock('../../SoundNotificationService', () => ({
+  SoundNotificationService: {
+    getInstance: () => ({ playCompletionSound: vi.fn() }),
+  },
+}));
+
+vi.mock('../../NotificationService', () => ({
+  notificationService: { showNotification: vi.fn() },
+}));
+
+vi.mock('../../../tray/TrayManager', () => ({
+  TrayManager: {
+    getInstance: () => ({ onSessionUnread: vi.fn() }),
+  },
+}));
+
+vi.mock('../../../window/WindowManager', () => ({
+  windowStates: new Map(),
+  findWindowByWorkspace: vi.fn(() => null),
+}));
+
+vi.mock('../../../utils/store', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../utils/store')>()),
+  getDefaultEffortLevel: () => 'high',
+}));
+
+import {
+  OpenAICodexProvider,
+  ProviderFactory,
+} from '@nimbalyst/runtime/ai/server';
+import { MessageStreamingHandler } from '../MessageStreamingHandler';
+
+describe('MessageStreamingHandler Codex effort production handoff (#899)', () => {
+  afterEach(() => {
+    ProviderFactory.destroyAll();
+    vi.restoreAllMocks();
+  });
+
+  it('passes persisted session effort to the actual OpenAICodexProvider initialization', async () => {
+    const sessionId = 'persisted-codex-effort-session';
+    const workspacePath = '/workspace/path';
+    const persistedSession = {
+      id: sessionId,
+      provider: 'openai-codex',
+      model: 'openai-codex:gpt-5.6-sol',
+      title: 'Persisted Codex child',
+      sessionType: 'session',
+      mode: 'agent',
+      workspacePath,
+      providerConfig: {},
+      providerSessionId: undefined,
+      metadata: { effortLevel: 'xhigh' },
+      messages: [
+        { type: 'assistant_message', role: 'assistant', content: 'existing', timestamp: 1 },
+        { type: 'user_message', role: 'user', content: 'existing', timestamp: 2 },
+      ],
+    };
+    const sessionManager = {
+      loadSession: vi.fn().mockResolvedValue(persistedSession),
+      addMessage: vi.fn().mockResolvedValue(undefined),
+      updateSessionTitle: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = {
+      sessionManager,
+      analytics: { sendEvent: vi.fn() },
+      sendMessageHandler: null,
+      processingQueuedPromptIds: new Set<string>(),
+      matchDebounceTimers: new Map(),
+      sessionsProcessingQueue: new Set<string>(),
+      hooklessWatcher: {
+        ensureForSession: vi.fn().mockResolvedValue(undefined),
+        stopForSession: vi.fn().mockResolvedValue(undefined),
+      },
+      getApiKeyForProvider: vi.fn(() => undefined),
+      createToolHandler: vi.fn(() => vi.fn()),
+    };
+    const stopAfterHandoff = new Error('stop after provider initialization handoff');
+    const initialize = vi
+      .spyOn(OpenAICodexProvider.prototype, 'initialize')
+      .mockRejectedValue(stopAfterHandoff);
+    const handler = new MessageStreamingHandler(service as never);
+
+    const result = await handler.handle(
+      { sender: { id: 1, send: vi.fn() } } as never,
+      'Run the persisted child',
+      undefined,
+      sessionId,
+      workspacePath,
+    );
+
+    expect(sessionManager.loadSession).toHaveBeenCalledWith(sessionId, workspacePath);
+    expect(ProviderFactory.getProvider('openai-codex', sessionId)).toBeInstanceOf(OpenAICodexProvider);
+    expect(initialize).toHaveBeenCalledWith(expect.objectContaining({
+      effortLevel: 'xhigh',
+      model: 'gpt-5.6-sol',
+    }));
+    expect(result).toEqual({ content: '' });
+
+    handler.destroy();
+  });
+});

--- a/packages/runtime/src/ai/server/protocols/__tests__/CodexAppServerProtocol.test.ts
+++ b/packages/runtime/src/ai/server/protocols/__tests__/CodexAppServerProtocol.test.ts
@@ -158,6 +158,45 @@ describe('CodexAppServerProtocol', () => {
     protocol.cleanupSession(session);
   });
 
+  it('normalizes requested max effort to xhigh in Codex thread config', async () => {
+    const protocol = new CodexAppServerProtocol();
+    const sessionPromise = protocol.createSession({
+      workspacePath: '/tmp/ws',
+      raw: { effortLevel: 'max' },
+    } as never);
+
+    const initReq = await nextWrittenMatching(child, 'initialize');
+    child.emitLine({ id: initReq.id, result: { codexHome: '/fake', platformFamily: 'unix', platformOs: 'macos', userAgent: 'fake/0' } });
+    const startReq = await nextWrittenMatching(child, 'thread/start');
+    expect((startReq.params as { config: { model_reasoning_effort: string } }).config.model_reasoning_effort).toBe('xhigh');
+    child.emitLine({ id: startReq.id, result: { thread: { id: 'thread-max-effort' } } });
+
+    const session = await sessionPromise;
+    protocol.cleanupSession(session);
+  });
+
+  it('forwards a suffixed model string without inferring effort from it', async () => {
+    const protocol = new CodexAppServerProtocol();
+    const sessionPromise = protocol.createSession({
+      workspacePath: '/tmp/ws',
+      model: 'gpt-5.6-sol-xhigh',
+    });
+
+    const initReq = await nextWrittenMatching(child, 'initialize');
+    child.emitLine({ id: initReq.id, result: { codexHome: '/fake', platformFamily: 'unix', platformOs: 'macos', userAgent: 'fake/0' } });
+    const startReq = await nextWrittenMatching(child, 'thread/start');
+    const params = startReq.params as {
+      model: string;
+      config: { model_reasoning_effort: string };
+    };
+    expect(params.model).toBe('gpt-5.6-sol-xhigh');
+    expect(params.config.model_reasoning_effort).toBe('high');
+    child.emitLine({ id: startReq.id, result: { thread: { id: 'thread-suffixed-model' } } });
+
+    const session = await sessionPromise;
+    protocol.cleanupSession(session);
+  });
+
   it('streams agentMessage deltas as text events and emits complete on turn/completed', async () => {
     const protocol = new CodexAppServerProtocol();
     const sessionPromise = protocol.createSession({ workspacePath: '/tmp/ws' });

--- a/packages/runtime/src/ai/server/protocols/__tests__/CodexSDKProtocol.test.ts
+++ b/packages/runtime/src/ai/server/protocols/__tests__/CodexSDKProtocol.test.ts
@@ -172,6 +172,58 @@ describe('CodexSDKProtocol', () => {
     expect('additionalDirectories' in passedOptions).toBe(false);
   });
 
+  it('normalizes requested max effort to xhigh in legacy SDK thread options', async () => {
+    const startThread = vi.fn((_options?: Record<string, unknown>) => ({
+      id: 'thread-max-effort',
+      runStreamed: vi.fn(),
+    }));
+    const protocol = new CodexSDKProtocol(
+      'test-key',
+      async () =>
+        ({
+          Codex: class {
+            startThread = startThread;
+            resumeThread = vi.fn();
+          },
+        }) as any
+    );
+
+    await protocol.createSession({
+      workspacePath: '/projects/main',
+      raw: { effortLevel: 'max' },
+    } as any);
+
+    const passedOptions = startThread.mock.calls[0]![0] as Record<string, unknown>;
+    expect(passedOptions.modelReasoningEffort).toBe('xhigh');
+    expect(passedOptions).not.toHaveProperty('effortLevel');
+  });
+
+  it('forwards a suffixed model string without inferring effort from it', async () => {
+    const startThread = vi.fn((_options?: Record<string, unknown>) => ({
+      id: 'thread-suffixed-model',
+      runStreamed: vi.fn(),
+    }));
+    const protocol = new CodexSDKProtocol(
+      'test-key',
+      async () =>
+        ({
+          Codex: class {
+            startThread = startThread;
+            resumeThread = vi.fn();
+          },
+        }) as any
+    );
+
+    await protocol.createSession({
+      workspacePath: '/projects/main',
+      model: 'gpt-5.6-sol-xhigh',
+    });
+
+    const passedOptions = startThread.mock.calls[0]![0] as Record<string, unknown>;
+    expect(passedOptions.model).toBe('gpt-5.6-sol-xhigh');
+    expect(passedOptions.modelReasoningEffort).toBe('high');
+  });
+
   it('passes image attachments as structured local_image inputs', async () => {
     const runStreamed = vi.fn(async () => ({
       events: createAsyncEventStream([

--- a/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
@@ -536,6 +536,53 @@ describe('OpenAICodexProvider', () => {
     );
   });
 
+  it('forwards initialized effort through the provider session options', async () => {
+    const createSession = vi.fn(async () => ({
+      id: 'thread-effort-forward',
+      platform: 'codex-app-server',
+      raw: { fake: true },
+    }));
+    const protocol = {
+      platform: 'codex-app-server',
+      createSession,
+      resumeSession: vi.fn(),
+      forkSession: vi.fn(),
+      sendMessage: vi.fn(() => createAsyncEventStream([
+        {
+          type: 'complete',
+          content: 'done',
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        },
+      ])),
+      abortSession: vi.fn(),
+      cleanupSession: vi.fn(),
+    } as any;
+    const provider = new OpenAICodexProvider(
+      { apiKey: 'test-key' },
+      { protocol },
+    );
+
+    await provider.initialize({
+      apiKey: 'test-key',
+      model: 'openai-codex:gpt-5.6-sol',
+      effortLevel: 'xhigh',
+    });
+    for await (const _chunk of provider.sendMessage(
+      'Use the configured effort',
+      undefined,
+      'session-effort-forward',
+      [],
+      process.cwd(),
+    )) {
+      // drain
+    }
+
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(createSession).toHaveBeenCalledWith(expect.objectContaining({
+      raw: expect.objectContaining({ effortLevel: 'xhigh' }),
+    }));
+  });
+
   it('persists Codex input attachments in logged message metadata for transcript restoration', async () => {
     const createSession = vi.fn(async () => ({
       id: 'thread-image-metadata',


### PR DESCRIPTION
## Summary

Adds optional `effortLevel` support to `create_session` and `spawn_session`. Explicit Codex effort is saved before the first prompt, unsupported combinations fail early, and responses report only the requested value.

`max` remains the requested value while existing Codex transports normalize it to `xhigh`.

## Checks

- Focused tests: 97 passed
- Workspace typecheck: passed
- Full pre-push: partial — 5,624 passed; two SafeExec-blocked Git tests and three full-suite timeouts remain

Fixes #899

_Prepared and published with OpenAI Codex under the user’s supervision._