### PR TITLE
fix(electron): dedupe session_files and make its unique index unique

### DIFF
--- a/packages/electron/src/main/database/sqlite/MigrationRunner.ts
+++ b/packages/electron/src/main/database/sqlite/MigrationRunner.ts
@@ -166,6 +166,11 @@ export function getMigrations(schemaDir: string): Migration[] {
       name: 'account_org_bindings',
       sqlFile: path.join(schemaDir, '0025_account_org_bindings.sql'),
     },
+    {
+      version: 26,
+      name: 'session_files_dedupe',
+      sqlFile: path.join(schemaDir, '0026_session_files_dedupe.sql'),
+    },
   ];
 }
 

--- a/packages/electron/src/main/database/sqlite/__tests__/MigrationRunner.test.ts
+++ b/packages/electron/src/main/database/sqlite/__tests__/MigrationRunner.test.ts
@@ -83,6 +83,7 @@ describe('runMigrations', () => {
     fs.writeFileSync(path.join(tmp, '0023_collab_asset_retry_schedule.sql'), '-- noop\n');
     fs.writeFileSync(path.join(tmp, '0024_tracker_personal_state.sql'), '-- noop\n');
     fs.writeFileSync(path.join(tmp, '0025_account_org_bindings.sql'), '-- noop\n');
+    fs.writeFileSync(path.join(tmp, '0026_session_files_dedupe.sql'), '-- noop\n');
 
     const db = new FakeDb();
     // Hack: inject our own migration list via reflection-equivalent. Re-using
@@ -96,13 +97,13 @@ describe('runMigrations', () => {
     // a stand-in implementation; for now, test the file-backed path with the
     // bundled migrations.
     const result = runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
-    expect(result.applied).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]);
+    expect(result.applied).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]);
     expect(result.skipped).toEqual([]);
 
     // Second invocation: nothing to apply, all skipped.
     const result2 = runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
     expect(result2.applied).toEqual([]);
-    expect(result2.skipped).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]);
+    expect(result2.skipped).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]);
 
     // Anti-flake: unused locals lint silencer.
     void customs;

--- a/packages/electron/src/main/database/sqlite/__tests__/MigrationRunner.test.ts
+++ b/packages/electron/src/main/database/sqlite/__tests__/MigrationRunner.test.ts
@@ -209,6 +209,10 @@ describe('runMigrations', () => {
       path.join(tmp, '0025_account_org_bindings.sql'),
       '-- noop\n',
     );
+    fs.writeFileSync(
+      path.join(tmp, '0026_session_files_dedupe.sql'),
+      '-- noop\n',
+    );
     const db = new FakeDb();
     runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
     expect(db.execs.some((s) => s.includes('CREATE TABLE foo'))).toBe(true);

--- a/packages/electron/src/main/database/sqlite/__tests__/sessionFilesDedupe.test.ts
+++ b/packages/electron/src/main/database/sqlite/__tests__/sessionFilesDedupe.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Regression tests for 0026_session_files_dedupe.
+ *
+ * session_files used to grow one row per attribution: addFileLink issued a plain
+ * INSERT and idx_session_files_unique was declared non-unique, so a session that
+ * edited the same file N times accumulated N rows. getFilesBySession then shipped
+ * the whole duplicate set to the renderer on every session-files:updated event.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SQLiteDatabase } from '../SQLiteDatabase';
+
+const SCHEMA_DIR = path.resolve(__dirname, '..', 'schemas');
+
+/** The upsert PGLiteSessionFileStore.addFileLink issues, with `?` placeholders. */
+const UPSERT_SQL = `INSERT INTO session_files (
+  id, session_id, workspace_id, file_path, link_type, timestamp, metadata
+) VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (session_id, file_path, link_type) DO UPDATE SET
+  workspace_id = EXCLUDED.workspace_id,
+  timestamp = EXCLUDED.timestamp,
+  metadata = EXCLUDED.metadata
+RETURNING id, timestamp, metadata`;
+
+async function withDb(
+  fn: (handle: import('better-sqlite3').Database) => void | Promise<void>,
+): Promise<void> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nim-sf-dedupe-'));
+  const sqlite = new SQLiteDatabase({
+    dbDir: tmpDir,
+    schemaDir: SCHEMA_DIR,
+    slowQueryThresholdMs: 1000,
+    sampleRate: 0,
+  });
+  try {
+    await sqlite.initialize();
+    const handle = sqlite.getRawHandle()!;
+    handle.pragma('foreign_keys = ON');
+    await fn(handle);
+  } finally {
+    await sqlite.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+/** Minimal parent rows so the ai_tool_call_file_edits foreign keys hold. */
+function seedSession(
+  handle: import('better-sqlite3').Database,
+  sessionId: string,
+): number {
+  handle
+    .prepare(`INSERT INTO ai_sessions (id, provider) VALUES (?, 'claude')`)
+    .run(sessionId);
+  const info = handle
+    .prepare(
+      `INSERT INTO ai_agent_messages (session_id, source, direction, content)
+       VALUES (?, 'test', 'output', 'msg')`,
+    )
+    .run(sessionId);
+  return Number(info.lastInsertRowid);
+}
+
+function insertFileRow(
+  handle: import('better-sqlite3').Database,
+  row: { id: string; sessionId: string; filePath: string; linkType: string; ts: string },
+): void {
+  handle
+    .prepare(
+      `INSERT INTO session_files
+         (id, session_id, workspace_id, file_path, link_type, timestamp, metadata)
+       VALUES (?, ?, 'ws', ?, ?, ?, '{}')`,
+    )
+    .run(row.id, row.sessionId, row.filePath, row.linkType, row.ts);
+}
+
+/** Recreate the pre-0026 state: a plain, non-unique index. */
+function revertToNonUniqueIndex(handle: import('better-sqlite3').Database): void {
+  handle.exec(`
+    DROP INDEX IF EXISTS idx_session_files_unique;
+    CREATE INDEX idx_session_files_unique
+      ON session_files(session_id, file_path, link_type);
+  `);
+}
+
+function indexIsUnique(
+  handle: import('better-sqlite3').Database,
+  name: string,
+): boolean {
+  const rows = handle.prepare(`PRAGMA index_list(session_files)`).all() as Array<{
+    name: string;
+    unique: number;
+  }>;
+  return rows.some((r) => r.name === name && r.unique === 1);
+}
+
+describe('0026_session_files_dedupe', () => {
+  it('leaves idx_session_files_unique actually unique', async () => {
+    await withDb((handle) => {
+      expect(indexIsUnique(handle, 'idx_session_files_unique')).toBe(true);
+    });
+  });
+
+  it('collapses a repeat attribution instead of appending a row', async () => {
+    await withDb((handle) => {
+      seedSession(handle, 's1');
+      const upsert = handle.prepare(UPSERT_SQL);
+
+      const first = upsert.get(
+        'id-1', 's1', 'ws', '/a/b.ts', 'edited', '2026-01-01T00:00:00.000Z', '{"n":1}',
+      ) as { id: string; timestamp: string; metadata: string };
+      const second = upsert.get(
+        'id-2', 's1', 'ws', '/a/b.ts', 'edited', '2026-01-02T00:00:00.000Z', '{"n":2}',
+      ) as { id: string; timestamp: string; metadata: string };
+
+      const count = handle
+        .prepare(`SELECT count(*) AS c FROM session_files WHERE session_id = 's1'`)
+        .get() as { c: number };
+
+      expect(count.c).toBe(1);
+      // The surviving row keeps its original id, so attributions that already
+      // reference it stay valid.
+      expect(second.id).toBe(first.id);
+      expect(second.timestamp).toBe('2026-01-02T00:00:00.000Z');
+      expect(second.metadata).toBe('{"n":2}');
+    });
+  });
+
+  it('keeps rows that differ only by link_type apart', async () => {
+    await withDb((handle) => {
+      seedSession(handle, 's1');
+      const upsert = handle.prepare(UPSERT_SQL);
+      upsert.run('id-1', 's1', 'ws', '/a/b.ts', 'edited', '2026-01-01T00:00:00.000Z', '{}');
+      upsert.run('id-2', 's1', 'ws', '/a/b.ts', 'read', '2026-01-01T00:00:00.000Z', '{}');
+
+      const count = handle
+        .prepare(`SELECT count(*) AS c FROM session_files WHERE session_id = 's1'`)
+        .get() as { c: number };
+      expect(count.c).toBe(2);
+    });
+  });
+
+  it('backfills existing duplicates, keeping the newest row per triple', async () => {
+    await withDb((handle) => {
+      seedSession(handle, 's1');
+      revertToNonUniqueIndex(handle);
+
+      insertFileRow(handle, { id: 'old', sessionId: 's1', filePath: '/a/b.ts', linkType: 'edited', ts: '2026-01-01T00:00:00.000Z' });
+      insertFileRow(handle, { id: 'mid', sessionId: 's1', filePath: '/a/b.ts', linkType: 'edited', ts: '2026-01-02T00:00:00.000Z' });
+      insertFileRow(handle, { id: 'new', sessionId: 's1', filePath: '/a/b.ts', linkType: 'edited', ts: '2026-01-03T00:00:00.000Z' });
+      insertFileRow(handle, { id: 'other', sessionId: 's1', filePath: '/c/d.ts', linkType: 'edited', ts: '2026-01-01T00:00:00.000Z' });
+
+      handle.exec(fs.readFileSync(path.join(SCHEMA_DIR, '0026_session_files_dedupe.sql'), 'utf8'));
+
+      const rows = handle
+        .prepare(`SELECT id, file_path FROM session_files WHERE session_id = 's1' ORDER BY file_path`)
+        .all() as Array<{ id: string; file_path: string }>;
+
+      expect(rows).toEqual([
+        { id: 'new', file_path: '/a/b.ts' },
+        { id: 'other', file_path: '/c/d.ts' },
+      ]);
+      expect(indexIsUnique(handle, 'idx_session_files_unique')).toBe(true);
+    });
+  });
+
+  it('re-points tool-call attributions instead of cascade-deleting them', async () => {
+    await withDb((handle) => {
+      const messageId = seedSession(handle, 's1');
+      revertToNonUniqueIndex(handle);
+
+      insertFileRow(handle, { id: 'old', sessionId: 's1', filePath: '/a/b.ts', linkType: 'edited', ts: '2026-01-01T00:00:00.000Z' });
+      insertFileRow(handle, { id: 'new', sessionId: 's1', filePath: '/a/b.ts', linkType: 'edited', ts: '2026-01-02T00:00:00.000Z' });
+
+      // Attribution points at the row the migration is about to delete; the FK is
+      // ON DELETE CASCADE, so without re-pointing this row would vanish.
+      handle
+        .prepare(
+          `INSERT INTO ai_tool_call_file_edits (session_id, session_file_id, message_id)
+           VALUES ('s1', 'old', ?)`,
+        )
+        .run(messageId);
+
+      handle.exec(fs.readFileSync(path.join(SCHEMA_DIR, '0026_session_files_dedupe.sql'), 'utf8'));
+
+      const edits = handle
+        .prepare(`SELECT session_file_id FROM ai_tool_call_file_edits`)
+        .all() as Array<{ session_file_id: string }>;
+
+      expect(edits).toEqual([{ session_file_id: 'new' }]);
+    });
+  });
+
+  it('is idempotent when re-run against an already-clean table', async () => {
+    await withDb((handle) => {
+      seedSession(handle, 's1');
+      insertFileRow(handle, { id: 'only', sessionId: 's1', filePath: '/a/b.ts', linkType: 'edited', ts: '2026-01-01T00:00:00.000Z' });
+
+      const sql = fs.readFileSync(path.join(SCHEMA_DIR, '0026_session_files_dedupe.sql'), 'utf8');
+      handle.exec(sql);
+      handle.exec(sql);
+
+      const count = handle
+        .prepare(`SELECT count(*) AS c FROM session_files WHERE session_id = 's1'`)
+        .get() as { c: number };
+      expect(count.c).toBe(1);
+      expect(indexIsUnique(handle, 'idx_session_files_unique')).toBe(true);
+    });
+  });
+});

--- a/packages/electron/src/main/database/sqlite/schemas/0026_session_files_dedupe.sql
+++ b/packages/electron/src/main/database/sqlite/schemas/0026_session_files_dedupe.sql
@@ -1,0 +1,54 @@
+-- Collapse duplicate session_files rows and make idx_session_files_unique
+-- actually unique.
+--
+-- session_files has been written append-only: addFileLink issues a plain INSERT
+-- with a fresh uuid for every attribution, and idx_session_files_unique -- despite
+-- its name -- was created in 0001_initial.sql as a plain, non-unique index, so
+-- nothing collapsed repeat attributions. A session that edits the same file N
+-- times accumulated N rows, and SessionEditQuota only caps the number of
+-- *distinct* files (it returns early with `true` for a file it has already seen,
+-- letting the write through).
+--
+-- getFilesBySession does `SELECT * ... WHERE session_id = ?` with no limit, so
+-- every session-files:updated refresh hauled the full duplicate set over IPC.
+-- On a long-running session this grew without bound: locally a single session
+-- held 6741 'edited' rows for 500 distinct paths (13.5x), one file repeated 134
+-- times, which stalled the main-process event loop for seconds and ballooned the
+-- renderer that kept the results.
+--
+-- Ordering note: attributions are re-pointed *before* the delete, because
+-- ai_tool_call_file_edits.session_file_id is ON DELETE CASCADE and would
+-- otherwise silently drop rows that referenced a duplicate.
+
+CREATE TEMP TABLE _session_files_dedupe AS
+WITH ranked AS (
+  SELECT
+    id,
+    FIRST_VALUE(id) OVER (
+      PARTITION BY session_id, file_path, link_type
+      ORDER BY timestamp DESC, id DESC
+    ) AS keep_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY session_id, file_path, link_type
+      ORDER BY timestamp DESC, id DESC
+    ) AS rn
+  FROM session_files
+)
+SELECT id AS dup_id, keep_id FROM ranked WHERE rn > 1;
+
+-- OR REPLACE resolves collisions on idx_atcfe_unique (session_file_id, message_id)
+-- that appear once several duplicates fold into one surviving row.
+UPDATE OR REPLACE ai_tool_call_file_edits
+SET session_file_id = (
+  SELECT keep_id FROM _session_files_dedupe WHERE dup_id = session_file_id
+)
+WHERE session_file_id IN (SELECT dup_id FROM _session_files_dedupe);
+
+DELETE FROM session_files
+WHERE id IN (SELECT dup_id FROM _session_files_dedupe);
+
+DROP TABLE _session_files_dedupe;
+
+DROP INDEX IF EXISTS idx_session_files_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_session_files_unique
+  ON session_files(session_id, file_path, link_type);

--- a/packages/electron/src/main/services/PGLiteSessionFileStore.ts
+++ b/packages/electron/src/main/services/PGLiteSessionFileStore.ts
@@ -37,6 +37,13 @@ export function createPGLiteSessionFileStore(db: PGliteLike, ensureDbReady?: Ens
       await ensureReady();
     },
 
+    /**
+     * Idempotent per (sessionId, filePath, linkType): a repeat attribution for a
+     * file the session already touched refreshes the existing row instead of
+     * appending another one. Without this the table grows once per edit, and
+     * getFilesBySession ships the whole duplicate set to the renderer on every
+     * session-files:updated event.
+     */
     async addFileLink(link: Omit<FileLink, 'id'>): Promise<FileLink> {
       await ensureReady();
 
@@ -51,6 +58,10 @@ export function createPGLiteSessionFileStore(db: PGliteLike, ensureDbReady?: Ens
         ) VALUES (
           $1, $2, $3, $4, $5, $6, $7
         )
+        ON CONFLICT (session_id, file_path, link_type) DO UPDATE SET
+          workspace_id = EXCLUDED.workspace_id,
+          timestamp = EXCLUDED.timestamp,
+          metadata = EXCLUDED.metadata
         RETURNING id, session_id, workspace_id, file_path, link_type, timestamp, metadata`,
         [
           id,


### PR DESCRIPTION
## Problem

`session_files` is written append-only. `addFileLink` issues a plain `INSERT` with a fresh uuid for every attribution, and `idx_session_files_unique` — despite the name — was created in `0001_initial.sql` as a plain, non-unique index:

```sql
CREATE INDEX IF NOT EXISTS idx_session_files_unique ON session_files(session_id, file_path, link_type);
```

so repeat attributions never collapse. `SessionEditQuota` only caps the number of *distinct* files per session — for a file it has already seen it returns early with `true` and lets the write through:

```ts
if (set.has(filePath)) return true;
```

`getFilesBySession` then does `SELECT * ... WHERE session_id = ?` with no limit, so every `session-files:updated` event ships the full duplicate set over IPC, and the set grows for as long as the session lives.

## Impact

Measured on my install (v0.66.9, 5+ concurrent sessions):

| | rows | distinct | bloat |
|---|---|---|---|
| one session, `edited` | 6741 | 500 paths | **13.5×** |
| same session, `read` | 674 | 674 paths | 1.0× |
| whole table | 38775 | 13612 | 2.8× (25163 redundant) |

One file (`integration_test.go`) was recorded **134 times** for a single session.

Those queries serialize in the database worker. In one main.log, **1799 of 1816** logged slow IPC calls were `session-files:get-by-session`, and they drain in batches — eleven concurrent calls all completing in the same millisecond at 2.4s each:

```
[IpcSlow] session-files:get-by-session took 2388ms (threshold 1000ms)
[IpcSlow] session-files:get-by-session took 2385ms (threshold 1000ms)
... 9 more, same timestamp ...
[PERF] Event loop lag: 2156ms
[MAIN] Window became unresponsive
```

Because it scales with session count, it lands hardest on exactly the multi-session workflow. The renderer holding those results grew to 8.3 GB RSS (4.1 GB in the V8 sandbox, 3.1 GB in PartitionAlloc — the repeated path strings) before wedging.

## Fix

1. **`PGLiteSessionFileStore.addFileLink`** — idempotent per `(session_id, file_path, link_type)` via `ON CONFLICT DO UPDATE`, refreshing `timestamp`/`metadata` on the existing row. The surviving row keeps its `id`, so references already stored in `ai_tool_call_file_edits` stay valid.

2. **Migration `0026_session_files_dedupe.sql`** — folds existing duplicates onto the newest row per triple and recreates `idx_session_files_unique` as `UNIQUE`.

   Ordering matters: `ai_tool_call_file_edits.session_file_id` is `ON DELETE CASCADE`, so attributions are re-pointed at the surviving row **before** the delete — otherwise they are silently destroyed. `UPDATE OR REPLACE` resolves the collisions on `idx_atcfe_unique (session_file_id, message_id)` that appear when several duplicates fold into one row.

Applied to my database: `session_files` 38775 → 13621, the hot session 7415 → 1174, `foreign_key_check` clean, `integrity_check` ok.

## Tests

`__tests__/sessionFilesDedupe.test.ts` covers:

- `idx_session_files_unique` is actually unique after migrations
- the upsert collapses a repeat attribution, preserving `id` and refreshing `timestamp`/`metadata`
- rows differing only by `link_type` are kept apart
- the backfill keeps the newest row per triple
- attributions are re-pointed rather than cascade-deleted
- re-running the migration is a no-op

## Notes

`0001_initial.sql` is deliberately left untouched — per the comment in `MigrationRunner.ts` it is the consolidated end state, and new schema changes belong in subsequent migrations.

Related: #918 debounces and coalesces the callers on this same hot path; this PR removes the redundant rows those calls were hauling.
