### PR TITLE
feat(ai): Claude Agent extended thinking toggle (clean reland of #734)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Claude Agent sessions now expose an `Extended: On` / `Extended: Off` selector next to the effort selector for supported Opus/Sonnet variants, letting you turn off extended thinking per session to reduce latency and token use. Extended thinking stays on by default.
 - Star tracker items and filter the list by Favorites, Recently Viewed, and Edited by Others.
 - Launch an isolated worktree session directly from a tracker item.
 - Text and code files such as TypeScript, HTML, Swift, and Python can now be shared and co-edited with live cursors.

--- a/docs/POSTHOG_EVENTS.md
+++ b/docs/POSTHOG_EVENTS.md
@@ -135,6 +135,7 @@ All events include `$session_id` property automatically. Dev users are marked wi
 | `ai_diff_rejected` | `DiffApprovalBar.tsx:380, 450`<br/>`TabEditor.tsx:1442` | User rejects diff or all diffs (markdown/code/mockup) | `rejectType` (partial/all)<br/>`replacementCount`<br/>`fileType` (mockup, optional) | v0.45.25 (2025-11-14) |  |
 | `session_reparented` | `SessionListItem.tsx:290` | User drags session to change parent (workstream reassignment) | `had_previous_parent`<br/>`workspace_path` | (pending release) |  |
 | `ai_effort_level_changed` | `SessionTranscript.tsx` | User changes effort level for Opus 4.6 adaptive reasoning | `effort_level` (low/medium/high/max)<br/>`previous_level` (low/medium/high/max) | (pending release) |  |
+| `ai_thinking_mode_changed` | `SessionTranscript.tsx` | User changes Claude Agent extended thinking mode | `thinking_mode` (enabled/disabled)<br/>`previous_mode` (enabled/disabled)<br/>`model` | (pending release) |  |
 | `ai_mode_changed` | `SessionTranscript.tsx` | User switches session mode via ModeTag or Shift+Tab | `from` (planning/agent)<br/>`to` (planning/agent)<br/>`provider` (string)<br/>`session_id` (string) | (pending release) | Auto mode is no longer user-selectable; it activates transparently via the "Allow All" trust level for supported providers |
 | `exit_plan_mode_response` | `SessionTranscript.tsx:923, 943, 974, 1060` | User responds to plan completion confirmation | `decision` (approved/denied/start_new_session/cancelled)<br/>`has_feedback` (boolean, for denied only)<br/>`is_worktree` (boolean, for start_new_session only) | (pending release) |  |
 | `ask_user_question_answered` | `SessionTranscript.tsx:1081` | User answers an AskUserQuestion prompt from Claude | `numQuestions` (number of questions answered) | (pending release) |  |
@@ -399,14 +400,14 @@ Events from the iOS companion app. These events share the same PostHog project a
 
 - **Total Events**: 118 unique event names
 - **Main Process Events**: 57 (via AnalyticsService)
-- **Renderer Process Events**: 53 (via usePostHog hook)
+- **Renderer Process Events**: 54 (via usePostHog hook)
 - **Mobile Events**: 7 (via Capacitor AnalyticsService)
 - **File Operations**: 7 events
 - **Workspace Operations**: 4 events
 - **Navigation & Editor Mode**: 4 events
 - **Session Kanban Board**: 6 events
 - **File History**: 2 events
-- **AI-Related**: 23 events
+- **AI-Related**: 24 events
 - **Blitz Mode**: 1 event
 - **Session/File Sharing**: 2 events
 - **Session Export**: 1 event

--- a/docs/WEEKLY_DASHBOARD.md
+++ b/docs/WEEKLY_DASHBOARD.md
@@ -15,7 +15,7 @@ All insights on this dashboard MUST query from the `WEEKLY_USERS_BASE_VIEW` mate
 - `ghost` -- zero file saves, zero file creates, <=2 editor opens, <=1 workspace opens, zero searches, zero terminal events
 
 **AI events used for classification (`has_ai` flag):**
-- Desktop: `ai_message_sent`, `ai_message_queued`, `ai_response_received`, `ai_stream_interrupted`, `ai_request_failed`, `ai_session_resumed`, `create_ai_session`, `cancel_ai_request`, `claude_code_session_started`, `codex_session_started`, `blitz_created`, `ai_diff_accepted`, `ai_diff_rejected`, `tool_permission_responded`, `ask_user_question_answered`, `ask_user_question_cancelled`, `exit_plan_mode_response`, `git_commit_proposal_response`, `ai_effort_level_changed`
+- Desktop: `ai_message_sent`, `ai_message_queued`, `ai_response_received`, `ai_stream_interrupted`, `ai_request_failed`, `ai_session_resumed`, `create_ai_session`, `cancel_ai_request`, `claude_code_session_started`, `codex_session_started`, `blitz_created`, `ai_diff_accepted`, `ai_diff_rejected`, `tool_permission_responded`, `ask_user_question_answered`, `ask_user_question_cancelled`, `exit_plan_mode_response`, `git_commit_proposal_response`, `ai_effort_level_changed`, `ai_thinking_mode_changed`
 - Voice: `voice_session_started`, `voice_prompt_submitted`
 - Mobile: `mobile_ai_message_sent`, `mobile_session_created`, `mobile_ask_user_question_response`, `mobile_tool_permission_response`, `mobile_exit_plan_mode_response`, `mobile_git_commit_response`
 

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -29,7 +29,7 @@ import { isModelEnabled } from './modelEnablementFilter';
 import { getSessionStateManager } from '@nimbalyst/runtime/ai/server/SessionStateManager';
 import { parseContextUsageMessage } from '@nimbalyst/runtime/ai/server/utils/contextUsage';
 import { isBedrockToolSearchError } from '@nimbalyst/runtime/ai/server/utils/errorDetection';
-import { resolveEffortLevel } from '@nimbalyst/runtime/ai/server/effortLevels';
+import { parseThinkingMode, resolveEffortLevel } from '@nimbalyst/runtime/ai/server/effortLevels';
 import type { SessionStore } from '@nimbalyst/runtime';
 import {
   ModelIdentifier,
@@ -592,6 +592,7 @@ export class AIService {
       temperature: (session.providerConfig as any)?.temperature,
       ...(apiKey ? { apiKey } : {}),
       ...(effortLevel && { effortLevel }),
+      thinkingMode: parseThinkingMode((session.metadata as any)?.thinkingMode),
     };
 
     const fullModel = session.model || session.providerConfig?.model;
@@ -1970,6 +1971,7 @@ export class AIService {
         if (effortLevel) {
           initConfig.effortLevel = effortLevel;
         }
+        initConfig.thinkingMode = parseThinkingMode((session.metadata as any)?.thinkingMode);
       }
 
       // Pass effort level for OpenAI Codex

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -35,7 +35,7 @@ import {
 } from '@nimbalyst/runtime/ai/server/types';
 import { getSessionStateManager } from '@nimbalyst/runtime/ai/server/SessionStateManager';
 import { isBedrockToolSearchError } from '@nimbalyst/runtime/ai/server/utils/errorDetection';
-import { resolveEffortLevel } from '@nimbalyst/runtime/ai/server/effortLevels';
+import { parseThinkingMode, resolveEffortLevel } from '@nimbalyst/runtime/ai/server/effortLevels';
 import type { RawDocumentContext, DocumentContextService } from '@nimbalyst/runtime';
 import { AISessionsRepository, resolveClaudeCodeParentContextWindow } from '@nimbalyst/runtime';
 import { toolRegistry } from './tools';
@@ -557,6 +557,9 @@ export class MessageStreamingHandler {
         // Effort level: explicit session value, else the app-wide default the
         // selector displays (Opus 4.6 adaptive reasoning).
         ...(reinitEffortLevel && { effortLevel: reinitEffortLevel }),
+        ...(isProviderClaudeCode ? {
+          thinkingMode: parseThinkingMode((session.metadata as any)?.thinkingMode),
+        } : {}),
       };
 
       // Add baseUrl for LMStudio

--- a/packages/electron/src/renderer/components/UnifiedAI/AIInput.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/AIInput.tsx
@@ -5,11 +5,12 @@ import { extractTriggerMatch, getSlashTypeaheadScope, insertAtTrigger, type Slas
 import { buildSlashCommandOptions, fetchSlashCommandEntries, type SlashCommandEntry } from '../Typeahead/slashCommandAutocomplete';
 import { readClipboard, encodeMarkdownLinkPath, type ChatAttachment } from '@nimbalyst/runtime';
 import type { TokenUsageCategory } from '@nimbalyst/runtime/ai/server/types';
-import type { EffortLevel } from '../../utils/modelUtils';
+import type { EffortLevel, ThinkingMode } from '../../utils/modelUtils';
 import { AttachmentPreviewList } from '../AgenticCoding/AttachmentPreviewList';
 import { ModeTag, AIMode } from './ModeTag';
 import { ModelSelector } from './ModelSelector';
 import { EffortLevelSelector } from './EffortLevelSelector';
+import { ThinkingModeSelector } from './ThinkingModeSelector';
 import { registerPendingVoiceCommandSetter } from './VoiceModeButton.tsx';
 import { PendingVoiceCommand } from './PendingVoiceCommand';
 import { pendingVoiceCommandAtom, voiceActiveSessionIdAtom, type PendingVoiceCommand as PendingVoiceCommandType } from '../../store/atoms/voiceModeState';
@@ -90,6 +91,11 @@ interface AIInputProps {
   effortLevel?: EffortLevel;
   onEffortLevelChange?: (level: EffortLevel) => void;
   showEffortLevel?: boolean;
+  thinkingMode?: ThinkingMode;
+  onThinkingModeChange?: (mode: ThinkingMode) => void;
+  showThinkingToggle?: boolean;
+  reasoningControlsDisabled?: boolean;
+  reasoningControlsDisabledTitle?: string;
 
   // Token usage display support (for Claude Code)
   tokenUsage?: {
@@ -169,6 +175,11 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
     effortLevel,
     onEffortLevelChange,
     showEffortLevel,
+    thinkingMode,
+    onThinkingModeChange,
+    showThinkingToggle,
+    reasoningControlsDisabled = false,
+    reasoningControlsDisabledTitle,
     tokenUsage,
     provider,
     onQueue,
@@ -1389,6 +1400,16 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
               <EffortLevelSelector
                 level={effortLevel}
                 onLevelChange={onEffortLevelChange}
+                disabled={reasoningControlsDisabled}
+                disabledTitle={reasoningControlsDisabledTitle}
+              />
+            )}
+            {showThinkingToggle && onThinkingModeChange && thinkingMode && (
+              <ThinkingModeSelector
+                mode={thinkingMode}
+                onModeChange={onThinkingModeChange}
+                disabled={reasoningControlsDisabled}
+                disabledTitle={reasoningControlsDisabledTitle}
               />
             )}
             {workspacePath && (

--- a/packages/electron/src/renderer/components/UnifiedAI/EffortLevelSelector.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/EffortLevelSelector.tsx
@@ -6,9 +6,11 @@ import { EFFORT_LEVELS, DEFAULT_EFFORT_LEVEL } from '../../utils/modelUtils';
 interface EffortLevelSelectorProps {
   level: EffortLevel;
   onLevelChange: (level: EffortLevel) => void;
+  disabled?: boolean;
+  disabledTitle?: string;
 }
 
-export function EffortLevelSelector({ level, onLevelChange }: EffortLevelSelectorProps) {
+export function EffortLevelSelector({ level, onLevelChange, disabled = false, disabledTitle }: EffortLevelSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -32,15 +34,25 @@ export function EffortLevelSelector({ level, onLevelChange }: EffortLevelSelecto
     };
   }, [isOpen]);
 
+  useEffect(() => {
+    if (disabled) {
+      setIsOpen(false);
+    }
+  }, [disabled]);
+
   const currentLevel = EFFORT_LEVELS.find(l => l.key === level) ?? EFFORT_LEVELS.find(l => l.key === DEFAULT_EFFORT_LEVEL)!;
 
   return (
     <div className="relative inline-block" ref={dropdownRef}>
       <button
         data-testid="effort-level-selector"
-        className="flex items-center gap-1 px-2 py-[3px] rounded-xl text-[11px] font-medium cursor-pointer transition-all duration-200 outline-none whitespace-nowrap bg-[var(--nim-bg-secondary)] text-[var(--nim-text-muted)] border border-[var(--nim-border)] hover:bg-[var(--nim-bg-hover)] hover:border-[var(--nim-primary)]"
-        onClick={() => setIsOpen(!isOpen)}
+        className={`flex items-center gap-1 px-2 py-[3px] rounded-xl text-[11px] font-medium transition-all duration-200 outline-none whitespace-nowrap bg-[var(--nim-bg-secondary)] text-[var(--nim-text-muted)] border border-[var(--nim-border)] ${disabled ? 'opacity-45 cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--nim-bg-hover)] hover:border-[var(--nim-primary)]'}`}
+        onClick={() => {
+          if (!disabled) setIsOpen(!isOpen);
+        }}
         aria-label={`Effort level: ${currentLevel.label}`}
+        disabled={disabled}
+        title={disabled ? disabledTitle : undefined}
       >
         <MaterialSymbol icon="psychology" size={12} />
         <span>{currentLevel.label}</span>

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -60,6 +60,7 @@ import {
   sessionWorktreePathAtom,
   sessionDocumentContextAtom,
   sessionEffortLevelRawAtom,
+  sessionThinkingModeRawAtom,
   sessionLoadingAtom,
   sessionModeAtom,
   sessionModelAtom,
@@ -105,7 +106,7 @@ import {
 import { scrollToTeammateAtom, scrollToMessageAtom, requestOpenSessionAtom } from '../../store/atoms/agentMode';
 import { usePostHog } from 'posthog-js/react';
 import { setAgentModeSettingsAtom, showPromptAdditionsAtom, hasExternalEditorAtom, externalEditorNameAtom, openInExternalEditorAtom, defaultAgentModelAtom, defaultEffortLevelAtom, chatShowToolCallsAtom } from '../../store/atoms/appSettings';
-import { supportsEffortLevel, parseEffortLevel, type EffortLevel } from '../../utils/modelUtils';
+import { supportsEffortLevel, supportsThinkingToggle, parseEffortLevel, parseThinkingMode, type EffortLevel, type ThinkingMode } from '../../utils/modelUtils';
 import { buildPlanImplementationPrompt, resolvePlanFilePath } from '../../utils/pathUtils';
 import { resolveTranscriptClickPath } from '../../utils/resolveTranscriptClickPath';
 import { autoCommitEnabledAtom, setAutoCommitEnabledAtom } from '../../store/atoms/autoCommitAtoms';
@@ -466,6 +467,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
   const sessionWorktreePath = useAtomValue(sessionWorktreePathAtom(sessionId));
   const sessionDocumentContext = useAtomValue(sessionDocumentContextAtom(sessionId));
   const rawEffortLevel = useAtomValue(sessionEffortLevelRawAtom(sessionId));
+  const rawThinkingMode = useAtomValue(sessionThinkingModeRawAtom(sessionId));
   const loadSessionData = useSetAtom(loadSessionDataAtom);
   const reloadSessionData = useSetAtom(reloadSessionDataAtom);
   const updateSessionStore = useSetAtom(updateSessionStoreAtom);
@@ -509,6 +511,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
       metadata: {
         ...safeMetadata,
         effortLevel: rawEffortLevel ?? (safeMetadata as Record<string, unknown> | undefined)?.effortLevel ?? null,
+        thinkingMode: rawThinkingMode ?? (safeMetadata as Record<string, unknown> | undefined)?.thinkingMode ?? null,
         sessionStatus,
         currentTeammates: metadataTeammates,
         currentTodos,
@@ -524,6 +527,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
     sessionDocumentContext,
     sessionWorktreePath,
     rawEffortLevel,
+    rawThinkingMode,
     sessionStatus,
     metadataTeammates,
     currentTodos,
@@ -534,6 +538,8 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
   const effortLevel = useMemo(() => {
     return rawEffortLevel != null ? parseEffortLevel(rawEffortLevel) : defaultEffortLevel;
   }, [rawEffortLevel, defaultEffortLevel]);
+  const showThinkingToggle = useMemo(() => supportsThinkingToggle(currentModel), [currentModel]);
+  const thinkingMode = useMemo(() => parseThinkingMode(rawThinkingMode), [rawThinkingMode]);
 
   // Memoize the teammate list passed to AgentTranscriptPanel so its memo
   // comparison doesn't see a new array reference on every keystroke. Without
@@ -1549,6 +1555,16 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
       previous_level: previousLevel,
     });
   }, [sessionId, updateSessionStore, setAgentModeSettings, effortLevel, posthog]);
+
+  const handleThinkingModeChange = useCallback(async (mode: ThinkingMode) => {
+    const previousMode = thinkingMode;
+    await updateSessionMetadataField(sessionId, 'thinkingMode', mode, null, updateSessionStore);
+    posthog?.capture('ai_thinking_mode_changed', {
+      thinking_mode: mode,
+      previous_mode: previousMode,
+      model: currentModel,
+    });
+  }, [sessionId, updateSessionStore, thinkingMode, currentModel, posthog]);
 
   const handleCommandSelect = useCallback((command: string) => {
     setDraftInput(command);
@@ -2600,6 +2616,9 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
         effortLevel={effortLevel}
         onEffortLevelChange={handleEffortLevelChange}
         showEffortLevel={isClaudeCliTerminalSession(provider) && cliSessionCommitted ? false : showEffortLevel}
+        thinkingMode={thinkingMode}
+        onThinkingModeChange={handleThinkingModeChange}
+        showThinkingToggle={isClaudeCliTerminalSession(provider) && cliSessionCommitted ? false : showThinkingToggle}
         tokenUsage={tokenUsage}
         provider={provider}
         onQueue={handleQueue}

--- a/packages/electron/src/renderer/components/UnifiedAI/ThinkingModeSelector.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/ThinkingModeSelector.tsx
@@ -1,0 +1,93 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { MaterialSymbol } from '@nimbalyst/runtime';
+import type { ThinkingMode } from '../../utils/modelUtils';
+import { DEFAULT_THINKING_MODE } from '../../utils/modelUtils';
+
+const THINKING_MODE_OPTIONS: Array<{ key: ThinkingMode; label: string }> = [
+  { key: 'enabled', label: 'Extended: On' },
+  { key: 'disabled', label: 'Extended: Off' },
+];
+
+interface ThinkingModeSelectorProps {
+  mode: ThinkingMode;
+  onModeChange: (mode: ThinkingMode) => void;
+  disabled?: boolean;
+  disabledTitle?: string;
+}
+
+export function ThinkingModeSelector({
+  mode,
+  onModeChange,
+  disabled = false,
+  disabledTitle,
+}: ThinkingModeSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (disabled) {
+      setIsOpen(false);
+    }
+  }, [disabled]);
+
+  const currentMode =
+    THINKING_MODE_OPTIONS.find(option => option.key === mode) ??
+    THINKING_MODE_OPTIONS.find(option => option.key === DEFAULT_THINKING_MODE)!;
+
+  return (
+    <div className="relative inline-block" ref={dropdownRef}>
+      <button
+        data-testid="thinking-mode-selector"
+        className={`thinking-mode-selector flex items-center gap-1 px-2 py-[3px] rounded-xl text-[11px] font-medium transition-all duration-200 outline-none whitespace-nowrap bg-[var(--nim-bg-secondary)] text-[var(--nim-text-muted)] border border-[var(--nim-border)] ${disabled ? 'opacity-45 cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--nim-bg-hover)] hover:border-[var(--nim-primary)]'}`}
+        onClick={() => {
+          if (!disabled) setIsOpen(!isOpen);
+        }}
+        aria-label={`Extended thinking: ${currentMode.label}`}
+        disabled={disabled}
+        title={disabled ? disabledTitle : undefined}
+      >
+        <MaterialSymbol icon="psychology_alt" size={12} />
+        <span>{currentMode.label}</span>
+        <MaterialSymbol icon="expand_more" size={14} className={`transition-transform duration-200 shrink-0 ${isOpen ? 'rotate-180' : ''}`} />
+      </button>
+
+      {isOpen && (
+        <div className="absolute bottom-full left-0 mb-1 min-w-[140px] rounded-lg p-1 z-[1000] bg-[var(--nim-bg)] border border-[var(--nim-border)] shadow-[0_4px_12px_rgba(0,0,0,0.15)]">
+          {THINKING_MODE_OPTIONS.map(option => (
+            <button
+              key={option.key}
+              className={`flex items-center justify-between gap-2 px-2 py-1.5 w-full border-none rounded text-xs cursor-pointer transition-[background] duration-150 text-left text-[var(--nim-text)] hover:bg-[var(--nim-bg-hover)] ${option.key === mode ? 'bg-[var(--nim-bg-secondary)] text-[var(--nim-primary)]' : ''}`}
+              onClick={() => {
+                onModeChange(option.key);
+                setIsOpen(false);
+              }}
+            >
+              <span>{option.label}</span>
+              {option.key === mode && <MaterialSymbol icon="check" size={14} />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/store/atoms/sessions.ts
+++ b/packages/electron/src/renderer/store/atoms/sessions.ts
@@ -925,6 +925,13 @@ export const sessionEffortLevelRawAtom = atomFamily((sessionId: string) =>
   })
 );
 
+export const sessionThinkingModeRawAtom = atomFamily((sessionId: string) =>
+  atom((get) => {
+    const metadata = get(sessionStoreAtom(sessionId))?.metadata as Record<string, unknown> | undefined;
+    return metadata?.thinkingMode ?? null;
+  })
+);
+
 // ============================================================
 // Hierarchical session support (workstreams)
 // These atoms enable parent-child session relationships for grouping

--- a/packages/electron/src/renderer/store/index.ts
+++ b/packages/electron/src/renderer/store/index.ts
@@ -127,6 +127,7 @@ export {
   sessionWorktreePathAtom,
   sessionDocumentContextAtom,
   sessionEffortLevelRawAtom,
+  sessionThinkingModeRawAtom,
   sessionLoadingAtom,
   sessionModeAtom,
   sessionModelAtom,

--- a/packages/electron/src/renderer/utils/__tests__/supportsThinkingToggle.test.ts
+++ b/packages/electron/src/renderer/utils/__tests__/supportsThinkingToggle.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { supportsThinkingToggle } from '../modelUtils';
+
+describe('supportsThinkingToggle', () => {
+  it('enables the toggle for the default opus and sonnet variants', () => {
+    expect(supportsThinkingToggle('claude-code:opus')).toBe(true);
+    expect(supportsThinkingToggle('claude-code:sonnet')).toBe(true);
+  });
+
+  it('enables the toggle for pinned opus variants', () => {
+    // These must stay in lock-step with the server-side canDisableThinkingForModel
+    // gate: it disables thinking for any opus/sonnet model, so the UI toggle must
+    // be present for those pinned variants or users cannot re-enable thinking.
+    // opus-4-7 was the variant stranded by the original gate.
+    expect(supportsThinkingToggle('claude-code:opus-4-7')).toBe(true);
+    expect(supportsThinkingToggle('claude-code:opus-4-6')).toBe(true);
+  });
+
+  it('disables the toggle for fable and haiku variants', () => {
+    expect(supportsThinkingToggle('claude-code:fable')).toBe(false);
+    expect(supportsThinkingToggle('claude-code:haiku')).toBe(false);
+  });
+
+  it('disables the toggle for non-claude-code and missing models', () => {
+    expect(supportsThinkingToggle(undefined)).toBe(false);
+    expect(supportsThinkingToggle('gpt-5.5')).toBe(false);
+  });
+});

--- a/packages/electron/src/renderer/utils/modelUtils.ts
+++ b/packages/electron/src/renderer/utils/modelUtils.ts
@@ -23,7 +23,15 @@ import {
 } from '@nimbalyst/runtime/ai/modelConstants';
 import { CLAUDE_CODE_VARIANTS, ModelIdentifier, isClaudeCodeFamily } from '@nimbalyst/runtime/ai/server/types';
 
-export { type EffortLevel, EFFORT_LEVELS, DEFAULT_EFFORT_LEVEL, parseEffortLevel } from '@nimbalyst/runtime/ai/server/effortLevels';
+export {
+  type EffortLevel,
+  type ThinkingMode,
+  EFFORT_LEVELS,
+  DEFAULT_EFFORT_LEVEL,
+  DEFAULT_THINKING_MODE,
+  parseEffortLevel,
+  parseThinkingMode,
+} from '@nimbalyst/runtime/ai/server/effortLevels';
 
 interface ModelInfo {
   providerId: string;
@@ -260,4 +268,20 @@ export function supportsEffortLevel(modelId?: string): boolean {
   if (parsed?.provider === 'openai-codex' || parsed?.provider === 'openai-codex-acp') return true;
   if (modelId.startsWith('openai-codex:') || modelId.startsWith('openai-codex-acp:')) return true;
   return false;
+}
+
+/**
+ * Check if a model supports explicit Claude Agent extended-thinking toggling.
+ * Fable/Haiku-style lightweight variants do not accept the SDK thinking option.
+ *
+ * Matches every opus/sonnet variant (including pinned ones like `opus-4-7` and
+ * `sonnet-4-6`) so this stays in lock-step with the server-side
+ * `canDisableThinkingForModel` gate in sdkOptionsBuilder. If the two drift, a
+ * model can have thinking disabled on the server with no UI toggle to restore it.
+ */
+export function supportsThinkingToggle(modelId?: string): boolean {
+  if (!modelId) return false;
+  const variant = extractClaudeCodeVariant(modelId);
+  if (!variant) return false;
+  return variant.startsWith('opus') || variant.startsWith('sonnet');
 }

--- a/packages/runtime/src/ai/server/__tests__/effortLevels.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/effortLevels.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { resolveEffortLevel, DEFAULT_EFFORT_LEVEL } from '../effortLevels';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_EFFORT_LEVEL,
+  DEFAULT_THINKING_MODE,
+  parseThinkingMode,
+  resolveEffortLevel,
+} from '../effortLevels';
 
 describe('resolveEffortLevel', () => {
   it('uses the explicit per-session effort when set', () => {
@@ -22,5 +27,24 @@ describe('resolveEffortLevel', () => {
 
   it('coerces an invalid stored session value to the default level', () => {
     expect(resolveEffortLevel('bogus', 'max')).toBe(DEFAULT_EFFORT_LEVEL);
+  });
+});
+
+describe('thinking mode parsing', () => {
+  it('defaults to enabled (preserving the SDK adaptive-thinking default)', () => {
+    expect(DEFAULT_THINKING_MODE).toBe('enabled');
+    expect(parseThinkingMode(undefined)).toBe('enabled');
+    expect(parseThinkingMode(null)).toBe('enabled');
+  });
+
+  it('accepts enabled and disabled modes', () => {
+    expect(parseThinkingMode('enabled')).toBe('enabled');
+    expect(parseThinkingMode('disabled')).toBe('disabled');
+  });
+
+  it('falls back to the default for unknown values', () => {
+    expect(parseThinkingMode('on')).toBe('enabled');
+    expect(parseThinkingMode('off')).toBe('enabled');
+    expect(parseThinkingMode('')).toBe('enabled');
   });
 });

--- a/packages/runtime/src/ai/server/effortLevels.ts
+++ b/packages/runtime/src/ai/server/effortLevels.ts
@@ -6,6 +6,7 @@
  */
 
 export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+export type ThinkingMode = 'enabled' | 'disabled';
 
 export const EFFORT_LEVELS: { key: EffortLevel; label: string }[] = [
   { key: 'low', label: 'Low' },
@@ -16,8 +17,13 @@ export const EFFORT_LEVELS: { key: EffortLevel; label: string }[] = [
 ];
 
 export const DEFAULT_EFFORT_LEVEL: EffortLevel = 'high';
+// Default to 'enabled' so the app omits the SDK thinking option and preserves
+// the SDK's default adaptive thinking (Claude decides depth) on supported
+// Opus/Sonnet models. Users can opt into 'disabled' (Extended: Off) per session.
+export const DEFAULT_THINKING_MODE: ThinkingMode = 'enabled';
 
 const VALID_EFFORT_LEVELS = new Set<string>(['low', 'medium', 'high', 'xhigh', 'max']);
+const VALID_THINKING_MODES = new Set<string>(['enabled', 'disabled']);
 
 /**
  * Validate and return a valid EffortLevel, or the default if invalid.
@@ -49,4 +55,14 @@ export function resolveEffortLevel(
     return parseEffortLevel(sessionEffortLevel);
   }
   return appDefaultEffortLevel;
+}
+
+/**
+ * Validate and return a valid ThinkingMode, or the default if invalid.
+ */
+export function parseThinkingMode(value: unknown): ThinkingMode {
+  if (typeof value === 'string' && VALID_THINKING_MODES.has(value)) {
+    return value as ThinkingMode;
+  }
+  return DEFAULT_THINKING_MODE;
 }

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -752,7 +752,8 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
             mcpServers: options.mcpServers ? Object.keys(options.mcpServers) : [],
             allowedTools: options.allowedTools,
             disallowedTools: options.disallowedTools,
-            permissionMode: options.permissionMode
+            permissionMode: options.permissionMode,
+            thinking: options.thinking
           }
         }), metadataToLog, hideMessages, undefined, true /* searchable */);
       }

--- a/packages/runtime/src/ai/server/providers/__tests__/sdkOptionsBuilder.envKeys.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/sdkOptionsBuilder.envKeys.test.ts
@@ -171,6 +171,36 @@ describe('buildSdkOptions env-key hardening', () => {
     expect(options.env.CLAUDE_CODE_ENTRYPOINT).toBe('cli');
   });
 
+  it('disables SDK extended thinking for supported Claude Agent models', async () => {
+    const { options } = await buildSdkOptions(
+      makeDeps({ config: { thinkingMode: 'disabled' } }),
+      makeParams()
+    );
+
+    expect(options.thinking).toEqual({ type: 'disabled' });
+  });
+
+  it('omits the SDK thinking option when extended thinking is enabled', async () => {
+    const { options } = await buildSdkOptions(
+      makeDeps({ config: { thinkingMode: 'enabled' } }),
+      makeParams()
+    );
+
+    expect(options.thinking).toBeUndefined();
+  });
+
+  it('omits the SDK thinking option for unsupported Claude Agent models', async () => {
+    const { options } = await buildSdkOptions(
+      makeDeps({
+        resolveModelVariant: () => 'claude-fable-4-6-20260615',
+        config: { thinkingMode: 'disabled' },
+      }),
+      makeParams()
+    );
+
+    expect(options.thinking).toBeUndefined();
+  });
+
   it('disables the CLI self-updater by default on every spawn (NIM-1573)', async () => {
     // The bundled native CLI is version-pinned to the SDK JS we ship. Its
     // built-in AutoUpdater does a non-atomic in-place `rename claude.exe ->

--- a/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import { app } from 'electron';
 import { ClaudeCodeDeps } from './dependencyInjection';
 import { resolveClaudeAgentCliPath } from './cliPathResolver';
-import { DEFAULT_EFFORT_LEVEL } from '../../effortLevels';
+import { DEFAULT_EFFORT_LEVEL, type ThinkingMode } from '../../effortLevels';
 
 type SessionMode = 'planning' | 'agent' | 'auto' | undefined;
 
@@ -38,7 +38,7 @@ export interface BuildSdkOptionsDeps {
     resolveTeamContext: (sessionId?: string) => Promise<string | undefined>;
   };
   sessions: { getSessionId: (sessionId: string) => string | null | undefined };
-  config: { model?: string; apiKey?: string; effortLevel?: string };
+  config: { model?: string; apiKey?: string; effortLevel?: string; thinkingMode?: ThinkingMode };
   abortController: AbortController;
 }
 
@@ -83,6 +83,14 @@ export interface BuildSdkOptionsResult {
   promptInput: AsyncIterable<SDKUserMessage>;
   promptController: PromptStreamController;
   helperMethod: 'native' | 'custom';
+}
+
+function canDisableThinkingForModel(model: string | undefined): boolean {
+  const normalized = model?.toLowerCase() ?? '';
+  if (!normalized || normalized.includes('fable') || normalized.includes('haiku')) {
+    return false;
+  }
+  return normalized.includes('opus') || normalized.includes('sonnet');
 }
 
 export function createPersistentPromptStream(
@@ -215,6 +223,7 @@ export async function buildSdkOptions(
   }
   const effectivePath = customPath || resolvedBinaryPath;
   // console.log(`[CLAUDE-CODE] Binary path: custom=${customPath || '(none)'} resolved=${resolvedBinaryPath ?? '(none)'} effective=${effectivePath ?? '(none)'}`);
+  const resolvedModel = resolveModelVariant();
 
   const options: any = {
     pathToClaudeCodeExecutable: effectivePath,
@@ -238,7 +247,7 @@ export async function buildSdkOptions(
     strictMcpConfig: true,
     cwd: workspacePath,
     abortController,
-    model: resolveModelVariant(),
+    model: resolvedModel,
     // IMPORTANT: Do NOT add manual tool restrictions or prompt injections for plan mode here.
     // The SDK's `permissionMode: 'plan'` natively enforces planning restrictions (scopes
     // Write to the plan file only). Manual filtering was removed in favour of this approach.
@@ -270,6 +279,14 @@ export async function buildSdkOptions(
       'PermissionDenied': [{ hooks: [toolHooksService.createPermissionDeniedHook()] }],
     },
   };
+
+  if (config.thinkingMode === 'disabled') {
+    if (canDisableThinkingForModel(resolvedModel)) {
+      options.thinking = { type: 'disabled' as const };
+    } else {
+      console.warn(`[CLAUDE-CODE] Extended thinking cannot be disabled for model "${resolvedModel}"; omitting SDK thinking option.`);
+    }
+  }
 
   if (currentMode === 'planning') {
     console.log('[CLAUDE-CODE] Plan mode active: delegating tool restrictions to SDK permissionMode=plan');

--- a/packages/runtime/src/ai/server/types.ts
+++ b/packages/runtime/src/ai/server/types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ToolDefinition } from '../tools';
-import type { EffortLevel } from './effortLevels';
+import type { EffortLevel, ThinkingMode } from './effortLevels';
 import type { ToolResult } from './protocols/ProtocolInterface';
 import { ModelIdentifier } from './ModelIdentifier';
 import {
@@ -404,6 +404,7 @@ export interface ProviderConfig {
   baseUrl?: string;
   allowedTools?: string[];  // List of allowed tool names, ['*'] for all tools
   effortLevel?: EffortLevel;  // Effort level for Opus 4.6 adaptive reasoning (low/medium/high/max)
+  thinkingMode?: ThinkingMode;  // Extended thinking mode for Claude Agent (enabled/disabled)
   responseFormat?: ProviderResponseFormat;  // Response format constraint (extension chat completions)
   skipLogging?: boolean;  // Skip message logging to DB (extension stateless completions)
 }


### PR DESCRIPTION
## Summary

Clean reland of the Claude Agent **Extended thinking** toggle originally contributed by Yogev (@Yogitmeister) in #734.

## Why this exists

The earlier merge of #734 (`0436aae`) landed **polluted** — it pulled in stray fixture files (`a.txt`, `seed.txt`) and ~418 spurious deletions from a contaminated branch, so it was reverted via #911. This PR reconstructs **only** the legitimate feature diff (19 files) as a single clean commit on top of current `main`, with no junk files, no `.gitignore` changes, and none of the bad-merge history.

## What's included

- Per-session `Extended: On` / `Extended: Off` selector next to the effort selector for supported Opus/Sonnet Claude Agent variants.
- Passes `thinking: { type: 'disabled' }` through the Claude Agent SDK when off; omits it otherwise.

## Fixes over the original PR

- **Default stays enabled (adaptive).** The original defaulted to Off, silently disabling extended thinking for all supported sessions including flagship Opus. Default is now `enabled` so today's adaptive-thinking behavior is preserved; users opt out per session.
- **Toggle covers all opus/sonnet variants.** The original gate omitted pinned variants (e.g. `opus-4-7`), which the server would disable with no UI to re-enable. The gate now matches every opus/sonnet variant, in lock-step with the server-side `canDisableThinkingForModel`.
- Added `supportsThinkingToggle` unit test.

## Verification

- Typecheck clean (electron + runtime).
- Affected tests pass (`effortLevels`, `sdkOptionsBuilder.envKeys`, `supportsThinkingToggle`).

Original work by Yogev (@Yogitmeister); superseded PR #734.
