### PR TITLE
feat(electron): make project tabs default and dockable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 <!-- Changes to existing functionality go here -->
+- Projects now open as tabs across the top of the current window by default and can be dragged between windows or out into a separate window.
 - Settings is reorganized into Application, Account, and Project sections, with organization management moved to a dedicated window.
 - Logging in to your Claude subscription now opens the terminal in your current project folder.
 

--- a/packages/electron/e2e/multi-project/multi-project-rail.spec.ts
+++ b/packages/electron/e2e/multi-project/multi-project-rail.spec.ts
@@ -7,10 +7,10 @@ import * as path from 'path';
 test.describe.configure({ mode: 'serial' });
 
 /**
- * E2E coverage for the multi-project rail (issue #155).
+ * E2E coverage for project tabs (issue #155).
  *
  * Scenarios covered:
- *   1. Toggle on `multiProjectMode` exposes the rail UI and an active item.
+ *   1. Project tabs are enabled by default and expose an active item.
  *   2. Adding a second project via `register-additional` puts it on the rail
  *      and switching activates it (workspace:set-active fires through the
  *      atom subscriber).
@@ -49,8 +49,13 @@ test.describe('Multi-Project Rail', () => {
     await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('.workspace-sidebar', { timeout: TEST_TIMEOUTS.SIDEBAR_LOAD });
 
-    // Enable multi-project mode through the IPC settings handler so the
-    // rail is rendered without going through the Settings UI.
+    const tabsEnabledByDefault = await page.evaluate(async () => {
+      return window.electronAPI.invoke('app:get-multi-project-mode');
+    });
+    expect(tabsEnabledByDefault).toBe(true);
+
+    // Keep the fixture deterministic if a developer reuses a persisted E2E
+    // profile that predates the default-on migration.
     await page.evaluate(async () => {
       await window.electronAPI.invoke('app:set-multi-project-mode', true);
     });
@@ -106,7 +111,7 @@ test.describe('Multi-Project Rail', () => {
     const items = rail.locator('[data-testid="project-rail-item"]');
     await expect(items).toHaveCount(2);
 
-    const active = rail.locator('[data-testid="project-rail-item"].active');
+    const active = rail.locator('[data-testid="project-rail-item"].is-active');
     await expect(active).toHaveCount(1);
   });
 
@@ -167,7 +172,7 @@ test.describe('Multi-Project Rail', () => {
 
     // Click the active item to surface its close button (CSS shows it on
     // hover or when active).
-    const activeItem = rail.locator('[data-testid="project-rail-item"].active');
+    const activeItem = rail.locator('[data-testid="project-rail-item"].is-active');
     await activeItem.hover();
 
     // Auto-accept the streaming-confirm dialog (none expected here, but
@@ -214,7 +219,7 @@ test.describe('Multi-Project Rail', () => {
       // panel must show its empty state — no leaked tabs from the
       // previously active workspace.
       const rail = page.locator('[data-testid="project-rail"]');
-      const activeItem = rail.locator('[data-testid="project-rail-item"].active');
+      const activeItem = rail.locator('[data-testid="project-rail-item"].is-active');
       await expect(activeItem).toHaveCount(1);
 
       const empty = page.locator('.agent-mode-empty');

--- a/packages/electron/src/main/ipc/MultiProjectRailHandlers.ts
+++ b/packages/electron/src/main/ipc/MultiProjectRailHandlers.ts
@@ -18,30 +18,38 @@
  */
 
 import { BrowserWindow } from 'electron';
+import { randomUUID } from 'node:crypto';
 import { basename } from 'path';
-import { existsSync } from 'fs';
-import { safeHandle } from '../utils/ipcRegistry';
+import { safeHandle, safeOn } from '../utils/ipcRegistry';
 import {
+    createWindow,
     getWindowId,
     windowStates,
+    windowFocusOrder,
     documentServices,
 } from '../window/WindowManager';
 import { startWorkspaceWatcher, stopWorkspaceWatcher } from '../file/WorkspaceWatcher.ts';
-import { anyWindowReferencesWorkspace, resolveDocumentServicePath } from '../window/windowState';
-import { ElectronDocumentService, setupDocumentServiceHandlers } from '../services/ElectronDocumentService';
-import { ElectronFileSystemService } from '../services/ElectronFileSystemService';
-import { addNimAssetRoot } from '../protocols/nimAssetProtocol';
-import { addNimPreviewWorkspaceRoot } from '../protocols/nimPreviewProtocol';
-import { getMcpConfigService } from '../index';
-import { addToRecentItems, getWorkspaceNavigationHistory } from '../utils/store';
-import { navigationHistoryService } from '../services/NavigationHistoryService';
+import { anyWindowReferencesWorkspace, resolveActiveWorkspacePath } from '../window/windowState';
+import { getMcpConfigService } from '../mcpConfigServiceRef';
+import { addToRecentItems } from '../utils/store';
 import {
   setFileSystemService,
   clearFileSystemService,
-  setFileSystemServiceFor,
   clearFileSystemServiceFor,
 } from '@nimbalyst/runtime';
 import { logger } from '../utils/logger';
+import {
+  MAX_OPEN_PROJECT_TABS,
+  PROJECT_TAB_MUTATION_CHANNEL,
+  type ProjectTabDragRegistration,
+  type ProjectTabMutation,
+} from '../../shared/projectTabs';
+import { ensureWorkspaceTabServices } from '../services/WorkspaceTabServices';
+import {
+  activateWorkspaceTabContext,
+  initializeWorkspaceTabBackground,
+  releaseWorkspaceTabBackground,
+} from '../services/WorkspaceTabBackground';
 
 // Re-uses the same Maps that WindowManager populates. WindowManager exports
 // `documentServices` only; the file-system service map lives module-internal
@@ -49,66 +57,474 @@ import { logger } from '../utils/logger';
 // (added below in this PR).
 import { fileSystemServices, getFileSystemService } from '../window/serviceRegistry';
 
-function resolveDocumentServiceForEvent(event: Electron.IpcMainInvokeEvent | Electron.IpcMainEvent): ElectronDocumentService | null {
-    const browserWindow = BrowserWindow.fromWebContents(event.sender);
-    if (!browserWindow) return null;
-    const windowId = getWindowId(browserWindow);
-    if (windowId === null) return null;
-    const state = windowStates.get(windowId);
-    const path = resolveDocumentServicePath(state);
-    if (!path) return null;
-    return documentServices.get(path) ?? null;
+const PROJECT_TAB_DRAG_TTL_MS = 30_000;
+const PROJECT_TAB_DROP_GRACE_MS = 750;
+const PROJECT_TAB_PREPARATION_TIMEOUT_MS = 5_000;
+
+interface ActiveProjectTabDrag {
+    sourceWindow: BrowserWindow;
+    sourceWindowId: number;
+    workspacePath: string;
+    expiresAt: number;
+    cleanupTimer: ReturnType<typeof setTimeout>;
+    claimed: boolean;
+    claimedDestinationWindowId: number | null;
+    moved: boolean;
+    ready: boolean;
+    preparationError: string | null;
+    resultWaiters: Set<() => void>;
+    preparationWaiters: Set<() => void>;
 }
 
-/**
- * Ensure per-workspace services exist for `workspacePath`. Idempotent — if
- * another window already created the services, this just makes sure the
- * window-side state is wired up.
- *
- * NOTE: Does NOT start the workspace file watcher and does NOT flip the
- * runtime-global `FileSystemService`. Both belong to the "active path" of
- * a window and are managed by the `workspace:set-active` handler. Calling
- * either here would tear down whatever the active path is currently using
- * (the watcher is single-active-per-window, the FS getter is a singleton).
- */
-function ensureServicesForPath(window: BrowserWindow, workspacePath: string): void {
-    if (!existsSync(workspacePath)) {
-        logger.main.warn('[MultiProject] Refusing to register non-existent path:', workspacePath);
-        return;
+const activeProjectTabDrags = new Map<string, ActiveProjectTabDrag>();
+
+function removeActiveProjectTabDrag(dragId: string): void {
+    const drag = activeProjectTabDrags.get(dragId);
+    if (!drag) return;
+    clearTimeout(drag.cleanupTimer);
+    drag.resultWaiters.forEach((resolve) => resolve());
+    drag.preparationWaiters.forEach((resolve) => resolve());
+    activeProjectTabDrags.delete(dragId);
+}
+
+function pruneExpiredProjectTabDrags(): void {
+    const now = Date.now();
+    for (const [dragId, drag] of activeProjectTabDrags) {
+        if (drag.expiresAt > now) continue;
+        removeActiveProjectTabDrag(dragId);
     }
+}
 
-    addNimAssetRoot(workspacePath);
-    addNimPreviewWorkspaceRoot(workspacePath);
+function referencesWorkspace(state: { workspacePath: string | null; additionalWorkspacePaths?: string[] }, workspacePath: string): boolean {
+    return state.workspacePath === workspacePath
+        || state.additionalWorkspacePaths?.includes(workspacePath) === true;
+}
 
-    if (!documentServices.has(workspacePath)) {
-        const docService = new ElectronDocumentService(workspacePath);
-        documentServices.set(workspacePath, docService);
-        setupDocumentServiceHandlers(resolveDocumentServiceForEvent);
+function referencedWorkspacePaths(state: { workspacePath: string | null; additionalWorkspacePaths?: string[] }): string[] {
+    return [...new Set([state.workspacePath, ...(state.additionalWorkspacePaths ?? [])]
+        .filter((path): path is string => typeof path === 'string' && path.length > 0))];
+}
+
+function queueProjectTabMutation(
+    state: { pendingProjectTabMutations?: ProjectTabMutation[] },
+    mutation: ProjectTabMutation,
+): void {
+    state.pendingProjectTabMutations = [
+        ...(state.pendingProjectTabMutations ?? []).filter((pending) => pending.id !== mutation.id),
+        mutation,
+    ];
+}
+
+function sendProjectTabMutation(window: BrowserWindow, mutation: ProjectTabMutation): void {
+    try {
+        if (typeof window.isDestroyed === 'function' && window.isDestroyed()) return;
+        if (typeof window.webContents?.isDestroyed === 'function' && window.webContents.isDestroyed()) return;
+        window.webContents?.send?.(PROJECT_TAB_MUTATION_CHANNEL, mutation);
+    } catch (error) {
+        // Main state and pending mutations are already committed. Live IPC is
+        // best-effort; a reloading renderer will consume the durable queue.
+        logger.main.warn('[MultiProject] Project tab mutation delivery deferred:', error);
     }
+}
 
-    if (!fileSystemServices.has(workspacePath)) {
-        const fileSystemService = new ElectronFileSystemService(workspacePath);
-        fileSystemServices.set(workspacePath, fileSystemService);
-        // Per-path runtime registry mirrors the electron-side map so AI
-        // tool dispatch (fileTools.searchFiles / listFiles / readFile)
-        // running inside a session whose workspace is currently INACTIVE
-        // in the rail still resolves to the right service. Without this,
-        // the runtime-global singleton (set on rail switch to the active
-        // workspace) would silently route those calls to the wrong fs.
-        setFileSystemServiceFor(workspacePath, fileSystemService);
-    }
-
-    // Restore navigation history (no-op if already restored for this window).
-    const windowId = getWindowId(window);
-    if (windowId !== null) {
-        const navHistory = getWorkspaceNavigationHistory(workspacePath);
-        if (navHistory) {
-            navigationHistoryService.restoreNavigationState(windowId, navHistory);
+function restoreGlobalFileSystemService(excludeWindowId: number): void {
+    let bestPath: string | null = null;
+    let bestFocusOrder = -1;
+    for (const [windowId, state] of windowStates) {
+        if (windowId === excludeWindowId) continue;
+        const candidatePath = resolveActiveWorkspacePath(state);
+        if (!candidatePath || !fileSystemServices.has(candidatePath)) continue;
+        const focusOrder = windowFocusOrder.get(windowId) ?? 0;
+        if (focusOrder > bestFocusOrder) {
+            bestFocusOrder = focusOrder;
+            bestPath = candidatePath;
         }
     }
+
+    const service = bestPath ? fileSystemServices.get(bestPath) : null;
+    if (service) setFileSystemService(service);
+    else clearFileSystemService();
+}
+
+function resolveMostRecentlyFocusedWorkspacePath(): string | null {
+    let bestPath: string | null = null;
+    let bestFocusOrder = -1;
+    for (const [windowId, state] of windowStates) {
+        const candidatePath = resolveActiveWorkspacePath(state);
+        if (!candidatePath) continue;
+        const focusOrder = windowFocusOrder.get(windowId) ?? 0;
+        if (focusOrder > bestFocusOrder) {
+            bestFocusOrder = focusOrder;
+            bestPath = candidatePath;
+        }
+    }
+    return bestPath;
 }
 
 export function registerMultiProjectRailHandlers(): void {
+    safeOn('workspace:begin-project-tab-drag', (event, data: ProjectTabDragRegistration) => {
+        pruneExpiredProjectTabDrags();
+        if (
+            data?.version !== 1
+            || typeof data.dragId !== 'string'
+            || data.dragId.length === 0
+            || typeof data.workspacePath !== 'string'
+            || data.workspacePath.length === 0
+        ) {
+            return;
+        }
+
+        const sourceWindow = BrowserWindow.fromWebContents(event.sender);
+        if (!sourceWindow) return;
+        const sourceWindowId = getWindowId(sourceWindow);
+        if (sourceWindowId === null) return;
+        const sourceState = windowStates.get(sourceWindowId);
+        if (!sourceState || !referencesWorkspace(sourceState, data.workspacePath)) return;
+
+        removeActiveProjectTabDrag(data.dragId);
+        const drag: ActiveProjectTabDrag = {
+            sourceWindow,
+            sourceWindowId,
+            workspacePath: data.workspacePath,
+            expiresAt: Date.now() + PROJECT_TAB_DRAG_TTL_MS,
+            cleanupTimer: setTimeout(() => removeActiveProjectTabDrag(data.dragId), PROJECT_TAB_DRAG_TTL_MS),
+            claimed: false,
+            claimedDestinationWindowId: null,
+            moved: false,
+            ready: false,
+            preparationError: null,
+            resultWaiters: new Set(),
+            preparationWaiters: new Set(),
+        };
+        activeProjectTabDrags.set(data.dragId, drag);
+    });
+
+    safeOn('workspace:project-tab-drag-ready', (event, data: {
+        dragId?: string;
+        error?: string;
+    }) => {
+        const dragId = data?.dragId;
+        if (!dragId) return;
+        const drag = activeProjectTabDrags.get(dragId);
+        if (!drag) return;
+        const sourceWindow = BrowserWindow.fromWebContents(event.sender);
+        if (!sourceWindow || getWindowId(sourceWindow) !== drag.sourceWindowId) return;
+        drag.preparationError = typeof data.error === 'string' && data.error.length > 0
+            ? data.error
+            : null;
+        drag.ready = !drag.preparationError;
+        drag.preparationWaiters.forEach((resolve) => resolve());
+        drag.preparationWaiters.clear();
+    });
+
+    safeOn('workspace:end-project-tab-drag', (event, data: { dragId?: string }) => {
+        const dragId = data?.dragId;
+        if (!dragId) return;
+        const drag = activeProjectTabDrags.get(dragId);
+        if (!drag || drag.claimed || drag.moved) return;
+        const sourceWindow = BrowserWindow.fromWebContents(event.sender);
+        if (!sourceWindow || getWindowId(sourceWindow) !== drag.sourceWindowId) return;
+        removeActiveProjectTabDrag(dragId);
+    });
+
+    // Chromium normally reports dropEffect=move after a destination rail
+    // accepts a tab. Some Linux window-manager combinations report `none`,
+    // so dragend gives the destination a short grace period to commit before
+    // falling back to the existing tear-out behavior.
+    safeHandle('workspace:wait-project-tab-drag-result', async (event, data: { dragId?: string }) => {
+        const dragId = data?.dragId;
+        if (!dragId) return { handled: false, moved: false };
+        pruneExpiredProjectTabDrags();
+        const drag = activeProjectTabDrags.get(dragId);
+        if (!drag) return { handled: false, moved: false };
+
+        const sourceWindow = BrowserWindow.fromWebContents(event.sender);
+        if (!sourceWindow || getWindowId(sourceWindow) !== drag.sourceWindowId) {
+            return { handled: false, moved: false };
+        }
+        if (drag.claimed || drag.moved) {
+            return { handled: true, moved: drag.moved };
+        }
+
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+                drag.resultWaiters.delete(onSettled);
+                resolve();
+            }, PROJECT_TAB_DROP_GRACE_MS);
+            const onSettled = () => {
+                clearTimeout(timer);
+                resolve();
+            };
+            drag.resultWaiters.add(onSettled);
+        });
+
+        const handled = drag.claimed || drag.moved;
+        if (!handled && activeProjectTabDrags.get(dragId) === drag) {
+            // Close the token before returning. A destination that arrives
+            // after this point is rejected, preventing both a move and a new
+            // detached window from being created for the same drag.
+            removeActiveProjectTabDrag(dragId);
+        }
+        return { handled, moved: drag.moved };
+    });
+
+    safeHandle('workspace:consume-pending-project-tab-mutations', async (event) => {
+        const window = BrowserWindow.fromWebContents(event.sender);
+        if (!window) return [];
+        const windowId = getWindowId(window);
+        if (windowId === null) return [];
+        return [...(windowStates.get(windowId)?.pendingProjectTabMutations ?? [])];
+    });
+
+    safeHandle('workspace:ack-project-tab-mutation', async (event, data: { mutationId?: string }) => {
+        const mutationId = data?.mutationId;
+        if (!mutationId) return { success: false };
+        const window = BrowserWindow.fromWebContents(event.sender);
+        if (!window) return { success: false };
+        const windowId = getWindowId(window);
+        if (windowId === null) return { success: false };
+        const state = windowStates.get(windowId);
+        if (!state) return { success: false };
+        state.pendingProjectTabMutations = (state.pendingProjectTabMutations ?? []).filter(
+            (mutation) => mutation.id !== mutationId,
+        );
+        return { success: true };
+    });
+
+    safeHandle('workspace:move-project-tab', async (event, data: { dragId?: string }) => {
+        pruneExpiredProjectTabDrags();
+        const dragId = data?.dragId;
+        if (!dragId) {
+            return { success: false, error: 'dragId required' };
+        }
+
+        const drag = activeProjectTabDrags.get(dragId);
+        if (!drag || drag.moved) {
+            return { success: false, error: 'Project tab drag is no longer active' };
+        }
+        const workspacePath = drag.workspacePath;
+
+        const destinationWindow = BrowserWindow.fromWebContents(event.sender);
+        if (!destinationWindow) return { success: false, error: 'No destination window' };
+        const destinationWindowId = getWindowId(destinationWindow);
+        if (destinationWindowId === null) return { success: false, error: 'No destination windowId' };
+        if (destinationWindowId === drag.sourceWindowId) {
+            // Dropping back onto the originating strip is a normal no-op.
+            // Keep the token claimed until dragend's Linux fallback check so
+            // a browser-reported dropEffect=none cannot tear it into a window.
+            drag.claimed = true;
+            drag.claimedDestinationWindowId = destinationWindowId;
+            drag.resultWaiters.forEach((resolve) => resolve());
+            drag.resultWaiters.clear();
+            return { success: true, alreadyInWindow: true };
+        }
+        if (typeof drag.sourceWindow.isDestroyed === 'function' && drag.sourceWindow.isDestroyed()) {
+            removeActiveProjectTabDrag(dragId);
+            return { success: false, error: 'Source window is no longer available' };
+        }
+
+        const initialSourceState = windowStates.get(drag.sourceWindowId);
+        const initialDestinationState = windowStates.get(destinationWindowId);
+        if (!initialSourceState || !initialDestinationState) {
+            return { success: false, error: 'Source or destination window state is unavailable' };
+        }
+        if (drag.claimedDestinationWindowId !== null) {
+            return { success: false, error: 'Project tab drag was already claimed by a destination window' };
+        }
+        // A real destination rail claimed the DOM drop. From this point on,
+        // even validation/preparation failure leaves the source tab in place
+        // instead of racing the fallback into a surprise third window.
+        drag.claimed = true;
+        drag.claimedDestinationWindowId = destinationWindowId;
+        drag.resultWaiters.forEach((resolve) => resolve());
+        drag.resultWaiters.clear();
+        if (!referencesWorkspace(initialSourceState, workspacePath)) {
+            removeActiveProjectTabDrag(dragId);
+            return { success: false, error: 'Project is not open in the source window' };
+        }
+        if (initialDestinationState.mode !== 'workspace' && initialDestinationState.mode !== 'agentic-coding') {
+            return { success: false, error: 'Destination is not a workspace window' };
+        }
+
+        if (!drag.ready && !drag.preparationError) {
+            await new Promise<void>((resolve) => {
+                const timer = setTimeout(() => {
+                    drag.preparationWaiters.delete(onPrepared);
+                    resolve();
+                }, PROJECT_TAB_PREPARATION_TIMEOUT_MS);
+                const onPrepared = () => {
+                    clearTimeout(timer);
+                    resolve();
+                };
+                drag.preparationWaiters.add(onPrepared);
+            });
+        }
+        if (drag.preparationError) {
+            return { success: false, error: drag.preparationError };
+        }
+        if (!drag.ready) {
+            return { success: false, error: 'Timed out while saving the project before moving it' };
+        }
+
+        // Preparation may take several seconds. Re-resolve every mutable
+        // participant after the await so a closed/reloaded window, a removed
+        // source tab, or another destination cannot commit stale state.
+        if (
+            activeProjectTabDrags.get(dragId) !== drag
+            || drag.moved
+            || drag.claimedDestinationWindowId !== destinationWindowId
+        ) {
+            return { success: false, error: 'Project tab drag is no longer active' };
+        }
+        if (
+            (typeof drag.sourceWindow.isDestroyed === 'function' && drag.sourceWindow.isDestroyed())
+            || (typeof destinationWindow.isDestroyed === 'function' && destinationWindow.isDestroyed())
+        ) {
+            return { success: false, error: 'Source or destination window is no longer available' };
+        }
+        const sourceState = windowStates.get(drag.sourceWindowId);
+        const destinationState = windowStates.get(destinationWindowId);
+        if (!sourceState || !destinationState) {
+            return { success: false, error: 'Source or destination window state is unavailable' };
+        }
+        if (!referencesWorkspace(sourceState, workspacePath)) {
+            return { success: false, error: 'Project is not open in the source window' };
+        }
+        if (destinationState.mode !== 'workspace' && destinationState.mode !== 'agentic-coding') {
+            return { success: false, error: 'Destination is not a workspace window' };
+        }
+
+        const destinationAlreadyReferences = referencesWorkspace(destinationState, workspacePath);
+        if (!destinationAlreadyReferences
+            && referencedWorkspacePaths(destinationState).length >= MAX_OPEN_PROJECT_TABS) {
+            return { success: false, error: `Project tab limit (${MAX_OPEN_PROJECT_TABS}) reached` };
+        }
+
+        // Service creation happens before either window state changes. It is
+        // normally idempotent because the source already owns the project,
+        // but retaining the check makes the transaction safe after a reload.
+        const serviceResult = ensureWorkspaceTabServices(destinationWindow, workspacePath);
+        if (!serviceResult.success) return serviceResult;
+
+        const sourceSnapshot = {
+            workspacePath: sourceState.workspacePath,
+            additionalWorkspacePaths: [...(sourceState.additionalWorkspacePaths ?? [])],
+            activeWorkspacePath: sourceState.activeWorkspacePath,
+            pendingProjectTabPaths: [...(sourceState.pendingProjectTabPaths ?? [])],
+            pendingProjectTabMutations: [...(sourceState.pendingProjectTabMutations ?? [])],
+        };
+        const destinationSnapshot = {
+            workspacePath: destinationState.workspacePath,
+            additionalWorkspacePaths: [...(destinationState.additionalWorkspacePaths ?? [])],
+            activeWorkspacePath: destinationState.activeWorkspacePath,
+            pendingProjectTabMutations: [...(destinationState.pendingProjectTabMutations ?? [])],
+        };
+        const sourceWasActive = (sourceState.activeWorkspacePath ?? sourceState.workspacePath) === workspacePath;
+        const destinationPreviousActive = destinationState.activeWorkspacePath ?? destinationState.workspacePath;
+        const previousGlobalPath = resolveMostRecentlyFocusedWorkspacePath();
+
+        try {
+            if (sourceWasActive) stopWorkspaceWatcher(drag.sourceWindowId);
+            if (destinationPreviousActive && destinationPreviousActive !== workspacePath) {
+                stopWorkspaceWatcher(destinationWindowId);
+            }
+
+            // Destination first: the workspace remains referenced throughout
+            // the handoff, so shared sessions/services cannot be torn down.
+            if (!destinationAlreadyReferences) {
+                if (!destinationState.workspacePath) {
+                    destinationState.workspacePath = workspacePath;
+                } else {
+                    destinationState.additionalWorkspacePaths = [
+                        ...(destinationState.additionalWorkspacePaths ?? []),
+                        workspacePath,
+                    ];
+                }
+            }
+
+            const sourcePaths = referencedWorkspacePaths(sourceState);
+            const sourceIndex = sourcePaths.indexOf(workspacePath);
+            const remainingSourcePaths = sourcePaths.filter((path) => path !== workspacePath);
+            const replacementWorkspacePath = remainingSourcePaths[sourceIndex]
+                ?? remainingSourcePaths[sourceIndex - 1]
+                ?? remainingSourcePaths[0]
+                ?? null;
+
+            if (sourceState.workspacePath === workspacePath) {
+                sourceState.workspacePath = replacementWorkspacePath;
+                sourceState.additionalWorkspacePaths = remainingSourcePaths.filter(
+                    (path) => path !== replacementWorkspacePath,
+                );
+            } else {
+                sourceState.additionalWorkspacePaths = (sourceState.additionalWorkspacePaths ?? []).filter(
+                    (path) => path !== workspacePath,
+                );
+            }
+            sourceState.pendingProjectTabPaths = (sourceState.pendingProjectTabPaths ?? []).filter(
+                (path) => path !== workspacePath,
+            );
+            if (sourceWasActive) sourceState.activeWorkspacePath = replacementWorkspacePath;
+
+            destinationState.activeWorkspacePath = workspacePath;
+
+            if (sourceWasActive && replacementWorkspacePath) {
+                startWorkspaceWatcher(drag.sourceWindow, replacementWorkspacePath);
+            }
+            if (destinationPreviousActive !== workspacePath) {
+                startWorkspaceWatcher(destinationWindow, workspacePath);
+            }
+
+            const destinationService = fileSystemServices.get(workspacePath);
+            if (destinationService) setFileSystemService(destinationService);
+            initializeWorkspaceTabBackground(workspacePath);
+            activateWorkspaceTabContext(workspacePath);
+            addToRecentItems('workspaces', workspacePath, basename(workspacePath));
+
+            const sourceMutation: ProjectTabMutation = {
+                id: randomUUID(),
+                kind: 'remove',
+                workspacePath,
+                replacementWorkspacePath: sourceWasActive ? replacementWorkspacePath : null,
+                closeWindowWhenEmpty: remainingSourcePaths.length === 0,
+            };
+            const destinationMutation: ProjectTabMutation = {
+                id: randomUUID(),
+                kind: 'add',
+                workspacePath,
+                activate: true,
+            };
+            queueProjectTabMutation(sourceState, sourceMutation);
+            queueProjectTabMutation(destinationState, destinationMutation);
+
+            drag.moved = true;
+            drag.resultWaiters.forEach((resolve) => resolve());
+            drag.resultWaiters.clear();
+            sendProjectTabMutation(drag.sourceWindow, sourceMutation);
+            sendProjectTabMutation(destinationWindow, destinationMutation);
+
+            return { success: true };
+        } catch (error) {
+            // Restore both window states and their previous active watchers.
+            // No service cleanup runs during a move, so rollback cannot lose a
+            // session even if a watcher transition throws unexpectedly.
+            stopWorkspaceWatcher(drag.sourceWindowId);
+            stopWorkspaceWatcher(destinationWindowId);
+            Object.assign(sourceState, sourceSnapshot);
+            Object.assign(destinationState, destinationSnapshot);
+            const previousSourceActive = sourceSnapshot.activeWorkspacePath ?? sourceSnapshot.workspacePath;
+            if (previousSourceActive) startWorkspaceWatcher(drag.sourceWindow, previousSourceActive);
+            if (destinationPreviousActive) startWorkspaceWatcher(destinationWindow, destinationPreviousActive);
+            const previousGlobalService = previousGlobalPath
+                ? fileSystemServices.get(previousGlobalPath)
+                : null;
+            if (previousGlobalService) setFileSystemService(previousGlobalService);
+            else restoreGlobalFileSystemService(-1);
+            if (previousGlobalPath) activateWorkspaceTabContext(previousGlobalPath);
+            logger.main.error('[MultiProject] Failed to move project tab:', error);
+            return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+    });
+
     safeHandle('workspace:register-additional', async (event, data: { workspacePath: string }) => {
         const { workspacePath } = data;
         if (!workspacePath || typeof workspacePath !== 'string') {
@@ -129,15 +545,53 @@ export function registerMultiProjectRailHandlers(): void {
         }
 
         const additional = state.additionalWorkspacePaths ?? [];
-        state.additionalWorkspacePaths = [...additional, workspacePath];
+        const registeredCount = new Set([state.workspacePath, ...additional].filter(Boolean)).size;
+        if (registeredCount >= MAX_OPEN_PROJECT_TABS) {
+            return { success: false, error: `Project tab limit (${MAX_OPEN_PROJECT_TABS}) reached` };
+        }
 
-        ensureServicesForPath(window, workspacePath);
+        // Build services before mutating the window reference list. If a
+        // constructor fails, the renderer never shows a tab and main retains
+        // no ghost reference.
+        const serviceResult = ensureWorkspaceTabServices(window, workspacePath);
+        if (!serviceResult.success) return serviceResult;
+
+        state.additionalWorkspacePaths = [...additional, workspacePath];
         addToRecentItems('workspaces', workspacePath, basename(workspacePath));
+        initializeWorkspaceTabBackground(workspacePath);
 
         return { success: true };
     });
 
-    safeHandle('workspace:unregister-additional', async (event, data: { workspacePath: string }) => {
+    safeHandle('workspace:consume-pending-project-tabs', async (event) => {
+        const window = BrowserWindow.fromWebContents(event.sender);
+        if (!window) return [];
+        const windowId = getWindowId(window);
+        if (windowId === null) return [];
+        const state = windowStates.get(windowId);
+        if (!state) return [];
+        return [...new Set(state.pendingProjectTabPaths ?? [])];
+    });
+
+    safeHandle('workspace:ack-project-tab-open', async (event, data: { workspacePath: string }) => {
+        const workspacePath = data?.workspacePath;
+        if (!workspacePath || typeof workspacePath !== 'string') return { success: false };
+        const window = BrowserWindow.fromWebContents(event.sender);
+        if (!window) return { success: false };
+        const windowId = getWindowId(window);
+        if (windowId === null) return { success: false };
+        const state = windowStates.get(windowId);
+        if (!state) return { success: false };
+        state.pendingProjectTabPaths = (state.pendingProjectTabPaths ?? []).filter(
+            (path) => path !== workspacePath,
+        );
+        return { success: true };
+    });
+
+    safeHandle('workspace:unregister-additional', async (event, data: {
+        workspacePath: string;
+        replacementWorkspacePath?: string | null;
+    }) => {
         const { workspacePath } = data;
         if (!workspacePath || typeof workspacePath !== 'string') {
             return { success: false, error: 'workspacePath required' };
@@ -151,25 +605,67 @@ export function registerMultiProjectRailHandlers(): void {
         const state = windowStates.get(windowId);
         if (!state) return { success: false, error: 'No window state' };
 
-        if (state.additionalWorkspacePaths?.includes(workspacePath)) {
-            state.additionalWorkspacePaths = state.additionalWorkspacePaths.filter((p) => p !== workspacePath);
+        const referencesProject = state.workspacePath === workspacePath
+            || state.additionalWorkspacePaths?.includes(workspacePath) === true;
+        if (!referencesProject) {
+            return { success: false, error: 'Project is not open in this window' };
         }
 
-        // If this window still references the path as primary, leave services alone.
-        if (state.workspacePath === workspacePath) {
-            return { success: true, stillPrimary: true };
-        }
+        const wasPrimary = state.workspacePath === workspacePath;
+        const wasActive = (state.activeWorkspacePath ?? state.workspacePath) === workspacePath;
+        let remainingAdditional = (state.additionalWorkspacePaths ?? []).filter((p) => p !== workspacePath);
 
-        // If the path being closed was this window's active path, tear down
-        // the active-only state (file watcher + global FS service). The
-        // renderer is expected to call `workspace:set-active` for the
-        // replacement path right after this; that call will start the
-        // watcher and flip the FS global to the new active project.
-        const wasActive = state.activeWorkspacePath === workspacePath;
+        // stopWorkspaceWatcher derives project-sync cleanup from the current
+        // state, so stop it before removing/promoting paths.
+        if (wasActive) stopWorkspaceWatcher(windowId);
+
+        // The legacy primary path must follow the remaining visible tabs.
+        // Otherwise closing/detaching the startup project leaves a hidden
+        // reference in this window forever and prevents service cleanup.
+        if (wasPrimary) {
+            const requestedReplacement = data.replacementWorkspacePath;
+            const promoted = requestedReplacement && remainingAdditional.includes(requestedReplacement)
+                ? requestedReplacement
+                : state.activeWorkspacePath && state.activeWorkspacePath !== workspacePath
+                    && remainingAdditional.includes(state.activeWorkspacePath)
+                    ? state.activeWorkspacePath
+                    : remainingAdditional[0] ?? null;
+            state.workspacePath = promoted;
+            remainingAdditional = remainingAdditional.filter((path) => path !== promoted);
+        }
+        state.additionalWorkspacePaths = remainingAdditional;
+        state.pendingProjectTabPaths = (state.pendingProjectTabPaths ?? []).filter(
+            (path) => path !== workspacePath,
+        );
+
+        // If the path being closed was this window's active path, move the
+        // active-only state (file watcher + global FS service) to the
+        // replacement immediately. The renderer will also publish its new
+        // active atom after this IPC resolves; that follow-up is idempotent.
         if (wasActive) {
-            stopWorkspaceWatcher(windowId);
-            state.activeWorkspacePath = null;
-            clearFileSystemService();
+            const referencedAfterClose = [state.workspacePath, ...remainingAdditional].filter(
+                (path): path is string => typeof path === 'string' && path.length > 0,
+            );
+            const requestedReplacement = data.replacementWorkspacePath;
+            const nextActive = requestedReplacement && referencedAfterClose.includes(requestedReplacement)
+                ? requestedReplacement
+                : referencedAfterClose[0] ?? null;
+            state.activeWorkspacePath = nextActive;
+
+            if (nextActive) {
+                startWorkspaceWatcher(window, nextActive);
+                const nextService = fileSystemServices.get(nextActive);
+                if (nextService) {
+                    setFileSystemService(nextService);
+                } else {
+                    restoreGlobalFileSystemService(windowId);
+                }
+            } else {
+                // A detach creates its destination before this close. Select
+                // the most recently focused remaining workspace's service so
+                // the handoff cannot leave the process-global service empty.
+                restoreGlobalFileSystemService(windowId);
+            }
         }
 
         // Free services only if no other window references the path.
@@ -195,9 +691,60 @@ export function registerMultiProjectRailHandlers(): void {
             } catch (error) {
                 logger.main.error('[MultiProject] Error stopping MCP config watcher:', error);
             }
+            releaseWorkspaceTabBackground(workspacePath);
         }
 
         return { success: true };
+    });
+
+    // Dragging a tab out creates its destination window before the renderer
+    // unregisters it from the source, keeping shared services and sessions
+    // alive throughout the handoff.
+    safeHandle('workspace:detach-project-tab', async (event, data: {
+        workspacePath: string;
+        position?: { screenX: number; screenY: number };
+    }) => {
+        const workspacePath = data?.workspacePath;
+        if (!workspacePath || typeof workspacePath !== 'string') {
+            return { success: false, error: 'workspacePath required' };
+        }
+
+        const sourceWindow = BrowserWindow.fromWebContents(event.sender);
+        if (!sourceWindow) return { success: false, error: 'No window for event sender' };
+        const sourceWindowId = getWindowId(sourceWindow);
+        if (sourceWindowId === null) return { success: false, error: 'No windowId' };
+        const state = windowStates.get(sourceWindowId);
+        const referencesProject = state?.workspacePath === workspacePath
+            || state?.additionalWorkspacePaths?.includes(workspacePath) === true;
+        if (!referencesProject) {
+            return { success: false, error: 'Project is not open in this window' };
+        }
+
+        const sourceBounds = typeof sourceWindow.getBounds === 'function'
+            ? sourceWindow.getBounds()
+            : null;
+        const position = data.position;
+        const detachedBounds = sourceBounds && position
+            && Number.isFinite(position.screenX) && Number.isFinite(position.screenY)
+            && (position.screenX !== 0 || position.screenY !== 0)
+            ? {
+                x: Math.round(position.screenX - 120),
+                y: Math.round(position.screenY - 20),
+                width: sourceBounds.width,
+                height: sourceBounds.height,
+            }
+            : undefined;
+
+        const detachedWindow = createWindow(false, true, workspacePath, detachedBounds);
+        const detachedWindowId = getWindowId(detachedWindow);
+        if (detachedWindowId !== null) {
+            const detachedState = windowStates.get(detachedWindowId);
+            if (detachedState) detachedState.activeWorkspacePath = workspacePath;
+        }
+        addToRecentItems('workspaces', workspacePath, basename(workspacePath));
+        initializeWorkspaceTabBackground(workspacePath);
+        activateWorkspaceTabContext(workspacePath);
+        return { success: true, windowId: detachedWindow.id };
     });
 
     safeHandle('workspace:set-active', async (event, data: { workspacePath: string }) => {
@@ -225,8 +772,15 @@ export function registerMultiProjectRailHandlers(): void {
             // pointing at the right place (covers the case of an early call
             // before the watcher was started, e.g. during create-window
             // bootstrap).
-            const svc = fileSystemServices.get(workspacePath);
-            if (svc) setFileSystemService(svc);
+            // A main-owned cross-window move updates both renderers. The
+            // unfocused source can publish its replacement after the focused
+            // destination publishes the moved project, so only the focused
+            // window may update process-global workspace context here.
+            if (window.isFocused()) {
+                const svc = fileSystemServices.get(workspacePath);
+                if (svc) setFileSystemService(svc);
+                activateWorkspaceTabContext(workspacePath);
+            }
             return { success: true, alreadyActive: true };
         }
 
@@ -245,14 +799,18 @@ export function registerMultiProjectRailHandlers(): void {
         // project. Sessions running in inactive rail projects must resolve
         // their FS service via the per-path map (`fileSystemServices.get`)
         // — see docs/AI_PROVIDER_TYPES.md.
-        const fsService = fileSystemServices.get(workspacePath);
-        if (fsService) {
-            setFileSystemService(fsService);
-        } else {
-            logger.main.warn(
-                '[MultiProject] set-active without registered FileSystemService for path:',
-                workspacePath,
-            );
+        if (window.isFocused()) {
+            const fsService = fileSystemServices.get(workspacePath);
+            if (fsService) {
+                setFileSystemService(fsService);
+            } else {
+                logger.main.warn(
+                    '[MultiProject] set-active without registered FileSystemService for path:',
+                    workspacePath,
+                );
+            }
+
+            activateWorkspaceTabContext(workspacePath);
         }
 
         return { success: true };

--- a/packages/electron/src/main/ipc/WindowHandlers.ts
+++ b/packages/electron/src/main/ipc/WindowHandlers.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, shell, nativeImage, app, powerMonitor } from 'electron';
 import { safeHandle, safeOn } from '../utils/ipcRegistry';
 import { windowStates, windows, getWindowId } from '../window/WindowManager';
+import { resolveActiveWorkspacePath } from '../window/windowState';
 import { basename, join } from 'path';
 import { writeFileSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
@@ -81,9 +82,10 @@ export function registerWindowHandlers() {
         const state = windowStates.get(windowId);
         if (!state || state.mode !== 'workspace') return null;
 
+        const workspacePath = resolveActiveWorkspacePath(state);
         return {
-            path: state.workspacePath,
-            name: state.workspacePath ? basename(state.workspacePath) : null
+            path: workspacePath,
+            name: workspacePath ? basename(workspacePath) : null
         };
     });
     // Set document edited state

--- a/packages/electron/src/main/ipc/__tests__/MultiProjectRailHandlers.test.ts
+++ b/packages/electron/src/main/ipc/__tests__/MultiProjectRailHandlers.test.ts
@@ -7,7 +7,7 @@ import type { WindowState } from '../../types';
  * inside the factories would be `undefined` at mock evaluation time.
  */
 const mocks = vi.hoisted(() => {
-  const handlers = new Map<string, (event: any, data: any) => Promise<any>>();
+  const handlers = new Map<string, (event: any, data: any) => any>();
   return {
     handlers,
     startWorkspaceWatcher: vi.fn(),
@@ -19,18 +19,31 @@ const mocks = vi.hoisted(() => {
     documentServices: new Map<string, any>(),
     fileSystemServices: new Map<string, any>(),
     windowStates: new Map<number, WindowState>(),
+    windowFocusOrder: new Map<number, number>(),
     addToRecentItems: vi.fn(),
     getWorkspaceNavigationHistory: vi.fn(() => null),
     setupDocumentServiceHandlers: vi.fn(),
     addNimAssetRoot: vi.fn(),
     getMcpConfigService: vi.fn(() => ({ stopWatchingWorkspaceConfig: vi.fn() })),
+    initializeWorkspaceTabBackground: vi.fn(),
+    activateWorkspaceTabContext: vi.fn(),
+    releaseWorkspaceTabBackground: vi.fn(),
     restoreNavigationState: vi.fn(),
+    createWindow: vi.fn(() => ({ id: 99 })),
+    electronFileSystemService: vi.fn(function () {
+      return { destroy: vi.fn() };
+    }),
+    fakeBrowserWindows: new Map<number, any>(),
     fakeBrowserWindowId: 1,
+    focusedBrowserWindowId: 1,
   };
 });
 
 vi.mock('../../utils/ipcRegistry', () => ({
   safeHandle: (channel: string, fn: (event: any, data: any) => Promise<any>) => {
+    mocks.handlers.set(channel, fn);
+  },
+  safeOn: (channel: string, fn: (event: any, data: any) => void) => {
     mocks.handlers.set(channel, fn);
   },
 }));
@@ -51,6 +64,10 @@ vi.mock('../../protocols/nimAssetProtocol', () => ({
   addNimAssetRoot: mocks.addNimAssetRoot,
 }));
 
+vi.mock('../../protocols/nimPreviewProtocol', () => ({
+  addNimPreviewWorkspaceRoot: vi.fn(),
+}));
+
 vi.mock('../../utils/store', () => ({
   addToRecentItems: mocks.addToRecentItems,
   getWorkspaceNavigationHistory: mocks.getWorkspaceNavigationHistory,
@@ -60,19 +77,43 @@ vi.mock('../../services/NavigationHistoryService', () => ({
   navigationHistoryService: { restoreNavigationState: mocks.restoreNavigationState },
 }));
 
-vi.mock('../../index', () => ({
+vi.mock('../../mcpConfigServiceRef', () => ({
   getMcpConfigService: mocks.getMcpConfigService,
 }));
 
+vi.mock('../../services/TeamService', () => ({
+  autoMatchTeamForWorkspace: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../services/TrackerSyncManager', () => ({
+  initializeTrackerSync: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../services/TrackerSchemaService', () => ({
+  updateTrackerSchemaWorkspace: vi.fn(),
+}));
+
+vi.mock('../../services/WorkspaceTabBackground', () => ({
+  initializeWorkspaceTabBackground: mocks.initializeWorkspaceTabBackground,
+  activateWorkspaceTabContext: mocks.activateWorkspaceTabContext,
+  releaseWorkspaceTabBackground: mocks.releaseWorkspaceTabBackground,
+}));
+
 vi.mock('../../window/WindowManager', () => ({
+  createWindow: mocks.createWindow,
   documentServices: mocks.documentServices,
   windowStates: mocks.windowStates,
+  windowFocusOrder: mocks.windowFocusOrder,
   getWindowId: (window: any) => window?.id ?? null,
 }));
 
 vi.mock('../../window/windowState', () => ({
   windowStates: mocks.windowStates,
   resolveActiveWorkspacePath: (state: WindowState | undefined) => {
+    if (!state) return null;
+    return state.activeWorkspacePath ?? state.workspacePath;
+  },
+  resolveDocumentServicePath: (state: WindowState | undefined) => {
     if (!state) return null;
     return state.activeWorkspacePath ?? state.workspacePath;
   },
@@ -113,14 +154,27 @@ vi.mock('../../services/ElectronDocumentService', () => ({
 }));
 
 vi.mock('../../services/ElectronFileSystemService', () => ({
-  ElectronFileSystemService: vi.fn(function () {
-    return new FakeService();
-  }),
+  ElectronFileSystemService: mocks.electronFileSystemService,
 }));
 
 vi.mock('electron', () => ({
   BrowserWindow: {
-    fromWebContents: () => ({ id: mocks.fakeBrowserWindowId }),
+    fromWebContents: () => {
+      let window = mocks.fakeBrowserWindows.get(mocks.fakeBrowserWindowId);
+      if (!window) {
+        const windowId = mocks.fakeBrowserWindowId;
+        window = {
+          id: windowId,
+          getBounds: () => ({ x: 20, y: 20, width: 1000, height: 700 }),
+          isDestroyed: () => false,
+          isFocused: () => mocks.focusedBrowserWindowId === windowId,
+          webContents: { send: vi.fn() },
+          close: vi.fn(),
+        };
+        mocks.fakeBrowserWindows.set(windowId, window);
+      }
+      return window;
+    },
   },
 }));
 
@@ -164,10 +218,21 @@ describe('MultiProjectRailHandlers', () => {
     mocks.documentServices.clear();
     mocks.fileSystemServices.clear();
     mocks.windowStates.clear();
+    mocks.windowFocusOrder.clear();
+    mocks.fakeBrowserWindows.clear();
+    mocks.focusedBrowserWindowId = 1;
     mocks.startWorkspaceWatcher.mockReset();
     mocks.stopWorkspaceWatcher.mockReset();
     mocks.setFileSystemService.mockReset();
     mocks.clearFileSystemService.mockReset();
+    mocks.initializeWorkspaceTabBackground.mockReset();
+    mocks.activateWorkspaceTabContext.mockReset();
+    mocks.releaseWorkspaceTabBackground.mockReset();
+    mocks.createWindow.mockClear();
+    mocks.electronFileSystemService.mockReset();
+    mocks.electronFileSystemService.mockImplementation(function () {
+      return { destroy: vi.fn() };
+    });
     registerMultiProjectRailHandlers();
   });
 
@@ -191,6 +256,20 @@ describe('MultiProjectRailHandlers', () => {
       expect(mocks.documentServices.has('/ws/b')).toBe(true);
       expect(mocks.fileSystemServices.has('/ws/b')).toBe(true);
       expect(mocks.windowStates.get(1)?.additionalWorkspacePaths).toEqual(['/ws/b']);
+    });
+
+    it('does not leave a ghost reference when service construction fails', async () => {
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/a' }));
+      mocks.electronFileSystemService.mockImplementationOnce(function () {
+        throw new Error('filesystem unavailable');
+      });
+
+      const result = await invoke('workspace:register-additional', { workspacePath: '/ws/b' }, 1);
+
+      expect(result).toMatchObject({ success: false, error: 'filesystem unavailable' });
+      expect(mocks.windowStates.get(1)?.additionalWorkspacePaths).toBeUndefined();
+      expect(mocks.documentServices.has('/ws/b')).toBe(false);
+      expect(mocks.fileSystemServices.has('/ws/b')).toBe(false);
     });
 
     it('does NOT start the watcher (regression guard for fix #1)', async () => {
@@ -219,6 +298,22 @@ describe('MultiProjectRailHandlers', () => {
 
       expect(result).toMatchObject({ success: true, alreadyRegistered: true });
       expect(mocks.windowStates.get(1)?.additionalWorkspacePaths).toEqual(['/ws/b']);
+    });
+
+    it('keeps queued tab opens until the renderer acknowledges them', async () => {
+      mocks.windowStates.set(1, makeState({
+        workspacePath: '/ws/a',
+        pendingProjectTabPaths: ['/ws/b', '/ws/b'],
+      }));
+
+      expect(await invoke('workspace:consume-pending-project-tabs', undefined, 1)).toEqual(['/ws/b']);
+      expect(await invoke('workspace:consume-pending-project-tabs', undefined, 1)).toEqual(['/ws/b']);
+      expect(await invoke(
+        'workspace:ack-project-tab-open',
+        { workspacePath: '/ws/b' },
+        1,
+      )).toEqual({ success: true });
+      expect(await invoke('workspace:consume-pending-project-tabs', undefined, 1)).toEqual([]);
     });
   });
 
@@ -252,6 +347,8 @@ describe('MultiProjectRailHandlers', () => {
       expect(mocks.startWorkspaceWatcher).toHaveBeenCalledWith(expect.anything(), '/ws/b');
       expect(mocks.setFileSystemService).toHaveBeenCalledTimes(1);
       expect(mocks.windowStates.get(1)?.activeWorkspacePath).toBe('/ws/b');
+      expect(mocks.activateWorkspaceTabContext).toHaveBeenCalledWith('/ws/b');
+      expect(mocks.initializeWorkspaceTabBackground).not.toHaveBeenCalled();
     });
 
     it('is idempotent when the path is already active', async () => {
@@ -264,6 +361,8 @@ describe('MultiProjectRailHandlers', () => {
       expect(result).toMatchObject({ alreadyActive: true });
       expect(mocks.stopWorkspaceWatcher).not.toHaveBeenCalled();
       expect(mocks.startWorkspaceWatcher).not.toHaveBeenCalled();
+      expect(mocks.activateWorkspaceTabContext).toHaveBeenCalledWith('/ws/a');
+      expect(mocks.initializeWorkspaceTabBackground).not.toHaveBeenCalled();
     });
   });
 
@@ -287,11 +386,23 @@ describe('MultiProjectRailHandlers', () => {
       expect(mocks.windowStates.get(1)?.additionalWorkspacePaths).toEqual([]);
     });
 
+    it('rejects a close for a path the source window does not reference', async () => {
+      const result = await invoke(
+        'workspace:unregister-additional',
+        { workspacePath: '/ws/missing' },
+        1,
+      );
+
+      expect(result).toMatchObject({ success: false });
+      expect(mocks.documentServices.has('/ws/warm')).toBe(true);
+    });
+
     it('destroys services when no other window references the path', async () => {
       await invoke('workspace:unregister-additional', { workspacePath: '/ws/warm' }, 1);
 
       expect(mocks.documentServices.has('/ws/warm')).toBe(false);
       expect(mocks.fileSystemServices.has('/ws/warm')).toBe(false);
+      expect(mocks.releaseWorkspaceTabBackground).toHaveBeenCalledWith('/ws/warm');
     });
 
     it('keeps services alive when another window still references the path', async () => {
@@ -301,6 +412,7 @@ describe('MultiProjectRailHandlers', () => {
 
       expect(mocks.documentServices.has('/ws/warm')).toBe(true);
       expect(mocks.fileSystemServices.has('/ws/warm')).toBe(true);
+      expect(mocks.releaseWorkspaceTabBackground).not.toHaveBeenCalled();
     });
 
     it('does not stop the watcher when the closed path was not active', async () => {
@@ -324,7 +436,434 @@ describe('MultiProjectRailHandlers', () => {
 
       expect(mocks.stopWorkspaceWatcher).toHaveBeenCalledWith(1);
       expect(mocks.clearFileSystemService).toHaveBeenCalled();
-      expect(mocks.windowStates.get(1)?.activeWorkspacePath).toBeNull();
+      expect(mocks.windowStates.get(1)?.activeWorkspacePath).toBe('/ws/primary');
+    });
+
+    it('stops the watcher before removing the active path from window state', async () => {
+      mocks.windowStates.set(
+        1,
+        makeState({
+          workspacePath: '/ws/primary',
+          additionalWorkspacePaths: ['/ws/warm'],
+          activeWorkspacePath: '/ws/warm',
+        }),
+      );
+      let pathsAtStop: string[] = [];
+      mocks.stopWorkspaceWatcher.mockImplementationOnce(() => {
+        const state = mocks.windowStates.get(1);
+        pathsAtStop = [state?.workspacePath, ...(state?.additionalWorkspacePaths ?? [])]
+          .filter((path): path is string => Boolean(path));
+      });
+
+      await invoke('workspace:unregister-additional', { workspacePath: '/ws/warm' }, 1);
+
+      expect(pathsAtStop).toContain('/ws/warm');
+    });
+
+    it('selects the detached destination service when the source loses its last tab', async () => {
+      const detachedService = new FakeService() as any;
+      mocks.windowStates.set(1, makeState({
+        workspacePath: '/ws/primary',
+        activeWorkspacePath: '/ws/primary',
+      }));
+      mocks.windowStates.set(2, makeState({
+        workspacePath: '/ws/primary',
+        activeWorkspacePath: '/ws/primary',
+      }));
+      mocks.windowFocusOrder.set(2, 10);
+      mocks.fileSystemServices.set('/ws/primary', detachedService);
+
+      await invoke('workspace:unregister-additional', { workspacePath: '/ws/primary' }, 1);
+
+      expect(mocks.setFileSystemService).toHaveBeenCalledWith(detachedService);
+      expect(mocks.clearFileSystemService).not.toHaveBeenCalled();
+    });
+
+    it('promotes a remaining tab when the primary project closes', async () => {
+      mocks.windowStates.set(
+        1,
+        makeState({
+          workspacePath: '/ws/primary',
+          additionalWorkspacePaths: ['/ws/next', '/ws/other'],
+          activeWorkspacePath: '/ws/primary',
+        }),
+      );
+      mocks.fileSystemServices.set('/ws/next', new FakeService() as any);
+
+      await invoke(
+        'workspace:unregister-additional',
+        { workspacePath: '/ws/primary', replacementWorkspacePath: '/ws/next' },
+        1,
+      );
+
+      expect(mocks.windowStates.get(1)).toMatchObject({
+        workspacePath: '/ws/next',
+        additionalWorkspacePaths: ['/ws/other'],
+        activeWorkspacePath: '/ws/next',
+      });
+      expect(mocks.startWorkspaceWatcher).toHaveBeenCalledWith(expect.anything(), '/ws/next');
+    });
+  });
+
+  describe('workspace:move-project-tab', () => {
+    async function beginDrag(workspacePath = '/ws/b', dragId = 'drag-1') {
+      await invoke('workspace:begin-project-tab-drag', {
+        version: 1,
+        dragId,
+        workspacePath,
+      }, 1);
+      await invoke('workspace:project-tab-drag-ready', { dragId }, 1);
+    }
+
+    it('moves a project into the destination before publishing renderer mutations', async () => {
+      mocks.windowStates.set(1, makeState({
+        workspacePath: '/ws/a',
+        additionalWorkspacePaths: ['/ws/b'],
+        activeWorkspacePath: '/ws/b',
+      }));
+      mocks.windowStates.set(2, makeState({
+        workspacePath: '/ws/c',
+        activeWorkspacePath: '/ws/c',
+      }));
+
+      await beginDrag();
+      const result = await invoke('workspace:move-project-tab', {
+        dragId: 'drag-1',
+      }, 2);
+
+      expect(result).toEqual({ success: true });
+      expect(mocks.windowStates.get(1)).toMatchObject({
+        workspacePath: '/ws/a',
+        additionalWorkspacePaths: [],
+        activeWorkspacePath: '/ws/a',
+      });
+      expect(mocks.windowStates.get(2)).toMatchObject({
+        workspacePath: '/ws/c',
+        additionalWorkspacePaths: ['/ws/b'],
+        activeWorkspacePath: '/ws/b',
+      });
+      expect(mocks.stopWorkspaceWatcher).toHaveBeenCalledWith(1);
+      expect(mocks.stopWorkspaceWatcher).toHaveBeenCalledWith(2);
+      expect(mocks.startWorkspaceWatcher).toHaveBeenCalledWith(
+        mocks.fakeBrowserWindows.get(1),
+        '/ws/a',
+      );
+      expect(mocks.startWorkspaceWatcher).toHaveBeenCalledWith(
+        mocks.fakeBrowserWindows.get(2),
+        '/ws/b',
+      );
+      expect(mocks.releaseWorkspaceTabBackground).not.toHaveBeenCalled();
+      expect(mocks.fakeBrowserWindows.get(1).webContents.send).toHaveBeenCalledWith(
+        'workspace:project-tab-mutation',
+        expect.objectContaining({ kind: 'remove', workspacePath: '/ws/b' }),
+      );
+      expect(mocks.fakeBrowserWindows.get(2).webContents.send).toHaveBeenCalledWith(
+        'workspace:project-tab-mutation',
+        expect.objectContaining({ kind: 'add', workspacePath: '/ws/b' }),
+      );
+    });
+
+    it('does not let the unfocused source reclaim global context after an active-tab move', async () => {
+      const sourceReplacementService = new FakeService() as any;
+      const movedService = new FakeService() as any;
+      mocks.windowStates.set(1, makeState({
+        workspacePath: '/ws/a',
+        additionalWorkspacePaths: ['/ws/b'],
+        activeWorkspacePath: '/ws/b',
+      }));
+      mocks.windowStates.set(2, makeState({
+        workspacePath: '/ws/c',
+        activeWorkspacePath: '/ws/c',
+      }));
+      mocks.fileSystemServices.set('/ws/a', sourceReplacementService);
+      mocks.fileSystemServices.set('/ws/b', movedService);
+
+      await beginDrag();
+      mocks.focusedBrowserWindowId = 2;
+      expect(await invoke('workspace:move-project-tab', { dragId: 'drag-1' }, 2))
+        .toEqual({ success: true });
+
+      // Applying the source renderer's queued remove mutation updates its atom
+      // to /ws/a and sends this idempotent notification after main committed
+      // the move. It must not overwrite the focused destination's globals.
+      mocks.setFileSystemService.mockClear();
+      mocks.activateWorkspaceTabContext.mockClear();
+      expect(await invoke('workspace:set-active', { workspacePath: '/ws/a' }, 1))
+        .toMatchObject({ success: true, alreadyActive: true });
+      expect(mocks.setFileSystemService).not.toHaveBeenCalled();
+      expect(mocks.activateWorkspaceTabContext).not.toHaveBeenCalled();
+    });
+
+    it('treats a drop back on the source strip as a claimed no-op', async () => {
+      mocks.windowStates.set(1, makeState({
+        workspacePath: '/ws/a',
+        additionalWorkspacePaths: ['/ws/b'],
+        activeWorkspacePath: '/ws/b',
+      }));
+
+      await beginDrag();
+      expect(await invoke('workspace:move-project-tab', { dragId: 'drag-1' }, 1)).toEqual({
+        success: true,
+        alreadyInWindow: true,
+      });
+      expect(await invoke('workspace:wait-project-tab-drag-result', { dragId: 'drag-1' }, 1))
+        .toEqual({ handled: true, moved: false });
+      expect(mocks.windowStates.get(1)).toMatchObject({
+        workspacePath: '/ws/a',
+        additionalWorkspacePaths: ['/ws/b'],
+        activeWorkspacePath: '/ws/b',
+      });
+    });
+
+    it('allows only one destination to claim a drag while preparation is pending', async () => {
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/b' }));
+      mocks.windowStates.set(2, makeState({ workspacePath: '/ws/c' }));
+      mocks.windowStates.set(3, makeState({ workspacePath: '/ws/d' }));
+      await invoke('workspace:begin-project-tab-drag', {
+        version: 1,
+        dragId: 'drag-concurrent',
+        workspacePath: '/ws/b',
+      }, 1);
+
+      const firstMove = invoke('workspace:move-project-tab', { dragId: 'drag-concurrent' }, 2);
+      const secondMove = invoke('workspace:move-project-tab', { dragId: 'drag-concurrent' }, 3);
+      await invoke('workspace:project-tab-drag-ready', { dragId: 'drag-concurrent' }, 1);
+      const [firstResult, secondResult] = await Promise.all([firstMove, secondMove]);
+
+      expect(firstResult).toEqual({ success: true });
+      expect(secondResult).toMatchObject({
+        success: false,
+        error: 'Project tab drag was already claimed by a destination window',
+      });
+      expect(mocks.windowStates.get(2)?.additionalWorkspacePaths).toEqual(['/ws/b']);
+      expect(mocks.windowStates.get(3)?.additionalWorkspacePaths).toBeUndefined();
+    });
+
+    it('revalidates the destination after preparation before removing the source tab', async () => {
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/b' }));
+      mocks.windowStates.set(2, makeState({ workspacePath: '/ws/c' }));
+      await invoke('workspace:begin-project-tab-drag', {
+        version: 1,
+        dragId: 'drag-closed-destination',
+        workspacePath: '/ws/b',
+      }, 1);
+
+      const move = invoke('workspace:move-project-tab', { dragId: 'drag-closed-destination' }, 2);
+      mocks.windowStates.delete(2);
+      await invoke('workspace:project-tab-drag-ready', { dragId: 'drag-closed-destination' }, 1);
+
+      expect(await move).toMatchObject({ success: false });
+      expect(mocks.windowStates.get(1)?.workspacePath).toBe('/ws/b');
+      expect(mocks.stopWorkspaceWatcher).not.toHaveBeenCalled();
+    });
+
+    it('marks the source mutation to close a window that lost its last tab', async () => {
+      mocks.windowStates.set(1, makeState({
+        workspacePath: '/ws/b',
+        activeWorkspacePath: '/ws/b',
+      }));
+      mocks.windowStates.set(2, makeState({ workspacePath: '/ws/c' }));
+
+      await beginDrag();
+      expect(await invoke('workspace:move-project-tab', {
+        dragId: 'drag-1',
+      }, 2)).toEqual({ success: true });
+
+      expect(mocks.windowStates.get(1)?.workspacePath).toBeNull();
+      expect(mocks.windowStates.get(1)?.pendingProjectTabMutations).toEqual([
+        expect.objectContaining({
+          kind: 'remove',
+          closeWindowWhenEmpty: true,
+          replacementWorkspacePath: null,
+        }),
+      ]);
+    });
+
+    it('keeps the source active tab unchanged when moving an inactive tab', async () => {
+      mocks.windowStates.set(1, makeState({
+        workspacePath: '/ws/a',
+        additionalWorkspacePaths: ['/ws/b'],
+        activeWorkspacePath: '/ws/a',
+      }));
+      mocks.windowStates.set(2, makeState({ workspacePath: '/ws/c' }));
+
+      await beginDrag();
+      expect(await invoke('workspace:move-project-tab', {
+        dragId: 'drag-1',
+      }, 2)).toEqual({ success: true });
+
+      expect(mocks.windowStates.get(1)?.activeWorkspacePath).toBe('/ws/a');
+      expect(mocks.windowStates.get(1)?.pendingProjectTabMutations).toEqual([
+        expect.objectContaining({
+          kind: 'remove',
+          replacementWorkspacePath: null,
+        }),
+      ]);
+      expect(mocks.stopWorkspaceWatcher).not.toHaveBeenCalledWith(1);
+    });
+
+    it('keeps the committed move when live renderer delivery throws', async () => {
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/b' }));
+      mocks.windowStates.set(2, makeState({ workspacePath: '/ws/c' }));
+
+      await beginDrag();
+      await invoke('workspace:consume-pending-project-tab-mutations', undefined, 2);
+      mocks.fakeBrowserWindows.get(2).webContents.send.mockImplementationOnce(() => {
+        throw new Error('renderer reloading');
+      });
+
+      expect(await invoke('workspace:move-project-tab', {
+        dragId: 'drag-1',
+      }, 2)).toEqual({ success: true });
+      expect(mocks.windowStates.get(1)?.workspacePath).toBeNull();
+      expect(mocks.windowStates.get(2)?.additionalWorkspacePaths).toEqual(['/ws/b']);
+      expect(mocks.windowStates.get(2)?.pendingProjectTabMutations).toEqual([
+        expect.objectContaining({ kind: 'add', workspacePath: '/ws/b' }),
+      ]);
+    });
+
+    it('leaves both windows unchanged when the destination is at the tab cap', async () => {
+      const fullDestination = makeState({
+        workspacePath: '/ws/c0',
+        additionalWorkspacePaths: Array.from({ length: 7 }, (_, index) => `/ws/c${index + 1}`),
+        activeWorkspacePath: '/ws/c0',
+      });
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/b' }));
+      mocks.windowStates.set(2, fullDestination);
+
+      await beginDrag();
+      const result = await invoke('workspace:move-project-tab', {
+        dragId: 'drag-1',
+      }, 2);
+
+      expect(result).toMatchObject({ success: false });
+      expect(mocks.windowStates.get(1)?.workspacePath).toBe('/ws/b');
+      expect(mocks.windowStates.get(2)).toEqual(fullDestination);
+      expect(mocks.stopWorkspaceWatcher).not.toHaveBeenCalled();
+      expect(await invoke('workspace:wait-project-tab-drag-result', {
+        dragId: 'drag-1',
+      }, 1)).toEqual({ handled: true, moved: false });
+    });
+
+    it('restores window and global active context when activation throws', async () => {
+      const previousDestinationService = new FakeService() as any;
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/b', activeWorkspacePath: '/ws/b' }));
+      mocks.windowStates.set(2, makeState({ workspacePath: '/ws/c', activeWorkspacePath: '/ws/c' }));
+      mocks.windowFocusOrder.set(2, 2);
+      mocks.fileSystemServices.set('/ws/c', previousDestinationService);
+      mocks.activateWorkspaceTabContext.mockImplementationOnce(() => {
+        throw new Error('activation failed');
+      });
+
+      await beginDrag();
+      const result = await invoke('workspace:move-project-tab', { dragId: 'drag-1' }, 2);
+
+      expect(result).toMatchObject({ success: false, error: 'activation failed' });
+      expect(mocks.windowStates.get(1)).toMatchObject({
+        workspacePath: '/ws/b',
+        activeWorkspacePath: '/ws/b',
+      });
+      expect(mocks.windowStates.get(2)).toMatchObject({
+        workspacePath: '/ws/c',
+        activeWorkspacePath: '/ws/c',
+      });
+      expect(mocks.setFileSystemService).toHaveBeenLastCalledWith(previousDestinationService);
+      expect(mocks.activateWorkspaceTabContext).toHaveBeenLastCalledWith('/ws/c');
+    });
+
+    it('restores the most recently focused global context when activation throws', async () => {
+      const focusedService = new FakeService() as any;
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/b', activeWorkspacePath: '/ws/b' }));
+      mocks.windowStates.set(2, makeState({ workspacePath: '/ws/c', activeWorkspacePath: '/ws/c' }));
+      mocks.windowStates.set(3, makeState({ workspacePath: '/ws/d', activeWorkspacePath: '/ws/d' }));
+      mocks.windowFocusOrder.set(1, 2);
+      mocks.windowFocusOrder.set(2, 1);
+      mocks.windowFocusOrder.set(3, 3);
+      mocks.fileSystemServices.set('/ws/d', focusedService);
+      mocks.activateWorkspaceTabContext.mockImplementationOnce(() => {
+        throw new Error('activation failed');
+      });
+
+      await beginDrag();
+      expect(await invoke('workspace:move-project-tab', { dragId: 'drag-1' }, 2))
+        .toMatchObject({ success: false, error: 'activation failed' });
+
+      expect(mocks.setFileSystemService).toHaveBeenLastCalledWith(focusedService);
+      expect(mocks.activateWorkspaceTabContext).toHaveBeenLastCalledWith('/ws/d');
+    });
+
+    it('leaves the source in place when editor preparation fails', async () => {
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/b' }));
+      mocks.windowStates.set(2, makeState({ workspacePath: '/ws/c' }));
+      await invoke('workspace:begin-project-tab-drag', {
+        version: 1,
+        dragId: 'drag-failed-save',
+        workspacePath: '/ws/b',
+      }, 1);
+      await invoke('workspace:project-tab-drag-ready', {
+        dragId: 'drag-failed-save',
+        error: 'Could not save dirty editor',
+      }, 1);
+
+      expect(await invoke('workspace:move-project-tab', {
+        dragId: 'drag-failed-save',
+      }, 2)).toEqual({ success: false, error: 'Could not save dirty editor' });
+      expect(mocks.windowStates.get(1)?.workspacePath).toBe('/ws/b');
+      expect(mocks.windowStates.get(2)?.workspacePath).toBe('/ws/c');
+      expect(await invoke('workspace:wait-project-tab-drag-result', {
+        dragId: 'drag-failed-save',
+      }, 1)).toEqual({ handled: true, moved: false });
+    });
+
+    it('rejects an unregistered or already-consumed drag token', async () => {
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/b' }));
+      mocks.windowStates.set(2, makeState({ workspacePath: '/ws/c' }));
+
+      const result = await invoke('workspace:move-project-tab', {
+        dragId: 'missing',
+      }, 2);
+
+      expect(result).toMatchObject({ success: false });
+      expect(mocks.windowStates.get(1)?.workspacePath).toBe('/ws/b');
+      expect(mocks.windowStates.get(2)?.workspacePath).toBe('/ws/c');
+    });
+  });
+
+  describe('workspace:detach-project-tab', () => {
+    it('creates the destination window at the drop point', async () => {
+      mocks.windowStates.set(1, makeState({
+        workspacePath: '/ws/a',
+        additionalWorkspacePaths: ['/ws/b'],
+      }));
+
+      const result = await invoke(
+        'workspace:detach-project-tab',
+        { workspacePath: '/ws/b', position: { screenX: 600, screenY: 240 } },
+        1,
+      );
+
+      expect(result).toMatchObject({ success: true, windowId: 99 });
+      expect(mocks.createWindow).toHaveBeenCalledWith(
+        false,
+        true,
+        '/ws/b',
+        { x: 480, y: 220, width: 1000, height: 700 },
+      );
+      expect(mocks.initializeWorkspaceTabBackground).toHaveBeenCalledWith('/ws/b');
+      expect(mocks.activateWorkspaceTabContext).toHaveBeenCalledWith('/ws/b');
+    });
+
+    it('rejects a project that is not open in the source window', async () => {
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/a' }));
+
+      const result = await invoke(
+        'workspace:detach-project-tab',
+        { workspacePath: '/ws/missing' },
+        1,
+      );
+
+      expect(result).toMatchObject({ success: false });
+      expect(mocks.createWindow).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/electron/src/main/menu/ApplicationMenu.ts
+++ b/packages/electron/src/main/menu/ApplicationMenu.ts
@@ -27,6 +27,8 @@ import * as path from 'path';
 import { existsSync } from 'fs';
 import * as fs from 'fs';
 import { windows, windowStates, createWindow, findWindowByFilePath, getWindowId } from '../window/WindowManager';
+import { routeWorkspaceToProjectTab } from '../window/projectTabRouting';
+import { resolveActiveWorkspacePath } from '../window/windowState';
 import { createAboutWindow } from '../window/AboutWindow';
 import { createWorkspaceManagerWindow } from '../window/WorkspaceManagerWindow.ts';
 import { createAIUsageReportWindow } from '../window/AIUsageReportWindow';
@@ -34,7 +36,12 @@ import { createDatabaseBrowserWindow } from '../window/DatabaseBrowserWindow';
 import { createDeveloperDashboardWindow } from '../window/DeveloperDashboardWindow';
 import { runDiffErgonomicsHarness } from '../file/DiffErgonomicsFixture';
 import { loadFileIntoWindow } from '../file/FileOperations';
-import { getRecentItems, clearRecentItems, addToRecentItems, getTheme, setTheme, store, getWorkspaceState, getWorkspaceWindowState, isExtensionDevToolsEnabled, setWorktreeOnboardingShown } from '../utils/store';
+import { getRecentItems, clearRecentItems, addToRecentItems, getTheme, setTheme, store, getWorkspaceState, getWorkspaceWindowState, getMultiProjectMode, isExtensionDevToolsEnabled, setWorktreeOnboardingShown } from '../utils/store';
+import { CLOSE_ACTIVE_PROJECT_TAB_CHANNEL } from '../../shared/projectTabs';
+import {
+    activateWorkspaceTabContext,
+    initializeWorkspaceTabBackground,
+} from '../services/WorkspaceTabBackground';
 import { updateWindowTitleBars, updateNativeTheme } from '../theme/ThemeManager';
 import { refreshWorkspaceFileTree } from '../file/FileWatcherDebug';
 import { getFolderContents } from '../utils/FileTree';
@@ -88,8 +95,8 @@ function createWindowListMenu(): any[] {
             title = 'About';
             category = 'other';
         } else if (state) {
-            if (state.mode === 'workspace' && state.workspacePath) {
-                title = basename(state.workspacePath);
+            if (state.mode === 'workspace' && resolveActiveWorkspacePath(state)) {
+                title = basename(resolveActiveWorkspacePath(state)!);
                 category = 'workspace';
             }
         }
@@ -182,11 +189,29 @@ async function createRecentSubmenu(): Promise<any[]> {
                 click: async () => {
                     // Check if workspace exists
                     if (existsSync(workspace.path)) {
+                        const tabRoute = routeWorkspaceToProjectTab(workspace.path, {
+                            preferredWindow: BrowserWindow.getFocusedWindow(),
+                        });
+                        if (tabRoute.status === 'routed') return;
+                        if (tabRoute.status === 'rejected') {
+                            await dialog.showMessageBox({
+                                type: 'warning',
+                                title: 'Unable to Open Project Tab',
+                                message: tabRoute.error,
+                                detail: tabRoute.reason === 'tab-cap'
+                                    ? 'Close a project tab first, or drag an existing tab into its own window.'
+                                    : 'The project was not opened in a separate window.',
+                            });
+                            return;
+                        }
+
                         // Check for saved workspace window state
                         const savedState = getWorkspaceWindowState(workspace.path);
 
                         // Create window with saved bounds if available
                         const window = createWindow(false, true, workspace.path, savedState?.bounds);
+                        initializeWorkspaceTabBackground(workspace.path);
+                        activateWorkspaceTabContext(workspace.path);
 
                         // Restore dev tools if they were open
                         if (savedState?.devToolsOpen) {
@@ -516,8 +541,9 @@ export async function createApplicationMenu() {
                             const state = windowId !== null ? windowStates.get(windowId) : undefined;
                             let projectName = 'Untitled';
 
-                            if (state?.mode === 'workspace' && state.workspacePath) {
-                                projectName = basename(state.workspacePath);
+                            const activeWorkspacePath = resolveActiveWorkspacePath(state);
+                            if (state?.mode === 'workspace' && activeWorkspacePath) {
+                                projectName = basename(activeWorkspacePath);
                             } else if (state?.filePath) {
                                 projectName = basename(state.filePath);
                             }
@@ -529,8 +555,11 @@ export async function createApplicationMenu() {
                                 electronId: focused.id
                             });
 
-                            // TODO: Add warning dialog if AI/agent is running
-                            focused.close();
+                            if (state?.mode === 'workspace' && getMultiProjectMode()) {
+                                focused.webContents.send(CLOSE_ACTIVE_PROJECT_TAB_CHANNEL);
+                            } else {
+                                focused.close();
+                            }
                         } else {
                             console.error('[Close Project] No focused window found or window is destroyed');
                         }

--- a/packages/electron/src/main/services/WorkspaceTabBackground.ts
+++ b/packages/electron/src/main/services/WorkspaceTabBackground.ts
@@ -1,0 +1,55 @@
+import { getMcpConfigService } from '../mcpConfigServiceRef';
+import { anyWindowReferencesWorkspace } from '../window/windowState';
+import { logger } from '../utils/logger';
+import { autoMatchTeamForWorkspace } from './TeamService';
+import { updateTrackerSchemaWorkspace } from './TrackerSchemaService';
+import { initializeTrackerSync } from './TrackerSyncManager';
+
+// A workspace can be referenced by several windows, and an active tab can be
+// selected repeatedly. Keep background bootstrap process-wide and tied to the
+// lifetime of the last workspace reference rather than to tab activation.
+const initializedWorkspaces = new Map<string, symbol>();
+
+/** Start per-workspace background services once while the path is referenced. */
+export function initializeWorkspaceTabBackground(workspacePath: string): void {
+  if (initializedWorkspaces.has(workspacePath)) return;
+
+  const lifecycleToken = Symbol(workspacePath);
+  initializedWorkspaces.set(workspacePath, lifecycleToken);
+
+  setTimeout(() => {
+    // A close followed by a quick reopen gets a new token. The stale deferred
+    // callback must not initialize a second set of watchers for that reopen.
+    if (initializedWorkspaces.get(workspacePath) !== lifecycleToken) return;
+
+    // The user may close a just-opened tab before this deferred work runs.
+    // Do not resurrect watchers or sync for an unreferenced workspace.
+    if (!anyWindowReferencesWorkspace(workspacePath)) {
+      initializedWorkspaces.delete(workspacePath);
+      return;
+    }
+
+    try {
+      getMcpConfigService()?.startWatchingWorkspaceConfig(workspacePath);
+    } catch (error) {
+      logger.main.error('[ProjectTabs] Failed to watch workspace MCP config:', workspacePath, error);
+    }
+
+    void autoMatchTeamForWorkspace(workspacePath).catch((error) => {
+      logger.main.warn('[ProjectTabs] Failed to match workspace team:', workspacePath, error);
+    });
+    void initializeTrackerSync(workspacePath).catch((error) => {
+      logger.main.warn('[ProjectTabs] Failed to initialize tracker sync:', workspacePath, error);
+    });
+  }, 0);
+}
+
+/** Update only the process-global context that follows the visible project. */
+export function activateWorkspaceTabContext(workspacePath: string): void {
+  updateTrackerSchemaWorkspace(workspacePath);
+}
+
+/** Allow a workspace to initialize again after its final reference closes. */
+export function releaseWorkspaceTabBackground(workspacePath: string): void {
+  initializedWorkspaces.delete(workspacePath);
+}

--- a/packages/electron/src/main/services/WorkspaceTabServices.ts
+++ b/packages/electron/src/main/services/WorkspaceTabServices.ts
@@ -1,0 +1,115 @@
+import { BrowserWindow } from 'electron';
+import { existsSync } from 'fs';
+import {
+  documentServices,
+  getWindowId,
+  windowStates,
+} from '../window/WindowManager';
+import { resolveDocumentServicePath } from '../window/windowState';
+import { fileSystemServices } from '../window/serviceRegistry';
+import {
+  ElectronDocumentService,
+  setupDocumentServiceHandlers,
+} from './ElectronDocumentService';
+import { ElectronFileSystemService } from './ElectronFileSystemService';
+import { addNimAssetRoot } from '../protocols/nimAssetProtocol';
+import { addNimPreviewWorkspaceRoot } from '../protocols/nimPreviewProtocol';
+import { getWorkspaceNavigationHistory } from '../utils/store';
+import { navigationHistoryService } from './NavigationHistoryService';
+import { setFileSystemServiceFor, clearFileSystemServiceFor } from '@nimbalyst/runtime';
+import { logger } from '../utils/logger';
+
+export interface EnsureWorkspaceTabServicesResult {
+  success: boolean;
+  error?: string;
+}
+
+function resolveDocumentServiceForEvent(
+  event: Electron.IpcMainInvokeEvent | Electron.IpcMainEvent,
+): ElectronDocumentService | null {
+  const browserWindow = BrowserWindow.fromWebContents(event.sender);
+  if (!browserWindow) return null;
+  const windowId = getWindowId(browserWindow);
+  if (windowId === null) return null;
+  const workspacePath = resolveDocumentServicePath(windowStates.get(windowId));
+  return workspacePath ? documentServices.get(workspacePath) ?? null : null;
+}
+
+/**
+ * Create the path-scoped services needed by a warm project tab.
+ *
+ * Service construction is transactional: the window state is updated by the
+ * caller only after this function succeeds, and any newly-created partial
+ * services are removed if construction or registration throws.
+ */
+export function ensureWorkspaceTabServices(
+  window: BrowserWindow,
+  workspacePath: string,
+): EnsureWorkspaceTabServicesResult {
+  if (!workspacePath || !existsSync(workspacePath)) {
+    return { success: false, error: 'Workspace path does not exist' };
+  }
+
+  let createdDocumentService: ElectronDocumentService | null = null;
+  let createdFileSystemService: ElectronFileSystemService | null = null;
+  let documentInserted = false;
+  let fileSystemInserted = false;
+
+  try {
+    if (!documentServices.has(workspacePath)) {
+      createdDocumentService = new ElectronDocumentService(workspacePath);
+    }
+    if (!fileSystemServices.has(workspacePath)) {
+      createdFileSystemService = new ElectronFileSystemService(workspacePath);
+    }
+
+    addNimAssetRoot(workspacePath);
+    addNimPreviewWorkspaceRoot(workspacePath);
+
+    if (createdDocumentService) {
+      documentServices.set(workspacePath, createdDocumentService);
+      documentInserted = true;
+      setupDocumentServiceHandlers(resolveDocumentServiceForEvent);
+    }
+
+    if (createdFileSystemService) {
+      fileSystemServices.set(workspacePath, createdFileSystemService);
+      fileSystemInserted = true;
+      setFileSystemServiceFor(workspacePath, createdFileSystemService);
+    }
+  } catch (error) {
+    if (documentInserted) documentServices.delete(workspacePath);
+    if (fileSystemInserted) {
+      fileSystemServices.delete(workspacePath);
+      clearFileSystemServiceFor(workspacePath);
+    }
+    try {
+      createdDocumentService?.destroy();
+    } catch {
+      // Preserve the original construction error.
+    }
+    try {
+      createdFileSystemService?.destroy();
+    } catch {
+      // Preserve the original construction error.
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    logger.main.error('[ProjectTabs] Failed to initialize workspace services:', workspacePath, error);
+    return { success: false, error: message };
+  }
+
+  // Navigation history is useful but non-critical; a malformed persisted
+  // history must not turn a successfully-created service set into a ghost
+  // registration.
+  try {
+    const windowId = getWindowId(window);
+    const navigationHistory = getWorkspaceNavigationHistory(workspacePath);
+    if (windowId !== null && navigationHistory) {
+      navigationHistoryService.restoreNavigationState(windowId, navigationHistory);
+    }
+  } catch (error) {
+    logger.main.warn('[ProjectTabs] Failed to restore navigation history:', workspacePath, error);
+  }
+
+  return { success: true };
+}

--- a/packages/electron/src/main/services/__tests__/WorkspaceTabBackground.test.ts
+++ b/packages/electron/src/main/services/__tests__/WorkspaceTabBackground.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  anyWindowReferencesWorkspace: vi.fn(() => true),
+  startWatchingWorkspaceConfig: vi.fn(),
+  autoMatchTeamForWorkspace: vi.fn(async () => undefined),
+  initializeTrackerSync: vi.fn(async () => undefined),
+  updateTrackerSchemaWorkspace: vi.fn(),
+}));
+
+vi.mock('../../window/windowState', () => ({
+  anyWindowReferencesWorkspace: mocks.anyWindowReferencesWorkspace,
+}));
+
+vi.mock('../../mcpConfigServiceRef', () => ({
+  getMcpConfigService: () => ({
+    startWatchingWorkspaceConfig: mocks.startWatchingWorkspaceConfig,
+  }),
+}));
+
+vi.mock('../TeamService', () => ({
+  autoMatchTeamForWorkspace: mocks.autoMatchTeamForWorkspace,
+}));
+
+vi.mock('../TrackerSyncManager', () => ({
+  initializeTrackerSync: mocks.initializeTrackerSync,
+}));
+
+vi.mock('../TrackerSchemaService', () => ({
+  updateTrackerSchemaWorkspace: mocks.updateTrackerSchemaWorkspace,
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    main: {
+      error: vi.fn(),
+      warn: vi.fn(),
+    },
+  },
+}));
+
+import {
+  activateWorkspaceTabContext,
+  initializeWorkspaceTabBackground,
+  releaseWorkspaceTabBackground,
+} from '../WorkspaceTabBackground';
+
+describe('WorkspaceTabBackground', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.anyWindowReferencesWorkspace.mockReset();
+    mocks.anyWindowReferencesWorkspace.mockReturnValue(true);
+    mocks.startWatchingWorkspaceConfig.mockReset();
+    mocks.autoMatchTeamForWorkspace.mockReset();
+    mocks.autoMatchTeamForWorkspace.mockResolvedValue(undefined);
+    mocks.initializeTrackerSync.mockReset();
+    mocks.initializeTrackerSync.mockResolvedValue(undefined);
+    mocks.updateTrackerSchemaWorkspace.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('initializes each referenced workspace only once per lifecycle', async () => {
+    const workspacePath = '/ws/once';
+
+    initializeWorkspaceTabBackground(workspacePath);
+    initializeWorkspaceTabBackground(workspacePath);
+    await vi.runAllTimersAsync();
+
+    expect(mocks.startWatchingWorkspaceConfig).toHaveBeenCalledOnce();
+    expect(mocks.autoMatchTeamForWorkspace).toHaveBeenCalledOnce();
+    expect(mocks.initializeTrackerSync).toHaveBeenCalledOnce();
+    releaseWorkspaceTabBackground(workspacePath);
+  });
+
+  it('activates tracker schema context without restarting background services', async () => {
+    const workspacePath = '/ws/activation';
+    initializeWorkspaceTabBackground(workspacePath);
+    await vi.runAllTimersAsync();
+    mocks.startWatchingWorkspaceConfig.mockClear();
+    mocks.autoMatchTeamForWorkspace.mockClear();
+    mocks.initializeTrackerSync.mockClear();
+
+    activateWorkspaceTabContext(workspacePath);
+    activateWorkspaceTabContext(workspacePath);
+
+    expect(mocks.updateTrackerSchemaWorkspace).toHaveBeenCalledTimes(2);
+    expect(mocks.startWatchingWorkspaceConfig).not.toHaveBeenCalled();
+    expect(mocks.autoMatchTeamForWorkspace).not.toHaveBeenCalled();
+    expect(mocks.initializeTrackerSync).not.toHaveBeenCalled();
+    releaseWorkspaceTabBackground(workspacePath);
+  });
+
+  it('ignores stale deferred work after a release and quick reopen', async () => {
+    const workspacePath = '/ws/reopen';
+
+    initializeWorkspaceTabBackground(workspacePath);
+    releaseWorkspaceTabBackground(workspacePath);
+    initializeWorkspaceTabBackground(workspacePath);
+    await vi.runAllTimersAsync();
+
+    expect(mocks.startWatchingWorkspaceConfig).toHaveBeenCalledOnce();
+    expect(mocks.autoMatchTeamForWorkspace).toHaveBeenCalledOnce();
+    expect(mocks.initializeTrackerSync).toHaveBeenCalledOnce();
+    releaseWorkspaceTabBackground(workspacePath);
+  });
+
+  it('releases the guard when deferred work finds no window reference', async () => {
+    const workspacePath = '/ws/closed-before-init';
+    mocks.anyWindowReferencesWorkspace.mockReturnValue(false);
+
+    initializeWorkspaceTabBackground(workspacePath);
+    await vi.runAllTimersAsync();
+    expect(mocks.startWatchingWorkspaceConfig).not.toHaveBeenCalled();
+
+    mocks.anyWindowReferencesWorkspace.mockReturnValue(true);
+    initializeWorkspaceTabBackground(workspacePath);
+    await vi.runAllTimersAsync();
+
+    expect(mocks.startWatchingWorkspaceConfig).toHaveBeenCalledOnce();
+    releaseWorkspaceTabBackground(workspacePath);
+  });
+});

--- a/packages/electron/src/main/session/SessionState.ts
+++ b/packages/electron/src/main/session/SessionState.ts
@@ -2,15 +2,26 @@ import { BrowserWindow } from 'electron';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { windows, windowStates, createWindow, windowFocusOrder, windowDevToolsState, getWindowId } from '../window/WindowManager';
 import { loadFileIntoWindow } from '../file/FileOperations';
-import { getSessionState, saveSessionState as saveToStore, SessionState, clearSessionState } from '../utils/store';
+import {
+    getSessionState,
+    saveSessionState as saveToStore,
+    SessionState,
+    clearSessionState,
+    getMultiProjectMode,
+    getRestorePreviousProjectsOnLaunch,
+} from '../utils/store';
 import { startWorkspaceWatcher } from '../file/WorkspaceWatcher.ts';
 import { getFolderContents } from '../utils/FileTree';
 import { basename } from 'path';
 import { logger } from '../utils/logger';
 import { AnalyticsService } from '../services/analytics/AnalyticsService';
 import { GitStatusService } from '../services/GitStatusService';
-import { autoMatchTeamForWorkspace } from '../services/TeamService';
-import { updateTrackerSchemaWorkspace } from '../services/TrackerSchemaService';
+import { ensureWorkspaceTabServices } from '../services/WorkspaceTabServices';
+import {
+    activateWorkspaceTabContext,
+    initializeWorkspaceTabBackground,
+} from '../services/WorkspaceTabBackground';
+import { MAX_OPEN_PROJECT_TABS } from '../../shared/projectTabs';
 
 // Save session state
 export async function saveSessionState() {
@@ -40,6 +51,14 @@ export async function saveSessionState() {
         }
         if (state.workspacePath) {
             sessionWindow.workspacePath = state.workspacePath;
+            const openProjectPaths = [state.workspacePath, ...(state.additionalWorkspacePaths ?? [])]
+                .filter((path, index, paths): path is string => Boolean(path) && paths.indexOf(path) === index)
+                .slice(0, MAX_OPEN_PROJECT_TABS);
+            sessionWindow.openProjectPaths = openProjectPaths;
+            sessionWindow.activeWorkspacePath = state.activeWorkspacePath
+                && openProjectPaths.includes(state.activeWorkspacePath)
+                ? state.activeWorkspacePath
+                : state.workspacePath;
         }
 
         sessionWindows.push(sessionWindow);
@@ -99,6 +118,7 @@ export async function restoreSessionState(): Promise<boolean> {
     // The last window (highest focus order) uses show() to activate the app once;
     // all earlier windows use showInactive() so the app doesn't steal focus repeatedly.
     const totalWindows = sortedWindows.length;
+    const restoreProjectTabs = getMultiProjectMode() && getRestorePreviousProjectsOnLaunch();
 
     for (let index = 0; index < totalWindows; index++) {
         const sessionWindow = sortedWindows[index];
@@ -109,15 +129,25 @@ export async function restoreSessionState(): Promise<boolean> {
                 let window: BrowserWindow | null = null;
 
                 if (sessionWindow.mode === 'workspace' && sessionWindow.workspacePath) {
+                    const primaryCandidates = restoreProjectTabs
+                        ? [
+                            sessionWindow.workspacePath,
+                            ...(sessionWindow.openProjectPaths ?? []),
+                            sessionWindow.activeWorkspacePath,
+                        ]
+                        : [sessionWindow.activeWorkspacePath, sessionWindow.workspacePath];
+                    const restoredPrimaryPath = primaryCandidates.find(
+                        (path): path is string => typeof path === 'string' && existsSync(path),
+                    ) ?? sessionWindow.workspacePath;
                     // Check if workspace path still exists
-                    if (existsSync(sessionWindow.workspacePath)) {
+                    if (existsSync(restoredPrimaryPath)) {
                         // Track workspace opened from startup restore
                         try {
                             // Count files and check for subfolders
                             let fileCount = 0;
                             let hasSubfolders = false;
                             try {
-                                const entries = readdirSync(sessionWindow.workspacePath, { withFileTypes: true });
+                                const entries = readdirSync(restoredPrimaryPath, { withFileTypes: true });
                                 for (const entry of entries) {
                                     if (entry.isFile()) {
                                         fileCount++;
@@ -141,9 +171,9 @@ export async function restoreSessionState(): Promise<boolean> {
 
                             try {
                                 const gitStatusService = new GitStatusService();
-                                isGitRepository = await gitStatusService.isGitRepo(sessionWindow.workspacePath);
+                                isGitRepository = await gitStatusService.isGitRepo(restoredPrimaryPath);
                                 if (isGitRepository) {
-                                    isGitHub = await gitStatusService.hasGitHubRemote(sessionWindow.workspacePath);
+                                    isGitHub = await gitStatusService.hasGitHubRemote(restoredPrimaryPath);
                                 }
                             } catch (gitError) {
                                 // Git checks failed - continue with defaults (false, false)
@@ -164,21 +194,54 @@ export async function restoreSessionState(): Promise<boolean> {
 
                         // Last window uses show() to activate app once; others use showInactive()
                         const isLastWindow = index === totalWindows - 1;
-                        window = createWindow(false, true, sessionWindow.workspacePath, sessionWindow.bounds, isLastWindow ? undefined : { showInactive: true });
-                        logger.session.info(`Restored workspace window: ${sessionWindow.workspacePath}`);
+                        window = createWindow(false, true, restoredPrimaryPath, sessionWindow.bounds, isLastWindow ? undefined : { showInactive: true });
+                        const windowId = getWindowId(window);
+                        const state = windowId !== null ? windowStates.get(windowId) : undefined;
+                        const requestedPaths = restoreProjectTabs
+                            ? [
+                                restoredPrimaryPath,
+                                ...(sessionWindow.openProjectPaths ?? []),
+                            ]
+                            : [restoredPrimaryPath];
+                        const distinctExistingPaths = [...new Set(requestedPaths)]
+                            .filter((path) => typeof path === 'string' && existsSync(path))
+                            .slice(0, MAX_OPEN_PROJECT_TABS);
+                        const restoredPaths = [restoredPrimaryPath];
 
-                        const restoredWorkspacePath = sessionWindow.workspacePath;
-                        setTimeout(() => {
-                            // Yield before running background workspace matching so
-                            // restored windows don't block the startup tick.
-                            void autoMatchTeamForWorkspace(restoredWorkspacePath).catch(() => {});
-                            updateTrackerSchemaWorkspace(restoredWorkspacePath);
-                        }, 0);
+                        for (const projectPath of distinctExistingPaths) {
+                            if (projectPath === restoredPrimaryPath) continue;
+                            const result = ensureWorkspaceTabServices(window, projectPath);
+                            if (result.success) restoredPaths.push(projectPath);
+                            else logger.session.warn(`Skipped project tab during restore: ${projectPath} (${result.error})`);
+                        }
+
+                        const requestedActivePath = restoreProjectTabs
+                            ? sessionWindow.activeWorkspacePath
+                            : restoredPrimaryPath;
+                        const activeWorkspacePath = requestedActivePath
+                            && restoredPaths.includes(requestedActivePath)
+                            ? requestedActivePath
+                            : restoredPrimaryPath;
+                        if (state) {
+                            state.additionalWorkspacePaths = restoredPaths.filter(
+                                (path) => path !== restoredPrimaryPath,
+                            );
+                            state.activeWorkspacePath = activeWorkspacePath;
+                        }
+
+                        for (const projectPath of restoredPaths) {
+                            initializeWorkspaceTabBackground(projectPath);
+                        }
+                        activateWorkspaceTabContext(activeWorkspacePath);
+
+                        logger.session.info(
+                            `Restored workspace window: ${restoredPrimaryPath} (${restoredPaths.length} project tab(s))`,
+                        );
 
                         // Note: Workspace tabs will be restored by the workspace's own tab state management
                         // We don't manually open files here to avoid interfering with tab restoration
                     } else {
-                        logger.session.warn(`Workspace path no longer exists: ${sessionWindow.workspacePath}`);
+                        logger.session.warn(`Workspace path no longer exists: ${restoredPrimaryPath}`);
                     }
                 } else if (sessionWindow.mode === 'document' && sessionWindow.filePath) {
                     // Check if file still exists

--- a/packages/electron/src/main/types.ts
+++ b/packages/electron/src/main/types.ts
@@ -1,3 +1,5 @@
+import type { ProjectTabMutation } from '../shared/projectTabs';
+
 export interface TabState {
     id: string;                  // Unique tab identifier
     filePath: string;            // Full file path
@@ -38,6 +40,14 @@ export interface WindowState {
      * and document caches stay alive even when the project is hidden.
      */
     additionalWorkspacePaths?: string[];
+    /**
+     * Main-to-renderer tab-open requests waiting to be consumed. This closes
+     * the small startup/reload race where a live IPC event can arrive before
+     * React installs its listener.
+     */
+    pendingProjectTabPaths?: string[];
+    /** Durable cross-window tab mutations awaiting renderer acknowledgement. */
+    pendingProjectTabMutations?: ProjectTabMutation[];
     documentEdited: boolean;
 
     // Tab management (optional for backward compatibility)
@@ -59,6 +69,10 @@ export interface SessionWindow {
     mode: 'document' | 'workspace' | 'agentic-coding';
     filePath?: string;
     workspacePath?: string;
+    /** Ordered project tabs belonging to this specific window. */
+    openProjectPaths?: string[];
+    /** Project tab that was visible when the session was saved. */
+    activeWorkspacePath?: string | null;
     bounds: {
         x: number;
         y: number;

--- a/packages/electron/src/main/utils/store.ts
+++ b/packages/electron/src/main/utils/store.ts
@@ -227,8 +227,8 @@ interface AppStoreSchema {
   usageIndicatorsMigratedToGutter?: boolean;
   // Extension marketplace install tracking
   marketplaceInstalls?: Record<string, MarketplaceInstallRecord>;
-  // Multi-project rail: opt-in flag to host multiple projects in a single
-  // window. When false (default), each project still gets its own window.
+  // Project tabs: host multiple projects in one window by default. Users can
+  // disable this to retain the legacy one-window-per-project behavior.
   multiProjectMode?: boolean;
   // Workspace paths currently warm in the multi-project rail, in display
   // order. Empty when multiProjectMode is off or before the user adds any.
@@ -2486,13 +2486,13 @@ export function updateMarketplaceInstall(extensionId: string, updates: Partial<M
   }
 }
 
-// Multi-Project Rail Settings
-// `multiProjectMode` is the opt-in toggle that lets users open several
-// projects in a single window via the project rail. The `openProjects` list
-// and `activeProjectPath` are restored on launch so the rail rehydrates.
+// Project Tab Settings
+// `multiProjectMode` keeps projects in tabs within the current window by
+// default. Users can disable it to retain one window per project. The
+// `openProjects` list and `activeProjectPath` are restored on launch.
 
 export function getMultiProjectMode(): boolean {
-  return getAppStore().get('multiProjectMode', false);
+  return getAppStore().get('multiProjectMode', true);
 }
 
 export function setMultiProjectMode(enabled: boolean): void {

--- a/packages/electron/src/main/window/WindowManager.ts
+++ b/packages/electron/src/main/window/WindowManager.ts
@@ -17,6 +17,7 @@ import {
   setFileSystemService,
   clearFileSystemService,
   setFileSystemServiceFor,
+  clearFileSystemServiceFor,
 } from '@nimbalyst/runtime';
 import { navigationHistoryService } from '../services/NavigationHistoryService';
 import { signalFirstWindowLoaded } from '../services/startupMaintenanceGate';
@@ -26,8 +27,18 @@ import { ExtensionLogService } from '../services/ExtensionLogService';
 import { getMcpConfigService } from '../mcpConfigServiceRef';
 import { addNimAssetRoot } from '../protocols/nimAssetProtocol';
 import { addNimPreviewWorkspaceRoot } from '../protocols/nimPreviewProtocol';
-import { windows, windowStates, anyWindowReferencesWorkspace, resolveDocumentServicePath } from './windowState';
+import {
+  windows,
+  windowStates,
+  anyWindowReferencesWorkspace,
+  resolveActiveWorkspacePath,
+  resolveDocumentServicePath,
+} from './windowState';
 import { shouldSaveSessionOnWindowClose } from './sessionSaveOnClose';
+import {
+  activateWorkspaceTabContext,
+  releaseWorkspaceTabBackground,
+} from '../services/WorkspaceTabBackground';
 
 // Window management
 export { windows, windowStates };
@@ -467,6 +478,7 @@ export function createWindow(
                     if (fileSystemService) {
                         fileSystemService.destroy();
                         fileSystemServices.delete(path);
+                        clearFileSystemServiceFor(path);
                         clearFileSystemService();
                         console.log('[MAIN] Destroyed FileSystemService for workspace:', path);
                     }
@@ -479,6 +491,7 @@ export function createWindow(
                     } catch (error) {
                         console.error('[MAIN] Error stopping MCP config watcher:', error);
                     }
+                    releaseWorkspaceTabBackground(path);
                 }
             }
 
@@ -501,6 +514,12 @@ export function createWindow(
         window.on('focus', () => {
             // Update focus order
             windowFocusOrder.set(windowId, ++focusOrderCounter);
+            const activeWorkspacePath = resolveActiveWorkspacePath(windowStates.get(windowId));
+            const activeFileSystemService = activeWorkspacePath
+                ? fileSystemServices.get(activeWorkspacePath)
+                : null;
+            if (activeFileSystemService) setFileSystemService(activeFileSystemService);
+            if (activeWorkspacePath) activateWorkspaceTabContext(activeWorkspacePath);
             // This will be handled by the menu system
         });
 
@@ -686,9 +705,15 @@ export function createWindow(
             if (isWorkspaceMode && workspacePath) {
                 // Don't send 'workspace-opened' here - the renderer already knows it's in workspace mode
                 // from the initial state. Sending this event causes the tabs to be cleared.
-                // Just start watching the workspace directory for changes
+                // Start the workspace that is actually visible. Session
+                // restoration may have populated additional project tabs and
+                // selected a non-primary active path before the renderer loads.
                 setTimeout(() => {
-                    startWorkspaceWatcher(window, workspacePath);
+                    const activeWorkspacePath = resolveActiveWorkspacePath(windowStates.get(windowId))
+                        ?? workspacePath;
+                    startWorkspaceWatcher(window, activeWorkspacePath);
+                    const activeFileSystemService = fileSystemServices.get(activeWorkspacePath);
+                    if (activeFileSystemService) setFileSystemService(activeFileSystemService);
                 }, 100);
             } else if (!isOpeningFile) {
                 // Create new untitled document

--- a/packages/electron/src/main/window/WorkspaceManagerWindow.ts
+++ b/packages/electron/src/main/window/WorkspaceManagerWindow.ts
@@ -6,15 +6,16 @@ import { readdir } from 'fs/promises';
 import { resolveEntryType } from '../utils/FileTree';
 import { shouldExcludeDir } from '../utils/fileFilters';
 import { getRecentItems, addToRecentItems, store, getWorkspaceWindowState, getTheme } from '../utils/store';
-import { createWindow, findWindowByWorkspace, windowStates } from './WindowManager';
+import { createWindow, windowStates } from './WindowManager';
+import { routeWorkspaceToProjectTab } from './projectTabRouting';
 import { safeHandle } from '../utils/ipcRegistry';
 import { getBackgroundColor } from '../theme/ThemeManager';
 import { AnalyticsService } from '../services/analytics/AnalyticsService';
 import { GitStatusService } from '../services/GitStatusService';
-import { getMcpConfigService } from '../index';
-import { autoMatchTeamForWorkspace } from '../services/TeamService';
-import { initializeTrackerSync } from '../services/TrackerSyncManager';
-import { updateTrackerSchemaWorkspace } from '../services/TrackerSchemaService';
+import {
+  activateWorkspaceTabContext,
+  initializeWorkspaceTabBackground,
+} from '../services/WorkspaceTabBackground';
 
 let workspaceManagerWindow: BrowserWindow | null = null;
 
@@ -235,13 +236,14 @@ export function setupWorkspaceManagerHandlers() {
 
   // Get currently open workspace paths (for Project Quick Open)
   safeHandle('workspace-manager:get-open-workspaces', async () => {
-    const openPaths: string[] = [];
+    const openPaths = new Set<string>();
     for (const [, state] of windowStates) {
       if (state.workspacePath && state.mode === 'workspace') {
-        openPaths.push(state.workspacePath);
+        openPaths.add(state.workspacePath);
+        state.additionalWorkspacePaths?.forEach((path) => openPaths.add(path));
       }
     }
-    return openPaths;
+    return [...openPaths];
   });
 
   // Get workspace statistics
@@ -336,23 +338,45 @@ export function setupWorkspaceManagerHandlers() {
   });
 
   // Open workspace (reuse existing window if already open)
-  safeHandle('workspace-manager:open-workspace', async (event, workspacePath: string) => {
+  safeHandle('workspace-manager:open-workspace', async (
+    event,
+    workspacePath: string,
+    options?: { forceNewWindow?: boolean },
+  ) => {
     // Add to recent workspaces
     addToRecentItems('workspaces', workspacePath, basename(workspacePath));
 
-    // Check if this workspace is already open in an existing window
-    const existingWindow = findWindowByWorkspace(workspacePath);
-    if (existingWindow && !existingWindow.isDestroyed()) {
-      // Focus the existing window instead of creating a new one
-      existingWindow.focus();
-
-      // Close workspace manager after focusing existing workspace
-      if (workspaceManagerWindow && !workspaceManagerWindow.isDestroyed()) {
-        workspaceManagerClosingForProject = true;
-        workspaceManagerWindow.close();
+    // Normal project opens prefer a tab in the invoking workspace window,
+    // then the most recently focused workspace window. Drag-out and the tab
+    // context menu pass forceNewWindow as the explicit escape hatch.
+    if (!options?.forceNewWindow) {
+      const invokingWindow = BrowserWindow.fromWebContents(event.sender);
+      const tabRoute = routeWorkspaceToProjectTab(workspacePath, {
+        preferredWindow: invokingWindow,
+      });
+      if (tabRoute.status === 'routed') {
+        if (workspaceManagerWindow && !workspaceManagerWindow.isDestroyed()) {
+          workspaceManagerClosingForProject = true;
+          workspaceManagerWindow.close();
+        }
+        return { success: true, disposition: 'tab' };
       }
-
-      return { success: true };
+      if (tabRoute.status === 'rejected') {
+        const parent = invokingWindow && !invokingWindow.isDestroyed()
+          ? invokingWindow
+          : workspaceManagerWindow ?? undefined;
+        const messageBoxOptions: Electron.MessageBoxOptions = {
+          type: 'warning',
+          title: 'Unable to Open Project Tab',
+          message: tabRoute.error,
+          detail: tabRoute.reason === 'tab-cap'
+            ? 'Close a project tab first, or drag an existing tab into its own window.'
+            : 'The project was not opened in a separate window.',
+        };
+        if (parent) await dialog.showMessageBox(parent, messageBoxOptions);
+        else await dialog.showMessageBox(messageBoxOptions);
+        return { success: false, disposition: 'blocked', error: tabRoute.error };
+      }
     }
 
     // Check for saved workspace window state
@@ -360,6 +384,8 @@ export function setupWorkspaceManagerHandlers() {
 
     // Create window with saved bounds if available
     const window = createWindow(false, true, workspacePath, savedState?.bounds);
+    initializeWorkspaceTabBackground(workspacePath);
+    activateWorkspaceTabContext(workspacePath);
 
     (async () => {
       try {
@@ -391,25 +417,6 @@ export function setupWorkspaceManagerHandlers() {
       }
     })();
 
-    setTimeout(() => {
-      // Start watching workspace MCP config for changes after the open handler returns.
-      try {
-        const mcpService = getMcpConfigService();
-        if (mcpService) {
-          mcpService.startWatchingWorkspaceConfig(workspacePath);
-        }
-      } catch (error) {
-        // Log error but don't throw - workspace opening must continue
-        console.error('[MCP] Failed to start watching workspace config:', error);
-      }
-
-      // Auto-match workspace to a team and initialize tracker sync only after
-      // we've yielded the main thread; both paths may probe git remotes.
-      void autoMatchTeamForWorkspace(workspacePath).catch(() => {});
-      void initializeTrackerSync(workspacePath).catch(() => {});
-      updateTrackerSchemaWorkspace(workspacePath);
-    }, 0);
-
     // Restore dev tools if they were open
     if (savedState?.devToolsOpen) {
       window.webContents.once('did-finish-load', () => {
@@ -434,7 +441,7 @@ export function setupWorkspaceManagerHandlers() {
       workspaceManagerWindow.close();
     }
 
-    return { success: true };
+    return { success: true, disposition: 'window' };
   });
 
   // Remove from recent.workspaces

--- a/packages/electron/src/main/window/__tests__/projectTabRouting.test.ts
+++ b/packages/electron/src/main/window/__tests__/projectTabRouting.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WindowState } from '../../types';
+
+const mocks = vi.hoisted(() => ({
+  multiProjectMode: true,
+  windowStates: new Map<number, WindowState>(),
+  windowIds: new Map<any, number>(),
+  existingWindow: null as any,
+  recentWindow: null as any,
+  ensureWorkspaceTabServices: vi.fn((): { success: boolean; error?: string } => ({ success: true })),
+  initializeWorkspaceTabBackground: vi.fn(),
+}));
+
+vi.mock('../../utils/store', () => ({
+  getMultiProjectMode: () => mocks.multiProjectMode,
+}));
+
+vi.mock('../WindowManager', () => ({
+  windowStates: mocks.windowStates,
+  findWindowByWorkspace: () => mocks.existingWindow,
+  getMostRecentlyFocusedWorkspaceWindow: () => mocks.recentWindow,
+  getWindowId: (window: any) => mocks.windowIds.get(window) ?? null,
+}));
+
+vi.mock('../../services/WorkspaceTabServices', () => ({
+  ensureWorkspaceTabServices: mocks.ensureWorkspaceTabServices,
+}));
+
+vi.mock('../../services/WorkspaceTabBackground', () => ({
+  initializeWorkspaceTabBackground: mocks.initializeWorkspaceTabBackground,
+}));
+
+import { routeWorkspaceToProjectTab } from '../projectTabRouting';
+
+function makeWindow(id: number) {
+  const window = {
+    isDestroyed: vi.fn(() => false),
+    focus: vi.fn(),
+    webContents: { send: vi.fn() },
+  };
+  mocks.windowIds.set(window, id);
+  return window;
+}
+
+function makeState(partial: Partial<WindowState> = {}): WindowState {
+  return {
+    mode: 'workspace',
+    filePath: null,
+    workspacePath: '/ws/a',
+    documentEdited: false,
+    ...partial,
+  };
+}
+
+describe('routeWorkspaceToProjectTab', () => {
+  beforeEach(() => {
+    mocks.multiProjectMode = true;
+    mocks.windowStates.clear();
+    mocks.windowIds.clear();
+    mocks.existingWindow = null;
+    mocks.recentWindow = null;
+    mocks.ensureWorkspaceTabServices.mockReset();
+    mocks.ensureWorkspaceTabServices.mockReturnValue({ success: true });
+    mocks.initializeWorkspaceTabBackground.mockReset();
+  });
+
+  it('routes a new project to the invoking workspace window', () => {
+    const preferred = makeWindow(1);
+    mocks.windowStates.set(1, makeState());
+
+    const result = routeWorkspaceToProjectTab('/ws/b', { preferredWindow: preferred as any });
+
+    expect(result).toEqual({ status: 'routed', window: preferred });
+    expect(preferred.webContents.send).toHaveBeenCalledWith(
+      'workspace:open-project-tab',
+      { workspacePath: '/ws/b' },
+    );
+    expect(preferred.focus).toHaveBeenCalled();
+    expect(mocks.windowStates.get(1)?.additionalWorkspacePaths).toEqual(['/ws/b']);
+    expect(mocks.windowStates.get(1)?.pendingProjectTabPaths).toEqual(['/ws/b']);
+  });
+
+  it('activates the window that already hosts the project', () => {
+    const existing = makeWindow(2);
+    mocks.existingWindow = existing;
+    mocks.windowStates.set(2, makeState({ additionalWorkspacePaths: ['/ws/b'] }));
+
+    const result = routeWorkspaceToProjectTab('/ws/b');
+
+    expect(result).toEqual({ status: 'routed', window: existing });
+    expect(existing.webContents.send).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to the most recently focused workspace window', () => {
+    const recent = makeWindow(3);
+    mocks.recentWindow = recent;
+    mocks.windowStates.set(3, makeState());
+
+    expect(routeWorkspaceToProjectTab('/ws/c')).toEqual({ status: 'routed', window: recent });
+  });
+
+  it('focuses an exact already-open workspace when project tabs are disabled', () => {
+    mocks.multiProjectMode = false;
+    const existing = makeWindow(2);
+    mocks.existingWindow = existing;
+    mocks.windowStates.set(2, makeState({ workspacePath: '/ws/b' }));
+
+    expect(routeWorkspaceToProjectTab('/ws/b')).toEqual({
+      status: 'routed',
+      window: existing,
+    });
+    expect(existing.focus).toHaveBeenCalledOnce();
+    expect(existing.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('does not mistake a related worktree window for the exact workspace when tabs are disabled', () => {
+    mocks.multiProjectMode = false;
+    const related = makeWindow(2);
+    mocks.existingWindow = related;
+    mocks.windowStates.set(2, makeState({ workspacePath: '/ws/related' }));
+
+    expect(routeWorkspaceToProjectTab('/ws/b')).toEqual({
+      status: 'fallback',
+      reason: 'tabs-disabled',
+    });
+    expect(related.focus).not.toHaveBeenCalled();
+    expect(related.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a new window when tabs are disabled and the workspace is not open', () => {
+    mocks.multiProjectMode = false;
+    const preferred = makeWindow(1);
+    mocks.windowStates.set(1, makeState());
+
+    expect(routeWorkspaceToProjectTab('/ws/b', { preferredWindow: preferred as any })).toEqual({
+      status: 'fallback',
+      reason: 'tabs-disabled',
+    });
+    expect(preferred.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('rejects instead of opening a surprise window when the host has eight tabs', () => {
+    const preferred = makeWindow(1);
+    mocks.windowStates.set(1, makeState({
+      additionalWorkspacePaths: Array.from({ length: 7 }, (_, index) => `/ws/${index + 1}`),
+    }));
+
+    expect(routeWorkspaceToProjectTab('/ws/overflow', { preferredWindow: preferred as any })).toMatchObject({
+      status: 'rejected',
+      reason: 'tab-cap',
+    });
+    expect(preferred.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('rejects transactionally when workspace services cannot be initialized', () => {
+    const preferred = makeWindow(1);
+    mocks.windowStates.set(1, makeState());
+    mocks.ensureWorkspaceTabServices.mockReturnValueOnce({
+      success: false,
+      error: 'service failed',
+    });
+
+    const result = routeWorkspaceToProjectTab('/ws/b', { preferredWindow: preferred as any });
+
+    expect(result).toEqual({
+      status: 'rejected',
+      reason: 'registration-failed',
+      error: 'service failed',
+    });
+    expect(mocks.windowStates.get(1)?.additionalWorkspacePaths).toBeUndefined();
+    expect(preferred.webContents.send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/electron/src/main/window/projectTabRouting.ts
+++ b/packages/electron/src/main/window/projectTabRouting.ts
@@ -1,0 +1,112 @@
+import type { BrowserWindow } from 'electron';
+import { getMultiProjectMode } from '../utils/store';
+import {
+  findWindowByWorkspace,
+  getMostRecentlyFocusedWorkspaceWindow,
+  getWindowId,
+  windowStates,
+} from './WindowManager';
+import {
+  MAX_OPEN_PROJECT_TABS,
+  OPEN_PROJECT_TAB_CHANNEL,
+} from '../../shared/projectTabs';
+import { ensureWorkspaceTabServices } from '../services/WorkspaceTabServices';
+import { initializeWorkspaceTabBackground } from '../services/WorkspaceTabBackground';
+
+export interface ProjectTabRouteOptions {
+  preferredWindow?: BrowserWindow | null;
+  focus?: boolean;
+}
+
+export type ProjectTabRouteResult =
+  | { status: 'routed'; window: BrowserWindow }
+  | { status: 'fallback'; reason: 'tabs-disabled' | 'no-host' }
+  | { status: 'rejected'; reason: 'tab-cap' | 'registration-failed'; error: string };
+
+function isWorkspaceHost(window: BrowserWindow | null | undefined): window is BrowserWindow {
+  if (!window || window.isDestroyed()) return false;
+  const windowId = getWindowId(window);
+  if (windowId === null) return false;
+  const state = windowStates.get(windowId);
+  return state?.mode === 'workspace' || state?.mode === 'agentic-coding';
+}
+
+function referencesExactWorkspace(
+  window: BrowserWindow | null | undefined,
+  workspacePath: string,
+): window is BrowserWindow {
+  if (!isWorkspaceHost(window)) return false;
+  const windowId = getWindowId(window);
+  if (windowId === null) return false;
+  const state = windowStates.get(windowId);
+  return state?.workspacePath === workspacePath ||
+    state?.additionalWorkspacePaths?.includes(workspacePath) === true;
+}
+
+/**
+ * Route a normal project-open request into a tab in an existing workspace
+ * window. A rejected result must not fall through to a new BrowserWindow:
+ * doing so at the tab cap would violate the tab-by-default contract.
+ */
+export function routeWorkspaceToProjectTab(
+  workspacePath: string,
+  options: ProjectTabRouteOptions = {},
+): ProjectTabRouteResult {
+  const existingHost = findWindowByWorkspace(workspacePath);
+  if (!getMultiProjectMode()) {
+    if (referencesExactWorkspace(existingHost, workspacePath)) {
+      if (options.focus !== false) existingHost.focus();
+      return { status: 'routed', window: existingHost };
+    }
+    return { status: 'fallback', reason: 'tabs-disabled' };
+  }
+
+  const preferredHost = isWorkspaceHost(options.preferredWindow)
+    ? options.preferredWindow
+    : null;
+  const host = existingHost ?? preferredHost ?? getMostRecentlyFocusedWorkspaceWindow();
+  if (!isWorkspaceHost(host)) return { status: 'fallback', reason: 'no-host' };
+
+  const windowId = getWindowId(host);
+  if (windowId === null) return { status: 'fallback', reason: 'no-host' };
+  const state = windowStates.get(windowId);
+  if (!state) return { status: 'fallback', reason: 'no-host' };
+
+  const referencedPaths = new Set<string>();
+  if (state.workspacePath) referencedPaths.add(state.workspacePath);
+  state.additionalWorkspacePaths?.forEach((path) => referencedPaths.add(path));
+
+  if (!referencedPaths.has(workspacePath) && referencedPaths.size >= MAX_OPEN_PROJECT_TABS) {
+    return {
+      status: 'rejected',
+      reason: 'tab-cap',
+      error: `You can have at most ${MAX_OPEN_PROJECT_TABS} project tabs open in one window.`,
+    };
+  }
+
+  if (!referencedPaths.has(workspacePath)) {
+    const serviceResult = ensureWorkspaceTabServices(host, workspacePath);
+    if (!serviceResult.success) {
+      return {
+        status: 'rejected',
+        reason: 'registration-failed',
+        error: serviceResult.error || 'Unable to initialize project tab services',
+      };
+    }
+    state.additionalWorkspacePaths = [
+      ...(state.additionalWorkspacePaths ?? []),
+      workspacePath,
+    ];
+    initializeWorkspaceTabBackground(workspacePath);
+  }
+
+  // Keep a pull-based copy until the renderer consumes it. The live event
+  // gives an already-mounted renderer an immediate switch, while the queue
+  // covers renderer startup/reload races where no listener exists yet.
+  state.pendingProjectTabPaths = [
+    ...new Set([...(state.pendingProjectTabPaths ?? []), workspacePath]),
+  ];
+  host.webContents.send(OPEN_PROJECT_TAB_CHANNEL, { workspacePath });
+  if (options.focus !== false) host.focus();
+  return { status: 'routed', window: host };
+}

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -765,7 +765,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getWorkspaceStats: (workspacePath: string) => ipcRenderer.invoke('workspace-manager:get-workspace-stats', workspacePath),
     openFolderDialog: () => ipcRenderer.invoke('workspace-manager:open-folder-dialog'),
     createWorkspaceDialog: () => ipcRenderer.invoke('workspace-manager:create-workspace-dialog'),
-    openWorkspace: (workspacePath: string) => ipcRenderer.invoke('workspace-manager:open-workspace', workspacePath),
+    openWorkspace: (workspacePath: string, options?: { forceNewWindow?: boolean }) =>
+      ipcRenderer.invoke('workspace-manager:open-workspace', workspacePath, options),
     removeRecent: (workspacePath: string) => ipcRenderer.invoke('workspace-manager:remove-recent', workspacePath),
     getOpenWorkspaces: () => ipcRenderer.invoke('workspace-manager:get-open-workspaces') as Promise<string[]>,
   },

--- a/packages/electron/src/renderer/App.tsx
+++ b/packages/electron/src/renderer/App.tsx
@@ -117,6 +117,7 @@ import { initCollabReplicaListeners } from './store/listeners/collabReplicaListe
 import { initNotificationListeners } from './store/listeners/notificationListeners';
 import { initExtensionPermissionListeners } from './store/listeners/extensionPermissionListeners';
 import { initPermissionListeners } from './store/listeners/permissionListeners';
+import { initProjectTabListeners } from './store/listeners/projectTabListeners';
 import { initSoundListeners } from './store/listeners/soundListeners';
 import { initStytchAuthListeners } from './store/listeners/stytchAuthListeners';
 import { initSyncListeners } from './store/listeners/syncListeners';
@@ -141,7 +142,7 @@ import { organizationDirectoryAtom, personalAccountsAtom } from './store/atoms/s
 import {
   activeWorkspacePathAtom,
   multiProjectModeAtom,
-  addOpenProjectAtom as addOpenProjectAction,
+  seedInitialOpenProjectAtom as seedInitialOpenProjectAction,
 } from './store/atoms/openProjects';
 import { registerDocumentLinkPlugin } from './plugins/registerDocumentLinkPlugin';
 import { registerTrackerLinkPlugin } from './plugins/registerTrackerLinkPlugin';
@@ -306,7 +307,7 @@ export default function App() {
     // Multi-project rail state — fire-and-forget so legacy single-project
     // startup is not blocked by IPC. The rail consumers re-render when the
     // atoms hydrate.
-    initOpenProjects();
+    const openProjectsReady = initOpenProjects();
     initWorkspaceStatePruner();
 
     // Extension-contributed agent provider ids are registered with
@@ -328,6 +329,7 @@ export default function App() {
     const cleanupNotification = initNotificationListeners();
     const cleanupExtensionPermission = initExtensionPermissionListeners();
     const cleanupPermission = initPermissionListeners();
+    const cleanupProjectTabs = initProjectTabListeners(openProjectsReady);
     const cleanupSound = initSoundListeners();
     const cleanupStytchAuth = initStytchAuthListeners();
     const cleanupSync = initSyncListeners();
@@ -358,6 +360,7 @@ export default function App() {
       cleanupNotification?.();
       cleanupExtensionPermission?.();
       cleanupPermission?.();
+      cleanupProjectTabs?.();
       cleanupSound?.();
       cleanupStytchAuth?.();
       cleanupSync?.();
@@ -484,7 +487,7 @@ export default function App() {
   // (which is wired to that state) re-renders for the new project.
   const isMultiProjectMode = useAtomValue(multiProjectModeAtom);
   const railActivePath = useAtomValue(activeWorkspacePathAtom);
-  const addOpenProject = useSetAtom(addOpenProjectAction);
+  const seedInitialOpenProject = useSetAtom(seedInitialOpenProjectAction);
   const setRailActivePath = useSetAtom(activeWorkspacePathAtom);
   // NOTE: fileTree, sidebarWidth, isNewFileDialogOpen, newFileDirectory, isHistoryDialogOpen moved to EditorMode
   // NOTE: Navigation dialogs (QuickOpen, SessionQuickOpen, PromptQuickOpen, ProjectQuickOpen) are now managed by DialogProvider
@@ -1730,7 +1733,7 @@ export default function App() {
               // Seed the multi-project rail: this window's primary
               // workspace is always represented in the rail (visible only
               // when multiProjectMode is on, hidden otherwise).
-              addOpenProject({
+              seedInitialOpenProject({
                 path: initialState.workspacePath,
                 name: initialState.workspaceName ?? initialState.workspacePath,
                 openedAt: Date.now(),
@@ -1746,7 +1749,7 @@ export default function App() {
     };
 
     loadInitialState();
-  }, [addOpenProject]);
+  }, [seedInitialOpenProject]);
 
   // Multi-project rail switch: when the rail's active path changes, mirror
   // it into the legacy `workspacePath` useState so the rest of the App
@@ -2097,11 +2100,11 @@ export default function App() {
     />
     <WalkthroughProvider currentMode={activeMode}>
     <TipProvider currentMode={activeMode} workspacePath={workspacePath || undefined}>
-    <div data-layout="root-container" className="h-screen flex flex-row">
-      {/* Far-left: project rail (Discord-style) — visible only when
-          multi-project mode is enabled in settings. */}
+    <div data-layout="root-container" className="h-screen flex flex-col">
+      {/* Project tabs sit directly below the native File/Edit menu. */}
       <ProjectRail />
-      {/* Left: Navigation Gutter - full height */}
+      <div data-layout="workspace-shell" className="flex-1 min-h-0 flex flex-row overflow-hidden">
+      {/* Left: Navigation Gutter - remaining workspace height */}
       <NavigationGutter
         contentMode={activeMode}
         onContentModeChange={setActiveMode}
@@ -2415,6 +2418,7 @@ export default function App() {
           }
           return null;
         })()}
+      </div>
       </div>
 
       {/* Navigation dialogs (QuickOpen, SessionQuickOpen, PromptQuickOpen, ProjectQuickOpen) */}

--- a/packages/electron/src/renderer/components/GlobalSettings/panels/AdvancedPanel.tsx
+++ b/packages/electron/src/renderer/components/GlobalSettings/panels/AdvancedPanel.tsx
@@ -624,9 +624,9 @@ export function AdvancedPanel() {
 }
 
 /**
- * Toggle for the multi-project rail. When the user disables it with
- * inactive warm projects in the rail, those projects' main-process
- * services are released and the rail collapses to just the active
+ * Toggle for project tabs. When the user disables it with inactive warm
+ * projects, those projects' main-process services are released and the
+ * tab strip collapses to just the active
  * project so state stays consistent.
  */
 function MultiProjectModeToggle() {
@@ -637,7 +637,7 @@ function MultiProjectModeToggle() {
   const handleChange = async (next: boolean) => {
     if (!next && openProjects.length > 1) {
       const proceed = window.confirm(
-        `${openProjects.length} projects are open in the rail. Disable multi-project mode? The other projects will be closed (their unsaved work stays on disk).`
+        `${openProjects.length} project tabs are open. Disable project tabs? The other projects will be closed (their unsaved work stays on disk).`
       );
       if (!proceed) return;
 
@@ -666,16 +666,16 @@ function MultiProjectModeToggle() {
     <SettingsToggle
       checked={enabled}
       onChange={handleChange}
-      name="Multi-project Mode"
-      description="Open multiple projects in a single window via a project rail. When off, each project opens in its own window."
+      name="Open projects in tabs"
+      description="Open projects as tabs across the top of the current window. Drag a tab out or use its context menu to open it in a separate window."
     />
   );
 }
 
 /**
- * Toggle for re-opening last session's rail projects on launch. Default
+ * Toggle for re-opening last session's project tabs on launch. Default
  * off so a normal launch from the project picker opens just the picked
- * project; warm rail projects must be added explicitly via the rail's
+ * project; warm tabs must be added explicitly via the tab strip's
  * `+` button.
  */
 function RestorePreviousProjectsToggle() {
@@ -689,8 +689,8 @@ function RestorePreviousProjectsToggle() {
       name="Restore last session's projects on launch"
       description={
         isMultiProject
-          ? 'When on, the project rail rehydrates with every project that was open at last close. When off, only the project you pick from the launch screen opens.'
-          : 'Only takes effect when Multi-project Mode is enabled.'
+          ? 'When on, the project tabs restore every project that was open at last close. When off, only the project you pick from the launch screen opens.'
+          : 'Only takes effect when project tabs are enabled.'
       }
     />
   );

--- a/packages/electron/src/renderer/components/OrgSwitcher.tsx
+++ b/packages/electron/src/renderer/components/OrgSwitcher.tsx
@@ -1,5 +1,5 @@
 /**
- * OrgSwitcher — the org-level nav element that sits above the project rail
+ * OrgSwitcher — the org-level nav element that leads the project tab strip
  * (Epic H1). Shows the organization the active workspace belongs to and lets
  * the user see every org they're a member of, jumping to Settings → Org to
  * administer one.
@@ -97,7 +97,7 @@ export function OrgSwitcher() {
   const { refs, floatingStyles, context } = useFloating({
     open,
     onOpenChange: setOpen,
-    placement: 'right-start',
+    placement: 'bottom-start',
     middleware: [offset(8), flip({ padding: 8 }), shift({ padding: 8 })],
     whileElementsMounted: autoUpdate,
   });
@@ -124,7 +124,7 @@ export function OrgSwitcher() {
       <button
         ref={refs.setReference}
         {...getReferenceProps()}
-        className="org-switcher-button w-10 h-10 mx-auto mt-2 mb-1 rounded-lg bg-gradient-to-br from-[#60a5fa] to-[#a78bfa] text-white text-[12px] font-semibold flex items-center justify-center shadow-sm hover:brightness-110 transition"
+        className="org-switcher-button w-7 h-7 mx-1 rounded-md bg-[var(--nim-bg-tertiary)] border border-[var(--nim-border)] text-[var(--nim-text)] text-[10px] font-semibold flex flex-none items-center justify-center hover:bg-[var(--nim-bg-hover)] transition"
         data-testid="org-switcher"
         title={activeOrg ? `Organization: ${activeOrg.name}` : 'Organization'}
         aria-label="Switch organization"

--- a/packages/electron/src/renderer/components/ProjectRail.css
+++ b/packages/electron/src/renderer/components/ProjectRail.css
@@ -1,94 +1,127 @@
 .project-rail {
-  width: 56px;
-  height: 100%;
+  width: 100%;
+  height: 40px;
   flex-shrink: 0;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  padding: 12px 0 8px;
-  gap: 8px;
-  background-color: var(--nim-bg-secondary, #1a1a1a);
-  border-right: 1px solid var(--nim-border, rgba(255, 255, 255, 0.06));
-  overflow-y: auto;
-  overflow-x: hidden;
+  padding: 4px 8px;
+  gap: 6px;
+  background-color: var(--nim-bg-secondary);
+  border-bottom: 1px solid var(--nim-border);
+  overflow: hidden;
   -webkit-app-region: no-drag;
 }
 
+.project-rail-tabs {
+  min-width: 0;
+  flex: 1;
+  height: 100%;
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  border-radius: 6px;
+  transition: background-color 120ms ease, box-shadow 120ms ease;
+}
+
+.project-rail-tabs.is-drop-target {
+  background-color: color-mix(in srgb, var(--nim-primary) 10%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--nim-primary) 65%, transparent);
+}
+
+.project-rail-tabs::-webkit-scrollbar {
+  display: none;
+}
+
 .project-rail-item {
-  /*
-   * --rail-item-accent is set inline per project (see ProjectRail.tsx:
-   * style={{ '--rail-item-accent': accentColor }}). It comes from
-   * generateWorkspaceAccentColor(path) so the rail icon shares its color
-   * with the workspace summary header bar. Falls back to --nim-primary so
-   * the rail still looks correct if the inline variable is ever missing.
-   */
+  --rail-item-accent: var(--nim-primary);
   position: relative;
-  width: 40px;
-  height: 40px;
+  min-width: 132px;
+  max-width: 220px;
+  height: 32px;
+  flex: 0 1 190px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  border-radius: 6px 6px 0 0;
+  border-top: 2px solid transparent;
+  background-color: transparent;
+  transition: background-color 120ms ease, border-color 120ms ease, opacity 120ms ease;
+}
+
+.project-rail-item:hover {
+  background-color: var(--nim-bg-hover);
+}
+
+.project-rail-item.is-active {
+  background-color: var(--nim-bg);
+  border-top-color: var(--rail-item-accent);
+}
+
+.project-rail-item.is-dragging {
+  opacity: 0.55;
 }
 
 .project-rail-item-main {
-  position: relative;
+  min-width: 0;
   width: 100%;
   height: 100%;
-  border-radius: 50%;
   display: flex;
   align-items: center;
-  justify-content: center;
-  background-color: var(--nim-bg-tertiary, #2a2a2a);
-  color: var(--rail-item-accent, var(--nim-primary, #3b82f6));
-  font-size: 14px;
-  font-weight: 600;
+  gap: 7px;
+  padding: 0 30px 0 8px;
+  border: 0;
+  background: transparent;
+  color: var(--nim-text-muted);
   cursor: pointer;
-  user-select: none;
-  border: 1.5px solid transparent;
-  padding: 0;
-  transition: border-radius 150ms ease, background-color 150ms ease,
-    border-color 150ms ease, color 150ms ease, transform 150ms ease;
-}
-
-.project-rail-item-main:hover {
-  border-radius: 14px;
-  background-color: var(--rail-item-accent, var(--nim-primary, #3b82f6));
-  color: #ffffff;
+  text-align: left;
 }
 
 .project-rail-item.is-active .project-rail-item-main {
-  border-radius: 14px;
-  background-color: var(--rail-item-accent, var(--nim-primary, #3b82f6));
-  color: #ffffff;
-  border-color: transparent;
+  color: var(--nim-text);
 }
 
-.project-rail-item.is-active::before {
-  content: '';
-  position: absolute;
-  left: -10px;
-  top: 8px;
-  bottom: 8px;
-  width: 4px;
-  border-radius: 0 4px 4px 0;
-  background-color: var(--rail-item-accent, var(--nim-text, #111827));
+.project-rail-item-icon {
+  position: relative;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: color-mix(in srgb, var(--rail-item-accent) 16%, transparent);
+  color: var(--rail-item-accent);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.project-rail-item-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .project-rail-item-badge {
   position: absolute;
-  bottom: -2px;
-  right: -2px;
-  width: 16px;
-  height: 16px;
+  top: -4px;
+  right: -5px;
+  min-width: 14px;
+  height: 14px;
   box-sizing: border-box;
-  padding: 0;
-  border-radius: 50%;
-  background-color: var(--nim-primary, #3b82f6);
-  border: 2px solid var(--nim-bg-secondary, #1a1a1a);
-  font-size: 9px;
+  padding: 0 3px;
+  border-radius: 7px;
+  background-color: var(--nim-primary);
+  border: 2px solid var(--nim-bg-secondary);
+  font-size: 8px;
   font-weight: 700;
   line-height: 1;
-  color: var(--nim-on-primary, #ffffff);
+  color: var(--nim-on-primary);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -97,61 +130,54 @@
 
 .project-rail-item-close {
   position: absolute;
-  top: -4px;
-  right: -4px;
+  top: 6px;
+  right: 6px;
   width: 18px;
   height: 18px;
-  border-radius: 50%;
-  background-color: var(--nim-bg-secondary, #1a1a1a);
-  color: var(--nim-text, #111827);
-  border: 1px solid var(--nim-border, rgba(255, 255, 255, 0.12));
+  border-radius: 4px;
+  background: transparent;
+  color: var(--nim-text-muted);
+  border: 0;
   display: none;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: 14px;
   line-height: 1;
   cursor: pointer;
   padding: 0;
 }
 
-.project-rail-item:hover .project-rail-item-close {
+.project-rail-item:hover .project-rail-item-close,
+.project-rail-item.is-active .project-rail-item-close {
   display: flex;
 }
 
 .project-rail-item-close:hover {
-  background-color: var(--nim-error, #ef4444);
-  color: #ffffff;
-}
-
-.project-rail-divider {
-  width: 32px;
-  height: 1px;
-  background-color: var(--nim-border, rgba(255, 255, 255, 0.06));
-  margin: 4px 0;
+  background-color: var(--nim-error);
+  color: var(--nim-on-primary);
 }
 
 .project-rail-add {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+  border-radius: 5px;
   display: flex;
   align-items: center;
   justify-content: center;
   background-color: transparent;
-  color: var(--nim-text-muted, #6b7280);
-  font-size: 22px;
+  color: var(--nim-text-muted);
+  font-size: 19px;
   line-height: 1;
   cursor: pointer;
-  border: 1px dashed var(--nim-border, rgba(255, 255, 255, 0.18));
+  border: 1px solid transparent;
   padding: 0;
-  transition: border-radius 150ms ease, background-color 150ms ease, color 150ms ease;
+  transition: background-color 120ms ease, color 120ms ease;
 }
 
 .project-rail-add:hover:not(:disabled) {
-  border-radius: 14px;
-  border-style: solid;
-  background-color: var(--nim-bg-tertiary, #2a2a2a);
-  color: var(--nim-text, #111827);
+  background-color: var(--nim-bg-hover);
+  color: var(--nim-text);
 }
 
 .project-rail-add:disabled {
@@ -162,11 +188,11 @@
 .project-rail-context-menu {
   position: fixed;
   min-width: 180px;
-  background-color: var(--nim-bg-secondary, #1a1a1a);
-  border: 1px solid var(--nim-border, rgba(255, 255, 255, 0.12));
+  background-color: var(--nim-bg-secondary);
+  border: 1px solid var(--nim-border);
   border-radius: 6px;
   padding: 4px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--nim-text) 20%, transparent);
   z-index: 2000;
   display: flex;
   flex-direction: column;
@@ -178,20 +204,20 @@
   padding: 6px 12px;
   text-align: left;
   font-size: 13px;
-  color: var(--nim-text, #111827);
+  color: var(--nim-text);
   border-radius: 4px;
   cursor: pointer;
   white-space: nowrap;
 }
 
 .project-rail-context-menu-item:hover {
-  background-color: var(--nim-primary, #3b82f6);
-  color: var(--nim-on-primary, #ffffff);
+  background-color: var(--nim-primary);
+  color: var(--nim-on-primary);
 }
 
 .project-rail-context-menu-divider {
   height: 1px;
-  background-color: var(--nim-border, rgba(255, 255, 255, 0.08));
+  background-color: var(--nim-border);
   margin: 4px 6px;
 }
 
@@ -201,7 +227,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--nim-text-muted, #6b7280);
+  color: var(--nim-text-muted);
 }
 
 .project-rail-add-menu {
@@ -223,7 +249,7 @@
 
 .project-rail-context-menu-item-path {
   font-size: 11px;
-  color: var(--nim-text-muted, #6b7280);
+  color: var(--nim-text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -231,43 +257,36 @@
 }
 
 .project-rail-context-menu-item-recent:hover .project-rail-context-menu-item-path {
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--nim-on-primary);
 }
 
-/*
- * Tooltip is rendered through @floating-ui/react's FloatingPortal
- * (see ProjectRail.tsx) so it escapes `.project-rail`'s `overflow: hidden`
- * clip. Position + visibility are owned by floating-ui — these rules cover
- * appearance only.
- */
 .project-rail-tooltip {
   padding: 6px 10px;
-  background-color: var(--nim-bg-tertiary, #2a2a2a);
-  color: var(--nim-text, #111827);
+  background-color: var(--nim-bg-tertiary);
+  color: var(--nim-text);
   font-size: 12px;
   font-weight: 500;
   white-space: nowrap;
   border-radius: 4px;
-  border: 1px solid var(--nim-border, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--nim-border);
   pointer-events: none;
   z-index: 1000;
   display: flex;
   flex-direction: column;
   gap: 2px;
   max-width: 320px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--nim-text) 18%, transparent);
 }
 
 .project-rail-tooltip-name {
   font-weight: 600;
-  color: var(--nim-text, #111827);
+  color: var(--nim-text);
 }
 
 .project-rail-tooltip-path {
   font-size: 11px;
   font-weight: 400;
-  color: var(--nim-text-muted, #6b7280);
+  color: var(--nim-text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
 }
-

--- a/packages/electron/src/renderer/components/ProjectRail.tsx
+++ b/packages/electron/src/renderer/components/ProjectRail.tsx
@@ -1,7 +1,7 @@
 /**
- * ProjectRail
+ * ProjectTabs
  *
- * Discord-style vertical rail of warm projects. Click an icon to switch
+ * Horizontal tab strip of warm projects. Click a tab to switch
  * the visible project; the inactive projects' state is kept warm via
  * per-workspace atom families and main-process service refcounting.
  *
@@ -22,22 +22,37 @@ import {
   shift,
   type VirtualElement,
 } from '@floating-ui/react';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { OrgSwitcher } from './OrgSwitcher';
 import {
   multiProjectModeAtom,
   openProjectsAtom,
   activeWorkspacePathAtom,
   isOpenProjectsAtCapAtom,
-  addOpenProjectAtom,
-  closeOpenProjectAtom,
   type OpenProject,
 } from '../store/atoms/openProjects';
-import {
-  globalSessionActivityAtom,
-  projectActivitySummaryAtom,
-} from '../store/atoms/sessionActivity';
+import { projectActivitySummaryAtom } from '../store/atoms/sessionActivity';
 import { generateWorkspaceAccentColor } from './WorkspaceSummaryHeader';
+import { errorNotificationService } from '../services/ErrorNotificationService';
+import { flushTabsSlot, getTabsSlotTransferBlocker, persistTabsSlot } from '../contexts/TabsContext';
+import {
+  closeProjectTab,
+  detachProjectTab,
+  moveProjectTabToCurrentWindow,
+  openProjectTab,
+} from '../services/projectTabs';
+import {
+  hasProjectTabDragType,
+  parseProjectTabDragPayload,
+  serializeProjectTabDragPayload,
+  shouldDetachProjectTabAfterDrag,
+  waitForProjectTabPreparation,
+} from './projectTabDrag';
+import {
+  PROJECT_TAB_DRAG_MIME,
+  type ProjectTabDragPayload,
+  type ProjectTabDragRegistration,
+} from '../../shared/projectTabs';
 import './ProjectRail.css';
 
 const REVEAL_LABEL = (() => {
@@ -63,7 +78,9 @@ interface ProjectRailIconProps {
   processingCount: number;
   unreadCount: number;
   onActivate: (path: string) => void;
+  onNavigate: (project: OpenProject, key: 'ArrowLeft' | 'ArrowRight' | 'Home' | 'End') => void;
   onClose: (project: OpenProject) => void;
+  onDetach: (project: OpenProject, screenX: number, screenY: number) => void;
   onContextMenu: (project: OpenProject, x: number, y: number) => void;
 }
 
@@ -73,9 +90,13 @@ function ProjectRailIcon({
   processingCount,
   unreadCount,
   onActivate,
+  onNavigate,
   onClose,
+  onDetach,
   onContextMenu,
 }: ProjectRailIconProps) {
+  const dragIdRef = React.useRef<string | null>(null);
+  const dragPreparationRef = React.useRef<Promise<{ success: boolean; error?: string }> | null>(null);
   // Hover tooltip via floating-ui. Renders through FloatingPortal so the
   // tooltip escapes the rail container's `overflow: hidden` clip — the
   // earlier CSS-only `:hover > .project-rail-tooltip` approach was clipped
@@ -84,7 +105,7 @@ function ProjectRailIcon({
   const { refs: tooltipRefs, floatingStyles: tooltipFloatingStyles, context: tooltipContext } = useFloating({
     open: tooltipOpen,
     onOpenChange: setTooltipOpen,
-    placement: 'right',
+    placement: 'bottom',
     middleware: [offset(12), flip({ padding: 8 }), shift({ padding: 8 })],
   });
   const tooltipHover = useHover(tooltipContext, { delay: { open: 200, close: 0 }, move: false });
@@ -112,6 +133,106 @@ function ProjectRailIcon({
     [onContextMenu, project]
   );
 
+  const handleDragStart = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    const dragId = globalThis.crypto?.randomUUID?.()
+      ?? `project-tab-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const payload: ProjectTabDragPayload = {
+      version: 1,
+      dragId,
+    };
+    const registration: ProjectTabDragRegistration = { ...payload, workspacePath: project.path };
+    dragIdRef.current = dragId;
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData(PROJECT_TAB_DRAG_MIME, serializeProjectTabDragPayload(payload));
+    window.electronAPI?.send?.('workspace:begin-project-tab-drag', registration);
+    dragPreparationRef.current = (async () => {
+      try {
+        // Moving removes this renderer's workspace slot. Flush buffers and
+        // persist its file-tab layout before main commits the handoff so the
+        // destination can restore it without losing unsaved work.
+        await flushTabsSlot(project.path);
+        const transferBlocker = getTabsSlotTransferBlocker(project.path);
+        if (transferBlocker) throw new Error(transferBlocker);
+        await persistTabsSlot(project.path);
+        window.electronAPI?.send?.('workspace:project-tab-drag-ready', { dragId });
+        return { success: true };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        window.electronAPI?.send?.('workspace:project-tab-drag-ready', { dragId, error: message });
+        return { success: false, error: message };
+      }
+    })();
+    event.currentTarget.classList.add('is-dragging');
+  }, [project.path]);
+
+  const handleDragEnd = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.currentTarget.classList.remove('is-dragging');
+    const dragId = dragIdRef.current;
+    const preparation = dragPreparationRef.current;
+    dragIdRef.current = null;
+    dragPreparationRef.current = null;
+
+    // A project rail accepted this drop. Main owns the move transaction and
+    // will publish mutations to both renderers, so the source must not also
+    // run its tear-out path and create a third window.
+    if (event.dataTransfer.dropEffect === 'move') return;
+
+    const strip = event.currentTarget.closest('.project-rail')?.getBoundingClientRect();
+    if (!strip) {
+      if (dragId) window.electronAPI?.send?.('workspace:end-project-tab-drag', { dragId });
+      return;
+    }
+
+    const shouldDetach = shouldDetachProjectTabAfterDrag({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      dropEffect: event.dataTransfer.dropEffect,
+    }, strip);
+    if (!shouldDetach) {
+      if (dragId) window.electronAPI?.send?.('workspace:end-project-tab-drag', { dragId });
+      return;
+    }
+
+    const { screenX, screenY } = event;
+    void (async () => {
+      // A Linux dragend can occasionally report dropEffect=none even though
+      // another BrowserWindow accepted the drop. Give that atomic move a
+      // brief chance to settle before creating a detached window.
+      let result: { handled?: boolean; moved?: boolean } | null = null;
+      try {
+        result = dragId
+          ? await window.electronAPI?.invoke?.('workspace:wait-project-tab-drag-result', { dragId })
+          : null;
+      } catch (error) {
+        console.error('[ProjectTabs] failed to resolve project-tab drag:', error);
+      }
+      if (result?.handled || result?.moved) return;
+
+      const prepared = await waitForProjectTabPreparation(preparation);
+      if (prepared && !prepared.success) {
+        errorNotificationService.showWarning(
+          'Project tab was not moved',
+          prepared.error || 'The project could not be saved before moving.',
+          { duration: 8000 },
+        );
+        return;
+      }
+      onDetach(project, screenX, screenY);
+    })();
+  }, [onDetach, project]);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (
+      event.key === 'ArrowLeft'
+      || event.key === 'ArrowRight'
+      || event.key === 'Home'
+      || event.key === 'End'
+    ) {
+      event.preventDefault();
+      onNavigate(project, event.key);
+    }
+  }, [onNavigate, project]);
+
   const className = isActive ? 'project-rail-item is-active' : 'project-rail-item';
 
   // Per-project accent color, derived deterministically from the workspace
@@ -133,6 +254,9 @@ function ProjectRailIcon({
       ref={tooltipRefs.setReference}
       className={className}
       onContextMenu={handleContextMenu}
+      draggable
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
       data-testid="project-rail-item"
       data-project-path={project.path}
       style={{ ['--rail-item-accent' as any]: accentColor }}
@@ -142,10 +266,16 @@ function ProjectRailIcon({
         type="button"
         className="project-rail-item-main"
         onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        role="tab"
         aria-label={`Switch to project ${project.name}`}
-        aria-current={isActive ? 'true' : undefined}
+        aria-selected={isActive}
+        tabIndex={isActive ? 0 : -1}
       >
-        {projectInitials(project.name)}
+        <span className="project-rail-item-icon" aria-hidden="true">
+          {projectInitials(project.name)}
+        </span>
+        <span className="project-rail-item-name">{project.name}</span>
         {showBadge && (
           <span
             className="project-rail-item-badge"
@@ -185,10 +315,8 @@ export function ProjectRail() {
   const openProjects = useAtomValue(openProjectsAtom);
   const [activePath, setActivePath] = useAtom(activeWorkspacePathAtom);
   const atCap = useAtomValue(isOpenProjectsAtCapAtom);
-  const addProject = useSetAtom(addOpenProjectAtom);
-  const closeProject = useSetAtom(closeOpenProjectAtom);
-  const activity = useAtomValue(globalSessionActivityAtom);
   const activitySummary = useAtomValue(projectActivitySummaryAtom);
+  const [isProjectTabDropTarget, setIsProjectTabDropTarget] = useState(false);
 
   const handleActivate = useCallback(
     (path: string) => {
@@ -201,27 +329,35 @@ export function ProjectRail() {
     [activePath, setActivePath]
   );
 
-  const addProjectByPath = useCallback(async (workspacePath: string) => {
-    if (!window.electronAPI?.invoke) return;
-    try {
-      const reg = await window.electronAPI.invoke('workspace:register-additional', { workspacePath });
-      if (!reg?.success) {
-        console.error('[ProjectRail] register-additional failed:', reg?.error);
-        return;
-      }
+  const handleNavigate = useCallback((
+    project: OpenProject,
+    key: 'ArrowLeft' | 'ArrowRight' | 'Home' | 'End',
+  ) => {
+    const index = openProjects.findIndex((entry) => entry.path === project.path);
+    if (index < 0 || openProjects.length === 0) return;
 
-      const project: OpenProject = {
-        path: workspacePath,
-        name: workspacePath.split(/[\\/]/).filter(Boolean).pop() || workspacePath,
-        openedAt: Date.now(),
-      };
-      // `addOpenProjectAtom` flips `activeWorkspacePathAtom` to this path;
-      // the atom subscriber dispatches `workspace:set-active` to main.
-      addProject(project);
-    } catch (err) {
-      console.error('[ProjectRail] addProjectByPath failed:', err);
+    let targetIndex = index;
+    if (key === 'ArrowLeft') targetIndex = (index - 1 + openProjects.length) % openProjects.length;
+    if (key === 'ArrowRight') targetIndex = (index + 1) % openProjects.length;
+    if (key === 'Home') targetIndex = 0;
+    if (key === 'End') targetIndex = openProjects.length - 1;
+
+    const target = openProjects[targetIndex];
+    handleActivate(target.path);
+    requestAnimationFrame(() => {
+      const item = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-testid="project-rail-item"]'),
+      ).find((element) => element.dataset.projectPath === target.path);
+      item?.querySelector<HTMLButtonElement>('[role="tab"]')?.focus();
+    });
+  }, [handleActivate, openProjects]);
+
+  const addProjectByPath = useCallback(async (workspacePath: string) => {
+    const result = await openProjectTab(workspacePath);
+    if (!result.success) {
+      console.error('[ProjectTabs] addProjectByPath failed:', result.error);
     }
-  }, [addProject]);
+  }, []);
 
   const handlePickFolder = useCallback(async () => {
     if (!window.electronAPI?.invoke) return;
@@ -251,7 +387,7 @@ export function ProjectRail() {
 
   const handleOpenAddMenu = useCallback(() => {
     if (atCap) {
-      window.alert('You can have at most 8 projects open in the rail. Close one first or open in a new window.');
+      window.alert('You can have at most 8 project tabs open. Close one first or open it in a new window.');
       return;
     }
     refreshRecents();
@@ -260,42 +396,53 @@ export function ProjectRail() {
 
   const handleClose = useCallback(
     async (project: OpenProject) => {
-      // Warn if there are streaming sessions for this project. Read from the
-      // cross-workspace activity tracker (kept in sync by sessionStateListeners
-      // for every warm rail project) instead of `sessionRegistryAtom`, which
-      // only carries the active project's sessions and would silently skip
-      // the prompt when closing an inactive rail project.
-      const streaming = activity.get(project.path)?.streaming.size ?? 0;
-      if (streaming > 0) {
-        const proceed = window.confirm(
-          `${project.name} has ${streaming} streaming session${streaming === 1 ? '' : 's'}. Close anyway? Sessions will be paused.`
-        );
-        if (!proceed) return;
-      }
-
-      const wasLast = openProjects.length <= 1;
-
-      closeProject(project.path);
-
-      try {
-        await window.electronAPI?.invoke?.('workspace:unregister-additional', { workspacePath: project.path });
-      } catch (err) {
-        console.error('[ProjectRail] unregister-additional failed:', err);
-      }
-
-      // Closing the last project leaves nothing to render in this window.
-      // Ask the host to close the window so the app can fall back to its
-      // initial project-selection flow.
-      if (wasLast) {
-        try {
-          await window.electronAPI?.invoke?.('workspace:close-rail-window');
-        } catch (err) {
-          console.error('[ProjectRail] close-rail-window failed:', err);
-        }
+      const result = await closeProjectTab(project.path);
+      if (!result.success && result.error !== 'cancelled') {
+        console.error('[ProjectTabs] close failed:', result.error);
       }
     },
-    [closeProject, activity, openProjects.length]
+    []
   );
+
+  const handleDetach = useCallback(async (project: OpenProject, screenX: number, screenY: number) => {
+    const result = await detachProjectTab(project.path, { screenX, screenY });
+    if (!result.success) console.error('[ProjectTabs] detach failed:', result.error);
+  }, []);
+
+  const handleProjectTabDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    if (!hasProjectTabDragType(event.dataTransfer.types)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = 'move';
+    setIsProjectTabDropTarget(true);
+  }, []);
+
+  const handleProjectTabDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    const relatedTarget = event.relatedTarget;
+    if (relatedTarget instanceof Node && event.currentTarget.contains(relatedTarget)) return;
+    setIsProjectTabDropTarget(false);
+  }, []);
+
+  const handleProjectTabDrop = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    if (!hasProjectTabDragType(event.dataTransfer.types)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = 'move';
+    setIsProjectTabDropTarget(false);
+
+    // DataTransfer contents must be read synchronously during the drop event.
+    const payload = parseProjectTabDragPayload(event.dataTransfer.getData(PROJECT_TAB_DRAG_MIME));
+    if (!payload) return;
+    void moveProjectTabToCurrentWindow(payload).then((result) => {
+      if (!result.success) {
+        errorNotificationService.showWarning(
+          'Project tab was not moved',
+          result.error || 'The destination window could not accept this project.',
+          { duration: 8000 },
+        );
+      }
+    });
+  }, []);
 
   // Right-click context menu state. Anchored to a virtual reference at the
   // cursor position so it works for any rail icon without per-icon refs.
@@ -315,7 +462,7 @@ export function ProjectRail() {
   } = useFloating({
     open: addMenuOpen,
     onOpenChange: setAddMenuOpen,
-    placement: 'right-end',
+    placement: 'bottom-end',
     middleware: [offset(8), flip(), shift({ padding: 8 })],
   });
   const addDismiss = useDismiss(addContext);
@@ -333,7 +480,7 @@ export function ProjectRail() {
   } = useFloating({
     open: addTooltipOpen,
     onOpenChange: setAddTooltipOpen,
-    placement: 'right',
+    placement: 'bottom',
     middleware: [offset(12), flip({ padding: 8 }), shift({ padding: 8 })],
   });
   const addTooltipHover = useHover(addTooltipContext, { delay: { open: 200, close: 0 }, move: false });
@@ -358,7 +505,7 @@ export function ProjectRail() {
     onOpenChange: (open) => {
       if (!open) closeMenu();
     },
-    placement: 'right-start',
+    placement: 'bottom-start',
     middleware: [offset(4), flip(), shift({ padding: 8 })],
   });
 
@@ -385,7 +532,11 @@ export function ProjectRail() {
   const handleOpenInNewWindow = useCallback(async (project: OpenProject) => {
     closeMenu();
     try {
-      await window.electronAPI?.invoke?.('workspace-manager:open-workspace', project.path);
+      await window.electronAPI?.invoke?.(
+        'workspace-manager:open-workspace',
+        project.path,
+        { forceNewWindow: true },
+      );
     } catch (err) {
       console.error('[ProjectRail] open-workspace failed:', err);
     }
@@ -403,25 +554,36 @@ export function ProjectRail() {
   if (!isMultiProjectMode) return null;
 
   return (
-    <nav className="project-rail" data-testid="project-rail" aria-label="Open projects">
-      {/* Epic H1: org switcher sits above the project switcher. */}
+    <nav className="project-rail" data-testid="project-rail" aria-label="Open project tabs">
+      {/* Org switcher leads the project tabs when team organizations exist. */}
       <OrgSwitcher />
-      {openProjects.map((project) => {
-        const activity = activitySummary.get(project.path);
-        return (
-          <ProjectRailIcon
-            key={project.path}
-            project={project}
-            isActive={project.path === activePath}
-            processingCount={activity?.processing ?? 0}
-            unreadCount={activity?.unread ?? 0}
-            onActivate={handleActivate}
-            onClose={handleClose}
-            onContextMenu={handleContextMenu}
-          />
-        );
-      })}
-      {openProjects.length > 0 && <div className="project-rail-divider" aria-hidden="true" />}
+      <div
+        className={isProjectTabDropTarget ? 'project-rail-tabs is-drop-target' : 'project-rail-tabs'}
+        role="tablist"
+        aria-label="Projects"
+        onDragEnter={handleProjectTabDragOver}
+        onDragOver={handleProjectTabDragOver}
+        onDragLeave={handleProjectTabDragLeave}
+        onDrop={handleProjectTabDrop}
+      >
+        {openProjects.map((project) => {
+          const activity = activitySummary.get(project.path);
+          return (
+            <ProjectRailIcon
+              key={project.path}
+              project={project}
+              isActive={project.path === activePath}
+              processingCount={activity?.processing ?? 0}
+              unreadCount={activity?.unread ?? 0}
+              onActivate={handleActivate}
+              onNavigate={handleNavigate}
+              onClose={handleClose}
+              onDetach={handleDetach}
+              onContextMenu={handleContextMenu}
+            />
+          );
+        })}
+      </div>
       <button
         ref={addButtonRef}
         type="button"
@@ -429,7 +591,7 @@ export function ProjectRail() {
         onClick={handleOpenAddMenu}
         disabled={atCap}
         data-testid="project-rail-add"
-        aria-label="Add project to rail"
+        aria-label="Open project tab"
         {...getAddTooltipRefProps()}
       >
         +
@@ -442,7 +604,7 @@ export function ProjectRail() {
             style={addTooltipFloatingStyles}
             {...getAddTooltipFloatingProps()}
           >
-            {atCap ? 'Rail full (8 projects max)' : 'Add project'}
+            {atCap ? 'Tab strip full (8 projects max)' : 'Open project tab'}
           </div>
         </FloatingPortal>
       )}

--- a/packages/electron/src/renderer/components/TabEditor/TabEditor.tsx
+++ b/packages/electron/src/renderer/components/TabEditor/TabEditor.tsx
@@ -1088,7 +1088,7 @@ export const TabEditor: React.FC<TabEditorProps> = ({
 
         const currentContent = getContentFnRef.current();
         logger.ui.info(`[TabEditor] DocumentModel autosave: ${fileName}`);
-        saveWithHistory(currentContent, 'auto').catch((err) => {
+        return saveWithHistory(currentContent, 'auto').catch((err) => {
           logger.ui.error(`[TabEditor] DocumentModel autosave failed for ${filePath}:`, err);
         });
       }),

--- a/packages/electron/src/renderer/components/__tests__/projectTabDrag.test.ts
+++ b/packages/electron/src/renderer/components/__tests__/projectTabDrag.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { PROJECT_TAB_DRAG_MIME } from '../../../shared/projectTabs';
+import {
+  hasProjectTabDragType,
+  parseProjectTabDragPayload,
+  serializeProjectTabDragPayload,
+  shouldDetachProjectTabAfterDrag,
+  waitForProjectTabPreparation,
+} from '../projectTabDrag';
+
+const strip = { left: 0, right: 1000, top: 0, bottom: 40 };
+
+describe('shouldDetachProjectTabAfterDrag', () => {
+  it('keeps a tab attached when released inside the strip', () => {
+    expect(shouldDetachProjectTabAfterDrag({ clientX: 400, clientY: 20 }, strip)).toBe(false);
+  });
+
+  it('detaches after a verified release outside the strip tolerance', () => {
+    expect(shouldDetachProjectTabAfterDrag({ clientX: 400, clientY: 100 }, strip)).toBe(true);
+  });
+
+  it('does not detach a cancelled or coordinate-less drag', () => {
+    expect(shouldDetachProjectTabAfterDrag({ clientX: 0, clientY: 0 }, strip)).toBe(false);
+  });
+
+  it('does not detach when Chromium supplies invalid coordinates', () => {
+    expect(shouldDetachProjectTabAfterDrag({ clientX: Number.NaN, clientY: 80 }, strip)).toBe(false);
+  });
+
+  it('does not detach after another project rail accepted the move', () => {
+    expect(shouldDetachProjectTabAfterDrag({
+      clientX: 400,
+      clientY: 100,
+      dropEffect: 'move',
+    }, strip)).toBe(false);
+  });
+});
+
+describe('project tab drag payload', () => {
+  it('round-trips the custom project-tab payload', () => {
+    const payload = { version: 1 as const, dragId: 'drag-1' };
+    expect(parseProjectTabDragPayload(serializeProjectTabDragPayload(payload))).toEqual(payload);
+  });
+
+  it('rejects malformed and unsupported payloads', () => {
+    expect(parseProjectTabDragPayload('{bad json')).toBeNull();
+    expect(parseProjectTabDragPayload(JSON.stringify({
+      version: 2,
+      dragId: 'drag-1',
+    }))).toBeNull();
+  });
+
+  it('distinguishes project tabs from ordinary text and file drags', () => {
+    expect(hasProjectTabDragType(['text/plain', PROJECT_TAB_DRAG_MIME])).toBe(true);
+    expect(hasProjectTabDragType(['text/plain', 'Files'])).toBe(false);
+  });
+});
+
+describe('waitForProjectTabPreparation', () => {
+  it('returns a successful preparation result', async () => {
+    await expect(waitForProjectTabPreparation(Promise.resolve({ success: true }), 10))
+      .resolves.toEqual({ success: true });
+  });
+
+  it('times out a hung preparation instead of blocking tear-out forever', async () => {
+    await expect(waitForProjectTabPreparation(new Promise(() => {}), 1))
+      .resolves.toEqual({
+        success: false,
+        error: 'Timed out while saving the project before moving it.',
+      });
+  });
+});

--- a/packages/electron/src/renderer/components/projectTabDrag.ts
+++ b/packages/electron/src/renderer/components/projectTabDrag.ts
@@ -1,0 +1,106 @@
+import {
+  PROJECT_TAB_DRAG_MIME,
+  type ProjectTabDragPayload,
+} from '../../shared/projectTabs';
+
+export interface ProjectTabDragPoint {
+  clientX: number;
+  clientY: number;
+  dropEffect?: string;
+}
+
+export interface ProjectTabStripBounds {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+export interface ProjectTabPreparationResult {
+  success: boolean;
+  error?: string;
+}
+
+const PROJECT_TAB_PREPARATION_TIMEOUT_MS = 5_000;
+
+/** Bound tear-out preparation so a hung editor save cannot stall forever. */
+export async function waitForProjectTabPreparation(
+  preparation: Promise<ProjectTabPreparationResult> | null,
+  timeoutMs = PROJECT_TAB_PREPARATION_TIMEOUT_MS,
+): Promise<ProjectTabPreparationResult | null> {
+  if (!preparation) return null;
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve({
+        success: false,
+        error: 'Timed out while saving the project before moving it.',
+      });
+    }, timeoutMs);
+    void preparation.then(
+      (result) => {
+        clearTimeout(timer);
+        resolve(result);
+      },
+      (error) => {
+        clearTimeout(timer);
+        resolve({ success: false, error: error instanceof Error ? error.message : String(error) });
+      },
+    );
+  });
+}
+
+export function serializeProjectTabDragPayload(payload: ProjectTabDragPayload): string {
+  return JSON.stringify(payload);
+}
+
+export function parseProjectTabDragPayload(value: string): ProjectTabDragPayload | null {
+  if (!value) return null;
+  try {
+    const candidate = JSON.parse(value) as Partial<ProjectTabDragPayload>;
+    if (
+      candidate.version !== 1
+      || typeof candidate.dragId !== 'string'
+      || candidate.dragId.length === 0
+    ) {
+      return null;
+    }
+    return candidate as ProjectTabDragPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function hasProjectTabDragType(types: ArrayLike<string>): boolean {
+  return Array.from(types).includes(PROJECT_TAB_DRAG_MIME);
+}
+
+/**
+ * Return true only for a verified pointer release outside the tab strip.
+ * Chromium reports (0, 0) for some cancelled/coordinate-less dragend events;
+ * treating that sentinel as a tear-out would create surprise windows.
+ */
+export function shouldDetachProjectTabAfterDrag(
+  point: ProjectTabDragPoint,
+  strip: ProjectTabStripBounds,
+  tolerance = 12,
+): boolean {
+  // A destination project rail accepted the drop. Its main-process move may
+  // still be settling, so never race it by creating a third window here.
+  if (point.dropEffect === 'move') return false;
+
+  const coordinates = [
+    point.clientX,
+    point.clientY,
+    strip.left,
+    strip.right,
+    strip.top,
+    strip.bottom,
+  ];
+  if (!coordinates.every(Number.isFinite)) return false;
+  if (point.clientX === 0 && point.clientY === 0) return false;
+
+  return point.clientX < strip.left - tolerance
+    || point.clientX > strip.right + tolerance
+    || point.clientY < strip.top - tolerance
+    || point.clientY > strip.bottom + tolerance;
+}

--- a/packages/electron/src/renderer/contexts/TabsContext.tsx
+++ b/packages/electron/src/renderer/contexts/TabsContext.tsx
@@ -17,6 +17,11 @@ import React, { createContext, useContext, useRef, useCallback, useSyncExternalS
 import { getFileName } from '../utils/pathUtils';
 import { isCollabUri } from '../utils/collabUri';
 import { store as jotaiStore, editorDirtyAtom, makeEditorKey } from '@nimbalyst/runtime/store';
+import { DocumentModelRegistry } from '../services/document-model/DocumentModelRegistry';
+import {
+  collabConnectionStatusAtom,
+  hasCollabUnsyncedChanges,
+} from '../store/atoms/collabEditor';
 
 export interface TabData {
   id: string;
@@ -182,6 +187,89 @@ export function pruneTabsSlot(workspacePath: string): void {
   if (!slot) return;
   slot.listeners.clear();
   persistentSlots.delete(workspacePath);
+}
+
+/** Whether these tabs currently own an unsaved editor. */
+export function hasDirtyTabs(tabs: Iterable<TabData>): boolean {
+  return Array.from(tabs).some((tab) => {
+    const editorKey = makeEditorKey(tab.filePath);
+    return jotaiStore.get(editorDirtyAtom(editorKey));
+  });
+}
+
+/** Whether collaborative tabs still have local updates awaiting the server. */
+export function hasUnsyncedCollaborativeTabs(tabs: Iterable<TabData>): boolean {
+  return Array.from(tabs).some((tab) => {
+    if (!isCollabUri(tab.filePath)) return false;
+    return hasCollabUnsyncedChanges(
+      jotaiStore.get(collabConnectionStatusAtom(tab.filePath)),
+    );
+  });
+}
+
+/** Avoid overwriting persisted tabs with an empty slot before hydration. */
+export function shouldPersistTabsSlot(hasRestored: boolean, openTabCount: number): boolean {
+  return hasRestored || openTabCount > 0;
+}
+
+/** Flush only the document models owned by one workspace's file tabs. */
+export async function flushTabsSlot(workspacePath: string): Promise<void> {
+  const slot = persistentSlots.get(workspacePath);
+  if (!slot) return;
+  await DocumentModelRegistry.flushPaths(
+    Array.from(slot.store.tabs.values(), (tab) => tab.filePath),
+  );
+}
+
+/** Explain why a workspace cannot safely be transferred to another renderer. */
+export function getTabsSlotTransferBlocker(workspacePath: string): string | null {
+  const slot = persistentSlots.get(workspacePath);
+  if (!slot) return null;
+  if (hasUnsyncedCollaborativeTabs(slot.store.tabs.values())) {
+    return 'Wait for the project\'s collaborative documents to finish syncing before moving it.';
+  }
+  if (hasDirtyTabs(slot.store.tabs.values())) {
+    return 'Save or discard the project\'s unsaved editor changes before moving it.';
+  }
+  return null;
+}
+
+/** Persist a workspace's open file tabs before its project tab changes windows. */
+export async function persistTabsSlot(workspacePath: string): Promise<void> {
+  const slot = persistentSlots.get(workspacePath);
+  if (!slot || !window.electronAPI?.invoke) return;
+  if (!shouldPersistTabsSlot(slot.hasRestored, slot.store.tabs.size)) return;
+
+  const tabs = slot.store.tabOrder
+    .map((id) => slot.store.tabs.get(id))
+    .filter((tab): tab is TabData => tab !== undefined)
+    .map((tab) => ({
+      id: tab.id,
+      filePath: tab.filePath,
+      fileName: tab.fileName,
+      isDirty: jotaiStore.get(editorDirtyAtom(makeEditorKey(tab.filePath))),
+      isPinned: tab.isPinned,
+      isVirtual: tab.isVirtual,
+      lastSaved: tab.lastSaved?.toISOString(),
+    }));
+  const closedTabs = slot.store.closedTabs.map((tab) => ({
+    id: tab.id,
+    filePath: tab.filePath,
+    fileName: tab.fileName,
+    isDirty: tab.isDirty,
+    isPinned: tab.isPinned,
+    isVirtual: tab.isVirtual,
+    lastSaved: tab.lastSaved?.toISOString(),
+  }));
+  const tabsState = {
+    tabs,
+    activeTabId: slot.store.activeTabId,
+    tabOrder: [...slot.store.tabOrder],
+    closedTabs,
+  };
+
+  await window.electronAPI.invoke('workspace:update-state', workspacePath, { tabs: tabsState });
+  slot.lastSavedState = JSON.stringify(tabsState);
 }
 
 /** Test seam: snapshot the live persistent slot map size. */
@@ -570,10 +658,12 @@ export function TabsProvider({
       try {
         const workspaceState = await window.electronAPI!.invoke('workspace:get-state', workspacePath);
         const savedState = workspaceState?.tabs;
+        // A successful read hydrates the slot even when the persisted layout
+        // is empty. Future zero-tab saves must be allowed to clear a layout
+        // that briefly became non-empty after this point.
+        slotState.hasRestored = true;
 
         if (savedState?.tabs?.length > 0) {
-          slotState.hasRestored = true;
-
           const store = slotState.store;
           const restoredTabs = new Map<string, TabData>();
           const restoredOrder: string[] = [];

--- a/packages/electron/src/renderer/contexts/__tests__/TabsContext.hydration.test.tsx
+++ b/packages/electron/src/renderer/contexts/__tests__/TabsContext.hydration.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  persistTabsSlot,
+  pruneTabsSlot,
+  TabsProvider,
+  useTabsActions,
+} from '../TabsContext';
+
+const workspacePath = '/workspace/empty-hydration';
+let actions: ReturnType<typeof useTabsActions>;
+let invoke: ReturnType<typeof vi.fn>;
+
+function Harness() {
+  actions = useTabsActions();
+  return null;
+}
+
+describe('TabsContext hydration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    invoke = vi.fn(async (channel: string) => {
+      if (channel === 'workspace:get-state') {
+        return { tabs: { tabs: [], tabOrder: [], activeTabId: null, closedTabs: [] } };
+      }
+      return { success: true };
+    });
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { invoke, send: vi.fn() },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    pruneTabsSlot(workspacePath);
+    vi.useRealTimers();
+    Reflect.deleteProperty(window, 'electronAPI');
+  });
+
+  it('persists an empty layout after an empty workspace hydrated and briefly opened a tab', async () => {
+    render(
+      <TabsProvider workspacePath={workspacePath}>
+        <Harness />
+      </TabsProvider>,
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    await act(async () => {
+      actions.addTab('/workspace/temporary.md');
+      await persistTabsSlot(workspacePath);
+      actions.closeAllTabs();
+    });
+    invoke.mockClear();
+
+    await persistTabsSlot(workspacePath);
+
+    expect(invoke).toHaveBeenCalledWith(
+      'workspace:update-state',
+      workspacePath,
+      { tabs: expect.objectContaining({ tabs: [], tabOrder: [] }) },
+    );
+  });
+});

--- a/packages/electron/src/renderer/contexts/__tests__/TabsContext.test.ts
+++ b/packages/electron/src/renderer/contexts/__tests__/TabsContext.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { editorDirtyAtom, makeEditorKey, store } from '@nimbalyst/runtime/store';
+import { collabConnectionStatusAtom } from '../../store/atoms/collabEditor';
+import {
+  hasDirtyTabs,
+  hasUnsyncedCollaborativeTabs,
+  shouldPersistTabsSlot,
+  type TabData,
+} from '../TabsContext';
+
+function tab(filePath: string, isDirty: boolean): TabData {
+  return {
+    id: filePath,
+    filePath,
+    fileName: filePath.split('/').at(-1) ?? filePath,
+    content: '',
+    isDirty,
+    isPinned: false,
+  };
+}
+
+const testedPaths = ['/workspace/restored.md', '/workspace/live.md'];
+const collabPath = 'collab://org:test:doc:pending';
+
+afterEach(() => {
+  for (const filePath of testedPaths) {
+    store.set(editorDirtyAtom(makeEditorKey(filePath)), false);
+  }
+  store.set(collabConnectionStatusAtom(collabPath), 'disconnected');
+});
+
+describe('hasUnsyncedCollaborativeTabs', () => {
+  it.each(['offline-unsynced', 'replaying'] as const)(
+    'blocks a collaborative tab while its status is %s',
+    (status) => {
+      const collaborativeTab = tab(collabPath, false);
+      store.set(collabConnectionStatusAtom(collabPath), status);
+
+      expect(hasUnsyncedCollaborativeTabs([collaborativeTab])).toBe(true);
+    },
+  );
+
+  it('allows a collaborative tab after its pending updates are connected', () => {
+    const collaborativeTab = tab(collabPath, false);
+    store.set(collabConnectionStatusAtom(collabPath), 'connected');
+
+    expect(hasUnsyncedCollaborativeTabs([collaborativeTab])).toBe(false);
+  });
+});
+
+describe('hasDirtyTabs', () => {
+  it('ignores a stale restored TabData dirty flag after the editor is saved', () => {
+    const restoredTab = tab('/workspace/restored.md', true);
+    store.set(editorDirtyAtom(makeEditorKey(restoredTab.filePath)), false);
+
+    expect(hasDirtyTabs([restoredTab])).toBe(false);
+  });
+
+  it('uses the live editor dirty atom as the source of truth', () => {
+    const liveTab = tab('/workspace/live.md', false);
+    store.set(editorDirtyAtom(makeEditorKey(liveTab.filePath)), true);
+
+    expect(hasDirtyTabs([liveTab])).toBe(true);
+  });
+});
+
+describe('shouldPersistTabsSlot', () => {
+  it('preserves existing persisted tabs while an empty slot is still hydrating', () => {
+    expect(shouldPersistTabsSlot(false, 0)).toBe(false);
+  });
+
+  it('allows persistence after hydration or once a live tab exists', () => {
+    expect(shouldPersistTabsSlot(true, 0)).toBe(true);
+    expect(shouldPersistTabsSlot(false, 1)).toBe(true);
+  });
+});

--- a/packages/electron/src/renderer/electron.d.ts
+++ b/packages/electron/src/renderer/electron.d.ts
@@ -498,7 +498,14 @@ interface ElectronAPI {
     getWorkspaceStats: (workspacePath: string) => Promise<any>;
     openFolderDialog: () => Promise<{ success: true; path: string } | { success: false }>;
     createWorkspaceDialog: () => Promise<{ success: true; path: string } | { success: false; error?: string }>;
-    openWorkspace: (workspacePath: string) => Promise<{ success: boolean }>;
+    openWorkspace: (
+      workspacePath: string,
+      options?: { forceNewWindow?: boolean },
+    ) => Promise<{
+      success: boolean;
+      disposition?: 'tab' | 'window' | 'blocked';
+      error?: string;
+    }>;
     removeRecent: (workspacePath: string) => Promise<{ success: boolean }>;
     getOpenWorkspaces: () => Promise<string[]>;
   };

--- a/packages/electron/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/packages/electron/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -14,8 +14,8 @@ import {
   multiProjectModeAtom,
   openProjectsAtom,
   activeWorkspacePathAtom,
-  closeOpenProjectAtom,
 } from '../store/atoms/openProjects';
+import { closeActiveProjectTab } from '../services/projectTabs';
 import { prRemoteAtom } from '../store/atoms/pullRequests';
 import { developerModeAtom } from '../store/atoms/appSettings';
 import posthog from 'posthog-js';
@@ -261,7 +261,6 @@ export function useKeyboardShortcuts({
             if (target.path !== currentActive) {
               if (isFullscreenPanelActive) exitFullscreenPanel();
               store.set(activeWorkspacePathAtom, target.path);
-              window.electronAPI?.invoke?.('workspace:set-active', { workspacePath: target.path }).catch(() => {});
             }
           }
         }
@@ -269,16 +268,7 @@ export function useKeyboardShortcuts({
         if (e.shiftKey && e.key === 'W') {
           e.preventDefault();
           e.stopPropagation();
-          const activePath = store.get(activeWorkspacePathAtom);
-          const projects = store.get(openProjectsAtom);
-          if (activePath) {
-            const wasLast = projects.length <= 1;
-            store.set(closeOpenProjectAtom, activePath);
-            window.electronAPI?.invoke?.('workspace:unregister-additional', { workspacePath: activePath }).catch(() => {});
-            if (wasLast) {
-              window.electronAPI?.invoke?.('workspace:close-rail-window').catch(() => {});
-            }
-          }
+          void closeActiveProjectTab().catch(() => {});
         }
       }
     };

--- a/packages/electron/src/renderer/services/__tests__/projectTabs.test.ts
+++ b/packages/electron/src/renderer/services/__tests__/projectTabs.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { store } from '@nimbalyst/runtime/store';
+import {
+  activeWorkspacePathAtom,
+  openProjectsAtom,
+  type OpenProject,
+} from '../../store/atoms/openProjects';
+import { globalSessionActivityAtom } from '../../store/atoms/sessionActivity';
+import {
+  applyProjectTabMutation,
+  closeProjectTab,
+  detachProjectTab,
+  moveProjectTabToCurrentWindow,
+  openProjectTab,
+} from '../projectTabs';
+
+const invoke = vi.fn();
+
+function project(path: string): OpenProject {
+  return { path, name: path.split('/').pop() || path, openedAt: 0 };
+}
+
+describe('project tab actions', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    invoke.mockResolvedValue({ success: true });
+    store.set(openProjectsAtom, []);
+    store.set(activeWorkspacePathAtom, null);
+    store.set(globalSessionActivityAtom, new Map());
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { invoke },
+    });
+  });
+
+  it('registers and activates a normal project open as a tab', async () => {
+    const result = await openProjectTab('/ws/new-project');
+
+    expect(result).toEqual({ success: true });
+    expect(invoke).toHaveBeenCalledWith(
+      'workspace:register-additional',
+      { workspacePath: '/ws/new-project' },
+    );
+    expect(store.get(openProjectsAtom).map((entry) => entry.path)).toEqual(['/ws/new-project']);
+    expect(store.get(activeWorkspacePathAtom)).toBe('/ws/new-project');
+  });
+
+  it('passes the adjacent replacement when closing the active tab', async () => {
+    store.set(openProjectsAtom, [project('/ws/a'), project('/ws/b'), project('/ws/c')]);
+    store.set(activeWorkspacePathAtom, '/ws/b');
+
+    const result = await closeProjectTab('/ws/b');
+
+    expect(result).toEqual({ success: true });
+    expect(invoke).toHaveBeenCalledWith('workspace:unregister-additional', {
+      workspacePath: '/ws/b',
+      replacementWorkspacePath: '/ws/c',
+    });
+    expect(store.get(activeWorkspacePathAtom)).toBe('/ws/c');
+  });
+
+  it('creates the new window before removing a detached tab from this window', async () => {
+    store.set(openProjectsAtom, [project('/ws/a'), project('/ws/b')]);
+    store.set(activeWorkspacePathAtom, '/ws/b');
+
+    const result = await detachProjectTab('/ws/b', { screenX: 640, screenY: 220 });
+
+    expect(result).toEqual({ success: true });
+    expect(invoke.mock.calls.map(([channel]) => channel)).toEqual([
+      'workspace:detach-project-tab',
+      'workspace:unregister-additional',
+    ]);
+    expect(store.get(openProjectsAtom).map((entry) => entry.path)).toEqual(['/ws/a']);
+  });
+
+  it('keeps the tab visible when main rejects the close', async () => {
+    store.set(openProjectsAtom, [project('/ws/a'), project('/ws/b')]);
+    store.set(activeWorkspacePathAtom, '/ws/b');
+    invoke.mockResolvedValueOnce({ success: false, error: 'window state changed' });
+
+    const result = await closeProjectTab('/ws/b');
+
+    expect(result).toEqual({ success: false, error: 'window state changed' });
+    expect(store.get(openProjectsAtom).map((entry) => entry.path)).toEqual(['/ws/a', '/ws/b']);
+    expect(store.get(activeWorkspacePathAtom)).toBe('/ws/b');
+  });
+
+  it('keeps a streaming project open when the user cancels close', async () => {
+    store.set(openProjectsAtom, [project('/ws/a')]);
+    store.set(activeWorkspacePathAtom, '/ws/a');
+    store.set(globalSessionActivityAtom, new Map([
+      ['/ws/a', { streaming: new Set(['session-1']), unread: new Set<string>() }],
+    ]));
+    vi.mocked(window.confirm).mockReturnValue(false);
+
+    const result = await closeProjectTab('/ws/a');
+
+    expect(result).toEqual({ success: false, error: 'cancelled' });
+    expect(invoke).not.toHaveBeenCalled();
+    expect(store.get(openProjectsAtom)).toHaveLength(1);
+  });
+
+  it('requests one atomic main-process move for a destination drop', async () => {
+    const result = await moveProjectTabToCurrentWindow({
+      version: 1,
+      dragId: 'drag-1',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith('workspace:move-project-tab', {
+      dragId: 'drag-1',
+    });
+  });
+
+  it('applies main-owned add and remove mutations without registration IPC', async () => {
+    store.set(openProjectsAtom, [project('/ws/a')]);
+    store.set(activeWorkspacePathAtom, '/ws/a');
+
+    await applyProjectTabMutation({
+      id: 'add-1',
+      kind: 'add',
+      workspacePath: '/ws/b',
+      activate: true,
+    });
+    await applyProjectTabMutation({
+      id: 'remove-1',
+      kind: 'remove',
+      workspacePath: '/ws/a',
+      replacementWorkspacePath: '/ws/b',
+      closeWindowWhenEmpty: false,
+    });
+
+    expect(store.get(openProjectsAtom).map((entry) => entry.path)).toEqual(['/ws/b']);
+    expect(store.get(activeWorkspacePathAtom)).toBe('/ws/b');
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('does not apply a stale replacement after the source activated another tab', async () => {
+    store.set(openProjectsAtom, [project('/ws/a'), project('/ws/b'), project('/ws/c')]);
+    store.set(activeWorkspacePathAtom, '/ws/c');
+
+    await applyProjectTabMutation({
+      id: 'remove-stale',
+      kind: 'remove',
+      workspacePath: '/ws/b',
+      replacementWorkspacePath: '/ws/a',
+      closeWindowWhenEmpty: false,
+    });
+
+    expect(store.get(openProjectsAtom).map((entry) => entry.path)).toEqual(['/ws/a', '/ws/c']);
+    expect(store.get(activeWorkspacePathAtom)).toBe('/ws/c');
+  });
+});

--- a/packages/electron/src/renderer/services/document-model/DocumentModel.ts
+++ b/packages/electron/src/renderer/services/document-model/DocumentModel.ts
@@ -48,7 +48,7 @@ interface EditorAttachment {
   id: string;
   isDirty: boolean;
   fileChangedCallbacks: Set<(content: string | ArrayBuffer) => void>;
-  saveRequestedCallbacks: Set<() => void>;
+  saveRequestedCallbacks: Set<() => void | Promise<void>>;
   diffRequestedCallbacks: Set<(state: DiffState) => void>;
   diffResolvedCallbacks: Set<(accepted: boolean) => void>;
 }

--- a/packages/electron/src/renderer/services/document-model/DocumentModelRegistry.ts
+++ b/packages/electron/src/renderer/services/document-model/DocumentModelRegistry.ts
@@ -155,8 +155,20 @@ class DocumentModelRegistryImpl {
    * Used during mode switches.
    */
   async flushAll(): Promise<void> {
+    await this.flushPaths(this.entries.keys());
+  }
+
+  /**
+   * Flush dirty editors for only the requested file paths.
+   * Used when transferring one workspace so unrelated projects are untouched.
+   */
+  async flushPaths(filePaths: Iterable<string>): Promise<void> {
     const promises: Promise<void>[] = [];
-    for (const entry of this.entries.values()) {
+    const visited = new Set<RegistryEntry>();
+    for (const filePath of filePaths) {
+      const entry = this.entries.get(this.normalizePath(filePath));
+      if (!entry || visited.has(entry)) continue;
+      visited.add(entry);
       if (entry.model.isDirty()) {
         promises.push(entry.model.flushDirtyEditors());
       }

--- a/packages/electron/src/renderer/services/document-model/__tests__/DocumentModel.test.ts
+++ b/packages/electron/src/renderer/services/document-model/__tests__/DocumentModel.test.ts
@@ -580,6 +580,27 @@ describe('DocumentModel', () => {
       expect(save1).toHaveBeenCalledTimes(1);
       expect(save2).not.toHaveBeenCalled();
     });
+
+    it('waits for an asynchronous editor save to finish', async () => {
+      const handle = model.attach();
+      let finishSave: (() => void) | undefined;
+      const save = vi.fn(() => new Promise<void>((resolve) => {
+        finishSave = resolve;
+      }));
+      handle.onSaveRequested(save);
+      handle.setDirty(true);
+      let flushFinished = false;
+
+      const flush = model.flushDirtyEditors().then(() => {
+        flushFinished = true;
+      });
+      await Promise.resolve();
+      expect(flushFinished).toBe(false);
+
+      finishSave?.();
+      await flush;
+      expect(flushFinished).toBe(true);
+    });
   });
 
   describe('getState', () => {

--- a/packages/electron/src/renderer/services/document-model/__tests__/DocumentModelRegistry.test.ts
+++ b/packages/electron/src/renderer/services/document-model/__tests__/DocumentModelRegistry.test.ts
@@ -118,6 +118,25 @@ describe('DocumentModelRegistry', () => {
     h2.detach();
   });
 
+  it('flushPaths flushes only dirty models in the requested workspace', async () => {
+    const { handle: projectAHandle } = DocumentModelRegistry.getOrCreate('/project-a/a.md');
+    const { handle: projectBHandle } = DocumentModelRegistry.getOrCreate('/project-b/b.md');
+    const saveProjectA = vi.fn();
+    const saveProjectB = vi.fn();
+    projectAHandle.onSaveRequested(saveProjectA);
+    projectBHandle.onSaveRequested(saveProjectB);
+    projectAHandle.setDirty(true);
+    projectBHandle.setDirty(true);
+
+    await DocumentModelRegistry.flushPaths(['/project-a/a.md']);
+
+    expect(saveProjectA).toHaveBeenCalledTimes(1);
+    expect(saveProjectB).not.toHaveBeenCalled();
+
+    projectAHandle.detach();
+    projectBHandle.detach();
+  });
+
   it('clear() disposes all models', () => {
     const { handle: h1 } = DocumentModelRegistry.getOrCreate('/test/a.md');
     const { handle: h2 } = DocumentModelRegistry.getOrCreate('/test/b.md');

--- a/packages/electron/src/renderer/services/document-model/types.ts
+++ b/packages/electron/src/renderer/services/document-model/types.ts
@@ -129,7 +129,7 @@ export interface DocumentModelEditorHandle {
    * Subscribe to save requests from the DocumentModel's autosave timer.
    * The editor should serialize its content and call saveContent().
    */
-  onSaveRequested(callback: () => void): () => void;
+  onSaveRequested(callback: () => void | Promise<void>): () => void;
 
   /**
    * Subscribe to diff mode requests.

--- a/packages/electron/src/renderer/services/projectTabs.ts
+++ b/packages/electron/src/renderer/services/projectTabs.ts
@@ -1,0 +1,176 @@
+import { store } from '@nimbalyst/runtime/store';
+import {
+  activeWorkspacePathAtom,
+  closeOpenProjectAtom,
+  getReplacementOpenProjectPath,
+  openProjectsAtom,
+  addOpenProjectAtom,
+  type OpenProject,
+} from '../store/atoms/openProjects';
+import { globalSessionActivityAtom } from '../store/atoms/sessionActivity';
+import { MAX_OPEN_PROJECT_TABS } from '../../shared/projectTabs';
+import type {
+  ProjectTabDragPayload,
+  ProjectTabMutation,
+} from '../../shared/projectTabs';
+
+export interface ProjectTabActionResult {
+  success: boolean;
+  error?: string;
+}
+
+function projectFromPath(workspacePath: string): OpenProject {
+  return {
+    path: workspacePath,
+    name: workspacePath.split(/[\\/]/).filter(Boolean).pop() || workspacePath,
+    openedAt: Date.now(),
+  };
+}
+
+/** Apply a main-owned cross-window mutation without re-registering/removing services. */
+export async function applyProjectTabMutation(mutation: ProjectTabMutation): Promise<void> {
+  if (mutation.kind === 'add') {
+    store.set(addOpenProjectAtom, projectFromPath(mutation.workspacePath));
+    return;
+  }
+
+  const currentlyOpen = store.get(openProjectsAtom);
+  const wasActive = store.get(activeWorkspacePathAtom) === mutation.workspacePath;
+  if (currentlyOpen.some((project) => project.path === mutation.workspacePath)) {
+    store.set(closeOpenProjectAtom, mutation.workspacePath);
+  }
+
+  const remaining = store.get(openProjectsAtom);
+  if (
+    wasActive
+    && mutation.replacementWorkspacePath
+    && remaining.some((project) => project.path === mutation.replacementWorkspacePath)
+  ) {
+    store.set(activeWorkspacePathAtom, mutation.replacementWorkspacePath);
+  }
+
+  if (mutation.closeWindowWhenEmpty && remaining.length === 0) {
+    await window.electronAPI?.invoke?.('workspace:close-rail-window');
+  }
+}
+
+/** Ask main to atomically move a source tab into this renderer's window. */
+export async function moveProjectTabToCurrentWindow(
+  payload: ProjectTabDragPayload,
+): Promise<ProjectTabActionResult> {
+  if (!window.electronAPI?.invoke) {
+    return { success: false, error: 'electronAPI is required' };
+  }
+  try {
+    const result = await window.electronAPI.invoke('workspace:move-project-tab', {
+      dragId: payload.dragId,
+    });
+    return result?.success
+      ? { success: true }
+      : { success: false, error: result?.error || 'Unable to move project tab' };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function openProjectTab(workspacePath: string): Promise<ProjectTabActionResult> {
+  if (!workspacePath || !window.electronAPI?.invoke) {
+    return { success: false, error: 'workspacePath and electronAPI are required' };
+  }
+
+  const openProjects = store.get(openProjectsAtom);
+  const alreadyOpen = openProjects.some((project) => project.path === workspacePath);
+  if (!alreadyOpen && openProjects.length >= MAX_OPEN_PROJECT_TABS) {
+    return { success: false, error: `You can have at most ${MAX_OPEN_PROJECT_TABS} project tabs open.` };
+  }
+
+  try {
+    const registration = await window.electronAPI.invoke('workspace:register-additional', { workspacePath });
+    if (!registration?.success) {
+      return { success: false, error: registration?.error || 'Unable to register project tab' };
+    }
+    store.set(addOpenProjectAtom, projectFromPath(workspacePath));
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function finalizeCloseProjectTab(workspacePath: string): Promise<ProjectTabActionResult> {
+  if (!window.electronAPI?.invoke) {
+    return { success: false, error: 'electronAPI is required' };
+  }
+  const projects = store.get(openProjectsAtom);
+  if (!projects.some((project) => project.path === workspacePath)) {
+    return { success: false, error: 'Project tab is not open' };
+  }
+
+  const replacementWorkspacePath = getReplacementOpenProjectPath(projects, workspacePath);
+  const wasLast = projects.length === 1;
+
+  try {
+    const result = await window.electronAPI.invoke('workspace:unregister-additional', {
+      workspacePath,
+      replacementWorkspacePath,
+    });
+    if (!result?.success) {
+      return { success: false, error: result?.error || 'Unable to unregister project tab' };
+    }
+    // Only remove the visible tab after the main process accepts the close.
+    // This avoids leaving the renderer and the service registry out of sync
+    // when an IPC validation or lifecycle check fails.
+    store.set(closeOpenProjectAtom, workspacePath);
+    if (wasLast) {
+      await window.electronAPI.invoke('workspace:close-rail-window');
+    }
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function closeProjectTab(
+  workspacePath: string,
+  options: { confirmStreaming?: boolean } = {},
+): Promise<ProjectTabActionResult> {
+  const project = store.get(openProjectsAtom).find((entry) => entry.path === workspacePath);
+  if (!project) return { success: false, error: 'Project tab is not open' };
+
+  if (options.confirmStreaming !== false) {
+    const streaming = store.get(globalSessionActivityAtom).get(workspacePath)?.streaming.size ?? 0;
+    if (streaming > 0) {
+      const proceed = window.confirm(
+        `${project.name} has ${streaming} streaming session${streaming === 1 ? '' : 's'}. Close anyway? Sessions will be paused.`,
+      );
+      if (!proceed) return { success: false, error: 'cancelled' };
+    }
+  }
+
+  return finalizeCloseProjectTab(workspacePath);
+}
+
+export async function closeActiveProjectTab(): Promise<ProjectTabActionResult> {
+  const activePath = store.get(activeWorkspacePathAtom);
+  if (!activePath) return { success: false, error: 'No active project tab' };
+  return closeProjectTab(activePath);
+}
+
+export async function detachProjectTab(
+  workspacePath: string,
+  position?: { screenX: number; screenY: number },
+): Promise<ProjectTabActionResult> {
+  try {
+    const result = await window.electronAPI?.invoke?.('workspace:detach-project-tab', {
+      workspacePath,
+      position,
+    });
+    if (!result?.success) {
+      return { success: false, error: result?.error || 'Unable to detach project tab' };
+    }
+    // The destination window now references the project, so removing it from
+    // this window cannot tear down shared services or interrupt sessions.
+    return finalizeCloseProjectTab(workspacePath);
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/packages/electron/src/renderer/store/atoms/__tests__/openProjects.test.ts
+++ b/packages/electron/src/renderer/store/atoms/__tests__/openProjects.test.ts
@@ -1,12 +1,17 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createStore } from 'jotai';
 import {
   openProjectsAtom,
   activeWorkspacePathAtom,
   activeOpenProjectAtom,
   addOpenProjectAtom,
+  seedInitialOpenProjectAtom,
   closeOpenProjectAtom,
   isOpenProjectsAtCapAtom,
+  getReplacementOpenProjectPath,
+  multiProjectModeAtom,
+  initOpenProjects,
+  teardownOpenProjects,
   attachWorkspaceSwitchCleanup,
   resolveInitialOpenProjectsState,
   selectProjectsToRegister,
@@ -29,6 +34,10 @@ describe('openProjects atoms', () => {
   });
 
   describe('addOpenProjectAtom', () => {
+    it('enables project tabs by default', () => {
+      expect(jotaiStore.get(multiProjectModeAtom)).toBe(true);
+    });
+
     it('adds a new project and activates it', () => {
       jotaiStore.set(addOpenProjectAtom, project('/ws/a'));
 
@@ -71,7 +80,40 @@ describe('openProjects atoms', () => {
     });
   });
 
+  describe('seedInitialOpenProjectAtom', () => {
+    it('preserves a restored active project when App startup seeds the primary afterward', () => {
+      jotaiStore.set(openProjectsAtom, [project('/ws/primary'), project('/ws/restored-active')]);
+      jotaiStore.set(activeWorkspacePathAtom, '/ws/restored-active');
+
+      jotaiStore.set(seedInitialOpenProjectAtom, project('/ws/primary'));
+
+      expect(jotaiStore.get(openProjectsAtom).map((entry) => entry.path)).toEqual([
+        '/ws/primary',
+        '/ws/restored-active',
+      ]);
+      expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/restored-active');
+    });
+
+    it('adds and activates the primary when startup seeding wins the hydration race', () => {
+      jotaiStore.set(seedInitialOpenProjectAtom, project('/ws/primary'));
+
+      expect(jotaiStore.get(openProjectsAtom)).toEqual([project('/ws/primary')]);
+      expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/primary');
+    });
+  });
+
   describe('closeOpenProjectAtom', () => {
+    it('selects the same adjacent replacement used by the main-process handoff', () => {
+      expect(getReplacementOpenProjectPath(
+        [project('/ws/a'), project('/ws/b'), project('/ws/c')],
+        '/ws/b',
+      )).toBe('/ws/c');
+      expect(getReplacementOpenProjectPath(
+        [project('/ws/a'), project('/ws/b')],
+        '/ws/b',
+      )).toBe('/ws/a');
+    });
+
     it('removes the project from the list', () => {
       jotaiStore.set(addOpenProjectAtom, project('/ws/a'));
       jotaiStore.set(addOpenProjectAtom, project('/ws/b'));
@@ -256,7 +298,7 @@ describe('openProjects atoms', () => {
       });
     });
 
-    it('uses persisted state on launch when restore previous projects is enabled', () => {
+    it('keeps a detached window isolated from the legacy global tab list', () => {
       const result = resolveInitialOpenProjectsState({
         persistedPaths: ['/ws/a', '/ws/b'],
         persistedActivePath: '/ws/b',
@@ -270,8 +312,8 @@ describe('openProjects atoms', () => {
       });
 
       expect(result).toEqual({
-        paths: ['/ws/a', '/ws/b'],
-        activePath: '/ws/b',
+        paths: ['/ws/a'],
+        activePath: '/ws/a',
       });
     });
 
@@ -292,6 +334,68 @@ describe('openProjects atoms', () => {
         paths: ['/ws/a'],
         activePath: '/ws/a',
       });
+    });
+  });
+
+  describe('initOpenProjects', () => {
+    beforeEach(() => {
+      teardownOpenProjects();
+    });
+
+    afterEach(() => {
+      teardownOpenProjects();
+      vi.unstubAllGlobals();
+    });
+
+    it('shares in-flight hydration across repeated setup calls and resets on teardown', async () => {
+      let resolveMode!: (mode: boolean) => void;
+      const modePromise = new Promise<boolean>((resolve) => {
+        resolveMode = resolve;
+      });
+      const invoke = vi.fn((channel: string): Promise<unknown> => {
+        switch (channel) {
+          case 'app:get-multi-project-mode':
+            return modePromise;
+          case 'app:get-restore-previous-projects':
+            return Promise.resolve(false);
+          case 'app:get-open-projects':
+            return Promise.resolve([]);
+          case 'app:get-active-project-path':
+            return Promise.resolve(null);
+          default:
+            return Promise.resolve(undefined);
+        }
+      });
+      const getInitialState = vi.fn().mockResolvedValue(null);
+      vi.stubGlobal('window', {
+        electronAPI: { invoke, getInitialState },
+      });
+
+      const firstInitialization = initOpenProjects();
+      const repeatedInitialization = initOpenProjects();
+
+      expect(repeatedInitialization).toBe(firstInitialization);
+      expect(invoke).toHaveBeenCalledTimes(4);
+      expect(getInitialState).toHaveBeenCalledOnce();
+
+      let repeatedCallSettled = false;
+      void repeatedInitialization.then(() => {
+        repeatedCallSettled = true;
+      });
+      await Promise.resolve();
+      expect(repeatedCallSettled).toBe(false);
+
+      resolveMode(true);
+      await firstInitialization;
+      expect(repeatedCallSettled).toBe(true);
+
+      teardownOpenProjects();
+      const initializationAfterTeardown = initOpenProjects();
+
+      expect(initializationAfterTeardown).not.toBe(firstInitialization);
+      await initializationAfterTeardown;
+      expect(invoke).toHaveBeenCalledTimes(8);
+      expect(getInitialState).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/electron/src/renderer/store/atoms/openProjects.ts
+++ b/packages/electron/src/renderer/store/atoms/openProjects.ts
@@ -1,9 +1,9 @@
 /**
  * Open Projects state
  *
- * Tracks the list of workspace projects warm in the multi-project rail and
- * which one is currently visible. The rail is opt-in: when
- * `multiProjectModeAtom` is `false`, the rail stays hidden and the host
+ * Tracks the list of workspace projects warm in the project tab strip and
+ * which one is currently visible. Tabs are enabled by default; when
+ * `multiProjectModeAtom` is `false`, the strip stays hidden and the host
  * window keeps the legacy "one project per window" behavior.
  *
  * `activeWorkspacePathAtom` is the single source of truth for the path
@@ -18,6 +18,7 @@ import { store } from '@nimbalyst/runtime/store';
 import { clearWorkspaceActivityAtom } from './sessionActivity';
 import { activeSessionIdAtom, selectedWorkstreamAtom } from './sessions';
 import { workstreamActiveChildAtom } from './workstreamState';
+import { MAX_OPEN_PROJECT_TABS } from '../../../shared/projectTabs';
 
 type JotaiStore = ReturnType<typeof createStore>;
 
@@ -44,8 +45,6 @@ interface ResolveInitialOpenProjectsInput {
   windowState: InitialWorkspaceWindowState | null;
 }
 
-const MAX_OPEN_PROJECTS = 8;
-
 /**
  * Path of the workspace currently visible in this window.
  *
@@ -57,25 +56,25 @@ const MAX_OPEN_PROJECTS = 8;
 export const activeWorkspacePathAtom = atom<string | null>(null);
 
 /**
- * Whether multi-project mode is enabled. When false, rail UI is hidden and
- * opening a new project spawns a fresh window (legacy behavior). When true,
- * opening a project adds it to the rail in the current window.
+ * Whether project tabs are enabled. When false, tab UI is hidden and opening
+ * a new project spawns a fresh window (legacy behavior). When true, opening a
+ * project adds it to the current window.
  *
  * Persisted via `app:set-multi-project-mode` IPC; seeded from store on
  * launch by an effect that reads `app:get-multi-project-mode`.
  */
-export const multiProjectModeAtom = atom<boolean>(false);
+export const multiProjectModeAtom = atom<boolean>(true);
 
 /**
- * When true, the rail rehydrates with the projects that were open at last
- * app close. When false (default), the rail starts with only the project
+ * When true, the tab strip rehydrates with the projects that were open at
+ * last app close. When false (default), it starts with only the project
  * the user picked from the launch screen; additional projects are added
  * explicitly via the `+` button.
  */
 export const restorePreviousProjectsAtom = atom<boolean>(false);
 
 /**
- * Ordered list of open projects in the rail. First entry is leftmost.
+ * Ordered list of open project tabs. First entry is leftmost.
  *
  * Capped at `MAX_OPEN_PROJECTS` to bound memory of warm projects.
  */
@@ -95,7 +94,7 @@ export const activeOpenProjectAtom = atom((get) => {
  * the "+" button and show a hint to close a project first.
  */
 export const isOpenProjectsAtCapAtom = atom((get) => {
-  return get(openProjectsAtom).length >= MAX_OPEN_PROJECTS;
+  return get(openProjectsAtom).length >= MAX_OPEN_PROJECT_TABS;
 });
 
 /**
@@ -116,13 +115,42 @@ export const addOpenProjectAtom = atom(
       return;
     }
 
-    if (current.length >= MAX_OPEN_PROJECTS) {
+    if (current.length >= MAX_OPEN_PROJECT_TABS) {
       return;
     }
 
     set(openProjectsAtom, [...current, project]);
     set(activeWorkspacePathAtom, project.path);
   }
+);
+
+/**
+ * Seed the BrowserWindow's primary project without overriding a tab selection
+ * that `initOpenProjects()` already restored. App startup and tab hydration
+ * are independent async paths, so this write must be safe in either order.
+ */
+export const seedInitialOpenProjectAtom = atom(
+  null,
+  (get, set, project: OpenProject) => {
+    const current = get(openProjectsAtom);
+    const activePath = get(activeWorkspacePathAtom);
+    const existing = current.find((entry) => entry.path === project.path);
+
+    if (existing) {
+      if (!activePath || !current.some((entry) => entry.path === activePath)) {
+        set(activeWorkspacePathAtom, existing.path);
+      }
+      return;
+    }
+
+    if (current.length >= MAX_OPEN_PROJECT_TABS) return;
+
+    const next = [...current, project];
+    set(openProjectsAtom, next);
+    if (!activePath || !next.some((entry) => entry.path === activePath)) {
+      set(activeWorkspacePathAtom, project.path);
+    }
+  },
 );
 
 /**
@@ -157,6 +185,17 @@ export const closeOpenProjectAtom = atom(
   }
 );
 
+/** Select the tab that should become active after `pathToClose` leaves. */
+export function getReplacementOpenProjectPath(
+  projects: OpenProject[],
+  pathToClose: string,
+): string | null {
+  const index = projects.findIndex((project) => project.path === pathToClose);
+  if (index === -1) return null;
+  const remaining = projects.filter((project) => project.path !== pathToClose);
+  return remaining[index]?.path ?? remaining[index - 1]?.path ?? remaining[0]?.path ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // Persistence
 // ---------------------------------------------------------------------------
@@ -177,7 +216,7 @@ function normalizeProjectPaths(paths: unknown): string[] {
     if (typeof path !== 'string' || path.length === 0 || seen.has(path)) continue;
     seen.add(path);
     normalized.push(path);
-    if (normalized.length >= MAX_OPEN_PROJECTS) break;
+    if (normalized.length >= MAX_OPEN_PROJECT_TABS) break;
   }
   return normalized;
 }
@@ -222,13 +261,11 @@ export function resolveInitialOpenProjectsState({
     windowState?.activeWorkspacePath && normalizedWindowPaths.includes(windowState.activeWorkspacePath)
       ? windowState.activeWorkspacePath
       : normalizedWindowPaths[0] ?? null;
-  const windowHasLiveRailState =
-    normalizedWindowPaths.length > 1 ||
-    (windowState?.workspacePath != null &&
-      normalizedWindowActivePath != null &&
-      normalizedWindowActivePath !== windowState.workspacePath);
-
-  if (windowHasLiveRailState) {
+  // Main-process window state is authoritative whenever present. Project
+  // tabs are persisted per BrowserWindow, so consulting the old app-global
+  // list here would make a detached one-tab window inherit another window's
+  // full tab set on reload.
+  if (normalizedWindowPaths.length > 0) {
     return {
       paths: normalizedWindowPaths,
       activePath: normalizedWindowActivePath,
@@ -251,7 +288,7 @@ export function resolveInitialOpenProjectsState({
   };
 }
 
-let initialized = false;
+let initializationPromise: Promise<void> | null = null;
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
 let unsubscribers: Array<() => void> = [];
 
@@ -264,10 +301,14 @@ let unsubscribers: Array<() => void> = [];
  *
  * Returns once the initial state has been loaded.
  */
-export async function initOpenProjects(): Promise<void> {
-  if (initialized) return;
-  initialized = true;
+export function initOpenProjects(): Promise<void> {
+  if (!initializationPromise) {
+    initializationPromise = initializeOpenProjects();
+  }
+  return initializationPromise;
+}
 
+async function initializeOpenProjects(): Promise<void> {
   if (!window.electronAPI?.invoke) return;
 
   try {
@@ -421,8 +462,9 @@ function schedulePersistActivePath(): void {
 }
 
 /**
- * Tear down persistence subscribers (e.g. for tests). Resets `initialized`
- * so the next `initOpenProjects` call re-loads from disk.
+ * Tear down persistence subscribers (e.g. for tests). Clears the cached
+ * initialization promise so the next `initOpenProjects` call re-loads from
+ * disk.
  */
 export function teardownOpenProjects(): void {
   unsubscribers.forEach((unsub) => unsub());
@@ -431,5 +473,5 @@ export function teardownOpenProjects(): void {
     clearTimeout(persistTimer);
     persistTimer = null;
   }
-  initialized = false;
+  initializationPromise = null;
 }

--- a/packages/electron/src/renderer/store/listeners/__tests__/projectTabListeners.test.ts
+++ b/packages/electron/src/renderer/store/listeners/__tests__/projectTabListeners.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PROJECT_TAB_MUTATION_CHANNEL, type ProjectTabMutation } from '../../../../shared/projectTabs';
+
+const mocks = vi.hoisted(() => ({
+  applyProjectTabMutation: vi.fn(async () => undefined),
+  closeActiveProjectTab: vi.fn(async () => ({ success: true })),
+  openProjectTab: vi.fn(async () => ({ success: true })),
+}));
+
+vi.mock('../../../services/projectTabs', () => ({
+  applyProjectTabMutation: mocks.applyProjectTabMutation,
+  closeActiveProjectTab: mocks.closeActiveProjectTab,
+  openProjectTab: mocks.openProjectTab,
+}));
+
+import { initProjectTabListeners } from '../projectTabListeners';
+
+describe('project tab mutation listeners', () => {
+  let cleanup: (() => void) | undefined;
+  let invoke: ReturnType<typeof vi.fn>;
+  let listeners: Map<string, (payload: any) => void>;
+
+  beforeEach(() => {
+    listeners = new Map();
+    mocks.applyProjectTabMutation.mockClear();
+    invoke = vi.fn(async (channel: string) => {
+      if (channel === 'workspace:consume-pending-project-tabs') return [];
+      if (channel === 'workspace:consume-pending-project-tab-mutations') return [];
+      return { success: true };
+    });
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        invoke,
+        on: vi.fn((channel: string, callback: (payload: any) => void) => {
+          listeners.set(channel, callback);
+          return () => listeners.delete(channel);
+        }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it('applies and acknowledges a live main-owned mutation after hydration', async () => {
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => { resolveReady = resolve; });
+    cleanup = initProjectTabListeners(ready);
+    const mutation: ProjectTabMutation = {
+      id: 'move-1',
+      kind: 'add',
+      workspacePath: '/ws/b',
+      activate: true,
+    };
+
+    listeners.get(PROJECT_TAB_MUTATION_CHANNEL)?.(mutation);
+    expect(mocks.applyProjectTabMutation).not.toHaveBeenCalled();
+    resolveReady();
+
+    await vi.waitFor(() => {
+      expect(mocks.applyProjectTabMutation).toHaveBeenCalledWith(mutation);
+      expect(invoke).toHaveBeenCalledWith('workspace:ack-project-tab-mutation', {
+        mutationId: 'move-1',
+      });
+    });
+  });
+
+  it('deduplicates the same mutation delivered live and from the pending queue', async () => {
+    const mutation: ProjectTabMutation = {
+      id: 'move-2',
+      kind: 'remove',
+      workspacePath: '/ws/a',
+      replacementWorkspacePath: '/ws/b',
+      closeWindowWhenEmpty: false,
+    };
+    invoke.mockImplementation(async (channel: string) => {
+      if (channel === 'workspace:consume-pending-project-tabs') return [];
+      if (channel === 'workspace:consume-pending-project-tab-mutations') return [mutation];
+      return { success: true };
+    });
+
+    cleanup = initProjectTabListeners(Promise.resolve());
+    listeners.get(PROJECT_TAB_MUTATION_CHANNEL)?.(mutation);
+
+    await vi.waitFor(() => {
+      expect(mocks.applyProjectTabMutation).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/electron/src/renderer/store/listeners/projectTabListeners.ts
+++ b/packages/electron/src/renderer/store/listeners/projectTabListeners.ts
@@ -1,0 +1,123 @@
+import {
+  CLOSE_ACTIVE_PROJECT_TAB_CHANNEL,
+  OPEN_PROJECT_TAB_CHANNEL,
+  PROJECT_TAB_MUTATION_CHANNEL,
+  type OpenProjectTabRequest,
+  type ProjectTabMutation,
+} from '../../../shared/projectTabs';
+import {
+  applyProjectTabMutation,
+  closeActiveProjectTab,
+  openProjectTab,
+} from '../../services/projectTabs';
+
+let initialized = false;
+
+export function initProjectTabListeners(
+  openProjectsReady: Promise<void> = Promise.resolve(),
+): () => void {
+  if (initialized) return () => {};
+  initialized = true;
+  let disposed = false;
+  let mutationQueue = Promise.resolve();
+  const processedMutationIds = new Set<string>();
+
+  const cleanups: Array<() => void> = [];
+  const queueMutation = (mutation: ProjectTabMutation | undefined) => {
+    if (!mutation?.id || (mutation.kind !== 'add' && mutation.kind !== 'remove')) return;
+    mutationQueue = mutationQueue.then(async () => {
+      await openProjectsReady;
+      if (disposed) return;
+      if (!processedMutationIds.has(mutation.id)) {
+        await applyProjectTabMutation(mutation);
+        processedMutationIds.add(mutation.id);
+      }
+      await window.electronAPI?.invoke?.('workspace:ack-project-tab-mutation', {
+        mutationId: mutation.id,
+      });
+    }).catch((error) => {
+      console.error('[ProjectTabs] Failed to process project tab mutation:', error);
+    });
+  };
+
+  const mutationCleanup = window.electronAPI?.on?.(
+    PROJECT_TAB_MUTATION_CHANNEL,
+    (mutation: ProjectTabMutation) => queueMutation(mutation),
+  );
+  if (typeof mutationCleanup === 'function') cleanups.push(mutationCleanup);
+
+  const openWhenReady = (workspacePath: string | undefined) => {
+    if (!workspacePath) return;
+    void openProjectsReady.then(async () => {
+      if (disposed) return;
+      const result = await openProjectTab(workspacePath);
+      if (!result.success) {
+        console.error('[ProjectTabs] Failed to open project tab:', result.error);
+        return;
+      }
+      await window.electronAPI?.invoke?.('workspace:ack-project-tab-open', { workspacePath });
+    }).catch((error) => {
+      console.error('[ProjectTabs] Failed to process project tab request:', error);
+    });
+  };
+
+  const openCleanup = window.electronAPI?.on?.(
+    OPEN_PROJECT_TAB_CHANNEL,
+    (request: OpenProjectTabRequest) => {
+      openWhenReady(request?.workspacePath);
+    },
+  );
+  if (typeof openCleanup === 'function') cleanups.push(openCleanup);
+
+  const closeCleanup = window.electronAPI?.on?.(CLOSE_ACTIVE_PROJECT_TAB_CHANNEL, () => {
+    void openProjectsReady
+      .then(() => closeActiveProjectTab())
+      .then((result) => {
+        if (!result.success && result.error !== 'cancelled') {
+          console.error('[ProjectTabs] Failed to close active project tab:', result.error);
+        }
+      })
+      .catch((error) => {
+        console.error('[ProjectTabs] Failed to process close request:', error);
+      });
+  });
+  if (typeof closeCleanup === 'function') cleanups.push(closeCleanup);
+
+  // Pull any request queued while this renderer was loading or reloading.
+  // The live listener is installed first, so an open racing this call is
+  // harmless: openProjectTab is idempotent and merely activates the tab.
+  void openProjectsReady.then(async () => {
+    if (disposed) return;
+    try {
+      const pending = await window.electronAPI?.invoke?.('workspace:consume-pending-project-tabs');
+      if (!Array.isArray(pending)) return;
+      for (const workspacePath of pending) {
+        if (typeof workspacePath === 'string') openWhenReady(workspacePath);
+      }
+    } catch (error) {
+      console.error('[ProjectTabs] Failed to consume pending project tabs:', error);
+    }
+  });
+
+  // Cross-window moves are committed in main before renderer delivery. Pull
+  // queued mutations after installing the live listener so reloads and event
+  // races converge on the same tab state.
+  void openProjectsReady.then(async () => {
+    if (disposed) return;
+    try {
+      const pending = await window.electronAPI?.invoke?.(
+        'workspace:consume-pending-project-tab-mutations',
+      );
+      if (!Array.isArray(pending)) return;
+      pending.forEach((mutation) => queueMutation(mutation as ProjectTabMutation));
+    } catch (error) {
+      console.error('[ProjectTabs] Failed to consume project tab mutations:', error);
+    }
+  });
+
+  return () => {
+    disposed = true;
+    cleanups.forEach((cleanup) => cleanup());
+    initialized = false;
+  };
+}

--- a/packages/electron/src/shared/projectTabs.ts
+++ b/packages/electron/src/shared/projectTabs.ts
@@ -1,0 +1,37 @@
+export const MAX_OPEN_PROJECT_TABS = 8;
+
+export const OPEN_PROJECT_TAB_CHANNEL = 'workspace:open-project-tab';
+export const CLOSE_ACTIVE_PROJECT_TAB_CHANNEL = 'workspace:close-active-project-tab';
+export const PROJECT_TAB_MUTATION_CHANNEL = 'workspace:project-tab-mutation';
+
+/** Custom drag type so project tabs cannot be confused with file/text drags. */
+export const PROJECT_TAB_DRAG_MIME = 'application/x-nimbalyst-project-tab+json';
+
+export interface ProjectTabDragPayload {
+  version: 1;
+  dragId: string;
+}
+
+/** Sent only over trusted renderer-to-main IPC; never exposed to external drop targets. */
+export interface ProjectTabDragRegistration extends ProjectTabDragPayload {
+  workspacePath: string;
+}
+
+export type ProjectTabMutation =
+  | {
+      id: string;
+      kind: 'add';
+      workspacePath: string;
+      activate: true;
+    }
+  | {
+      id: string;
+      kind: 'remove';
+      workspacePath: string;
+      replacementWorkspacePath: string | null;
+      closeWindowWhenEmpty: boolean;
+    };
+
+export interface OpenProjectTabRequest {
+  workspacePath: string;
+}


### PR DESCRIPTION
## Summary
- Open projects in top tabs in the current window by default.
- Keep a new-window escape hatch through drag-out and the tab context menu.
- Move tabs atomically between existing windows with durable mutations, rollback, dirty-editor save preparation, and per-window state.

## Related issue
Follow-up to #188, which closed #155.

## Testing
- npm run typecheck:prepush
- TMPDIR=/var/tmp npm run test:prepush — 713 files and 5,978 tests passed; 7 files and 26 tests skipped
- Focused project-tab suite — 11 files and 153 tests passed
- Targeted ESLint
- npm run build --prefix packages/electron
- Packaged Linux app restart and user-confirmed native cross-window drag

## Notes for reviewers
- Main owns the cross-window move transaction, revalidates after editor-save preparation, rolls back state/watchers/global context on failure, and queues renderer mutations durably across reloads.
- Workspace Manager, recent-project, and tab-strip opens route to tabs; legacy new-window behavior remains when project tabs are disabled or explicitly forced.