### PR TITLE
fix: reap Codex child process trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 <!-- Bug fixes go here -->
 - Usage indicators (Claude, Codex, Gemini) hidden from the navigation gutter can now be restored by right-clicking the gutter.
+- Codex sessions now reap owned child process trees and release idle or archived providers, preventing orphan Git and MCP processes from accumulating.
 - Commit with AI in a worktree no longer sweeps in ignored files like node_modules when an untracked folder is present, so it proposes only the files you actually changed.
 - Team shared documents and trackers no longer show as locked ("No encryption key available") after a network change or brief server outage.
 - Embedded spreadsheets and code editors in the chat transcript no longer steal focus and scroll-jump the transcript back to themselves.

--- a/packages/electron/src/main/ipc/SessionHandlers.ts
+++ b/packages/electron/src/main/ipc/SessionHandlers.ts
@@ -26,6 +26,7 @@ import {
 import { enrichTranscriptMessagesWithToolCallDiffs } from '../services/TranscriptToolCallEnricher';
 import { setSessionPendingPrompt } from '../services/ai/pendingPromptPersistence';
 import { normalizeSessionPhaseMetadataUpdate } from '../services/session/sessionPhaseTransition';
+import { destroyProviderForArchivedSession } from '../services/ai/archiveSessionProviderLifecycle';
 
 // Initialize session manager
 const sessionManager = new SessionManager();
@@ -350,6 +351,7 @@ export async function registerSessionHandlers() {
 
     // Delete session
     safeHandle('session:delete', async (event, sessionId: string) => {
+        ProviderFactory.destroyProvider(sessionId);
         await sessionManager.deleteSession(sessionId);
     });
 
@@ -422,6 +424,16 @@ export async function registerSessionHandlers() {
             }
 
             await AISessionsRepository.updateMetadata(sessionId, updates);
+
+            if (updates.isArchived === true) {
+                destroyProviderForArchivedSession(
+                    sessionId,
+                    (id) => ProviderFactory.destroyProvider(id),
+                    (id, cleanupError) => {
+                        console.error(`[SessionHandlers] Failed to destroy provider for archived session ${id}:`, cleanupError);
+                    }
+                );
+            }
 
             // Notify renderer windows so session list state stays in sync without waiting for full refresh.
             // This covers model/provider/title updates from SessionTranscript and similar paths.

--- a/packages/electron/src/main/ipc/WorktreeHandlers.ts
+++ b/packages/electron/src/main/ipc/WorktreeHandlers.ts
@@ -15,6 +15,7 @@ import { createSuperLoopStore } from '../services/SuperLoopStore';
 import { getDatabase } from '../database/initialize';
 import { archiveProgressManager } from '../services/ArchiveProgressManager';
 import { AISessionsRepository } from '@nimbalyst/runtime/storage/repositories/AISessionsRepository';
+import { ProviderFactory } from '@nimbalyst/runtime/ai/server';
 import { AnalyticsService } from '../services/analytics/AnalyticsService';
 import { getTerminalSessionManager } from '../services/TerminalSessionManager';
 import { getTerminalsByWorktreeId, deleteTerminalInstance } from '../utils/terminalStore';
@@ -22,6 +23,7 @@ import { gitRefWatcher } from '../file/GitRefWatcher';
 import type { WorktreeCreateResult } from '../../shared/ipc/types';
 import { gitOperationLock } from '../services/GitOperationLock';
 import fs from 'node:fs';
+import { archiveSessionsAndDestroyProviders } from '../services/ai/archiveSessionProviderLifecycle';
 
 const logger = log.scope('WorktreeHandlers');
 
@@ -77,18 +79,32 @@ async function archiveSessionsForWorktree(
   sessionIds: string[],
   archiveLogger: ReturnType<typeof log.scope>
 ): Promise<number> {
-  let failedSessions = 0;
-
-  for (const sessionId of sessionIds) {
-    try {
+  const result = await archiveSessionsAndDestroyProviders(sessionIds, {
+    archiveSession: async (sessionId) => {
       await AISessionsRepository.updateMetadata(sessionId, { isArchived: true });
-    } catch (err) {
-      failedSessions++;
-      archiveLogger.error('Failed to archive session', { sessionId, worktreeId, error: err });
-    }
+    },
+    destroyProvider: (sessionId) => ProviderFactory.destroyProvider(sessionId),
+    onArchiveError: (sessionId, error) => {
+      archiveLogger.error('Failed to archive session', { sessionId, worktreeId, error });
+    },
+    onProviderCleanupError: (sessionId, error) => {
+      archiveLogger.error('Failed to destroy archived session provider', {
+        sessionId,
+        worktreeId,
+        error,
+      });
+    },
+  });
+
+  if (result.providerCleanupFailures > 0) {
+    archiveLogger.warn('Some archived session providers failed to clean up', {
+      worktreeId,
+      failedCount: result.providerCleanupFailures,
+      totalCount: sessionIds.length,
+    });
   }
 
-  return failedSessions;
+  return result.archiveFailures;
 }
 
 /**

--- a/packages/electron/src/main/services/ai/__tests__/archiveSessionProviderLifecycle.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/archiveSessionProviderLifecycle.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  archiveSessionsAndDestroyProviders,
+  destroyProviderForArchivedSession,
+} from '../archiveSessionProviderLifecycle';
+
+describe('archive session provider lifecycle', () => {
+  it('archives and destroys only the providers owned by the supplied sessions', async () => {
+    const events: string[] = [];
+    const result = await archiveSessionsAndDestroyProviders(
+      ['session-a', 'session-b'],
+      {
+        archiveSession: vi.fn(async (sessionId) => {
+          events.push(`archive:${sessionId}`);
+        }),
+        destroyProvider: vi.fn((sessionId) => {
+          events.push(`destroy:${sessionId}`);
+        }),
+      },
+    );
+
+    expect(events).toEqual([
+      'archive:session-a',
+      'destroy:session-a',
+      'archive:session-b',
+      'destroy:session-b',
+    ]);
+    expect(result).toEqual({ archiveFailures: 0, providerCleanupFailures: 0 });
+  });
+
+  it('does not destroy a provider when that session failed to archive', async () => {
+    const destroyProvider = vi.fn();
+    const onArchiveError = vi.fn();
+    const result = await archiveSessionsAndDestroyProviders(
+      ['session-failed', 'session-ok'],
+      {
+        archiveSession: vi.fn(async (sessionId) => {
+          if (sessionId === 'session-failed') throw new Error('database unavailable');
+        }),
+        destroyProvider,
+        onArchiveError,
+      },
+    );
+
+    expect(destroyProvider).toHaveBeenCalledTimes(1);
+    expect(destroyProvider).toHaveBeenCalledWith('session-ok');
+    expect(onArchiveError).toHaveBeenCalledWith('session-failed', expect.any(Error));
+    expect(result).toEqual({ archiveFailures: 1, providerCleanupFailures: 0 });
+  });
+
+  it('bounds provider cleanup errors and continues archiving the remaining sessions', async () => {
+    const destroyProvider = vi.fn((sessionId: string) => {
+      if (sessionId === 'session-a') throw new Error('provider cleanup failed');
+    });
+    const onProviderCleanupError = vi.fn();
+    const result = await archiveSessionsAndDestroyProviders(
+      ['session-a', 'session-b'],
+      {
+        archiveSession: vi.fn(async () => {}),
+        destroyProvider,
+        onProviderCleanupError,
+      },
+    );
+
+    expect(destroyProvider).toHaveBeenCalledTimes(2);
+    expect(onProviderCleanupError).toHaveBeenCalledWith('session-a', expect.any(Error));
+    expect(result).toEqual({ archiveFailures: 0, providerCleanupFailures: 1 });
+  });
+
+  it('provides a bounded exact-session cleanup primitive for ordinary archive paths', () => {
+    const destroyProvider = vi.fn(() => {
+      throw new Error('cleanup failed');
+    });
+    const onProviderCleanupError = vi.fn();
+
+    expect(destroyProviderForArchivedSession(
+      'ordinary-session',
+      destroyProvider,
+      onProviderCleanupError,
+    )).toBe(false);
+    expect(destroyProvider).toHaveBeenCalledOnce();
+    expect(destroyProvider).toHaveBeenCalledWith('ordinary-session');
+    expect(onProviderCleanupError).toHaveBeenCalledWith(
+      'ordinary-session',
+      expect.any(Error),
+    );
+  });
+});

--- a/packages/electron/src/main/services/ai/archiveSessionProviderLifecycle.ts
+++ b/packages/electron/src/main/services/ai/archiveSessionProviderLifecycle.ts
@@ -1,0 +1,61 @@
+export interface ArchiveSessionProviderLifecycleDeps {
+  archiveSession(sessionId: string): Promise<void>;
+  destroyProvider(sessionId: string): void;
+  onArchiveError?(sessionId: string, error: unknown): void;
+  onProviderCleanupError?(sessionId: string, error: unknown): void;
+}
+
+export interface ArchiveSessionProviderLifecycleResult {
+  archiveFailures: number;
+  providerCleanupFailures: number;
+}
+
+/**
+ * Release the provider owned by one session after its archive write succeeds.
+ * Errors are bounded so archive/delete workflows can continue converging.
+ */
+export function destroyProviderForArchivedSession(
+  sessionId: string,
+  destroyProvider: (sessionId: string) => void,
+  onProviderCleanupError?: (sessionId: string, error: unknown) => void,
+): boolean {
+  try {
+    destroyProvider(sessionId);
+    return true;
+  } catch (error) {
+    onProviderCleanupError?.(sessionId, error);
+    return false;
+  }
+}
+
+/**
+ * Archive an exact set of sessions and then release only their providers.
+ * A failed archive does not kill that session's live provider; other sessions
+ * continue independently and both failure classes are reported separately.
+ */
+export async function archiveSessionsAndDestroyProviders(
+  sessionIds: Iterable<string>,
+  deps: ArchiveSessionProviderLifecycleDeps,
+): Promise<ArchiveSessionProviderLifecycleResult> {
+  let archiveFailures = 0;
+  let providerCleanupFailures = 0;
+
+  for (const sessionId of new Set(sessionIds)) {
+    try {
+      await deps.archiveSession(sessionId);
+    } catch (error) {
+      archiveFailures++;
+      deps.onArchiveError?.(sessionId, error);
+      continue;
+    }
+
+    const cleaned = destroyProviderForArchivedSession(
+      sessionId,
+      deps.destroyProvider,
+      deps.onProviderCleanupError,
+    );
+    if (!cleaned) providerCleanupFailures++;
+  }
+
+  return { archiveFailures, providerCleanupFailures };
+}

--- a/packages/runtime/src/ai/server/ProviderFactory.ts
+++ b/packages/runtime/src/ai/server/ProviderFactory.ts
@@ -17,6 +17,7 @@ import { ProviderConfig, AIProviderType, assertExhaustiveProvider } from './type
 
 export class ProviderFactory {
   private static providers: Map<string, AIProvider> = new Map();
+  private static providerOwners: Map<string, string> = new Map();
 
   /**
    * Get an existing AI provider instance
@@ -87,6 +88,7 @@ export class ProviderFactory {
     
     // Cache the provider
     this.providers.set(key, provider);
+    this.providerOwners.set(key, sessionId);
     // console.log(`[ProviderFactory] Created ${type} provider in ${Date.now() - startTime}ms`);
 
     return provider;
@@ -127,6 +129,7 @@ export class ProviderFactory {
       model: args.model,
     });
     this.providers.set(key, provider);
+    this.providerOwners.set(key, args.sessionId);
     return provider;
   }
 
@@ -153,17 +156,28 @@ export class ProviderFactory {
       const key = `${type}-${sessionId}`;
       const provider = this.providers.get(key);
       if (provider) {
-        provider.destroy();
-        this.providers.delete(key);
+        this.destroyProviderEntry(key, provider);
       }
     } else {
       // Destroy all providers for this session
-      for (const [key, provider] of this.providers.entries()) {
-        if (key.endsWith(`-${sessionId}`)) {
-          provider.destroy();
-          this.providers.delete(key);
+      for (const [key, provider] of [...this.providers.entries()]) {
+        if (this.providerOwners.get(key) === sessionId) {
+          this.destroyProviderEntry(key, provider);
         }
       }
+    }
+  }
+
+  private static destroyProviderEntry(key: string, provider: AIProvider): void {
+    try {
+      provider.destroy();
+    } catch (error) {
+      console.error(`[ProviderFactory] Error destroying provider ${key}:`, error);
+    } finally {
+      // Never retain a failed provider handle. Reusing a half-destroyed
+      // instance is more dangerous than recreating it on the next turn.
+      this.providers.delete(key);
+      this.providerOwners.delete(key);
     }
   }
 
@@ -174,19 +188,15 @@ export class ProviderFactory {
     // console.log(`[ProviderFactory] Destroying ${this.providers.size} providers`);
 
     // Try to destroy each provider individually with error handling
-    for (const [key, provider] of this.providers.entries()) {
-      try {
-        // console.log(`[ProviderFactory] Destroying provider: ${key}`);
-        provider.destroy();
-      } catch (error) {
-        console.error(`[ProviderFactory] Error destroying provider ${key}:`, error);
-        // Continue destroying other providers
-      }
+    for (const [key, provider] of [...this.providers.entries()]) {
+      // console.log(`[ProviderFactory] Destroying provider: ${key}`);
+      this.destroyProviderEntry(key, provider);
     }
     
     // Clear the map even if some providers failed to destroy
     try {
       this.providers.clear();
+      this.providerOwners.clear();
     } catch (error) {
       console.error('[ProviderFactory] Error clearing providers map:', error);
     }

--- a/packages/runtime/src/ai/server/__tests__/ProviderFactory.lifecycle.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/ProviderFactory.lifecycle.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProviderFactory } from '../ProviderFactory';
+
+function providerMap(): Map<string, { destroy: () => void }> {
+  return (ProviderFactory as unknown as {
+    providers: Map<string, { destroy: () => void }>;
+  }).providers;
+}
+
+function providerOwnerMap(): Map<string, string> {
+  return (ProviderFactory as unknown as {
+    providerOwners: Map<string, string>;
+  }).providerOwners;
+}
+
+function cacheProvider(key: string, sessionId: string, destroy: () => void): void {
+  providerMap().set(key, fakeProvider(destroy));
+  providerOwnerMap().set(key, sessionId);
+}
+
+function fakeProvider(destroy: () => void) {
+  return { destroy } as never;
+}
+
+describe('ProviderFactory lifecycle cleanup', () => {
+  beforeEach(() => {
+    providerMap().clear();
+    providerOwnerMap().clear();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    providerMap().clear();
+    providerOwnerMap().clear();
+    vi.restoreAllMocks();
+  });
+
+  it('destroys only providers owned by the exact session id', () => {
+    const codexDestroy = vi.fn();
+    const claudeDestroy = vi.fn();
+    const otherDestroy = vi.fn();
+    const suffixCollisionDestroy = vi.fn();
+    cacheProvider('openai-codex-session-1', 'session-1', codexDestroy);
+    cacheProvider('claude-session-1', 'session-1', claudeDestroy);
+    cacheProvider('openai-codex-session-10', 'session-10', otherDestroy);
+    cacheProvider('openai-codex-prefix-session-1', 'prefix-session-1', suffixCollisionDestroy);
+
+    ProviderFactory.destroyProvider('session-1');
+
+    expect(codexDestroy).toHaveBeenCalledTimes(1);
+    expect(claudeDestroy).toHaveBeenCalledTimes(1);
+    expect(otherDestroy).not.toHaveBeenCalled();
+    expect(suffixCollisionDestroy).not.toHaveBeenCalled();
+    expect(providerMap().has('openai-codex-session-1')).toBe(false);
+    expect(providerMap().has('claude-session-1')).toBe(false);
+    expect(providerMap().has('openai-codex-session-10')).toBe(true);
+    expect(providerMap().has('openai-codex-prefix-session-1')).toBe(true);
+  });
+
+  it('is an idempotent no-op when a typed provider is not cached', () => {
+    expect(() => {
+      ProviderFactory.destroyProvider('missing-session', 'openai-codex');
+      ProviderFactory.destroyProvider('missing-session', 'openai-codex');
+    }).not.toThrow();
+    expect(providerMap().size).toBe(0);
+  });
+
+  it('bounds provider destroy errors, removes the failed entry, and continues', () => {
+    const throwingDestroy = vi.fn(() => {
+      throw new Error('cleanup failed');
+    });
+    const nextDestroy = vi.fn();
+    cacheProvider('openai-codex-session-1', 'session-1', throwingDestroy);
+    cacheProvider('claude-session-1', 'session-1', nextDestroy);
+
+    expect(() => ProviderFactory.destroyProvider('session-1')).not.toThrow();
+
+    expect(throwingDestroy).toHaveBeenCalledTimes(1);
+    expect(nextDestroy).toHaveBeenCalledTimes(1);
+    expect(providerMap().has('openai-codex-session-1')).toBe(false);
+    expect(providerMap().has('claude-session-1')).toBe(false);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error destroying provider'),
+      expect.any(Error),
+    );
+  });
+
+  it('keeps app shutdown cleanup bounded and clears every cached provider', () => {
+    const throwingDestroy = vi.fn(() => {
+      throw new Error('shutdown cleanup failed');
+    });
+    const nextDestroy = vi.fn();
+    cacheProvider('openai-codex-session-1', 'session-1', throwingDestroy);
+    cacheProvider('claude-session-2', 'session-2', nextDestroy);
+
+    expect(() => ProviderFactory.destroyAll()).not.toThrow();
+
+    expect(throwingDestroy).toHaveBeenCalledTimes(1);
+    expect(nextDestroy).toHaveBeenCalledTimes(1);
+    expect(providerMap().size).toBe(0);
+  });
+});

--- a/packages/runtime/src/ai/server/protocols/CodexAppServerProtocol.ts
+++ b/packages/runtime/src/ai/server/protocols/CodexAppServerProtocol.ts
@@ -44,6 +44,7 @@ import {
   getCodexVendorPathEntries,
   resolveCodexBinaryPath,
 } from './codexAppServer/codexAppServerBinary';
+import { terminateOwnedProcessTree } from './processTreeTermination';
 import type {
   AnyItem,
   ApprovalResponse,
@@ -108,6 +109,8 @@ export interface CodexAppServerProtocolOptions {
   host?: CodexAppServerHostBindings;
   /** Optional client info to send in initialize. */
   clientInfo?: { name: string; version: string };
+  /** Injectable exact-tree terminator for deterministic lifecycle tests. */
+  terminateProcessTreeOverride?: (child: ChildProcessWithoutNullStreams) => void;
 }
 
 interface AppServerSessionRaw {
@@ -122,6 +125,8 @@ interface AppServerSessionRaw {
   activeTurnId: string | null;
   /** stderr buffer for diagnostic surface on failure. */
   stderrTail: string[];
+  /** Prevent duplicate cleanup from re-targeting a PID after it exits. */
+  cleanupStarted: boolean;
 }
 
 function previewForLog(value: string | undefined, max = 300): string | undefined {
@@ -186,12 +191,15 @@ export class CodexAppServerProtocol implements AgentProtocol {
   private readonly resolveCodexPathOverride: () => string | undefined;
   private readonly host: CodexAppServerHostBindings;
   private readonly clientInfo: { name: string; version: string };
+  private readonly terminateProcessTree: (child: ChildProcessWithoutNullStreams) => void;
 
   constructor(options: CodexAppServerProtocolOptions = {}) {
     this.apiKey = options.apiKey ?? '';
     this.resolveCodexPathOverride = options.resolveCodexPathOverride ?? (() => undefined);
     this.host = options.host ?? {};
     this.clientInfo = options.clientInfo ?? { name: 'nimbalyst', version: '0.0.0' };
+    this.terminateProcessTree = options.terminateProcessTreeOverride
+      ?? ((child) => terminateOwnedProcessTree(child));
   }
 
   setApiKey(apiKey: string): void {
@@ -417,11 +425,10 @@ export class CodexAppServerProtocol implements AgentProtocol {
   }
 
   private killChild(raw: AppServerSessionRaw): void {
+    if (raw.cleanupStarted) return;
+    raw.cleanupStarted = true;
     try { raw.client.close('cleanup'); } catch { /* noop */ }
-    if (!raw.child.killed) {
-      try { raw.child.stdin?.end(); } catch { /* noop */ }
-      try { raw.child.kill(); } catch { /* noop */ }
-    }
+    this.terminateProcessTree(raw.child);
   }
 
   private async spawnAndInit(options: SessionOptions): Promise<AppServerSessionRaw> {
@@ -464,7 +471,7 @@ export class CodexAppServerProtocol implements AgentProtocol {
       client.notify('initialized', {});
     } catch (err) {
       try { client.close('init failed'); } catch { /* noop */ }
-      try { child.kill(); } catch { /* noop */ }
+      this.terminateProcessTree(child);
       const tail = stderrTail.join('').slice(-2000);
       const rawError = `${err instanceof Error ? err.message : String(err)}${tail ? `\nstderr tail: ${tail}` : ''}`;
       const configHint = describeCodexConfigError(rawError);
@@ -479,6 +486,7 @@ export class CodexAppServerProtocol implements AgentProtocol {
       dynamicTools: this.extractDynamicTools(options),
       activeTurnId: null,
       stderrTail,
+      cleanupStarted: false,
     };
   }
 

--- a/packages/runtime/src/ai/server/protocols/__tests__/CodexAppServerProtocol.test.ts
+++ b/packages/runtime/src/ai/server/protocols/__tests__/CodexAppServerProtocol.test.ts
@@ -11,8 +11,11 @@ import { PassThrough } from 'node:stream';
 // IMPORTANT: mock `node:child_process` BEFORE importing the protocol so the
 // module under test picks up the stub.
 const spawnMock = vi.fn();
+const taskkillSpawnMock = vi.fn();
 vi.mock('node:child_process', () => {
-  const spawn = (...args: unknown[]) => spawnMock(...args);
+  const spawn = (...args: unknown[]) => args[0] === 'taskkill.exe'
+    ? taskkillSpawnMock(...args)
+    : spawnMock(...args);
   return { spawn, default: { spawn } };
 });
 
@@ -117,6 +120,18 @@ describe('CodexAppServerProtocol', () => {
     child = new FakeChildProcess();
     spawnMock.mockReset();
     spawnMock.mockReturnValue(child);
+    taskkillSpawnMock.mockReset();
+    taskkillSpawnMock.mockImplementation(() => {
+      const taskkill = {
+        once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+          if (event === 'exit') queueMicrotask(() => callback(0, null));
+          return taskkill;
+        }),
+        unref: vi.fn(),
+        kill: vi.fn(() => true),
+      };
+      return taskkill;
+    });
   });
 
   afterEach(() => {
@@ -156,6 +171,32 @@ describe('CodexAppServerProtocol', () => {
     expect(args).toEqual(['app-server', '--listen', 'stdio://']);
 
     protocol.cleanupSession(session);
+  });
+
+  it('routes cleanup through the owned process-tree terminator exactly once', async () => {
+    const terminateProcessTree = vi.fn((ownedChild: FakeChildProcess) => {
+      // Keep the root alive until the tree terminator has captured it. Ending
+      // stdin first can make codex exit before taskkill /T can traverse.
+      expect(ownedChild.stdin.writableEnded).toBe(false);
+    });
+    const protocol = new CodexAppServerProtocol({
+      terminateProcessTreeOverride: terminateProcessTree,
+    } as never);
+    const sessionPromise = protocol.createSession({ workspacePath: '/tmp/ws' });
+    const initReq = await nextWrittenMatching(child, 'initialize');
+    child.emitLine({ id: initReq.id, result: { codexHome: '/fake', platformFamily: 'unix', platformOs: 'macos', userAgent: 'fake/0' } });
+    const startReq = await nextWrittenMatching(child, 'thread/start');
+    child.emitLine({ id: startReq.id, result: { thread: { id: 'thread-cleanup' } } });
+    const session = await sessionPromise;
+
+    protocol.cleanupSession(session);
+    protocol.cleanupSession(session);
+
+    expect(terminateProcessTree).toHaveBeenCalledTimes(1);
+    expect(terminateProcessTree).toHaveBeenCalledWith(child);
+    // The tree terminator owns shutdown now. Closing stdin here would race the
+    // detached taskkill process and could erase its root before traversal.
+    expect(child.stdin.writableEnded).toBe(false);
   });
 
   it('streams agentMessage deltas as text events and emits complete on turn/completed', async () => {

--- a/packages/runtime/src/ai/server/protocols/__tests__/processTreeTermination.test.ts
+++ b/packages/runtime/src/ai/server/protocols/__tests__/processTreeTermination.test.ts
@@ -1,0 +1,159 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { terminateOwnedProcessTree } from '../processTreeTermination';
+
+function makeChild(overrides: Partial<{
+  pid: number;
+  killed: boolean;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+}> = {}) {
+  return {
+    pid: 4242,
+    killed: false,
+    exitCode: null,
+    signalCode: null,
+    kill: vi.fn(() => true),
+    ...overrides,
+  };
+}
+
+class FakeTaskkillProcess extends EventEmitter {
+  readonly unref = vi.fn();
+  readonly kill = vi.fn(() => true);
+}
+
+describe('terminateOwnedProcessTree', () => {
+  it('spawns an exact detached Windows taskkill tree for the owned root PID', () => {
+    const child = makeChild();
+    const taskkill = new FakeTaskkillProcess();
+    const spawn = vi.fn(() => taskkill);
+
+    terminateOwnedProcessTree(child as never, {
+      platform: 'win32',
+      spawn: spawn as never,
+    });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith(
+      'taskkill.exe',
+      ['/PID', '4242', '/T', '/F'],
+      {
+        stdio: 'ignore',
+        windowsHide: true,
+        detached: true,
+      },
+    );
+    expect(taskkill.unref).toHaveBeenCalledTimes(1);
+    expect(child.kill).not.toHaveBeenCalled();
+    taskkill.emit('exit', 0, null);
+  });
+
+  it('falls back to direct-child termination when Windows tree-kill spawn fails', () => {
+    const child = makeChild();
+    const spawn = vi.fn(() => {
+      throw new Error('taskkill unavailable');
+    });
+
+    terminateOwnedProcessTree(child as never, {
+      platform: 'win32',
+      spawn: spawn as never,
+    });
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back when taskkill exits unsuccessfully', () => {
+    const child = makeChild();
+    const taskkill = new FakeTaskkillProcess();
+
+    terminateOwnedProcessTree(child as never, {
+      platform: 'win32',
+      spawn: vi.fn(() => taskkill) as never,
+    });
+    taskkill.emit('exit', 1, null);
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds a hung taskkill helper and falls back without blocking', () => {
+    vi.useFakeTimers();
+    const child = makeChild();
+    const taskkill = new FakeTaskkillProcess();
+
+    try {
+      terminateOwnedProcessTree(child as never, {
+        platform: 'win32',
+        spawn: vi.fn(() => taskkill) as never,
+      });
+      vi.advanceTimersByTime(5_000);
+
+      expect(taskkill.kill).toHaveBeenCalledTimes(1);
+      expect(child.kill).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still converges the Windows tree after a prior direct kill signal', () => {
+    const child = makeChild({ killed: true });
+    const taskkill = new FakeTaskkillProcess();
+    const spawn = vi.fn(() => taskkill);
+
+    terminateOwnedProcessTree(child as never, {
+      platform: 'win32',
+      spawn: spawn as never,
+    });
+
+    expect(spawn).toHaveBeenCalledWith(
+      'taskkill.exe',
+      ['/PID', '4242', '/T', '/F'],
+      expect.any(Object),
+    );
+    expect(child.kill).not.toHaveBeenCalled();
+    taskkill.emit('exit', 0, null);
+  });
+
+  it('is idempotent for the same owned child identity', () => {
+    const child = makeChild();
+    const taskkill = new FakeTaskkillProcess();
+    const spawn = vi.fn(() => taskkill);
+    const deps = {
+      platform: 'win32' as const,
+      spawn: spawn as never,
+    };
+
+    terminateOwnedProcessTree(child as never, deps);
+    terminateOwnedProcessTree(child as never, deps);
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(child.kill).not.toHaveBeenCalled();
+    taskkill.emit('exit', 0, null);
+  });
+
+  it('does not target a PID after the owned child has already exited', () => {
+    const child = makeChild({ exitCode: 0 });
+    const spawn = vi.fn();
+
+    terminateOwnedProcessTree(child as never, {
+      platform: 'win32',
+      spawn: spawn as never,
+    });
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('uses direct-child termination on non-Windows platforms', () => {
+    const child = makeChild();
+    const spawn = vi.fn();
+
+    terminateOwnedProcessTree(child as never, {
+      platform: 'linux',
+      spawn: spawn as never,
+    });
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/runtime/src/ai/server/protocols/processTreeTermination.ts
+++ b/packages/runtime/src/ai/server/protocols/processTreeTermination.ts
@@ -1,0 +1,107 @@
+import {
+  spawn as defaultSpawn,
+  type ChildProcess,
+} from 'node:child_process';
+
+const WINDOWS_TREE_KILL_TIMEOUT_MS = 5_000;
+const terminationStarted = new WeakSet<object>();
+
+type OwnedChildProcess = Pick<
+  ChildProcess,
+  'pid' | 'killed' | 'exitCode' | 'signalCode' | 'kill'
+>;
+
+type TaskkillProcess = Pick<ChildProcess, 'once' | 'unref' | 'kill'>;
+type SpawnTaskkill = (
+  command: string,
+  args: string[],
+  options: { stdio: 'ignore'; windowsHide: true; detached: true },
+) => TaskkillProcess;
+
+export interface ProcessTreeTerminationDeps {
+  platform?: NodeJS.Platform;
+  spawn?: SpawnTaskkill;
+}
+
+function hasExited(child: OwnedChildProcess): boolean {
+  return typeof child.exitCode === 'number'
+    || (child.signalCode !== null && child.signalCode !== undefined);
+}
+
+function terminateDirectChild(child: OwnedChildProcess): void {
+  if (child.killed || hasExited(child)) return;
+  try {
+    child.kill();
+  } catch {
+    // Cleanup is intentionally idempotent and best-effort.
+  }
+}
+
+/**
+ * Terminate only the process tree rooted at a child process Nimbalyst spawned.
+ *
+ * Windows does not propagate `ChildProcess.kill()` to descendants. Codex can
+ * leave git/MCP grandchildren behind, so start taskkill's exact root-PID tree
+ * mode before the caller closes stdin. The detached helper cannot freeze the
+ * Electron main thread and can finish during app shutdown. A bounded fallback
+ * preserves direct-child cleanup if taskkill cannot start, fails, or hangs.
+ *
+ * This deliberately never scans by executable name, command line, or age. A
+ * Windows Job Object bound at spawn time would eliminate the OS-level PID reuse
+ * window entirely; until that larger native integration exists, keeping the
+ * owned root alive while taskkill starts is the narrowest safe tree approach.
+ */
+export function terminateOwnedProcessTree(
+  child: OwnedChildProcess,
+  deps: ProcessTreeTerminationDeps = {},
+): void {
+  if (!child || typeof child !== 'object') return;
+  if (terminationStarted.has(child)) return;
+  terminationStarted.add(child);
+  if (hasExited(child)) return;
+
+  const platform = deps.platform ?? process.platform;
+  const pid = child.pid;
+  if (platform !== 'win32' || !Number.isSafeInteger(pid) || (pid ?? 0) <= 0) {
+    terminateDirectChild(child);
+    return;
+  }
+
+  const spawnTaskkill: SpawnTaskkill = deps.spawn
+    ?? ((command, args, options) => defaultSpawn(command, args, options));
+  let taskkill: TaskkillProcess;
+  try {
+    taskkill = spawnTaskkill(
+      'taskkill.exe',
+      ['/PID', String(pid), '/T', '/F'],
+      {
+        stdio: 'ignore',
+        windowsHide: true,
+        detached: true,
+      },
+    );
+  } catch {
+    terminateDirectChild(child);
+    return;
+  }
+
+  let settled = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const settle = (succeeded: boolean) => {
+    if (settled) return;
+    settled = true;
+    if (timeout) clearTimeout(timeout);
+    if (!succeeded) terminateDirectChild(child);
+  };
+
+  taskkill.once('error', () => settle(false));
+  taskkill.once('exit', (code) => settle(code === 0));
+  taskkill.unref();
+
+  timeout = setTimeout(() => {
+    try { taskkill.kill(); } catch { /* noop */ }
+    settle(false);
+  }, WINDOWS_TREE_KILL_TIMEOUT_MS);
+  (timeout as { unref?: () => void }).unref?.();
+  if (settled) clearTimeout(timeout);
+}

--- a/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
+++ b/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
@@ -55,6 +55,11 @@ export interface CodexProtocol extends AgentProtocol {
   setApiKey?(apiKey: string): void;
 }
 
+interface ProtocolSessionIdleScheduler {
+  setTimeout(callback: () => void, timeoutMs: number): ReturnType<typeof setTimeout>;
+  clearTimeout(handle: ReturnType<typeof setTimeout>): void;
+}
+
 interface OpenAICodexProviderDeps {
   protocol?: CodexProtocol;
   permissionService?: ToolPermissionService;
@@ -63,6 +68,10 @@ interface OpenAICodexProviderDeps {
   // Legacy: for existing tests that mock the SDK loader
   loadSdkModule?: () => Promise<CodexSdkModuleLike>;
   resolveCodexPathOverride?: () => string | undefined;
+  /** Override the bounded app-server retention window in lifecycle tests. */
+  idleProtocolSessionTimeoutMs?: number;
+  /** Injectable scheduler keeps lifecycle tests deterministic without global fake timers. */
+  idleProtocolSessionScheduler?: ProtocolSessionIdleScheduler;
 }
 
 interface OpenAICodexModelDiscoveryDeps {
@@ -84,6 +93,7 @@ const PERSISTED_APP_SERVER_NOTIFICATION_METHODS = new Set([
 
 export class OpenAICodexProvider extends BaseAgentProvider {
   static readonly DEFAULT_MODEL = DEFAULT_MODELS['openai-codex'];
+  private static readonly APP_SERVER_IDLE_TIMEOUT_MS = 60_000;
   private static readonly CODEX_EXECUTION_PATTERN = 'OpenAICodex(agent-run:*)';
   private static readonly SESSION_NAMING_REMINDER_PROMPT =
     '<SYSTEM_REMINDER>Call the session metadata tool now before continuing. ' +
@@ -185,6 +195,13 @@ export class OpenAICodexProvider extends BaseAgentProvider {
    * `liveProtocolSessions` is in-memory only.
    */
   private readonly liveProtocolSessions = new Map<string, ProtocolSession>();
+  private readonly activeProtocolSessionCounts = new Map<string, number>();
+  private readonly protocolSessionIdleTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  private readonly idleProtocolSessionTimeoutMs: number;
+  private readonly idleProtocolSessionScheduler: ProtocolSessionIdleScheduler;
 
   // Analytics initialization data, captured during first sendMessage call
   private _initData: {
@@ -284,6 +301,12 @@ export class OpenAICodexProvider extends BaseAgentProvider {
   constructor(config?: { apiKey?: string }, deps?: OpenAICodexProviderDeps) {
     super();
     const apiKey = config?.apiKey || '';
+    this.idleProtocolSessionTimeoutMs = deps?.idleProtocolSessionTimeoutMs
+      ?? OpenAICodexProvider.APP_SERVER_IDLE_TIMEOUT_MS;
+    this.idleProtocolSessionScheduler = deps?.idleProtocolSessionScheduler ?? {
+      setTimeout: (callback, timeoutMs) => setTimeout(callback, timeoutMs),
+      clearTimeout: (handle) => clearTimeout(handle),
+    };
 
     // Resolve transport: explicit dep > registered resolver > SDK-specific test
     // deps > default 'app-server'.
@@ -946,6 +969,14 @@ export class OpenAICodexProvider extends BaseAgentProvider {
     this.abortController = abortController;
 
     let fullText = '';
+    if (sessionId) {
+      // The protocol turn owns the child from this point onward. Keeping the
+      // prior idle deadline through prompt preparation means an early setup
+      // error cannot accidentally remove the only eviction deadline.
+      this.cancelProtocolSessionIdleTimer(sessionId);
+      const activeCount = this.activeProtocolSessionCounts.get(sessionId) ?? 0;
+      this.activeProtocolSessionCounts.set(sessionId, activeCount + 1);
+    }
 
     try {
       // Check permission using ToolPermissionService
@@ -1333,6 +1364,18 @@ export class OpenAICodexProvider extends BaseAgentProvider {
       if (this.abortController === abortController) {
         this.abortController = null;
       }
+      if (sessionId) {
+        const remainingTurns = Math.max(
+          0,
+          (this.activeProtocolSessionCounts.get(sessionId) ?? 1) - 1,
+        );
+        if (remainingTurns > 0) {
+          this.activeProtocolSessionCounts.set(sessionId, remainingTurns);
+        } else {
+          this.activeProtocolSessionCounts.delete(sessionId);
+          this.armProtocolSessionIdleTimer(sessionId);
+        }
+      }
     }
   }
 
@@ -1342,11 +1385,37 @@ export class OpenAICodexProvider extends BaseAgentProvider {
    */
   private evictLiveProtocolSession(sessionId: string | undefined): void {
     if (!sessionId) return;
+    this.cancelProtocolSessionIdleTimer(sessionId);
     const cached = this.liveProtocolSessions.get(sessionId);
     if (!cached) return;
     this.liveProtocolSessions.delete(sessionId);
     try { this.protocol.cleanupSession(cached); }
     catch (err) { console.warn('[CODEX] protocol.cleanupSession threw during eviction:', err); }
+  }
+
+  private cancelProtocolSessionIdleTimer(sessionId: string | undefined): void {
+    if (!sessionId) return;
+    const timer = this.protocolSessionIdleTimers.get(sessionId);
+    if (!timer) return;
+    this.protocolSessionIdleTimers.delete(sessionId);
+    this.idleProtocolSessionScheduler.clearTimeout(timer);
+  }
+
+  private armProtocolSessionIdleTimer(sessionId: string): void {
+    this.cancelProtocolSessionIdleTimer(sessionId);
+    if (this.transport !== 'app-server') return;
+    if (!this.liveProtocolSessions.has(sessionId)) return;
+    if (!Number.isFinite(this.idleProtocolSessionTimeoutMs) || this.idleProtocolSessionTimeoutMs < 0) return;
+
+    const timer = this.idleProtocolSessionScheduler.setTimeout(() => {
+      this.protocolSessionIdleTimers.delete(sessionId);
+      if ((this.activeProtocolSessionCounts.get(sessionId) ?? 0) > 0) return;
+      // evictLiveProtocolSession intentionally preserves ProviderSessionManager's
+      // persisted thread id so a later turn resumes instead of starting over.
+      this.evictLiveProtocolSession(sessionId);
+    }, this.idleProtocolSessionTimeoutMs);
+    this.protocolSessionIdleTimers.set(sessionId, timer);
+    (timer as { unref?: () => void }).unref?.();
   }
 
   /**
@@ -1715,12 +1784,18 @@ export class OpenAICodexProvider extends BaseAgentProvider {
    * Call this when a session is deleted or no longer needed.
    */
   cleanupSession(sessionId: string): void {
+    this.activeProtocolSessionCounts.delete(sessionId);
     this.evictLiveProtocolSession(sessionId);
     this.sessions.deleteSession(sessionId);
     this.appServerNotificationDeduper.delete(sessionId);
   }
 
   destroy(): void {
+    for (const timer of this.protocolSessionIdleTimers.values()) {
+      this.idleProtocolSessionScheduler.clearTimeout(timer);
+    }
+    this.protocolSessionIdleTimers.clear();
+    this.activeProtocolSessionCounts.clear();
     // Tear down every live ProtocolSession so we don't orphan codex child
     // processes when the provider is replaced (e.g., on API key rotation).
     for (const session of this.liveProtocolSessions.values()) {

--- a/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.lifecycle.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.lifecycle.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OpenAICodexProvider } from '../OpenAICodexProvider';
+import { configureMcpServers } from '../../services/mcpServerConfig';
+
+interface ManualTimerHandle {
+  dueAt: number;
+  callback: () => void;
+  unref: ReturnType<typeof vi.fn>;
+}
+
+class ManualIdleScheduler {
+  private now = 0;
+  private readonly handles = new Set<ManualTimerHandle>();
+  readonly setTimeout = vi.fn((callback: () => void, delayMs: number) => {
+    const handle: ManualTimerHandle = {
+      dueAt: this.now + delayMs,
+      callback,
+      unref: vi.fn(),
+    };
+    this.handles.add(handle);
+    return handle as never;
+  });
+  readonly clearTimeout = vi.fn((handle: ManualTimerHandle) => {
+    this.handles.delete(handle);
+  });
+
+  advanceBy(delayMs: number): void {
+    this.now += delayMs;
+    const due = [...this.handles]
+      .filter((handle) => handle.dueAt <= this.now)
+      .sort((a, b) => a.dueAt - b.dueAt);
+    for (const handle of due) {
+      if (!this.handles.delete(handle)) continue;
+      handle.callback();
+    }
+  }
+
+  get lastHandle(): ManualTimerHandle | undefined {
+    return [...this.handles].at(-1);
+  }
+}
+
+function completeEventStream(beforeComplete?: () => Promise<void>) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      if (beforeComplete) await beforeComplete();
+      yield {
+        type: 'complete',
+        content: 'ok',
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      };
+    },
+  };
+}
+
+async function drainTurn(provider: OpenAICodexProvider, message: string): Promise<void> {
+  for await (const _chunk of provider.sendMessage(
+    message,
+    undefined,
+    'session-lifecycle',
+    [],
+    process.cwd(),
+  )) {
+    // drain
+  }
+}
+
+function createHarness(options: {
+  idleTimeoutMs?: number;
+  beforeSecondTurnCompletes?: () => Promise<void>;
+  beforeTurnCompletes?: (turnCount: number) => Promise<void> | undefined;
+} = {}) {
+  const idleScheduler = new ManualIdleScheduler();
+  const protocolSession = {
+    id: 'thread-retained',
+    platform: 'codex-app-server',
+    raw: { fake: true },
+  };
+  const createSession = vi.fn(async () => protocolSession);
+  const resumeSession = vi.fn(async () => protocolSession);
+  const cleanupSession = vi.fn();
+  let turnCount = 0;
+  const sendMessage = vi.fn(() => {
+    turnCount++;
+    const turnGate = options.beforeTurnCompletes?.(turnCount);
+    return completeEventStream(
+      turnGate
+        ? async () => turnGate
+        : (turnCount === 2 ? options.beforeSecondTurnCompletes : undefined),
+    );
+  });
+  const protocol = {
+    platform: 'codex-app-server',
+    createSession,
+    resumeSession,
+    forkSession: vi.fn(),
+    sendMessage,
+    abortSession: vi.fn(),
+    cleanupSession,
+  } as never;
+
+  const provider = new OpenAICodexProvider(
+    { apiKey: 'test-key' },
+    {
+      transport: 'app-server',
+      protocol,
+      idleProtocolSessionTimeoutMs: options.idleTimeoutMs ?? 1_000,
+      idleProtocolSessionScheduler: idleScheduler,
+    } as never,
+  );
+
+  return {
+    provider,
+    createSession,
+    resumeSession,
+    sendMessage,
+    cleanupSession,
+    protocolSession,
+    idleScheduler,
+  };
+}
+
+describe('OpenAICodexProvider app-server lifecycle retention', () => {
+  beforeEach(() => {
+    configureMcpServers({ mcpServerPort: null, extensionDevServerPort: null });
+    OpenAICodexProvider.setTrustChecker(() => ({ trusted: true, mode: 'allow-all' }));
+    OpenAICodexProvider.setPermissionPatternChecker(async () => false);
+    OpenAICodexProvider.setPermissionPatternSaver(async () => {});
+    OpenAICodexProvider.setSecurityLogger(() => {});
+    OpenAICodexProvider.setCodexAuthGate(null);
+  });
+
+  afterEach(() => {
+    configureMcpServers({ mcpServerPort: null, extensionDevServerPort: null });
+  });
+
+  it('evicts an idle app-server child while preserving the thread id for resume', async () => {
+    const h = createHarness();
+    await h.provider.initialize({ apiKey: 'test-key', model: 'openai-codex:gpt-5' });
+
+    try {
+      await drainTurn(h.provider, 'first');
+
+      expect(h.idleScheduler.lastHandle).toBeDefined();
+      expect(h.idleScheduler.lastHandle!.unref).toHaveBeenCalledTimes(1);
+      h.idleScheduler.advanceBy(999);
+      expect(h.cleanupSession).not.toHaveBeenCalled();
+      h.idleScheduler.advanceBy(1);
+      expect(h.cleanupSession).toHaveBeenCalledTimes(1);
+      expect(h.cleanupSession).toHaveBeenCalledWith(h.protocolSession);
+
+      await drainTurn(h.provider, 'resume after idle eviction');
+      expect(h.createSession).toHaveBeenCalledTimes(1);
+      expect(h.resumeSession).toHaveBeenCalledTimes(1);
+      expect(h.resumeSession).toHaveBeenCalledWith(
+        'thread-retained',
+        expect.any(Object),
+      );
+    } finally {
+      h.provider.destroy();
+    }
+  });
+
+  it('cancels and restarts the idle deadline when a new turn arrives', async () => {
+    const h = createHarness();
+    await h.provider.initialize({ apiKey: 'test-key', model: 'openai-codex:gpt-5' });
+
+    try {
+      await drainTurn(h.provider, 'first');
+      h.idleScheduler.advanceBy(500);
+
+      await drainTurn(h.provider, 'second');
+      h.idleScheduler.advanceBy(500);
+      expect(h.cleanupSession).not.toHaveBeenCalled();
+
+      h.idleScheduler.advanceBy(500);
+      expect(h.cleanupSession).toHaveBeenCalledTimes(1);
+    } finally {
+      h.provider.destroy();
+    }
+  });
+
+  it('never evicts a child while its next turn is active', async () => {
+    let releaseSecondTurn!: () => void;
+    let markSecondTurnStarted!: () => void;
+    const secondTurnStarted = new Promise<void>((resolve) => {
+      markSecondTurnStarted = resolve;
+    });
+    const secondTurnGate = new Promise<void>((resolve) => {
+      releaseSecondTurn = resolve;
+    });
+    const h = createHarness({
+      beforeSecondTurnCompletes: async () => {
+        markSecondTurnStarted();
+        await secondTurnGate;
+      },
+    });
+    await h.provider.initialize({ apiKey: 'test-key', model: 'openai-codex:gpt-5' });
+
+    try {
+      await drainTurn(h.provider, 'first');
+      h.idleScheduler.advanceBy(500);
+
+      const activeTurn = drainTurn(h.provider, 'long second turn');
+      await secondTurnStarted;
+      h.idleScheduler.advanceBy(5_000);
+      expect(h.cleanupSession).not.toHaveBeenCalled();
+
+      releaseSecondTurn();
+      await activeTurn;
+      h.idleScheduler.advanceBy(999);
+      expect(h.cleanupSession).not.toHaveBeenCalled();
+      h.idleScheduler.advanceBy(1);
+      expect(h.cleanupSession).toHaveBeenCalledTimes(1);
+    } finally {
+      h.provider.destroy();
+    }
+  });
+
+  it('does not arm idle eviction until every overlapping turn has settled', async () => {
+    let releaseSecondTurn!: () => void;
+    let releaseThirdTurn!: () => void;
+    const secondTurnGate = new Promise<void>((resolve) => {
+      releaseSecondTurn = resolve;
+    });
+    const thirdTurnGate = new Promise<void>((resolve) => {
+      releaseThirdTurn = resolve;
+    });
+    let activeTurnsStarted = 0;
+    let markBothTurnsStarted!: () => void;
+    const bothTurnsStarted = new Promise<void>((resolve) => {
+      markBothTurnsStarted = resolve;
+    });
+    const h = createHarness({
+      beforeTurnCompletes: (turnCount) => {
+        if (turnCount < 2) return undefined;
+        activeTurnsStarted++;
+        if (activeTurnsStarted === 2) markBothTurnsStarted();
+        return turnCount === 2 ? secondTurnGate : thirdTurnGate;
+      },
+    });
+    await h.provider.initialize({ apiKey: 'test-key', model: 'openai-codex:gpt-5' });
+
+    try {
+      await drainTurn(h.provider, 'establish cached child');
+
+      const secondTurn = drainTurn(h.provider, 'overlap one');
+      const thirdTurn = drainTurn(h.provider, 'overlap two');
+      await bothTurnsStarted;
+
+      releaseSecondTurn();
+      await secondTurn;
+      h.idleScheduler.advanceBy(5_000);
+      expect(h.cleanupSession).not.toHaveBeenCalled();
+
+      releaseThirdTurn();
+      await thirdTurn;
+      h.idleScheduler.advanceBy(999);
+      expect(h.cleanupSession).not.toHaveBeenCalled();
+      h.idleScheduler.advanceBy(1);
+      expect(h.cleanupSession).toHaveBeenCalledTimes(1);
+    } finally {
+      h.provider.destroy();
+    }
+  });
+
+  it('clears the pending idle deadline during provider destruction', async () => {
+    const h = createHarness();
+    await h.provider.initialize({ apiKey: 'test-key', model: 'openai-codex:gpt-5' });
+
+    await drainTurn(h.provider, 'first');
+    h.provider.destroy();
+    expect(h.cleanupSession).toHaveBeenCalledTimes(1);
+
+    h.idleScheduler.advanceBy(5_000);
+    expect(h.cleanupSession).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- terminate each owned Codex app-server process tree on Windows with a bounded, detached
  `taskkill /PID /T /F` attempt and direct-child fallback
- evict idle live Codex protocol sessions after 60 seconds while preserving persisted thread IDs for
  resume, and protect active or overlapping turns from eviction
- release exact provider instances after session/worktree archive and legacy delete paths, while
  bounding individual cleanup failures so one poisoned provider cannot block the rest

## Validation

- `vitest` focused lifecycle suite: 8 files passed; 88 tests passed, 1 existing skip
- `npm run typecheck --prefix packages/runtime`: passed
- `npm run typecheck --prefix packages/electron`: passed
- independent adversarial review: no actionable behavioral defects remained

The full clean-checkout checks were also executed. `npm run test:prepush` reached 637 passing files
and 5,530 passing tests, with 19 files / 100 tests failing in the existing unrelated Windows/Node 26
path, fixture, and generated-output baseline. The monorepo typecheck likewise reaches unrelated
extension packages that lack generated workspace dist outputs in a fresh checkout. None of those
failures overlap the 13 changed paths; the two affected packages typecheck cleanly.

## Residual risk

Windows Job Object ownership would eliminate the remaining theoretical PID-reuse window more
strongly than PID-scoped teardown. This patch deliberately avoids process-name, age, or global scans
and keeps all termination tied to the exact child process owned by the protocol instance.

Refs NIM-349
