### PR TITLE
Debounce session-files:updated refresh and coalesce tool-call matches (fix main-thread stalls with many sessions)

### DIFF
--- a/packages/electron/src/renderer/store/listeners/__tests__/toolCallMatchesCoalescer.test.ts
+++ b/packages/electron/src/renderer/store/listeners/__tests__/toolCallMatchesCoalescer.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createToolCallMatchesCoalescer } from '../toolCallMatchesCoalescer';
+
+describe('createToolCallMatchesCoalescer', () => {
+  it('shares one in-flight request per session (single-flight)', async () => {
+    let resolve!: (v: number) => void;
+    const fetch = vi.fn(
+      (_sessionId: string) => new Promise<number>((r) => { resolve = r; })
+    );
+    const c = createToolCallMatchesCoalescer<number>(fetch, 500, () => 0);
+
+    const p1 = c.get('s1');
+    const p2 = c.get('s1');
+    const p3 = c.get('s1');
+    expect(fetch).toHaveBeenCalledTimes(1); // three callers, one fetch
+
+    resolve(42);
+    expect(await Promise.all([p1, p2, p3])).toEqual([42, 42, 42]);
+  });
+
+  it('serves from cache within TTL and refetches after it expires', async () => {
+    let t = 1000;
+    const fetch = vi.fn(async (sessionId: string) => `${sessionId}:${fetch.mock.calls.length}`);
+    const c = createToolCallMatchesCoalescer<string>(fetch, 500, () => t);
+
+    const a = await c.get('s1'); // fetch #1
+    const b = await c.get('s1'); // cache hit
+    expect(a).toBe(b);
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    t += 600; // move past the TTL
+    await c.get('s1'); // fetch #2
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('keys sessions independently', async () => {
+    const fetch = vi.fn(async (sessionId: string) => sessionId.toUpperCase());
+    const c = createToolCallMatchesCoalescer<string>(fetch, 500, () => 0);
+
+    expect(await c.get('a')).toBe('A');
+    expect(await c.get('b')).toBe('B');
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidate() drops both cache and in-flight for a session', async () => {
+    const fetch = vi.fn(async (sessionId: string) => `${sessionId}:${fetch.mock.calls.length}`);
+    const c = createToolCallMatchesCoalescer<string>(fetch, 10_000, () => 0);
+
+    await c.get('s1'); // fetch #1, cached
+    c.invalidate('s1');
+    await c.get('s1'); // cache dropped -> fetch #2
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a rejected fetch', async () => {
+    let shouldFail = true;
+    const fetch = vi.fn((_sessionId: string) =>
+      shouldFail ? Promise.reject(new Error('boom')) : Promise.resolve('ok')
+    );
+    const c = createToolCallMatchesCoalescer<string>(fetch, 500, () => 0);
+
+    await expect(c.get('s1')).rejects.toThrow('boom');
+    shouldFail = false;
+    expect(await c.get('s1')).toBe('ok'); // retried, not a cached rejection
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/electron/src/renderer/store/listeners/fileStateListeners.ts
+++ b/packages/electron/src/renderer/store/listeners/fileStateListeners.ts
@@ -24,6 +24,7 @@ import {
 } from '../atoms/sessionFiles';
 import { workstreamStagedFilesAtom, setWorkstreamStagedFilesAtom } from '../atoms/workstreamState';
 import { getRelativeWorkspacePath } from '../../../shared/pathUtils';
+import { createToolCallMatchesCoalescer } from './toolCallMatchesCoalescer';
 import { createPerKeyDebouncer } from './perKeyDebounce';
 
 /**
@@ -215,6 +216,8 @@ export function initFileStateListeners(workspacePath: string): () => void {
   const enrichDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const gitStatusDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const pendingCountDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const sessionFilesFetchTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const SESSION_FILES_FETCH_DEBOUNCE_MS = 250;
   // session-files:updated fires once per file edit (hundreds/sec during active
   // AI tool execution); coalesce its per-session git-status refresh so bursts
   // collapse into a single trailing git:get-file-status call per session.
@@ -238,8 +241,9 @@ export function initFileStateListeners(workspacePath: string): () => void {
   // Session Files Updated
   // =========================================================================
 
-  cleanups.push(
-    window.electronAPI.on('session-files:updated', async (sessionId: string) => {
+  // Fetch + enrich + git-status refresh for a single session. Kept as a
+  // sibling helper so the event handler below can debounce its invocation.
+  const runSessionFilesRefresh = async (sessionId: string) => {
       try {
         const result = await window.electronAPI.invoke(
           'session-files:get-by-session',
@@ -297,6 +301,24 @@ export function initFileStateListeners(workspacePath: string): () => void {
       } catch (error) {
         console.error('[fileStateListeners] Failed to fetch file edits for session:', sessionId, error);
       }
+  };
+
+  cleanups.push(
+    window.electronAPI.on('session-files:updated', (sessionId: string) => {
+      // The file-attribution service emits session-files:updated once per file
+      // edit during AI tool execution (hundreds/sec). Multiplied by open
+      // windows × active sessions, an un-debounced refresh here serializes in
+      // the single-threaded PGLite worker and stalls the main thread. Debounce
+      // per session so a burst collapses to a single trailing refresh.
+      const existingTimer = sessionFilesFetchTimers.get(sessionId);
+      if (existingTimer) clearTimeout(existingTimer);
+      sessionFilesFetchTimers.set(
+        sessionId,
+        setTimeout(() => {
+          sessionFilesFetchTimers.delete(sessionId);
+          void runSessionFilesRefresh(sessionId);
+        }, SESSION_FILES_FETCH_DEBOUNCE_MS)
+      );
     })
   );
 
@@ -411,6 +433,8 @@ export function initFileStateListeners(workspacePath: string): () => void {
     gitStatusDebounceTimers.clear();
     pendingCountDebounceTimers.forEach(timer => clearTimeout(timer));
     pendingCountDebounceTimers.clear();
+    sessionFilesFetchTimers.forEach(timer => clearTimeout(timer));
+    sessionFilesFetchTimers.clear();
     sessionGitStatusRefresh.cancelAll();
   };
 }
@@ -419,18 +443,32 @@ export function initFileStateListeners(workspacePath: string): () => void {
  * Enrich file edits with tool call match data.
  * Fetches matches from the database and merges tool call info into the edits.
  */
+/**
+ * Coalesces `session-files:get-tool-call-matches` per session so concurrent
+ * enrich calls (initial multi-session load + debounced updates) collapse to a
+ * single worker round-trip instead of piling up on the single-threaded PGLite
+ * worker. Short TTL keeps results fresh during active editing.
+ */
+const toolCallMatchesCoalescer = createToolCallMatchesCoalescer<any[]>(
+  async (sessionId: string) => {
+    const result = await window.electronAPI.invoke(
+      'session-files:get-tool-call-matches',
+      sessionId
+    );
+    return result.success && result.matches ? result.matches : [];
+  },
+  500
+);
+
 async function enrichEditsWithToolCallMatches(
   sessionId: string,
   edits: FileEditWithSession[],
   rawFiles: Array<{ id: string; filePath: string }>
 ): Promise<FileEditWithSession[]> {
   try {
-    const matchResult = await window.electronAPI.invoke(
-      'session-files:get-tool-call-matches',
-      sessionId
-    );
+    const matches = await toolCallMatchesCoalescer.get(sessionId);
 
-    if (!matchResult.success || !matchResult.matches || matchResult.matches.length === 0) {
+    if (!matches || matches.length === 0) {
       return edits;
     }
 
@@ -440,7 +478,7 @@ async function enrichEditsWithToolCallMatches(
     // The match has sessionFileId which maps to a session_files row.
     // For now, store match data on the match itself and merge by message info.
     const matchByFileId = new Map<string, any>();
-    for (const match of matchResult.matches) {
+    for (const match of matches) {
       matchByFileId.set(match.sessionFileId, match);
     }
 

--- a/packages/electron/src/renderer/store/listeners/toolCallMatchesCoalescer.ts
+++ b/packages/electron/src/renderer/store/listeners/toolCallMatchesCoalescer.ts
@@ -1,0 +1,56 @@
+/**
+ * Per-session coalescer for `session-files:get-tool-call-matches`.
+ *
+ * `enrichEditsWithToolCallMatches` runs both on the (debounced)
+ * `session-files:updated` path and, un-debounced, during the initial
+ * multi-session file-state load. The underlying IPC resolves against a
+ * single-threaded PGLite worker, so a burst of concurrent calls (open
+ * windows × active sessions) serializes there and can block the main thread
+ * for seconds. This shares one in-flight request per session and briefly
+ * caches its result, so a burst collapses to a single worker round-trip.
+ *
+ * Dependency-free and time-injectable so it can be unit-tested without the
+ * IPC/store graph.
+ */
+export function createToolCallMatchesCoalescer<T>(
+  fetch: (sessionId: string) => Promise<T>,
+  ttlMs: number,
+  now: () => number = () => Date.now()
+): {
+  get: (sessionId: string) => Promise<T>;
+  invalidate: (sessionId: string) => void;
+} {
+  const inFlight = new Map<string, Promise<T>>();
+  const cache = new Map<string, { ts: number; value: T }>();
+
+  return {
+    get(sessionId: string): Promise<T> {
+      const cached = cache.get(sessionId);
+      if (cached && now() - cached.ts < ttlMs) {
+        return Promise.resolve(cached.value);
+      }
+      const pending = inFlight.get(sessionId);
+      if (pending) {
+        return pending;
+      }
+      const p = fetch(sessionId)
+        .then((value) => {
+          cache.set(sessionId, { ts: now(), value });
+          return value;
+        })
+        .finally(() => {
+          // Only clear if we are still the current in-flight request for the key.
+          if (inFlight.get(sessionId) === p) {
+            inFlight.delete(sessionId);
+          }
+        });
+      inFlight.set(sessionId, p);
+      return p;
+    },
+
+    invalidate(sessionId: string): void {
+      cache.delete(sessionId);
+      inFlight.delete(sessionId);
+    },
+  };
+}


### PR DESCRIPTION
## Problem

With multiple concurrent sessions the main process periodically freezes. On my
machine (5+ open sessions, 2 windows) `[PERF] Event loop lag` on the **main
process** reached **0.5–46 s** stalls, with the corresponding `[IpcSlow]` lines
showing bursts of `session-files:get-by-session` and a single
`session-files:get-tool-call-matches` taking tens of seconds.

Root cause is the renderer's `session-files:updated` handler. The
file-attribution service emits `session-files:updated` **once per file edit**
during AI tool execution (hundreds/sec — this file already documents that for
the pending-count path). The handler responded to every event by synchronously
fetching files, enriching them, and refreshing git status. Multiplied by open
windows × active sessions, the resulting IPC burst serializes on the
single-threaded PGLite worker and blocks the main-process event loop.

## Fix

#897 already coalesced the per-session **git-status** refresh on this hot path.
This PR coalesces the two remaining un-debounced costs:

- **Debounce the per-session fetch/enrich/git-status refresh** (250 ms
  trailing), so a burst of `session-files:updated` events for a session
  collapses to a single refresh — mirroring the `GIT_STATUS_DEBOUNCE_MS` /
  `PENDING_COUNT_DEBOUNCE_MS` debouncing already in this file.
- **Coalesce `session-files:get-tool-call-matches` per session**
  (single-flight + 500 ms TTL), extracted into a small dependency-free helper
  `toolCallMatchesCoalescer.ts`. `enrichEditsWithToolCallMatches` runs both on
  the debounced update path and, un-debounced, during the initial multi-session
  load; the coalescer makes concurrent calls for a session share one worker
  round-trip.

No behavior change for a single session at rest — only rapid-fire bursts are
collapsed, and the trailing debounce still reflects the latest DB state.

## Testing

- New unit tests for the coalescer: single-flight, TTL cache + refetch,
  per-session keying, `invalidate()`, and no-cache-on-rejection (5 tests).
- `vitest run` green.
