### PR TITLE
fix(ios): preserve session feeds across reconnects

### DIFF
--- a/packages/ios/NimbalystNative/Sources/App/AppState.swift
+++ b/packages/ios/NimbalystNative/Sources/App/AppState.swift
@@ -117,6 +117,25 @@ public final class AppState: ObservableObject {
 
         // Auto-connect when auth state changes
         observeAuth()
+        observeAppLifecycle()
+    }
+
+    private func observeAppLifecycle() {
+        #if canImport(UIKit)
+        NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.syncManager?.setAppInForeground(false)
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.syncManager?.setAppInForeground(true)
+            }
+            .store(in: &cancellables)
+        #endif
     }
 
     /// Initialize with pre-built managers (for testing and previews).

--- a/packages/ios/NimbalystNative/Sources/Database/DatabaseManager.swift
+++ b/packages/ios/NimbalystNative/Sources/Database/DatabaseManager.swift
@@ -368,6 +368,102 @@ public final class DatabaseManager: @unchecked Sendable {
         }
     }
 
+    /// Applies a server index row only when it is not older than the durable
+    /// session snapshot. Session-room metadata can have a later independent
+    /// revision; in that case index-owned fields (including pin state) advance
+    /// while live execution/attention fields remain authoritative.
+    @discardableResult
+    public func upsertRemoteSession(_ session: Session) throws -> Bool {
+        try writer.write { db in
+            guard let existing = try Session.fetchOne(db, id: session.id) else {
+                try session.insert(db)
+                return true
+            }
+            guard session.updatedAt >= existing.updatedAt else { return false }
+
+            var reconciled = session
+            reconciled.lastSyncedSeq = max(session.lastSyncedSeq, existing.lastSyncedSeq)
+            if let existingLastMessageAt = existing.lastMessageAt {
+                reconciled.lastMessageAt = max(
+                    session.lastMessageAt ?? existingLastMessageAt,
+                    existingLastMessageAt
+                )
+            }
+            if let state = try SyncState.fetchOne(db, id: session.id),
+               let cursor = state.lastCursor,
+               let metadataRevision = Int(cursor),
+               metadataRevision >= session.updatedAt {
+                reconciled.titleEncrypted = existing.titleEncrypted
+                reconciled.titleIv = existing.titleIv
+                reconciled.titleDecrypted = existing.titleDecrypted
+                reconciled.provider = existing.provider
+                reconciled.model = existing.model
+                reconciled.mode = existing.mode
+                reconciled.phase = existing.phase
+                reconciled.tagsJson = existing.tagsJson
+                reconciled.isExecuting = existing.isExecuting
+                reconciled.hasPendingPrompt = existing.hasPendingPrompt
+                reconciled.attentionPending = existing.attentionPending
+                reconciled.attentionSeverity = existing.attentionSeverity
+                reconciled.attentionEventId = existing.attentionEventId
+                reconciled.attentionEffectiveDeadline = existing.attentionEffectiveDeadline
+                reconciled.contextTokens = existing.contextTokens
+                reconciled.contextWindow = existing.contextWindow
+                reconciled.draftInput = existing.draftInput
+                reconciled.draftUpdatedAt = existing.draftUpdatedAt
+                reconciled.hasBeenNamed = existing.hasBeenNamed
+            }
+
+            try reconciled.save(db)
+            return true
+        }
+    }
+
+    public struct RemoteMetadataUpdateResult: Sendable {
+        public let previous: Session
+        public let current: Session
+    }
+
+    /// Compares the session-room revision, reconciles every metadata-owned
+    /// field, and advances the durable cursor in one database transaction.
+    /// Returning nil means the session is absent or the revision is stale.
+    @discardableResult
+    public func updateRemoteSessionMetadata(
+        sessionId: String,
+        revision: Int?,
+        update: (inout Session) -> Void
+    ) throws -> RemoteMetadataUpdateResult? {
+        try writer.write { db in
+            guard var session = try Session.fetchOne(db, id: sessionId) else {
+                return nil
+            }
+
+            let existingState = try SyncState.fetchOne(db, id: sessionId)
+            if let revision,
+               let storedCursor = existingState?.lastCursor,
+               let storedRevision = Int(storedCursor),
+               revision < storedRevision {
+                return nil
+            }
+
+            let previous = session
+            update(&session)
+            try session.save(db)
+
+            if let revision {
+                let state = SyncState(
+                    roomId: sessionId,
+                    lastCursor: String(revision),
+                    lastSequence: existingState?.lastSequence ?? 0,
+                    lastSyncedAt: existingState?.lastSyncedAt
+                )
+                try state.save(db)
+            }
+
+            return RemoteMetadataUpdateResult(previous: previous, current: session)
+        }
+    }
+
     public func session(byId sessionId: String) throws -> Session? {
         try writer.read { db in
             try Session.fetchOne(db, id: sessionId)
@@ -457,6 +553,46 @@ public final class DatabaseManager: @unchecked Sendable {
         }
     }
 
+    /// Persists server-originated messages and advances both the transcript
+    /// cursor and the observed session row in one transaction. Replays are
+    /// harmless, and an older catch-up page cannot move durable progress behind
+    /// a live broadcast that already arrived.
+    public func appendRemoteMessages(
+        _ messages: [Message],
+        roomId: String,
+        syncedAt: Int
+    ) throws {
+        try writer.write { db in
+            for message in messages {
+                try message.insert(db, onConflict: .ignore)
+            }
+
+            let maxSequence = messages.map(\.sequence).max() ?? 0
+            if maxSequence > 0 {
+                let maxCreatedAt = messages.map(\.createdAt).max() ?? 0
+                try db.execute(
+                    sql: """
+                        UPDATE sessions SET
+                            lastSyncedSeq = MAX(lastSyncedSeq, ?),
+                            lastMessageAt = MAX(COALESCE(lastMessageAt, 0), ?),
+                            updatedAt = MAX(updatedAt, ?)
+                        WHERE id = ?
+                    """,
+                    arguments: [maxSequence, maxCreatedAt, maxCreatedAt, roomId]
+                )
+            }
+
+            let existing = try SyncState.fetchOne(db, id: roomId)
+            let state = SyncState(
+                roomId: roomId,
+                lastCursor: existing?.lastCursor,
+                lastSequence: max(existing?.lastSequence ?? 0, maxSequence),
+                lastSyncedAt: max(existing?.lastSyncedAt ?? 0, syncedAt)
+            )
+            try state.save(db)
+        }
+    }
+
     // MARK: - Sync State Queries
 
     public func syncState(forRoom roomId: String) throws -> SyncState? {
@@ -467,7 +603,26 @@ public final class DatabaseManager: @unchecked Sendable {
 
     public func updateSyncState(_ state: SyncState) throws {
         try writer.write { db in
-            try state.save(db)
+            let existing = try SyncState.fetchOne(db, id: state.roomId)
+            let lastCursor: String?
+            if let incoming = state.lastCursor,
+               let incomingNumber = Int(incoming),
+               let existingCursor = existing?.lastCursor,
+               let existingNumber = Int(existingCursor) {
+                lastCursor = String(max(incomingNumber, existingNumber))
+            } else {
+                lastCursor = state.lastCursor ?? existing?.lastCursor
+            }
+
+            let merged = SyncState(
+                roomId: state.roomId,
+                lastCursor: lastCursor,
+                lastSequence: max(existing?.lastSequence ?? 0, state.lastSequence),
+                lastSyncedAt: [existing?.lastSyncedAt, state.lastSyncedAt]
+                    .compactMap { $0 }
+                    .max()
+            )
+            try merged.save(db)
         }
     }
 

--- a/packages/ios/NimbalystNative/Sources/Database/DatabaseManager.swift
+++ b/packages/ios/NimbalystNative/Sources/Database/DatabaseManager.swift
@@ -402,16 +402,11 @@ public final class DatabaseManager: @unchecked Sendable {
                 reconciled.phase = existing.phase
                 reconciled.tagsJson = existing.tagsJson
                 reconciled.isExecuting = existing.isExecuting
-                reconciled.hasPendingPrompt = existing.hasPendingPrompt
-                reconciled.attentionPending = existing.attentionPending
-                reconciled.attentionSeverity = existing.attentionSeverity
-                reconciled.attentionEventId = existing.attentionEventId
-                reconciled.attentionEffectiveDeadline = existing.attentionEffectiveDeadline
+                reconciled.hasQueuedPrompts = existing.hasQueuedPrompts
                 reconciled.contextTokens = existing.contextTokens
                 reconciled.contextWindow = existing.contextWindow
                 reconciled.draftInput = existing.draftInput
                 reconciled.draftUpdatedAt = existing.draftUpdatedAt
-                reconciled.hasBeenNamed = existing.hasBeenNamed
             }
 
             try reconciled.save(db)

--- a/packages/ios/NimbalystNative/Sources/Sync/DocumentSyncManager.swift
+++ b/packages/ios/NimbalystNative/Sources/Sync/DocumentSyncManager.swift
@@ -2,6 +2,14 @@ import Foundation
 import CryptoKit
 import os
 
+typealias DocumentWebSocketClientFactory = @MainActor () -> WebSocketClient
+typealias DocumentMessageWillHandle = @MainActor @Sendable (Data, String) async -> Void
+
+private struct DocumentClientGenerationScope {
+    let clientId: ObjectIdentifier
+    var highestAcceptedGeneration: Int?
+}
+
 /// Manages document sync with ProjectSyncRoom Durable Objects.
 /// Handles one WebSocket connection per project for syncing .md files.
 ///
@@ -44,12 +52,36 @@ public final class DocumentSyncManager: ObservableObject {
 
     /// Track per-project connection state for queueing decisions.
     private var projectConnected: [String: Bool] = [:]
+    private var projectContexts: [String: WebSocketConnectionContext] = [:]
+    private var projectGenerationScopes: [String: DocumentClientGenerationScope] = [:]
+    private let clientFactory: DocumentWebSocketClientFactory
+    private let messageWillHandle: DocumentMessageWillHandle
 
-    public init(crypto: CryptoManager, database: DatabaseManager, serverUrl: String, userId: String) {
+    public convenience init(crypto: CryptoManager, database: DatabaseManager, serverUrl: String, userId: String) {
+        self.init(
+            crypto: crypto,
+            database: database,
+            serverUrl: serverUrl,
+            userId: userId,
+            clientFactory: { WebSocketClient() },
+            messageWillHandle: { _, _ in }
+        )
+    }
+
+    init(
+        crypto: CryptoManager,
+        database: DatabaseManager,
+        serverUrl: String,
+        userId: String,
+        clientFactory: @escaping DocumentWebSocketClientFactory,
+        messageWillHandle: @escaping DocumentMessageWillHandle
+    ) {
         self.crypto = crypto
         self.database = database
         self.serverUrl = serverUrl
         self.userId = userId
+        self.clientFactory = clientFactory
+        self.messageWillHandle = messageWillHandle
     }
 
     /// The user ID to use for room routing. Prefers authUserId (from JWT) over pairing userId.
@@ -91,30 +123,69 @@ public final class DocumentSyncManager: ObservableObject {
 
         activeProjectId = projectId
 
-        let client = WebSocketClient()
-        projectClients[projectId] = client
+        let client = clientFactory()
+        let retiredClient = projectClients.updateValue(client, forKey: projectId)
+        projectContexts.removeValue(forKey: projectId)
+        projectConnected[projectId] = false
+        projectGenerationScopes[projectId] = DocumentClientGenerationScope(
+            clientId: ObjectIdentifier(client),
+            highestAcceptedGeneration: nil
+        )
+        if activeProjectId == projectId {
+            isConnected = false
+        }
+
+        // Rebind authority to the new identity before retiring the old client.
+        // Any synchronous or delayed callback from the retired client then
+        // fails the exact identity/scope guard and cannot regain authority.
+        retiredClient?.disconnect()
 
         let roomId = "org:\(orgId):user:\(effectiveUserId):project:\(hashedId)"
         logger.info("[DocSync] Connecting to project room: \(roomId)")
 
-        client.onConnectionStateChanged = { [weak self] connected in
-            Task { @MainActor in
-                guard let self = self else { return }
-                self.projectConnected[projectId] = connected
+        client.onConnectionStateChangedWithContext = { [weak self, weak client] connected, context in
+            guard let self,
+                  let client,
+                  self.projectClients[projectId] === client,
+                  var generationScope = self.projectGenerationScopes[projectId],
+                  generationScope.clientId == ObjectIdentifier(client),
+                  context.roomId == roomId else { return }
+
+            if connected {
+                guard WebSocketConnectedContextGate.accepts(
+                    highestAcceptedGeneration: generationScope.highestAcceptedGeneration,
+                    incomingContext: context
+                ) else { return }
+                generationScope.highestAcceptedGeneration = context.generation
+                self.projectGenerationScopes[projectId] = generationScope
+                self.projectContexts[projectId] = context
+                self.projectConnected[projectId] = true
                 if self.activeProjectId == projectId {
-                    self.isConnected = connected
+                    self.isConnected = true
                 }
-                if connected {
-                    self.sendSyncRequest(projectId: projectId)
-                    self.replayOfflineQueue(projectId: projectId)
+                self.sendSyncRequest(projectId: projectId)
+                self.replayOfflineQueue(projectId: projectId)
+            } else if self.projectContexts[projectId] == context {
+                self.projectContexts.removeValue(forKey: projectId)
+                self.projectConnected[projectId] = false
+                if self.activeProjectId == projectId {
+                    self.isConnected = false
                 }
             }
         }
 
-        client.onMessage = { [weak self] data in
-            Task { @MainActor in
-                self?.handleMessage(data, projectId: projectId)
-            }
+        client.onMessageWithContext = { [weak self, weak client] data, context in
+            guard let self,
+                  let client,
+                  self.projectClients[projectId] === client,
+                  self.projectGenerationScopes[projectId]?.clientId == ObjectIdentifier(client),
+                  self.projectContexts[projectId] == context else { return }
+            await self.handleMessage(
+                data,
+                projectId: projectId,
+                client: client,
+                context: context
+            )
         }
 
         client.connect(serverUrl: serverUrl, roomId: roomId, authToken: authToken)
@@ -122,9 +193,11 @@ public final class DocumentSyncManager: ObservableObject {
 
     /// Disconnect from a project's sync room.
     public func disconnectProject(_ projectId: String) {
-        projectClients[projectId]?.disconnect()
-        projectClients.removeValue(forKey: projectId)
+        let retiredClient = projectClients.removeValue(forKey: projectId)
         projectConnected.removeValue(forKey: projectId)
+        projectContexts.removeValue(forKey: projectId)
+        projectGenerationScopes.removeValue(forKey: projectId)
+        retiredClient?.disconnect()
         // Keep offline queue -- it will replay if we reconnect later
         if activeProjectId == projectId {
             activeProjectId = nil
@@ -134,14 +207,17 @@ public final class DocumentSyncManager: ObservableObject {
 
     /// Disconnect from all project rooms.
     public func disconnectAll() {
-        for (_, client) in projectClients {
-            client.disconnect()
-        }
+        let retiredClients = Array(projectClients.values)
         projectClients.removeAll()
         projectConnected.removeAll()
+        projectContexts.removeAll()
+        projectGenerationScopes.removeAll()
         offlineQueues.removeAll()
         activeProjectId = nil
         isConnected = false
+        for client in retiredClients {
+            client.disconnect()
+        }
     }
 
     /// Reconnect active project if WebSocket was dropped (e.g., app returning from background).
@@ -216,7 +292,17 @@ public final class DocumentSyncManager: ObservableObject {
 
     // MARK: - Message Handling
 
-    private func handleMessage(_ data: Data, projectId: String) {
+    private func handleMessage(
+        _ data: Data,
+        projectId: String,
+        client: WebSocketClient,
+        context: WebSocketConnectionContext
+    ) async {
+        await messageWillHandle(data, projectId)
+        guard projectClients[projectId] === client,
+              projectGenerationScopes[projectId]?.clientId == ObjectIdentifier(client),
+              projectContexts[projectId] == context else { return }
+
         guard let envelope = try? decoder.decode(ServerMessage.self, from: data) else {
             logger.error("[DocSync] Failed to decode message envelope")
             return

--- a/packages/ios/NimbalystNative/Sources/Sync/SyncManager.swift
+++ b/packages/ios/NimbalystNative/Sources/Sync/SyncManager.swift
@@ -236,6 +236,7 @@ public final class SyncManager: ObservableObject {
     private var sessionCatchUpSessionId: String?
     private var sessionCatchUpEpoch: UInt64 = 0
     private var sessionCatchUpAuthority: SessionCatchUpAuthority?
+    private var sessionCatchUpRequestGeneration: UInt64 = 0
     private var sessionSyncTotalCount = 0
     private var sessionSyncStoredCount = 0
     private var sessionSyncFailedIds: [String] = []
@@ -1216,9 +1217,11 @@ public final class SyncManager: ObservableObject {
 
     // MARK: - Error Handling
 
-    private func handleServerError(_ data: Data) {
-        guard let error = try? decoder.decode(ServerError.self, from: data) else { return }
+    @discardableResult
+    private func handleServerError(_ data: Data) -> ServerError? {
+        guard let error = try? decoder.decode(ServerError.self, from: data) else { return nil }
         logger.error("Server error [\(error.code)]: \(error.message)")
+        return error
     }
 
     // MARK: - Session Client Setup
@@ -1261,6 +1264,7 @@ public final class SyncManager: ObservableObject {
     private func resetSessionCatchUp(for sessionId: String?) {
         sessionCatchUpEpoch &+= 1
         sessionCatchUpAuthority = nil
+        sessionCatchUpRequestGeneration = 0
         sessionCatchUpInFlight = false
         sessionCatchUpPending = false
         sessionCatchUpSessionId = sessionId
@@ -1285,6 +1289,7 @@ public final class SyncManager: ObservableObject {
             context: context
         )
         sessionCatchUpAuthority = authority
+        sessionCatchUpRequestGeneration = 0
         sessionCatchUpInFlight = true
         sessionCatchUpPending = false
         sessionCatchUpSessionId = sessionId
@@ -1301,6 +1306,22 @@ public final class SyncManager: ObservableObject {
             && sessionCatchUpSessionId == authority.sessionId
             && activeSessionId == authority.sessionId
             && activeSessionContext == authority.context
+    }
+
+    private func scheduleSessionCatchUpResponseTimeout(
+        for authority: SessionCatchUpAuthority
+    ) {
+        sessionCatchUpRequestGeneration &+= 1
+        let requestGeneration = sessionCatchUpRequestGeneration
+        scheduler.schedule(after: 15.0) { [weak self] in
+            guard let self,
+                  self.ownsSessionCatchUp(authority),
+                  self.sessionCatchUpRequestGeneration == requestGeneration else { return }
+            self.finishSessionCatchUp(
+                authority: authority,
+                error: "Session sync response timed out"
+            )
+        }
     }
 
     private func requestSessionSync() {
@@ -1405,6 +1426,7 @@ public final class SyncManager: ObservableObject {
                 }
             } else {
                 self.logger.debug("requestSessionSync: send acknowledged for \(sessionId)")
+                self.scheduleSessionCatchUpResponseTimeout(for: authority)
             }
         }
     }
@@ -1428,7 +1450,19 @@ public final class SyncManager: ObservableObject {
         case "metadataBroadcast":
             handleMetadataBroadcast(data, sessionId: sessionId)
         case "error":
-            handleServerError(data)
+            let serverError = handleServerError(data)
+            if let authority = sessionCatchUpAuthority,
+               authority.sessionId == sessionId,
+               authority.context == context,
+               ownsSessionCatchUp(authority) {
+                let detail: String
+                if let serverError {
+                    detail = "Server sync error [\(serverError.code)]: \(serverError.message)"
+                } else {
+                    detail = "Server sync error"
+                }
+                finishSessionCatchUp(authority: authority, error: detail)
+            }
         default:
             logger.info("Unhandled session message type: \(envelope.type)")
         }

--- a/packages/ios/NimbalystNative/Sources/Sync/SyncManager.swift
+++ b/packages/ios/NimbalystNative/Sources/Sync/SyncManager.swift
@@ -42,6 +42,37 @@ enum SessionRoomEventGate {
     }
 }
 
+enum WebSocketConnectedContextGate {
+    /// A connected callback may arrive after a replacement connection has
+    /// already been accepted. Only a strictly newer generation may advance
+    /// manager-owned context; disconnect/message events still require equality.
+    static func accepts(
+        highestAcceptedGeneration: Int?,
+        incomingContext: WebSocketConnectionContext
+    ) -> Bool {
+        guard let highestAcceptedGeneration else { return true }
+        return incomingContext.generation > highestAcceptedGeneration
+    }
+}
+
+struct SessionCatchUpAuthority: Equatable {
+    let epoch: UInt64
+    let sessionId: String
+    let context: WebSocketConnectionContext
+}
+
+@MainActor
+protocol SessionCatchUpYielding: AnyObject {
+    func yieldAfterPersistedChunk() async
+}
+
+@MainActor
+final class TaskSessionCatchUpYielder: SessionCatchUpYielding {
+    func yieldAfterPersistedChunk() async {
+        await Task.yield()
+    }
+}
+
 typealias SyncScheduledOperation = @MainActor () -> Void
 
 @MainActor
@@ -198,13 +229,18 @@ public final class SyncManager: ObservableObject {
     private var foregroundReconnectGate = ForegroundReconnectGate(initiallyForeground: true)
     private var activeIndexContext: WebSocketConnectionContext?
     private var activeSessionContext: WebSocketConnectionContext?
+    private var highestAcceptedIndexGeneration: Int?
+    private var highestAcceptedSessionGeneration: Int?
     private var sessionCatchUpInFlight = false
     private var sessionCatchUpPending = false
     private var sessionCatchUpSessionId: String?
+    private var sessionCatchUpEpoch: UInt64 = 0
+    private var sessionCatchUpAuthority: SessionCatchUpAuthority?
     private var sessionSyncTotalCount = 0
     private var sessionSyncStoredCount = 0
     private var sessionSyncFailedIds: [String] = []
     private var sessionSyncFailedSequences: [Int] = []
+    private let sessionCatchUpYielder: any SessionCatchUpYielding
 
     public convenience init(crypto: CryptoManager, database: DatabaseManager, serverUrl: String, userId: String) {
         self.init(
@@ -215,7 +251,8 @@ public final class SyncManager: ObservableObject {
             indexClient: WebSocketClient(),
             sessionClient: WebSocketClient(),
             scheduler: MainQueueSyncScheduler(),
-            indexExecutor: SerialIndexWorkExecutor()
+            indexExecutor: SerialIndexWorkExecutor(),
+            sessionCatchUpYielder: TaskSessionCatchUpYielder()
         )
     }
 
@@ -227,7 +264,8 @@ public final class SyncManager: ObservableObject {
         indexClient: any SyncWebSocketClient,
         sessionClient: any SyncWebSocketClient,
         scheduler: any SyncScheduling,
-        indexExecutor: any IndexWorkExecuting
+        indexExecutor: any IndexWorkExecuting,
+        sessionCatchUpYielder: any SessionCatchUpYielding = TaskSessionCatchUpYielder()
     ) {
         self.crypto = crypto
         self.database = database
@@ -237,6 +275,7 @@ public final class SyncManager: ObservableObject {
         self.sessionClient = sessionClient
         self.scheduler = scheduler
         self.indexExecutor = indexExecutor
+        self.sessionCatchUpYielder = sessionCatchUpYielder
         self.indexClient.sendsDeviceAnnounce = true
 
         setupIndexClient()
@@ -373,32 +412,33 @@ public final class SyncManager: ObservableObject {
 
     private func setupIndexClient() {
         indexClient.onConnectionStateChangedWithContext = { [weak self] connected, context in
-            Task { @MainActor in
-                guard let self else { return }
-                if connected {
-                    self.activeIndexContext = context
-                    self.indexExecutor.setActiveGeneration(context.generation)
-                    self.isConnected = true
-                    self.requestIndexSync()
-                    if NotificationManager.shared.shouldRegisterForPush,
-                       let token = NotificationManager.shared.deviceToken {
-                        self.registerPushToken(token)
-                    } else {
-                        self.unregisterPushToken()
-                    }
-                } else if self.activeIndexContext == context {
-                    self.activeIndexContext = nil
-                    self.indexExecutor.setActiveGeneration(nil)
-                    self.isConnected = false
+            guard let self else { return }
+            if connected {
+                guard WebSocketConnectedContextGate.accepts(
+                    highestAcceptedGeneration: self.highestAcceptedIndexGeneration,
+                    incomingContext: context
+                ) else { return }
+                self.highestAcceptedIndexGeneration = context.generation
+                self.activeIndexContext = context
+                self.indexExecutor.setActiveGeneration(context.generation)
+                self.isConnected = true
+                self.requestIndexSync()
+                if NotificationManager.shared.shouldRegisterForPush,
+                   let token = NotificationManager.shared.deviceToken {
+                    self.registerPushToken(token)
+                } else {
+                    self.unregisterPushToken()
                 }
+            } else if self.activeIndexContext == context {
+                self.activeIndexContext = nil
+                self.indexExecutor.setActiveGeneration(nil)
+                self.isConnected = false
             }
         }
 
         indexClient.onMessageWithContext = { [weak self] data, context in
-            Task { @MainActor in
-                guard let self, self.activeIndexContext == context else { return }
-                self.handleIndexMessage(data, context: context)
-            }
+            guard let self, self.activeIndexContext == context else { return }
+            self.handleIndexMessage(data, context: context)
         }
     }
 
@@ -419,17 +459,15 @@ public final class SyncManager: ObservableObject {
               let json = String(data: data, encoding: .utf8) else { return }
 
         indexClient.sendRaw(json) { [weak self] error in
-            Task { @MainActor in
-                guard let self,
-                      error != nil,
-                      self.activeIndexContext == context,
-                      attempt < 3 else { return }
+            guard let self,
+                  error != nil,
+                  self.activeIndexContext == context,
+                  attempt < 3 else { return }
 
-                self.logger.info("Index sync request failed, retrying (attempt \(attempt + 1))")
-                self.scheduler.schedule(after: 1.0) { [weak self] in
-                    guard let self, self.activeIndexContext == context else { return }
-                    self.requestIndexSync(fullSync: fullSync, attempt: attempt + 1)
-                }
+            self.logger.info("Index sync request failed, retrying (attempt \(attempt + 1))")
+            self.scheduler.schedule(after: 1.0) { [weak self] in
+                guard let self, self.activeIndexContext == context else { return }
+                self.requestIndexSync(fullSync: fullSync, attempt: attempt + 1)
             }
         }
     }
@@ -1187,39 +1225,42 @@ public final class SyncManager: ObservableObject {
 
     private func setupSessionClient() {
         sessionClient.onConnectionStateChangedWithContext = { [weak self] connected, context in
-            Task { @MainActor in
-                guard let self = self else { return }
-                self.logger.info("sessionClient connection state: \(connected) (activeSessionId=\(self.activeSessionId ?? "nil"))")
-                if connected {
-                    guard let sessionId = self.activeSessionId else { return }
-                    let expectedRoomId = self.sessionRoomId(for: sessionId)
-                    guard context.roomId == expectedRoomId else { return }
-                    self.activeSessionContext = context
-                    self.resetSessionCatchUp(for: sessionId)
-                    self.requestSessionSync()
-                } else if self.activeSessionContext == context {
-                    self.activeSessionContext = nil
-                    self.sessionCatchUpInFlight = false
-                }
+            guard let self else { return }
+            self.logger.info("sessionClient connection state: \(connected) (activeSessionId=\(self.activeSessionId ?? "nil"))")
+            if connected {
+                guard let sessionId = self.activeSessionId else { return }
+                let expectedRoomId = self.sessionRoomId(for: sessionId)
+                guard context.roomId == expectedRoomId,
+                      WebSocketConnectedContextGate.accepts(
+                        highestAcceptedGeneration: self.highestAcceptedSessionGeneration,
+                        incomingContext: context
+                      ) else { return }
+                self.highestAcceptedSessionGeneration = context.generation
+                self.activeSessionContext = context
+                self.resetSessionCatchUp(for: sessionId)
+                self.requestSessionSync()
+            } else if self.activeSessionContext == context {
+                self.activeSessionContext = nil
+                self.invalidateSessionCatchUp(for: self.activeSessionId)
             }
         }
 
         sessionClient.onMessageWithContext = { [weak self] data, context in
-            Task { @MainActor in
-                guard let self, let sessionId = self.activeSessionId else { return }
-                let expectedRoomId = self.sessionRoomId(for: sessionId)
-                guard SessionRoomEventGate.accepts(
-                    activeSessionId: sessionId,
-                    expectedRoomId: expectedRoomId,
-                    activeContext: self.activeSessionContext,
-                    eventContext: context
-                ) else { return }
-                await self.handleSessionMessage(data, sessionId: sessionId, context: context)
-            }
+            guard let self, let sessionId = self.activeSessionId else { return }
+            let expectedRoomId = self.sessionRoomId(for: sessionId)
+            guard SessionRoomEventGate.accepts(
+                activeSessionId: sessionId,
+                expectedRoomId: expectedRoomId,
+                activeContext: self.activeSessionContext,
+                eventContext: context
+            ) else { return }
+            await self.handleSessionMessage(data, sessionId: sessionId, context: context)
         }
     }
 
     private func resetSessionCatchUp(for sessionId: String?) {
+        sessionCatchUpEpoch &+= 1
+        sessionCatchUpAuthority = nil
         sessionCatchUpInFlight = false
         sessionCatchUpPending = false
         sessionCatchUpSessionId = sessionId
@@ -1229,23 +1270,56 @@ public final class SyncManager: ObservableObject {
         sessionSyncFailedSequences = []
     }
 
+    private func invalidateSessionCatchUp(for sessionId: String?) {
+        resetSessionCatchUp(for: sessionId)
+    }
+
+    private func beginSessionCatchUp(
+        sessionId: String,
+        context: WebSocketConnectionContext
+    ) -> SessionCatchUpAuthority {
+        sessionCatchUpEpoch &+= 1
+        let authority = SessionCatchUpAuthority(
+            epoch: sessionCatchUpEpoch,
+            sessionId: sessionId,
+            context: context
+        )
+        sessionCatchUpAuthority = authority
+        sessionCatchUpInFlight = true
+        sessionCatchUpPending = false
+        sessionCatchUpSessionId = sessionId
+        sessionSyncTotalCount = 0
+        sessionSyncStoredCount = 0
+        sessionSyncFailedIds = []
+        sessionSyncFailedSequences = []
+        return authority
+    }
+
+    private func ownsSessionCatchUp(_ authority: SessionCatchUpAuthority) -> Bool {
+        sessionCatchUpInFlight
+            && sessionCatchUpAuthority == authority
+            && sessionCatchUpSessionId == authority.sessionId
+            && activeSessionId == authority.sessionId
+            && activeSessionContext == authority.context
+    }
+
     private func requestSessionSync() {
         guard let sessionId = activeSessionId else {
             logger.warning("requestSessionSync skipped: activeSessionId is nil (connection state fired without a target)")
             return
         }
-        guard activeSessionContext != nil else {
+        guard let context = activeSessionContext else {
             logger.debug("requestSessionSync deferred until the session connection is current")
             sessionCatchUpPending = true
             return
         }
 
-        if sessionCatchUpInFlight, sessionCatchUpSessionId == sessionId {
+        if let authority = sessionCatchUpAuthority,
+           ownsSessionCatchUp(authority) {
             sessionCatchUpPending = true
             return
         }
-        resetSessionCatchUp(for: sessionId)
-        sessionCatchUpInFlight = true
+        let authority = beginSessionCatchUp(sessionId: sessionId, context: context)
 
         let localMessages = (try? database.messages(forSession: sessionId)) ?? []
         let localCount = localMessages.count
@@ -1268,22 +1342,30 @@ public final class SyncManager: ObservableObject {
             sinceSeq = nil
         }
 
-        sendSessionSyncRequest(sessionId: sessionId, sinceSeq: sinceSeq)
+        sendSessionSyncRequest(
+            sessionId: sessionId,
+            sinceSeq: sinceSeq,
+            authority: authority
+        )
     }
 
     private func sendSessionSyncRequest(
         sessionId: String,
         sinceSeq: Int?,
-        attempt: Int = 0
+        attempt: Int = 0,
+        authority: SessionCatchUpAuthority
     ) {
-        guard activeSessionId == sessionId,
-              let context = activeSessionContext else { return }
+        guard authority.sessionId == sessionId,
+              ownsSessionCatchUp(authority) else { return }
 
         let request = SessionSyncRequest(sinceSeq: sinceSeq)
         guard let data = try? JSONEncoder().encode(request),
               let json = String(data: data, encoding: .utf8) else {
             logger.error("requestSessionSync failed to encode request for session \(sessionId)")
-            sessionCatchUpInFlight = false
+            finishSessionCatchUp(
+                authority: authority,
+                error: "Sync request encode failed"
+            )
             return
         }
 
@@ -1298,31 +1380,31 @@ public final class SyncManager: ObservableObject {
         // Without a successful syncRequest, the server won't mark this connection
         // as synced and won't include it in message broadcasts.
         sessionClient.sendRaw(json) { [weak self] error in
-            Task { @MainActor in
-                guard let self,
-                      self.activeSessionId == sessionId,
-                      self.activeSessionContext == context else { return }
-                if let error {
-                    self.logger.warning("requestSessionSync send failed for \(sessionId): \(error.localizedDescription)")
-                    guard attempt < 3 else {
-                        self.sessionCatchUpInFlight = false
-                        return
-                    }
-
-                    self.logger.info("Session sync request failed, retrying (attempt \(attempt + 1))")
-                    self.scheduler.schedule(after: 1.0) { [weak self] in
-                        guard let self,
-                              self.activeSessionId == sessionId,
-                              self.activeSessionContext == context else { return }
-                        self.sendSessionSyncRequest(
-                            sessionId: sessionId,
-                            sinceSeq: sinceSeq,
-                            attempt: attempt + 1
-                        )
-                    }
-                } else {
-                    self.logger.debug("requestSessionSync: send acknowledged for \(sessionId)")
+            guard let self,
+                  self.ownsSessionCatchUp(authority) else { return }
+            if let error {
+                self.logger.warning("requestSessionSync send failed for \(sessionId): \(error.localizedDescription)")
+                guard attempt < 3 else {
+                    self.finishSessionCatchUp(
+                        authority: authority,
+                        error: "Sync request failed: \(error.localizedDescription)"
+                    )
+                    return
                 }
+
+                self.logger.info("Session sync request failed, retrying (attempt \(attempt + 1))")
+                self.scheduler.schedule(after: 1.0) { [weak self] in
+                    guard let self,
+                          self.ownsSessionCatchUp(authority) else { return }
+                    self.sendSessionSyncRequest(
+                        sessionId: sessionId,
+                        sinceSeq: sinceSeq,
+                        attempt: attempt + 1,
+                        authority: authority
+                    )
+                }
+            } else {
+                self.logger.debug("requestSessionSync: send acknowledged for \(sessionId)")
             }
         }
     }
@@ -1359,9 +1441,10 @@ public final class SyncManager: ObservableObject {
         sessionId: String,
         context: WebSocketConnectionContext
     ) async {
-        guard sessionCatchUpInFlight,
-              sessionCatchUpSessionId == sessionId,
-              activeSessionContext == context else { return }
+        guard let authority = sessionCatchUpAuthority,
+              authority.sessionId == sessionId,
+              authority.context == context,
+              ownsSessionCatchUp(authority) else { return }
 
         let response: SessionSyncResponse
         do {
@@ -1371,7 +1454,7 @@ public final class SyncManager: ObservableObject {
             let rawPreview = String(data: data.prefix(500), encoding: .utf8) ?? "<binary>"
             logger.error("Failed to decode session syncResponse: \(error.localizedDescription) — raw: \(rawPreview)")
             finishSessionCatchUp(
-                sessionId: sessionId,
+                authority: authority,
                 error: "Sync response decode failed: \(error.localizedDescription)"
             )
             return
@@ -1379,8 +1462,7 @@ public final class SyncManager: ObservableObject {
 
         sessionSyncTotalCount += response.messages.count
         for entryChunk in SessionFeedBatching.chunks(response.messages) {
-            guard activeSessionId == sessionId,
-                  activeSessionContext == context else { return }
+            guard ownsSessionCatchUp(authority) else { return }
 
             var decrypted: [Message] = []
             for entry in entryChunk {
@@ -1402,41 +1484,55 @@ public final class SyncManager: ObservableObject {
             } catch {
                 logger.error("Failed to store session message chunk: \(error.localizedDescription)")
                 finishSessionCatchUp(
-                    sessionId: sessionId,
+                    authority: authority,
                     error: "Database write failed: \(error.localizedDescription)"
                 )
                 return
             }
-            await Task.yield()
+            await sessionCatchUpYielder.yieldAfterPersistedChunk()
+            guard ownsSessionCatchUp(authority) else { return }
         }
 
+        guard ownsSessionCatchUp(authority) else { return }
         if let metadata = response.metadata {
             applySessionMetadata(metadata, sessionId: sessionId)
         }
 
+        guard ownsSessionCatchUp(authority) else { return }
         if response.hasMore {
             guard let cursor = response.cursor,
                   let sinceSeq = Int(cursor) else {
                 finishSessionCatchUp(
-                    sessionId: sessionId,
+                    authority: authority,
                     error: "Missing or invalid session sync cursor"
                 )
                 return
             }
-            sendSessionSyncRequest(sessionId: sessionId, sinceSeq: sinceSeq)
+            guard ownsSessionCatchUp(authority) else { return }
+            sendSessionSyncRequest(
+                sessionId: sessionId,
+                sinceSeq: sinceSeq,
+                authority: authority
+            )
         } else {
-            finishSessionCatchUp(sessionId: sessionId, error: nil)
+            guard ownsSessionCatchUp(authority) else { return }
+            finishSessionCatchUp(authority: authority, error: nil)
         }
     }
 
-    private func finishSessionCatchUp(sessionId: String, error: String?) {
-        guard sessionCatchUpSessionId == sessionId else { return }
+    private func finishSessionCatchUp(
+        authority: SessionCatchUpAuthority,
+        error: String?
+    ) {
+        guard ownsSessionCatchUp(authority) else { return }
+        let sessionId = authority.sessionId
 
         let totalCount = sessionSyncTotalCount
         let storedCount = sessionSyncStoredCount
         let failedIds = sessionSyncFailedIds
         let failedSequences = sessionSyncFailedSequences
         sessionCatchUpInFlight = false
+        sessionCatchUpAuthority = nil
 
         let diagnosticError: String?
         if let error {
@@ -1462,7 +1558,7 @@ public final class SyncManager: ObservableObject {
 
         if sessionCatchUpPending,
            activeSessionId == sessionId,
-           activeSessionContext != nil {
+           activeSessionContext == authority.context {
             sessionCatchUpPending = false
             requestSessionSync()
         }

--- a/packages/ios/NimbalystNative/Sources/Sync/SyncManager.swift
+++ b/packages/ios/NimbalystNative/Sources/Sync/SyncManager.swift
@@ -2,6 +2,106 @@ import Foundation
 import Combine
 import os
 
+struct ForegroundReconnectGate {
+    private var isForeground: Bool
+
+    init(initiallyForeground: Bool) {
+        isForeground = initiallyForeground
+    }
+
+    /// Returns true only for a background -> foreground transition.
+    mutating func update(isForeground: Bool) -> Bool {
+        let shouldRecover = !self.isForeground && isForeground
+        self.isForeground = isForeground
+        return shouldRecover
+    }
+}
+
+enum SessionFeedBatching {
+    static let defaultLimit = 128
+
+    static func chunks<Element>(_ elements: [Element], limit: Int = defaultLimit) -> [[Element]] {
+        precondition(limit > 0)
+        guard !elements.isEmpty else { return [] }
+        return stride(from: 0, to: elements.count, by: limit).map { start in
+            Array(elements[start..<min(start + limit, elements.count)])
+        }
+    }
+}
+
+enum SessionRoomEventGate {
+    static func accepts(
+        activeSessionId: String?,
+        expectedRoomId: String,
+        activeContext: WebSocketConnectionContext?,
+        eventContext: WebSocketConnectionContext
+    ) -> Bool {
+        activeSessionId != nil
+            && eventContext.roomId == expectedRoomId
+            && eventContext == activeContext
+    }
+}
+
+typealias SyncScheduledOperation = @MainActor () -> Void
+
+@MainActor
+protocol SyncScheduling: AnyObject {
+    func schedule(after delay: TimeInterval, _ operation: @escaping SyncScheduledOperation)
+}
+
+@MainActor
+final class MainQueueSyncScheduler: SyncScheduling {
+    func schedule(after delay: TimeInterval, _ operation: @escaping SyncScheduledOperation) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            operation()
+        }
+    }
+}
+
+typealias IndexGenerationCheck = () -> Bool
+typealias IndexWork = (IndexGenerationCheck) -> Void
+
+private final class IndexWorkBox: @unchecked Sendable {
+    let work: IndexWork
+
+    init(_ work: @escaping IndexWork) {
+        self.work = work
+    }
+}
+
+protocol IndexWorkExecuting: AnyObject {
+    func setActiveGeneration(_ generation: Int?)
+    func enqueue(generation: Int, _ work: @escaping IndexWork)
+}
+
+/// A single serial lane for index database application. Updating the active
+/// generation invalidates queued work from a replaced socket; work also gets a
+/// generation check so it can stop before each durable write.
+final class SerialIndexWorkExecutor: IndexWorkExecuting, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "com.nimbalyst.app.index-application")
+    private let lock = NSLock()
+    private var activeGeneration: Int?
+
+    func setActiveGeneration(_ generation: Int?) {
+        lock.withLock {
+            activeGeneration = generation
+        }
+    }
+
+    func enqueue(generation: Int, _ work: @escaping IndexWork) {
+        let box = IndexWorkBox(work)
+        queue.async { [weak self] in
+            guard let self else { return }
+            let isCurrent: IndexGenerationCheck = { [weak self] in
+                guard let self else { return false }
+                return self.lock.withLock { self.activeGeneration == generation }
+            }
+            guard isCurrent() else { return }
+            box.work(isCurrent)
+        }
+    }
+}
+
 /// Manages synchronization between the native app and the desktop via WebSocket.
 /// Handles index room sync (projects + sessions) and session room sync (messages).
 ///
@@ -16,12 +116,10 @@ public final class SyncManager: ObservableObject {
 
     private let crypto: CryptoManager
     private let database: DatabaseManager
-    private let indexClient: WebSocketClient = {
-        let client = WebSocketClient()
-        client.sendsDeviceAnnounce = true
-        return client
-    }()
-    private let sessionClient = WebSocketClient()
+    private let indexClient: any SyncWebSocketClient
+    private let sessionClient: any SyncWebSocketClient
+    private let scheduler: any SyncScheduling
+    private let indexExecutor: any IndexWorkExecuting
     private let decoder = JSONDecoder()
 
     @Published public var isConnected = false
@@ -97,14 +195,49 @@ public final class SyncManager: ObservableObject {
     /// The Stytch organization ID for org-scoped room IDs.
     private var orgId: String?
 
-    /// Buffer for paginated sync responses before committing to DB.
-    private var sessionSyncBuffer: [ServerMessageEntry] = []
+    private var foregroundReconnectGate = ForegroundReconnectGate(initiallyForeground: true)
+    private var activeIndexContext: WebSocketConnectionContext?
+    private var activeSessionContext: WebSocketConnectionContext?
+    private var sessionCatchUpInFlight = false
+    private var sessionCatchUpPending = false
+    private var sessionCatchUpSessionId: String?
+    private var sessionSyncTotalCount = 0
+    private var sessionSyncStoredCount = 0
+    private var sessionSyncFailedIds: [String] = []
+    private var sessionSyncFailedSequences: [Int] = []
 
-    public init(crypto: CryptoManager, database: DatabaseManager, serverUrl: String, userId: String) {
+    public convenience init(crypto: CryptoManager, database: DatabaseManager, serverUrl: String, userId: String) {
+        self.init(
+            crypto: crypto,
+            database: database,
+            serverUrl: serverUrl,
+            userId: userId,
+            indexClient: WebSocketClient(),
+            sessionClient: WebSocketClient(),
+            scheduler: MainQueueSyncScheduler(),
+            indexExecutor: SerialIndexWorkExecutor()
+        )
+    }
+
+    init(
+        crypto: CryptoManager,
+        database: DatabaseManager,
+        serverUrl: String,
+        userId: String,
+        indexClient: any SyncWebSocketClient,
+        sessionClient: any SyncWebSocketClient,
+        scheduler: any SyncScheduling,
+        indexExecutor: any IndexWorkExecuting
+    ) {
         self.crypto = crypto
         self.database = database
         self.serverUrl = serverUrl
         self.userId = userId
+        self.indexClient = indexClient
+        self.sessionClient = sessionClient
+        self.scheduler = scheduler
+        self.indexExecutor = indexExecutor
+        self.indexClient.sendsDeviceAnnounce = true
 
         setupIndexClient()
         setupSessionClient()
@@ -124,24 +257,14 @@ public final class SyncManager: ObservableObject {
     /// When returning to foreground, reconnects WebSockets if they were dropped while backgrounded.
     public func setAppInForeground(_ inForeground: Bool) {
         indexClient.setAppInForeground(inForeground)
-        if inForeground {
+        if foregroundReconnectGate.update(isForeground: inForeground) {
             reconnectIfNeeded()
-            // Defense in depth: even if the reconnect's onConnectionStateChanged
-            // callback fires the sync request, also trigger one explicitly
-            // here. Two sync requests are harmless (database appends are
-            // idempotent on message ID), and this guarantees a catch-up
-            // happens even if the reconnect callback chain ever changes.
-            if activeSessionId != nil {
-                requestSessionSync()
-            }
         }
     }
 
-    /// Reconnect the index WebSocket if it was dropped (e.g., by iOS suspending the app).
-    /// Also reconnects the active session room if one was open.
+    /// Replace both sockets after every real background -> foreground transition.
     ///
-    /// The session client is reconnected unconditionally (not gated on
-    /// `isConnected`) because URLSessionWebSocketTask can hold a backgrounded
+    /// URLSessionWebSocketTask can hold a backgrounded
     /// task in `.running` state long after the underlying TCP connection has
     /// died, so `isConnected` would lie and the user would be left with a
     /// silently-dead transcript channel until they navigate away and back.
@@ -150,10 +273,8 @@ public final class SyncManager: ObservableObject {
     /// reconnect (via `onConnectionStateChanged`), so any broadcasts dropped
     /// while we were backgrounded are caught up via the syncResponse cursor.
     private func reconnectIfNeeded() {
-        if !indexClient.isConnected {
-            logger.info("[Reconnect] Index client disconnected, reconnecting...")
-            indexClient.reconnect()
-        }
+        logger.info("[Reconnect] Forcing index client reconnect and catch-up")
+        indexClient.reconnect()
         if let sessionId = activeSessionId {
             logger.info("[Reconnect] Forcing session client reconnect for \(sessionId)")
             sessionClient.reconnect()
@@ -189,6 +310,10 @@ public final class SyncManager: ObservableObject {
         authUserId ?? userId
     }
 
+    private func sessionRoomId(for sessionId: String) -> String {
+        "org:\(orgId ?? ""):user:\(effectiveUserId):session:\(sessionId)"
+    }
+
     /// Disconnect from all rooms.
     public func disconnect() {
         leaveSessionRoom()
@@ -209,9 +334,10 @@ public final class SyncManager: ObservableObject {
         }
 
         activeSessionId = sessionId
-        sessionSyncBuffer = []
+        activeSessionContext = nil
+        resetSessionCatchUp(for: sessionId)
 
-        let roomId = "org:\(orgId ?? ""):user:\(effectiveUserId):session:\(sessionId)"
+        let roomId = sessionRoomId(for: sessionId)
         sessionClient.connect(serverUrl: serverUrl, roomId: roomId, authToken: authToken)
 
         // If the session is already mid-turn when we join, start pings now.
@@ -239,30 +365,39 @@ public final class SyncManager: ObservableObject {
         }
         sessionClient.disconnect()
         activeSessionId = nil
-        sessionSyncBuffer = []
+        activeSessionContext = nil
+        resetSessionCatchUp(for: nil)
     }
 
     // MARK: - Index Client Setup
 
     private func setupIndexClient() {
-        indexClient.onConnectionStateChanged = { [weak self] connected in
+        indexClient.onConnectionStateChangedWithContext = { [weak self] connected, context in
             Task { @MainActor in
-                self?.isConnected = connected
+                guard let self else { return }
                 if connected {
-                    self?.requestIndexSync()
+                    self.activeIndexContext = context
+                    self.indexExecutor.setActiveGeneration(context.generation)
+                    self.isConnected = true
+                    self.requestIndexSync()
                     if NotificationManager.shared.shouldRegisterForPush,
                        let token = NotificationManager.shared.deviceToken {
-                        self?.registerPushToken(token)
+                        self.registerPushToken(token)
                     } else {
-                        self?.unregisterPushToken()
+                        self.unregisterPushToken()
                     }
+                } else if self.activeIndexContext == context {
+                    self.activeIndexContext = nil
+                    self.indexExecutor.setActiveGeneration(nil)
+                    self.isConnected = false
                 }
             }
         }
 
-        indexClient.onMessage = { [weak self] data in
+        indexClient.onMessageWithContext = { [weak self] data, context in
             Task { @MainActor in
-                self?.handleIndexMessage(data)
+                guard let self, self.activeIndexContext == context else { return }
+                self.handleIndexMessage(data, context: context)
             }
         }
     }
@@ -276,6 +411,7 @@ public final class SyncManager: ObservableObject {
     /// By default, sends the last sync watermark for incremental sync.
     /// Pass `fullSync: true` to request everything (e.g., pull-to-refresh).
     private func requestIndexSync(fullSync: Bool = false, attempt: Int = 0) {
+        guard let context = activeIndexContext else { return }
         let since: Int? = fullSync ? nil : (try? database.syncState(forRoom: "index"))?.lastSyncedAt
 
         let request = IndexSyncRequest(projectId: nil, since: since)
@@ -283,19 +419,24 @@ public final class SyncManager: ObservableObject {
               let json = String(data: data, encoding: .utf8) else { return }
 
         indexClient.sendRaw(json) { [weak self] error in
-            guard let self = self, error != nil else { return }
-            guard attempt < 3 else { return }
+            Task { @MainActor in
+                guard let self,
+                      error != nil,
+                      self.activeIndexContext == context,
+                      attempt < 3 else { return }
 
-            self.logger.info("Index sync request failed, retrying (attempt \(attempt + 1))")
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-                self?.requestIndexSync(attempt: attempt + 1)
+                self.logger.info("Index sync request failed, retrying (attempt \(attempt + 1))")
+                self.scheduler.schedule(after: 1.0) { [weak self] in
+                    guard let self, self.activeIndexContext == context else { return }
+                    self.requestIndexSync(fullSync: fullSync, attempt: attempt + 1)
+                }
             }
         }
     }
 
     // MARK: - Message Handling
 
-    private func handleIndexMessage(_ data: Data) {
+    private func handleIndexMessage(_ data: Data, context: WebSocketConnectionContext) {
         // First, determine the message type
         guard let envelope = try? decoder.decode(ServerMessage.self, from: data) else {
             logger.warning("Could not decode message type")
@@ -304,13 +445,13 @@ public final class SyncManager: ObservableObject {
 
         switch envelope.type {
         case "indexSyncResponse":
-            handleIndexSyncResponse(data)
+            enqueueIndexSyncResponse(data, context: context)
         case "indexBroadcast":
-            handleIndexBroadcast(data)
+            enqueueIndexBroadcast(data, context: context)
         case "indexDeleteBroadcast":
-            handleIndexDeleteBroadcast(data)
+            enqueueIndexDeleteBroadcast(data, context: context)
         case "projectBroadcast":
-            handleProjectBroadcast(data)
+            enqueueProjectBroadcast(data, context: context)
         case "createSessionResponseBroadcast":
             handleCreateSessionResponse(data)
         case "devicesList":
@@ -336,7 +477,10 @@ public final class SyncManager: ObservableObject {
 
     // MARK: - Index Sync Response
 
-    private func handleIndexSyncResponse(_ data: Data) {
+    private func enqueueIndexSyncResponse(
+        _ data: Data,
+        context: WebSocketConnectionContext
+    ) {
         guard let response = try? decoder.decode(IndexSyncResponse.self, from: data) else {
             logger.error("Failed to decode index_sync_response")
             return
@@ -348,20 +492,19 @@ public final class SyncManager: ObservableObject {
         }
         logger.info("Index sync received: \(response.sessions.count) sessions, \(response.projects.count) projects\(isIncremental ? " (incremental)" : "") (server total: \(response.totalSessionCount.map(String.init) ?? "unknown"))")
 
-        // Heavy crypto + DB work runs off the main thread to avoid UI freezes
         let crypto = self.crypto
         let database = self.database
-        Task.detached {
-            // Process projects
+        indexExecutor.enqueue(generation: context.generation) { [weak self] isCurrent in
             for serverProject in response.projects {
+                guard isCurrent() else { return }
                 Self.processServerProjectBackground(serverProject, crypto: crypto, database: database)
             }
 
-            // Process sessions - track success/failure/skip counts
             var processedCount = 0
             var skippedCount = 0
             var failedDecryptCount = 0
             for serverSession in response.sessions {
+                guard isCurrent() else { return }
                 let result = Self.processServerSessionBackground(serverSession, crypto: crypto, database: database)
                 switch result {
                 case .updated: processedCount += 1
@@ -374,20 +517,17 @@ public final class SyncManager: ObservableObject {
                 logger.info("Session processing: \(processedCount) updated, \(skippedCount) unchanged, \(failedDecryptCount) failed")
             }
 
-            // If the vast majority of sessions failed to decrypt, the encryption key is wrong.
-            // This happens when the pairing encryption seed or userId salt is out of sync
-            // with the desktop. The user needs to re-pair.
             let totalAttempted = processedCount + failedDecryptCount
             let isMismatch = totalAttempted > 5 && failedDecryptCount > (totalAttempted * 80 / 100)
             if isMismatch {
                 let logger = Logger(subsystem: "com.nimbalyst.app", category: "SyncManager")
                 logger.error("Encryption key mismatch detected: \(failedDecryptCount)/\(totalAttempted) sessions failed to decrypt")
-                await MainActor.run { [weak self] in
+                Task { @MainActor [weak self] in
                     self?.encryptionKeyMismatch = true
                 }
             }
 
-            // Recalculate project stats from session data (more reliable than server-side stats)
+            guard isCurrent() else { return }
             do {
                 try database.refreshAllProjectStats()
             } catch {
@@ -395,10 +535,7 @@ public final class SyncManager: ObservableObject {
                 logger.error("Failed to refresh project stats: \(error.localizedDescription)")
             }
 
-            // Update sync state watermark using the max updatedAt from received sessions.
-            // This ensures the `since` parameter on the next request matches server timestamps exactly.
-            let maxUpdatedAt = response.sessions.map(\.updatedAt).max()
-            if let watermark = maxUpdatedAt {
+            if isCurrent(), let watermark = response.sessions.map(\.updatedAt).max() {
                 let syncState = SyncState(roomId: "index", lastCursor: nil, lastSequence: 0, lastSyncedAt: watermark)
                 try? database.updateSyncState(syncState)
             }
@@ -546,7 +683,9 @@ public final class SyncManager: ObservableObject {
         )
 
         do {
-            try database.upsertSession(session)
+            guard try database.upsertRemoteSession(session) else {
+                return .skipped
+            }
             try database.updateProjectLastActivity(projectId: projectId, activityAt: entry.updatedAt)
 
             // Decrypt and store queued prompts from remote for display
@@ -632,16 +771,16 @@ public final class SyncManager: ObservableObject {
         _ = processServerSessionWithResult(entry)
     }
 
-    /// Process a server session entry, returning true on success, false on decrypt failure.
+    /// Process a server session entry with monotonic stale-snapshot protection.
     @discardableResult
-    private func processServerSessionWithResult(_ entry: ServerSessionEntry) -> Bool {
+    private func processServerSessionWithResult(_ entry: ServerSessionEntry) -> SyncResult {
         // Decrypt project ID to find the parent project
         guard let projectId = crypto.decryptOrNil(
             encryptedBase64: entry.encryptedProjectId,
             ivBase64: entry.projectIdIv
         ) else {
             logger.warning("Failed to decrypt project ID for session \(entry.sessionId)")
-            return false
+            return .failed
         }
 
         // Ensure the project exists (don't overwrite if it already has data from processServerProject)
@@ -714,7 +853,9 @@ public final class SyncManager: ObservableObject {
         )
 
         do {
-            try database.upsertSession(session)
+            guard try database.upsertRemoteSession(session) else {
+                return .skipped
+            }
             // Update the project's lastUpdatedAt if this session is more recent
             try database.updateProjectLastActivity(projectId: projectId, activityAt: entry.updatedAt)
 
@@ -726,10 +867,10 @@ public final class SyncManager: ObservableObject {
                 try? database.deleteRemoteQueuedPrompts(forSession: entry.sessionId)
             }
 
-            return true
+            return .updated
         } catch {
             logger.error("Failed to upsert session: \(error.localizedDescription)")
-            return false
+            return .failed
         }
     }
 
@@ -757,39 +898,70 @@ public final class SyncManager: ObservableObject {
 
     // MARK: - Real-time Broadcasts
 
-    private func handleIndexBroadcast(_ data: Data) {
+    private func enqueueIndexBroadcast(
+        _ data: Data,
+        context: WebSocketConnectionContext
+    ) {
         guard let broadcast = try? decoder.decode(IndexBroadcast.self, from: data) else {
             logger.error("Failed to decode index_broadcast")
             return
         }
-        processServerSession(broadcast.session)
+        let crypto = self.crypto
+        let database = self.database
+        indexExecutor.enqueue(generation: context.generation) { isCurrent in
+            guard isCurrent() else { return }
+            _ = Self.processServerSessionBackground(
+                broadcast.session,
+                crypto: crypto,
+                database: database
+            )
+        }
     }
 
-    private func handleIndexDeleteBroadcast(_ data: Data) {
+    private func enqueueIndexDeleteBroadcast(
+        _ data: Data,
+        context: WebSocketConnectionContext
+    ) {
         guard let broadcast = try? decoder.decode(IndexDeleteBroadcast.self, from: data) else {
             logger.error("Failed to decode index_delete_broadcast")
             return
         }
-        logger.info("Session deleted: \(broadcast.sessionId)")
-
-        do {
-            // Look up project before deleting so we can refresh count
-            let projectId = try database.session(byId: broadcast.sessionId)?.projectId
-            try database.deleteSession(broadcast.sessionId)
-            if let projectId {
-                try database.refreshSessionCount(forProject: projectId)
+        let database = self.database
+        indexExecutor.enqueue(generation: context.generation) { isCurrent in
+            guard isCurrent() else { return }
+            let logger = Logger(subsystem: "com.nimbalyst.app", category: "SyncManager")
+            logger.info("Session deleted: \(broadcast.sessionId)")
+            do {
+                let projectId = try database.session(byId: broadcast.sessionId)?.projectId
+                guard isCurrent() else { return }
+                try database.deleteSession(broadcast.sessionId)
+                if let projectId {
+                    try database.refreshSessionCount(forProject: projectId)
+                }
+            } catch {
+                logger.error("Failed to delete session: \(error.localizedDescription)")
             }
-        } catch {
-            logger.error("Failed to delete session: \(error.localizedDescription)")
         }
     }
 
-    private func handleProjectBroadcast(_ data: Data) {
+    private func enqueueProjectBroadcast(
+        _ data: Data,
+        context: WebSocketConnectionContext
+    ) {
         guard let broadcast = try? decoder.decode(ProjectBroadcast.self, from: data) else {
             logger.error("Failed to decode project_broadcast")
             return
         }
-        processServerProject(broadcast.project)
+        let crypto = self.crypto
+        let database = self.database
+        indexExecutor.enqueue(generation: context.generation) { isCurrent in
+            guard isCurrent() else { return }
+            Self.processServerProjectBackground(
+                broadcast.project,
+                crypto: crypto,
+                database: database
+            )
+        }
     }
 
     private func handleCreateSessionResponse(_ data: Data) {
@@ -1014,28 +1186,66 @@ public final class SyncManager: ObservableObject {
     // MARK: - Session Client Setup
 
     private func setupSessionClient() {
-        sessionClient.onConnectionStateChanged = { [weak self] connected in
+        sessionClient.onConnectionStateChangedWithContext = { [weak self] connected, context in
             Task { @MainActor in
                 guard let self = self else { return }
                 self.logger.info("sessionClient connection state: \(connected) (activeSessionId=\(self.activeSessionId ?? "nil"))")
                 if connected {
+                    guard let sessionId = self.activeSessionId else { return }
+                    let expectedRoomId = self.sessionRoomId(for: sessionId)
+                    guard context.roomId == expectedRoomId else { return }
+                    self.activeSessionContext = context
+                    self.resetSessionCatchUp(for: sessionId)
                     self.requestSessionSync()
+                } else if self.activeSessionContext == context {
+                    self.activeSessionContext = nil
+                    self.sessionCatchUpInFlight = false
                 }
             }
         }
 
-        sessionClient.onMessage = { [weak self] data in
+        sessionClient.onMessageWithContext = { [weak self] data, context in
             Task { @MainActor in
-                self?.handleSessionMessage(data)
+                guard let self, let sessionId = self.activeSessionId else { return }
+                let expectedRoomId = self.sessionRoomId(for: sessionId)
+                guard SessionRoomEventGate.accepts(
+                    activeSessionId: sessionId,
+                    expectedRoomId: expectedRoomId,
+                    activeContext: self.activeSessionContext,
+                    eventContext: context
+                ) else { return }
+                await self.handleSessionMessage(data, sessionId: sessionId, context: context)
             }
         }
     }
 
-    private func requestSessionSync(attempt: Int = 0) {
+    private func resetSessionCatchUp(for sessionId: String?) {
+        sessionCatchUpInFlight = false
+        sessionCatchUpPending = false
+        sessionCatchUpSessionId = sessionId
+        sessionSyncTotalCount = 0
+        sessionSyncStoredCount = 0
+        sessionSyncFailedIds = []
+        sessionSyncFailedSequences = []
+    }
+
+    private func requestSessionSync() {
         guard let sessionId = activeSessionId else {
             logger.warning("requestSessionSync skipped: activeSessionId is nil (connection state fired without a target)")
             return
         }
+        guard activeSessionContext != nil else {
+            logger.debug("requestSessionSync deferred until the session connection is current")
+            sessionCatchUpPending = true
+            return
+        }
+
+        if sessionCatchUpInFlight, sessionCatchUpSessionId == sessionId {
+            sessionCatchUpPending = true
+            return
+        }
+        resetSessionCatchUp(for: sessionId)
+        sessionCatchUpInFlight = true
 
         let localMessages = (try? database.messages(forSession: sessionId)) ?? []
         let localCount = localMessages.count
@@ -1058,10 +1268,22 @@ public final class SyncManager: ObservableObject {
             sinceSeq = nil
         }
 
+        sendSessionSyncRequest(sessionId: sessionId, sinceSeq: sinceSeq)
+    }
+
+    private func sendSessionSyncRequest(
+        sessionId: String,
+        sinceSeq: Int?,
+        attempt: Int = 0
+    ) {
+        guard activeSessionId == sessionId,
+              let context = activeSessionContext else { return }
+
         let request = SessionSyncRequest(sinceSeq: sinceSeq)
         guard let data = try? JSONEncoder().encode(request),
               let json = String(data: data, encoding: .utf8) else {
             logger.error("requestSessionSync failed to encode request for session \(sessionId)")
+            sessionCatchUpInFlight = false
             return
         }
 
@@ -1076,23 +1298,40 @@ public final class SyncManager: ObservableObject {
         // Without a successful syncRequest, the server won't mark this connection
         // as synced and won't include it in message broadcasts.
         sessionClient.sendRaw(json) { [weak self] error in
-            guard let self = self else { return }
-            if let error = error {
-                self.logger.warning("requestSessionSync send failed for \(sessionId): \(error.localizedDescription)")
-                guard attempt < 3, self.activeSessionId == sessionId else { return }
+            Task { @MainActor in
+                guard let self,
+                      self.activeSessionId == sessionId,
+                      self.activeSessionContext == context else { return }
+                if let error {
+                    self.logger.warning("requestSessionSync send failed for \(sessionId): \(error.localizedDescription)")
+                    guard attempt < 3 else {
+                        self.sessionCatchUpInFlight = false
+                        return
+                    }
 
-                self.logger.info("Session sync request failed, retrying (attempt \(attempt + 1))")
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-                    guard let self = self, self.activeSessionId == sessionId else { return }
-                    self.requestSessionSync(attempt: attempt + 1)
+                    self.logger.info("Session sync request failed, retrying (attempt \(attempt + 1))")
+                    self.scheduler.schedule(after: 1.0) { [weak self] in
+                        guard let self,
+                              self.activeSessionId == sessionId,
+                              self.activeSessionContext == context else { return }
+                        self.sendSessionSyncRequest(
+                            sessionId: sessionId,
+                            sinceSeq: sinceSeq,
+                            attempt: attempt + 1
+                        )
+                    }
+                } else {
+                    self.logger.debug("requestSessionSync: send acknowledged for \(sessionId)")
                 }
-            } else {
-                self.logger.debug("requestSessionSync: send acknowledged for \(sessionId)")
             }
         }
     }
 
-    private func handleSessionMessage(_ data: Data) {
+    private func handleSessionMessage(
+        _ data: Data,
+        sessionId: String,
+        context: WebSocketConnectionContext
+    ) async {
         guard let envelope = try? decoder.decode(ServerMessage.self, from: data) else {
             let rawPreview = String(data: data.prefix(200), encoding: .utf8) ?? "<binary>"
             logger.warning("Could not decode session message type — raw: \(rawPreview)")
@@ -1101,11 +1340,11 @@ public final class SyncManager: ObservableObject {
 
         switch envelope.type {
         case "syncResponse":
-            handleSessionSyncResponse(data)
+            await handleSessionSyncResponse(data, sessionId: sessionId, context: context)
         case "messageBroadcast":
-            handleMessageBroadcast(data)
+            handleMessageBroadcast(data, sessionId: sessionId)
         case "metadataBroadcast":
-            handleMetadataBroadcast(data)
+            handleMetadataBroadcast(data, sessionId: sessionId)
         case "error":
             handleServerError(data)
         default:
@@ -1115,126 +1354,124 @@ public final class SyncManager: ObservableObject {
 
     // MARK: - Session Sync Response
 
-    private func handleSessionSyncResponse(_ data: Data) {
+    private func handleSessionSyncResponse(
+        _ data: Data,
+        sessionId: String,
+        context: WebSocketConnectionContext
+    ) async {
+        guard sessionCatchUpInFlight,
+              sessionCatchUpSessionId == sessionId,
+              activeSessionContext == context else { return }
+
         let response: SessionSyncResponse
         do {
             response = try decoder.decode(SessionSyncResponse.self, from: data)
-            logger.info("handleSessionSyncResponse: \(response.messages.count) messages, hasMore=\(response.hasMore) for session \(self.activeSessionId ?? "nil")")
+            logger.info("handleSessionSyncResponse: \(response.messages.count) messages, hasMore=\(response.hasMore) for session \(sessionId)")
         } catch {
             let rawPreview = String(data: data.prefix(500), encoding: .utf8) ?? "<binary>"
             logger.error("Failed to decode session syncResponse: \(error.localizedDescription) — raw: \(rawPreview)")
-            if let sessionId = activeSessionId {
-                emitSessionSyncDiagnostic(sessionId, SessionSyncDiagnostic(
-                    totalServerMessages: 0, decryptedCount: 0, storedCount: 0,
-                    failedMessageIds: [], failedSequences: [],
-                    error: "Sync response decode failed: \(error.localizedDescription)"
-                ))
-            }
+            finishSessionCatchUp(
+                sessionId: sessionId,
+                error: "Sync response decode failed: \(error.localizedDescription)"
+            )
             return
         }
 
-        // Buffer messages for batch insert
-        sessionSyncBuffer.append(contentsOf: response.messages)
+        sessionSyncTotalCount += response.messages.count
+        for entryChunk in SessionFeedBatching.chunks(response.messages) {
+            guard activeSessionId == sessionId,
+                  activeSessionContext == context else { return }
 
-        if response.hasMore, let cursor = response.cursor {
-            // Request next page
-            let sinceSeq = Int(cursor)
-            let request = SessionSyncRequest(sinceSeq: sinceSeq)
-            if let data = try? JSONEncoder().encode(request),
-               let json = String(data: data, encoding: .utf8) {
-                sessionClient.sendRaw(json)
+            var decrypted: [Message] = []
+            for entry in entryChunk {
+                if let message = decryptServerMessage(entry, sessionId: sessionId) {
+                    decrypted.append(message)
+                } else {
+                    sessionSyncFailedIds.append(entry.id)
+                    sessionSyncFailedSequences.append(entry.sequence)
+                }
             }
+
+            do {
+                try database.appendRemoteMessages(
+                    decrypted,
+                    roomId: sessionId,
+                    syncedAt: Int(Date().timeIntervalSince1970 * 1000)
+                )
+                sessionSyncStoredCount += decrypted.count
+            } catch {
+                logger.error("Failed to store session message chunk: \(error.localizedDescription)")
+                finishSessionCatchUp(
+                    sessionId: sessionId,
+                    error: "Database write failed: \(error.localizedDescription)"
+                )
+                return
+            }
+            await Task.yield()
+        }
+
+        if let metadata = response.metadata {
+            applySessionMetadata(metadata, sessionId: sessionId)
+        }
+
+        if response.hasMore {
+            guard let cursor = response.cursor,
+                  let sinceSeq = Int(cursor) else {
+                finishSessionCatchUp(
+                    sessionId: sessionId,
+                    error: "Missing or invalid session sync cursor"
+                )
+                return
+            }
+            sendSessionSyncRequest(sessionId: sessionId, sinceSeq: sinceSeq)
         } else {
-            // All pages received - decrypt and store
-            commitSessionMessages()
+            finishSessionCatchUp(sessionId: sessionId, error: nil)
         }
     }
 
-    private func commitSessionMessages() {
-        guard let sessionId = activeSessionId else { return }
+    private func finishSessionCatchUp(sessionId: String, error: String?) {
+        guard sessionCatchUpSessionId == sessionId else { return }
 
-        let totalCount = sessionSyncBuffer.count
-        var failedIds: [String] = []
-        var failedSeqs: [Int] = []
+        let totalCount = sessionSyncTotalCount
+        let storedCount = sessionSyncStoredCount
+        let failedIds = sessionSyncFailedIds
+        let failedSequences = sessionSyncFailedSequences
+        sessionCatchUpInFlight = false
 
-        let messages = sessionSyncBuffer.compactMap { entry -> Message? in
-            let msg = decryptServerMessage(entry, sessionId: sessionId)
-            if msg == nil {
-                failedIds.append(entry.id)
-                failedSeqs.append(entry.sequence)
-            }
-            return msg
+        let diagnosticError: String?
+        if let error {
+            diagnosticError = error
+        } else if storedCount == 0 && totalCount > 0 {
+            diagnosticError = "All \(totalCount) messages failed decryption"
+        } else if !failedIds.isEmpty {
+            diagnosticError = "\(failedIds.count) of \(totalCount) messages failed decryption"
+        } else {
+            diagnosticError = nil
         }
 
-        sessionSyncBuffer = []
+        emitSessionSyncDiagnostic(sessionId, SessionSyncDiagnostic(
+            totalServerMessages: totalCount,
+            decryptedCount: storedCount,
+            storedCount: error == nil ? storedCount : 0,
+            failedMessageIds: failedIds,
+            failedSequences: failedSequences,
+            error: diagnosticError
+        ))
 
-        // Log decryption results
-        if !failedIds.isEmpty {
-            logger.error("Decryption failed for \(failedIds.count)/\(totalCount) messages in session \(sessionId). Failed sequences: \(failedSeqs.prefix(10))")
-        }
+        logger.info("Stored \(storedCount)/\(totalCount) messages for session \(sessionId)")
 
-        do {
-            try database.appendMessages(messages)
-
-            // Update sync watermark to max sequence
-            if let maxSeq = messages.map(\.sequence).max() {
-                let now = Int(Date().timeIntervalSince1970 * 1000)
-                let syncState = SyncState(
-                    roomId: sessionId,
-                    lastCursor: nil,
-                    lastSequence: maxSeq,
-                    lastSyncedAt: now
-                )
-                try database.updateSyncState(syncState)
-            }
-
-            logger.info("Stored \(messages.count)/\(totalCount) messages for session \(sessionId)")
-
-            // Report diagnostics
-            if messages.isEmpty && totalCount > 0 {
-                logger.error("All \(totalCount) messages failed decryption for session \(sessionId)")
-                emitSessionSyncDiagnostic(sessionId, SessionSyncDiagnostic(
-                    totalServerMessages: totalCount, decryptedCount: 0, storedCount: 0,
-                    failedMessageIds: failedIds, failedSequences: failedSeqs,
-                    error: "All \(totalCount) messages failed decryption"
-                ))
-            } else if messages.isEmpty && totalCount == 0 {
-                logger.info("Session sync returned 0 messages for session \(sessionId) — transcript may not exist on server")
-                emitSessionSyncDiagnostic(sessionId, SessionSyncDiagnostic(
-                    totalServerMessages: 0, decryptedCount: 0, storedCount: 0,
-                    failedMessageIds: [], failedSequences: [],
-                    error: nil
-                ))
-            } else if !failedIds.isEmpty {
-                emitSessionSyncDiagnostic(sessionId, SessionSyncDiagnostic(
-                    totalServerMessages: totalCount, decryptedCount: messages.count,
-                    storedCount: messages.count,
-                    failedMessageIds: failedIds, failedSequences: failedSeqs,
-                    error: "\(failedIds.count) of \(totalCount) messages failed decryption"
-                ))
-            } else {
-                emitSessionSyncDiagnostic(sessionId, SessionSyncDiagnostic(
-                    totalServerMessages: totalCount, decryptedCount: messages.count,
-                    storedCount: messages.count,
-                    failedMessageIds: [], failedSequences: [],
-                    error: nil
-                ))
-            }
-        } catch {
-            logger.error("Failed to store session messages: \(error.localizedDescription)")
-            emitSessionSyncDiagnostic(sessionId, SessionSyncDiagnostic(
-                totalServerMessages: totalCount, decryptedCount: messages.count, storedCount: 0,
-                failedMessageIds: failedIds, failedSequences: failedSeqs,
-                error: "Database write failed: \(error.localizedDescription)"
-            ))
+        if sessionCatchUpPending,
+           activeSessionId == sessionId,
+           activeSessionContext != nil {
+            sessionCatchUpPending = false
+            requestSessionSync()
         }
     }
 
     // MARK: - Real-time Session Messages
 
-    private func handleMessageBroadcast(_ data: Data) {
-        guard let broadcast = try? decoder.decode(MessageBroadcast.self, from: data),
-              let sessionId = activeSessionId else {
+    private func handleMessageBroadcast(_ data: Data, sessionId: String) {
+        guard let broadcast = try? decoder.decode(MessageBroadcast.self, from: data) else {
             let rawPreview = String(data: data.prefix(200), encoding: .utf8) ?? "<binary>"
             logger.error("Failed to decode messageBroadcast — raw: \(rawPreview)")
             return
@@ -1246,92 +1483,108 @@ public final class SyncManager: ObservableObject {
         }
 
         do {
-            try database.appendMessage(message)
-
-            // Update sync watermark
-            let now = Int(Date().timeIntervalSince1970 * 1000)
-            let syncState = SyncState(
+            try database.appendRemoteMessages(
+                [message],
                 roomId: sessionId,
-                lastCursor: nil,
-                lastSequence: message.sequence,
-                lastSyncedAt: now
+                syncedAt: Int(Date().timeIntervalSince1970 * 1000)
             )
-            try database.updateSyncState(syncState)
         } catch {
             logger.error("Failed to store broadcast message: \(error.localizedDescription)")
         }
     }
 
-    private func handleMetadataBroadcast(_ data: Data) {
-        guard let broadcast = try? decoder.decode(MetadataBroadcast.self, from: data),
-              let sessionId = activeSessionId else {
-            return
+    private func handleMetadataBroadcast(_ data: Data, sessionId: String) {
+        guard let broadcast = try? decoder.decode(MetadataBroadcast.self, from: data) else { return }
+        applySessionMetadata(broadcast.metadata, sessionId: sessionId)
+    }
+
+    /// Applies authoritative session-room metadata even when no transcript
+    /// message accompanies the transition. `updatedAt`, when supplied, is kept
+    /// as a durable metadata revision in SyncState.lastCursor so duplicate and
+    /// older replay cannot regress running/terminal UI state.
+    func applySessionMetadata(_ metadata: SessionRoomMetadata, sessionId: String) {
+        let decryptedTitle: String?
+        if let encryptedTitle = metadata.encryptedTitle,
+           let titleIv = metadata.titleIv {
+            decryptedTitle = crypto.decryptOrNil(
+                encryptedBase64: encryptedTitle,
+                ivBase64: titleIv
+            )
+        } else {
+            decryptedTitle = nil
         }
 
-        // Update session metadata in the database
-        do {
-            if var session = try database.session(byId: sessionId) {
-                let wasExecuting = session.isExecuting
+        var decodedClientMeta: ClientMetadata?
+        if let encryptedMeta = metadata.encryptedClientMetadata,
+           let metaIv = metadata.clientMetadataIv,
+           let metaJson = crypto.decryptOrNil(encryptedBase64: encryptedMeta, ivBase64: metaIv),
+           let metaData = metaJson.data(using: .utf8) {
+            decodedClientMeta = try? JSONDecoder().decode(ClientMetadata.self, from: metaData)
+        }
+        let encodedTags: String?
+        if let tags = decodedClientMeta?.tags,
+           !tags.isEmpty,
+           let data = try? JSONEncoder().encode(tags) {
+            encodedTags = String(data: data, encoding: .utf8)
+        } else {
+            encodedTags = nil
+        }
 
-                if let isExecuting = broadcast.metadata.isExecuting {
+        do {
+            guard let result = try database.updateRemoteSessionMetadata(
+                sessionId: sessionId,
+                revision: metadata.updatedAt
+            ) { session in
+                if let isExecuting = metadata.isExecuting {
                     session.isExecuting = isExecuting
                 }
-                if let provider = broadcast.metadata.provider {
+                if let provider = metadata.provider {
                     session.provider = provider
                 }
-                if let model = broadcast.metadata.model {
+                if let model = metadata.model {
                     session.model = model
                 }
-                if let mode = broadcast.metadata.mode {
+                if let mode = metadata.mode {
                     session.mode = mode
                 }
-                // Decrypt client metadata (context usage, pending prompt state, etc.)
-                if let encryptedMeta = broadcast.metadata.encryptedClientMetadata,
-                   let metaIv = broadcast.metadata.clientMetadataIv,
-                   let metaJson = crypto.decryptOrNil(encryptedBase64: encryptedMeta, ivBase64: metaIv),
-                   let metaData = metaJson.data(using: .utf8),
-                   let clientMeta = try? JSONDecoder().decode(ClientMetadata.self, from: metaData) {
-                    if let ctx = clientMeta.currentContext {
-                        session.contextTokens = ctx.tokens
-                        session.contextWindow = ctx.contextWindow
-                    }
-                    if let pending = clientMeta.hasPendingPrompt {
-                        session.hasQueuedPrompts = pending
-                    }
-                    if let phase = clientMeta.phase {
-                        session.phase = phase
-                    }
-                    if let tags = clientMeta.tags, !tags.isEmpty,
-                       let tagData = try? JSONEncoder().encode(tags) {
-                        session.tagsJson = String(data: tagData, encoding: .utf8)
-                    }
+                if let encryptedTitle = metadata.encryptedTitle,
+                   let titleIv = metadata.titleIv,
+                   let decryptedTitle {
+                    session.titleEncrypted = encryptedTitle
+                    session.titleIv = titleIv
+                    session.titleDecrypted = decryptedTitle
                 }
-                // NOTE: Do NOT apply updatedAt from metadata broadcasts.
-                // Metadata updates (read state, isExecuting, context) should not
-                // change the sort timestamp. Only index sync and message appends
-                // set updatedAt, ensuring the session list stays correctly sorted.
-                try database.upsertSession(session)
+                if let ctx = decodedClientMeta?.currentContext {
+                    session.contextTokens = ctx.tokens
+                    session.contextWindow = ctx.contextWindow
+                }
+                if let phase = decodedClientMeta?.phase {
+                    session.phase = phase
+                }
+                if let encodedTags {
+                    session.tagsJson = encodedTags
+                }
+                if let pending = decodedClientMeta?.hasPendingPrompt {
+                    session.hasQueuedPrompts = pending
+                }
+            } else {
+                logger.debug("Ignoring absent session or stale metadata for \(sessionId)")
+                return
+            }
 
-                // Gate the session-client ping heartbeat on whether the AI is
-                // currently producing output. Pings only matter while we're
-                // expecting `messageBroadcast` events; running a 20s repeating
-                // timer on an idle session kept the device awake on real
-                // hardware. The transitions are:
-                //   !executing -> executing : startPings (turn just began)
-                //   executing -> !executing : stopPings  (turn just ended)
-                if !wasExecuting && session.isExecuting {
-                    sessionClient.startPings()
-                } else if wasExecuting && !session.isExecuting {
-                    sessionClient.stopPings()
-                }
+            let wasExecuting = result.previous.isExecuting
+            let isExecuting = result.current.isExecuting
+            if !wasExecuting && isExecuting {
+                sessionClient.startPings()
+            } else if wasExecuting && !isExecuting {
+                sessionClient.stopPings()
+            }
 
-                // Detect execution completion (isExecuting: true -> false)
-                if wasExecuting && !session.isExecuting {
-                    let messages = try database.messages(forSession: sessionId)
-                    let lastAssistant = messages.last { $0.source == "assistant" }
-                    let summary = String((lastAssistant?.contentDecrypted ?? "Task completed").prefix(200))
-                    onSessionCompleted?(sessionId, summary)
-                }
+            if wasExecuting && !isExecuting {
+                let messages = try database.messages(forSession: sessionId)
+                let lastAssistant = messages.last { $0.source == "assistant" }
+                let summary = String((lastAssistant?.contentDecrypted ?? "Task completed").prefix(200))
+                onSessionCompleted?(sessionId, summary)
             }
         } catch {
             logger.error("Failed to update session metadata: \(error.localizedDescription)")

--- a/packages/ios/NimbalystNative/Sources/Sync/SyncManager.swift
+++ b/packages/ios/NimbalystNative/Sources/Sync/SyncManager.swift
@@ -1324,6 +1324,10 @@ public final class SyncManager: ObservableObject {
         }
     }
 
+    private func invalidateSessionCatchUpResponseTimeout() {
+        sessionCatchUpRequestGeneration &+= 1
+    }
+
     private func requestSessionSync() {
         guard let sessionId = activeSessionId else {
             logger.warning("requestSessionSync skipped: activeSessionId is nil (connection state fired without a target)")
@@ -1479,6 +1483,7 @@ public final class SyncManager: ObservableObject {
               authority.sessionId == sessionId,
               authority.context == context,
               ownsSessionCatchUp(authority) else { return }
+        invalidateSessionCatchUpResponseTimeout()
 
         let response: SessionSyncResponse
         do {

--- a/packages/ios/NimbalystNative/Sources/Sync/WebSocketClient.swift
+++ b/packages/ios/NimbalystNative/Sources/Sync/WebSocketClient.swift
@@ -4,6 +4,53 @@ import os
 import UIKit
 #endif
 
+struct WebSocketConnectionContext: Equatable, Sendable {
+    let generation: Int
+    let roomId: String
+}
+
+protocol SyncWebSocketClient: AnyObject {
+    var sendsDeviceAnnounce: Bool { get set }
+    var onMessageWithContext: ((Data, WebSocketConnectionContext) -> Void)? { get set }
+    var onConnectionStateChangedWithContext: ((Bool, WebSocketConnectionContext) -> Void)? { get set }
+    var isConnected: Bool { get }
+
+    func reportActivity()
+    func setAppInForeground(_ inForeground: Bool)
+    func connect(serverUrl: String, roomId: String, authToken: String)
+    func disconnect()
+    func reconnect()
+    func sendRaw(_ json: String)
+    func sendRaw(_ json: String, completion: ((Error?) -> Void)?)
+    func startPings()
+    func stopPings()
+}
+
+enum WebSocketReconnectPolicy {
+    static func accepts(currentGeneration: Int, context: WebSocketConnectionContext) -> Bool {
+        currentGeneration == context.generation
+    }
+
+    static func shouldSchedule(
+        isIntentionallyClosed: Bool,
+        hasScheduledReconnect: Bool,
+        currentGeneration: Int,
+        context: WebSocketConnectionContext
+    ) -> Bool {
+        !isIntentionallyClosed
+            && !hasScheduledReconnect
+            && accepts(currentGeneration: currentGeneration, context: context)
+    }
+
+    static func shouldRunScheduled(
+        isIntentionallyClosed: Bool,
+        currentGeneration: Int,
+        scheduledGeneration: Int
+    ) -> Bool {
+        !isIntentionallyClosed && currentGeneration == scheduledGeneration
+    }
+}
+
 /// A WebSocket client using URLSessionWebSocketTask with automatic reconnection
 /// and periodic device announcements (heartbeat).
 final class WebSocketClient: @unchecked Sendable {
@@ -19,6 +66,7 @@ final class WebSocketClient: @unchecked Sendable {
     /// dead socket can't be mistaken for liveness on the new socket.
     private var connectionGeneration: Int = 0
     private var isIntentionallyClosed = false
+    private var reconnectWorkItem: DispatchWorkItem?
 
     /// The server URL and auth token needed to (re)connect.
     private var serverUrl: String?
@@ -28,8 +76,18 @@ final class WebSocketClient: @unchecked Sendable {
     /// Callback for received messages.
     var onMessage: ((Data) -> Void)?
 
+    /// Generation-bound callback used by session/index owners that need to
+    /// reject work queued across a room handoff. The legacy callback remains
+    /// available for clients whose room identity is fixed for their lifetime.
+    var onMessageWithContext: ((Data, WebSocketConnectionContext) -> Void)?
+
     /// Callback for connection state changes.
     var onConnectionStateChanged: ((Bool) -> Void)?
+
+    /// Generation-bound connection callback. A callback may be delivered after
+    /// its caller has already queued a replacement connection, so consumers
+    /// must retain and compare this context before mutating their state.
+    var onConnectionStateChangedWithContext: ((Bool, WebSocketConnectionContext) -> Void)?
 
     var isConnected: Bool {
         task?.state == .running
@@ -123,11 +181,20 @@ final class WebSocketClient: @unchecked Sendable {
     /// Disconnect and stop reconnection attempts.
     func disconnect() {
         isIntentionallyClosed = true
+        reconnectWorkItem?.cancel()
+        reconnectWorkItem = nil
         stopDeviceAnnounceTimer()
         stopPings()
+        let closedContext = roomId.map {
+            WebSocketConnectionContext(generation: connectionGeneration, roomId: $0)
+        }
+        connectionGeneration &+= 1
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
         onConnectionStateChanged?(false)
+        if let closedContext {
+            onConnectionStateChangedWithContext?(false, closedContext)
+        }
     }
 
     /// Reconnect using the previously stored connection parameters.
@@ -137,6 +204,8 @@ final class WebSocketClient: @unchecked Sendable {
     }
 
     private func performConnect() {
+        reconnectWorkItem?.cancel()
+        reconnectWorkItem = nil
         // Clean up existing connection
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
@@ -172,10 +241,15 @@ final class WebSocketClient: @unchecked Sendable {
         let wsTask = session.webSocketTask(with: url)
         wsTask.maximumMessageSize = 16 * 1024 * 1024 // 16 MB (default is 1 MB)
         self.task = wsTask
+        let context = WebSocketConnectionContext(
+            generation: connectionGeneration,
+            roomId: roomId
+        )
         wsTask.resume()
 
         onConnectionStateChanged?(true)
-        startReceiving(on: wsTask)
+        onConnectionStateChangedWithContext?(true, context)
+        startReceiving(on: wsTask, context: context)
         if sendsDeviceAnnounce {
             startDeviceAnnounceTimer()
         }
@@ -221,9 +295,20 @@ final class WebSocketClient: @unchecked Sendable {
             completion?(NSError(domain: "WebSocketClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Not connected"]))
             return
         }
+        let generation = connectionGeneration
         task.send(.string(json)) { [weak self] error in
+            guard let self,
+                  self.task === task,
+                  self.connectionGeneration == generation else {
+                completion?(NSError(
+                    domain: "WebSocketClient",
+                    code: -2,
+                    userInfo: [NSLocalizedDescriptionKey: "Connection was replaced before send completed"]
+                ))
+                return
+            }
             if let error = error {
-                self?.logger.error("Send raw error: \(error.localizedDescription)")
+                self.logger.error("Send raw error: \(error.localizedDescription)")
             }
             completion?(error)
         }
@@ -231,10 +316,17 @@ final class WebSocketClient: @unchecked Sendable {
 
     // MARK: - Receive Loop
 
-    private func startReceiving(on wsTask: URLSessionWebSocketTask) {
+    private func startReceiving(
+        on wsTask: URLSessionWebSocketTask,
+        context: WebSocketConnectionContext
+    ) {
         wsTask.receive { [weak self] result in
             guard let self = self else { return }
-            guard self.task === wsTask else { return }
+            guard self.task === wsTask,
+                  WebSocketReconnectPolicy.accepts(
+                    currentGeneration: self.connectionGeneration,
+                    context: context
+                  ) else { return }
 
             switch result {
             case .success(let message):
@@ -242,42 +334,69 @@ final class WebSocketClient: @unchecked Sendable {
                 case .string(let text):
                     if let data = text.data(using: .utf8) {
                         self.onMessage?(data)
+                        self.onMessageWithContext?(data, context)
                     }
                 case .data(let data):
                     self.onMessage?(data)
+                    self.onMessageWithContext?(data, context)
                 @unknown default:
                     break
                 }
                 // Continue receiving
-                self.startReceiving(on: wsTask)
+                self.startReceiving(on: wsTask, context: context)
 
             case .failure(let error):
                 self.logger.error("Receive error: \(error.localizedDescription)")
-                self.handleDisconnect(for: wsTask)
+                self.handleDisconnect(for: wsTask, context: context)
             }
         }
     }
 
     // MARK: - Reconnection
 
-    private func handleDisconnect(for wsTask: URLSessionWebSocketTask) {
+    private func handleDisconnect(
+        for wsTask: URLSessionWebSocketTask,
+        context: WebSocketConnectionContext
+    ) {
         // Receive callbacks fire on a URLSession background queue.
         // Hop to main for Timer invalidation and shared state mutation.
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            guard self.task === wsTask else { return }
+            guard self.task === wsTask,
+                  WebSocketReconnectPolicy.accepts(
+                    currentGeneration: self.connectionGeneration,
+                    context: context
+                  ) else { return }
             self.task = nil
             self.stopDeviceAnnounceTimer()
             self.stopPings()
             self.onConnectionStateChanged?(false)
+            self.onConnectionStateChangedWithContext?(false, context)
 
-            guard !self.isIntentionallyClosed else { return }
+            guard WebSocketReconnectPolicy.shouldSchedule(
+                isIntentionallyClosed: self.isIntentionallyClosed,
+                hasScheduledReconnect: self.reconnectWorkItem != nil,
+                currentGeneration: self.connectionGeneration,
+                context: context
+            ) else { return }
 
             self.logger.info("Scheduling reconnect in \(self.reconnectDelay)s")
-            DispatchQueue.main.asyncAfter(deadline: .now() + self.reconnectDelay) { [weak self] in
-                guard let self = self, !self.isIntentionallyClosed else { return }
+            let scheduledGeneration = context.generation
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self = self else { return }
+                self.reconnectWorkItem = nil
+                guard WebSocketReconnectPolicy.shouldRunScheduled(
+                    isIntentionallyClosed: self.isIntentionallyClosed,
+                    currentGeneration: self.connectionGeneration,
+                    scheduledGeneration: scheduledGeneration
+                ) else { return }
                 self.performConnect()
             }
+            self.reconnectWorkItem = workItem
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + self.reconnectDelay,
+                execute: workItem
+            )
         }
     }
 
@@ -338,7 +457,11 @@ final class WebSocketClient: @unchecked Sendable {
                 if let error = error {
                     self.logger.warning("Ping failed -- treating connection as dead: \(error.localizedDescription)")
                     if let deadTask = self.task {
-                        self.handleDisconnect(for: deadTask)
+                        let context = WebSocketConnectionContext(
+                            generation: generation,
+                            roomId: self.roomId ?? ""
+                        )
+                        self.handleDisconnect(for: deadTask, context: context)
                     }
                 }
             }
@@ -418,3 +541,5 @@ final class WebSocketClient: @unchecked Sendable {
         return clamped.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? clamped
     }
 }
+
+extension WebSocketClient: SyncWebSocketClient {}

--- a/packages/ios/NimbalystNative/Sources/Sync/WebSocketClient.swift
+++ b/packages/ios/NimbalystNative/Sources/Sync/WebSocketClient.swift
@@ -9,10 +9,21 @@ struct WebSocketConnectionContext: Equatable, Sendable {
     let roomId: String
 }
 
+typealias WebSocketMessageHandler = @MainActor @Sendable (
+    Data,
+    WebSocketConnectionContext
+) async -> Void
+typealias WebSocketConnectionHandler = @MainActor @Sendable (
+    Bool,
+    WebSocketConnectionContext
+) -> Void
+typealias WebSocketSendCompletion = @MainActor @Sendable (Error?) -> Void
+
+@MainActor
 protocol SyncWebSocketClient: AnyObject {
     var sendsDeviceAnnounce: Bool { get set }
-    var onMessageWithContext: ((Data, WebSocketConnectionContext) -> Void)? { get set }
-    var onConnectionStateChangedWithContext: ((Bool, WebSocketConnectionContext) -> Void)? { get set }
+    var onMessageWithContext: WebSocketMessageHandler? { get set }
+    var onConnectionStateChangedWithContext: WebSocketConnectionHandler? { get set }
     var isConnected: Bool { get }
 
     func reportActivity()
@@ -21,9 +32,125 @@ protocol SyncWebSocketClient: AnyObject {
     func disconnect()
     func reconnect()
     func sendRaw(_ json: String)
-    func sendRaw(_ json: String, completion: ((Error?) -> Void)?)
+    func sendRaw(_ json: String, completion: WebSocketSendCompletion?)
     func startPings()
     func stopPings()
+}
+
+typealias WebSocketEventOperation = @MainActor @Sendable () async -> Void
+
+protocol WebSocketEventDelivering: Sendable {
+    func deliver(_ operation: @escaping WebSocketEventOperation)
+}
+
+/// URLSession completion handlers may run on arbitrary queues. Every one is
+/// admitted to the WebSocket client's actor through this single seam before it
+/// can inspect or mutate connection state. The receive loop has at most one
+/// outstanding callback and does not arm its successor until delivery finishes.
+struct MainActorWebSocketEventDelivery: WebSocketEventDelivering {
+    func deliver(_ operation: @escaping WebSocketEventOperation) {
+        Task { @MainActor in
+            await operation()
+        }
+    }
+}
+
+enum WebSocketTransportMessage: Sendable {
+    case string(String)
+    case data(Data)
+}
+
+protocol WebSocketTransportTask: AnyObject {
+    var state: URLSessionTask.State { get }
+
+    func resume()
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?)
+    func send(
+        text: String,
+        completionHandler: @escaping @Sendable (Error?) -> Void
+    )
+    func receive(
+        completionHandler: @escaping @Sendable (
+            Result<WebSocketTransportMessage, Error>
+        ) -> Void
+    )
+    func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void)
+}
+
+/// This adapter remains actor-owned. Only immutable task identifiers and
+/// Sendable completion payloads cross from URLSession back to the actor.
+private final class URLSessionWebSocketTransportTask: WebSocketTransportTask {
+    private let rawTask: URLSessionWebSocketTask
+
+    init(rawTask: URLSessionWebSocketTask) {
+        self.rawTask = rawTask
+    }
+
+    var state: URLSessionTask.State { rawTask.state }
+
+    func resume() {
+        rawTask.resume()
+    }
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        rawTask.cancel(with: closeCode, reason: reason)
+    }
+
+    func send(
+        text: String,
+        completionHandler: @escaping @Sendable (Error?) -> Void
+    ) {
+        rawTask.send(.string(text), completionHandler: completionHandler)
+    }
+
+    func receive(
+        completionHandler: @escaping @Sendable (
+            Result<WebSocketTransportMessage, Error>
+        ) -> Void
+    ) {
+        rawTask.receive { result in
+            completionHandler(result.map { message in
+                switch message {
+                case .string(let text):
+                    return .string(text)
+                case .data(let data):
+                    return .data(data)
+                @unknown default:
+                    return .data(Data())
+                }
+            })
+        }
+    }
+
+    func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
+        rawTask.sendPing(pongReceiveHandler: pongReceiveHandler)
+    }
+}
+
+@MainActor
+protocol WebSocketTransportCreating: AnyObject {
+    func makeTask(url: URL) -> any WebSocketTransportTask
+}
+
+@MainActor
+private final class URLSessionWebSocketTransportFactory: WebSocketTransportCreating {
+    private let session: URLSession
+
+    init() {
+        let config = URLSessionConfiguration.default
+        config.waitsForConnectivity = true
+        session = URLSession(configuration: config)
+    }
+
+    func makeTask(url: URL) -> any WebSocketTransportTask {
+        let rawTask = session.webSocketTask(with: url)
+        rawTask.maximumMessageSize = 16 * 1024 * 1024
+        return URLSessionWebSocketTransportTask(rawTask: rawTask)
+    }
+
+    deinit {
+        session.invalidateAndCancel()
+    }
 }
 
 enum WebSocketReconnectPolicy {
@@ -53,11 +180,13 @@ enum WebSocketReconnectPolicy {
 
 /// A WebSocket client using URLSessionWebSocketTask with automatic reconnection
 /// and periodic device announcements (heartbeat).
-final class WebSocketClient: @unchecked Sendable {
+@MainActor
+final class WebSocketClient {
     private let logger = Logger(subsystem: "com.nimbalyst.app", category: "WebSocket")
 
-    private var task: URLSessionWebSocketTask?
-    private let session: URLSession
+    private var task: (any WebSocketTransportTask)?
+    private let transportFactory: any WebSocketTransportCreating
+    private let eventDelivery: any WebSocketEventDelivering
     private var reconnectDelay: TimeInterval = 5.0
     private var deviceAnnounceTimer: Timer?
     private var pingTimer: Timer?
@@ -66,7 +195,8 @@ final class WebSocketClient: @unchecked Sendable {
     /// dead socket can't be mistaken for liveness on the new socket.
     private var connectionGeneration: Int = 0
     private var isIntentionallyClosed = false
-    private var reconnectWorkItem: DispatchWorkItem?
+    private var reconnectTask: Task<Void, Never>?
+    private var reconnectSourceTaskId: ObjectIdentifier?
 
     /// The server URL and auth token needed to (re)connect.
     private var serverUrl: String?
@@ -74,20 +204,20 @@ final class WebSocketClient: @unchecked Sendable {
     private var roomId: String?
 
     /// Callback for received messages.
-    var onMessage: ((Data) -> Void)?
+    var onMessage: (@MainActor @Sendable (Data) async -> Void)?
 
     /// Generation-bound callback used by session/index owners that need to
     /// reject work queued across a room handoff. The legacy callback remains
     /// available for clients whose room identity is fixed for their lifetime.
-    var onMessageWithContext: ((Data, WebSocketConnectionContext) -> Void)?
+    var onMessageWithContext: WebSocketMessageHandler?
 
     /// Callback for connection state changes.
-    var onConnectionStateChanged: ((Bool) -> Void)?
+    var onConnectionStateChanged: (@MainActor @Sendable (Bool) -> Void)?
 
     /// Generation-bound connection callback. A callback may be delivered after
     /// its caller has already queued a replacement connection, so consumers
     /// must retain and compare this context before mutating their state.
-    var onConnectionStateChangedWithContext: ((Bool, WebSocketConnectionContext) -> Void)?
+    var onConnectionStateChangedWithContext: WebSocketConnectionHandler?
 
     var isConnected: Bool {
         task?.state == .running
@@ -144,14 +274,19 @@ final class WebSocketClient: @unchecked Sendable {
         return "active"
     }
 
-    init() {
-        let config = URLSessionConfiguration.default
-        config.waitsForConnectivity = true
-        self.session = URLSession(configuration: config)
+    convenience init() {
+        self.init(
+            transportFactory: URLSessionWebSocketTransportFactory(),
+            eventDelivery: MainActorWebSocketEventDelivery()
+        )
     }
 
-    deinit {
-        task?.cancel(with: .goingAway, reason: nil)
+    init(
+        transportFactory: any WebSocketTransportCreating,
+        eventDelivery: any WebSocketEventDelivering
+    ) {
+        self.transportFactory = transportFactory
+        self.eventDelivery = eventDelivery
     }
 
     // MARK: - Connect / Disconnect
@@ -181,8 +316,9 @@ final class WebSocketClient: @unchecked Sendable {
     /// Disconnect and stop reconnection attempts.
     func disconnect() {
         isIntentionallyClosed = true
-        reconnectWorkItem?.cancel()
-        reconnectWorkItem = nil
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        reconnectSourceTaskId = nil
         stopDeviceAnnounceTimer()
         stopPings()
         let closedContext = roomId.map {
@@ -204,8 +340,9 @@ final class WebSocketClient: @unchecked Sendable {
     }
 
     private func performConnect() {
-        reconnectWorkItem?.cancel()
-        reconnectWorkItem = nil
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        reconnectSourceTaskId = nil
         // Clean up existing connection
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
@@ -238,8 +375,7 @@ final class WebSocketClient: @unchecked Sendable {
         }
 
         logger.info("Connecting to \(roomId)...")
-        let wsTask = session.webSocketTask(with: url)
-        wsTask.maximumMessageSize = 16 * 1024 * 1024 // 16 MB (default is 1 MB)
+        let wsTask = transportFactory.makeTask(url: url)
         self.task = wsTask
         let context = WebSocketConnectionContext(
             generation: connectionGeneration,
@@ -247,11 +383,13 @@ final class WebSocketClient: @unchecked Sendable {
         )
         wsTask.resume()
 
-        onConnectionStateChanged?(true)
-        onConnectionStateChangedWithContext?(true, context)
-        startReceiving(on: wsTask, context: context)
-        if sendsDeviceAnnounce {
-            startDeviceAnnounceTimer()
+        // Treat connection admission like every other URLSession-originated
+        // event. Tests can deliberately delay this hop; task identity plus the
+        // generation guard ensures a late N admission cannot overwrite N+1.
+        let taskId = ObjectIdentifier(wsTask)
+        eventDelivery.deliver { [weak self] in
+            guard let self else { return }
+            await self.acceptConnected(taskId: taskId, context: context)
         }
         // Pings are NOT auto-started on connect. The owner (SyncManager) calls
         // `startPings()` / `stopPings()` based on whether the active session is
@@ -259,6 +397,37 @@ final class WebSocketClient: @unchecked Sendable {
         // output, since outside an active turn there are no broadcasts to
         // miss. Keeping a 20s timer running on an idle session caused the
         // device to stay awake on real hardware.
+    }
+
+    private func acceptConnected(
+        taskId: ObjectIdentifier,
+        context: WebSocketConnectionContext
+    ) async {
+        guard isCurrent(taskId: taskId, context: context) else { return }
+
+        onConnectionStateChanged?(true)
+        onConnectionStateChangedWithContext?(true, context)
+
+        // A callback may synchronously replace the connection. Revalidate
+        // before granting receive/timer authority to this task.
+        guard isCurrent(taskId: taskId, context: context),
+              let wsTask = task else { return }
+        startReceiving(on: wsTask, context: context)
+        if sendsDeviceAnnounce {
+            startDeviceAnnounceTimer()
+        }
+    }
+
+    private func isCurrent(
+        taskId candidateId: ObjectIdentifier,
+        context: WebSocketConnectionContext
+    ) -> Bool {
+        guard let task else { return false }
+        return ObjectIdentifier(task) == candidateId
+            && WebSocketReconnectPolicy.accepts(
+                currentGeneration: connectionGeneration,
+                context: context
+            )
     }
 
     // MARK: - Send
@@ -273,9 +442,18 @@ final class WebSocketClient: @unchecked Sendable {
         do {
             let data = try JSONEncoder().encode(message)
             let string = String(data: data, encoding: .utf8) ?? ""
-            task.send(.string(string)) { [weak self] error in
-                if let error = error {
-                    self?.logger.error("Send error: \(error.localizedDescription)")
+            let context = WebSocketConnectionContext(
+                generation: connectionGeneration,
+                roomId: roomId ?? ""
+            )
+            let taskId = ObjectIdentifier(task)
+            let delivery = eventDelivery
+            task.send(text: string) { [weak self] error in
+                delivery.deliver { [weak self] in
+                    guard let self,
+                          self.isCurrent(taskId: taskId, context: context),
+                          let error else { return }
+                    self.logger.error("Send error: \(error.localizedDescription)")
                 }
             }
         } catch {
@@ -289,114 +467,128 @@ final class WebSocketClient: @unchecked Sendable {
     }
 
     /// Send raw JSON string with completion handler to detect send failures.
-    func sendRaw(_ json: String, completion: ((Error?) -> Void)?) {
+    func sendRaw(_ json: String, completion: WebSocketSendCompletion?) {
         guard let task = task else {
             logger.warning("Cannot send raw: not connected")
             completion?(NSError(domain: "WebSocketClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Not connected"]))
             return
         }
-        let generation = connectionGeneration
-        task.send(.string(json)) { [weak self] error in
-            guard let self,
-                  self.task === task,
-                  self.connectionGeneration == generation else {
-                completion?(NSError(
-                    domain: "WebSocketClient",
-                    code: -2,
-                    userInfo: [NSLocalizedDescriptionKey: "Connection was replaced before send completed"]
-                ))
-                return
+        let context = WebSocketConnectionContext(
+            generation: connectionGeneration,
+            roomId: roomId ?? ""
+        )
+        let taskId = ObjectIdentifier(task)
+        let delivery = eventDelivery
+        task.send(text: json) { [weak self] error in
+            delivery.deliver { [weak self] in
+                guard let self,
+                      self.isCurrent(taskId: taskId, context: context) else {
+                    completion?(NSError(
+                        domain: "WebSocketClient",
+                        code: -2,
+                        userInfo: [NSLocalizedDescriptionKey: "Connection was replaced before send completed"]
+                    ))
+                    return
+                }
+                if let error {
+                    self.logger.error("Send raw error: \(error.localizedDescription)")
+                }
+                completion?(error)
             }
-            if let error = error {
-                self.logger.error("Send raw error: \(error.localizedDescription)")
-            }
-            completion?(error)
         }
     }
 
     // MARK: - Receive Loop
 
     private func startReceiving(
-        on wsTask: URLSessionWebSocketTask,
+        on wsTask: any WebSocketTransportTask,
         context: WebSocketConnectionContext
     ) {
+        let delivery = eventDelivery
+        let taskId = ObjectIdentifier(wsTask)
         wsTask.receive { [weak self] result in
-            guard let self = self else { return }
-            guard self.task === wsTask,
-                  WebSocketReconnectPolicy.accepts(
-                    currentGeneration: self.connectionGeneration,
-                    context: context
-                  ) else { return }
-
-            switch result {
-            case .success(let message):
-                switch message {
-                case .string(let text):
-                    if let data = text.data(using: .utf8) {
-                        self.onMessage?(data)
-                        self.onMessageWithContext?(data, context)
-                    }
-                case .data(let data):
-                    self.onMessage?(data)
-                    self.onMessageWithContext?(data, context)
-                @unknown default:
-                    break
-                }
-                // Continue receiving
-                self.startReceiving(on: wsTask, context: context)
-
-            case .failure(let error):
-                self.logger.error("Receive error: \(error.localizedDescription)")
-                self.handleDisconnect(for: wsTask, context: context)
+            // Do not read actor state on URLSession's callback queue. Also do
+            // not arm another receive here: this event must be accepted and
+            // delivered in full before the actor starts the next one.
+            delivery.deliver { [weak self] in
+                guard let self else { return }
+                await self.handleReceive(result, taskId: taskId, context: context)
             }
+        }
+    }
+
+    private func handleReceive(
+        _ result: Result<WebSocketTransportMessage, Error>,
+        taskId: ObjectIdentifier,
+        context: WebSocketConnectionContext
+    ) async {
+        guard isCurrent(taskId: taskId, context: context) else { return }
+
+        switch result {
+        case .success(let message):
+            let data: Data?
+            switch message {
+            case .string(let text):
+                data = text.data(using: .utf8)
+            case .data(let bytes):
+                data = bytes
+            }
+
+            if let data {
+                await onMessage?(data)
+                guard isCurrent(taskId: taskId, context: context) else { return }
+                await onMessageWithContext?(data, context)
+            }
+
+            // Handler suspension permits actor reentrancy. A reconnect during
+            // delivery revokes this task before it can arm another receive.
+            guard isCurrent(taskId: taskId, context: context),
+                  let wsTask = task else { return }
+            startReceiving(on: wsTask, context: context)
+
+        case .failure(let error):
+            logger.error("Receive error: \(error.localizedDescription)")
+            handleDisconnect(taskId: taskId, context: context)
         }
     }
 
     // MARK: - Reconnection
 
     private func handleDisconnect(
-        for wsTask: URLSessionWebSocketTask,
+        taskId: ObjectIdentifier,
         context: WebSocketConnectionContext
     ) {
-        // Receive callbacks fire on a URLSession background queue.
-        // Hop to main for Timer invalidation and shared state mutation.
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            guard self.task === wsTask,
-                  WebSocketReconnectPolicy.accepts(
-                    currentGeneration: self.connectionGeneration,
-                    context: context
-                  ) else { return }
-            self.task = nil
-            self.stopDeviceAnnounceTimer()
-            self.stopPings()
-            self.onConnectionStateChanged?(false)
-            self.onConnectionStateChangedWithContext?(false, context)
+        guard isCurrent(taskId: taskId, context: context) else { return }
+        task = nil
+        stopDeviceAnnounceTimer()
+        stopPings()
+        onConnectionStateChanged?(false)
+        onConnectionStateChangedWithContext?(false, context)
 
-            guard WebSocketReconnectPolicy.shouldSchedule(
+        guard WebSocketReconnectPolicy.shouldSchedule(
+            isIntentionallyClosed: isIntentionallyClosed,
+            hasScheduledReconnect: reconnectTask != nil,
+            currentGeneration: connectionGeneration,
+            context: context
+        ) else { return }
+
+        logger.info("Scheduling reconnect in \(reconnectDelay)s")
+        let scheduledGeneration = context.generation
+        let sourceTaskId = taskId
+        let delayNanoseconds = UInt64(reconnectDelay * 1_000_000_000)
+        reconnectSourceTaskId = sourceTaskId
+        reconnectTask = Task { @MainActor [weak self] in
+            try? await Task<Never, Never>.sleep(nanoseconds: delayNanoseconds)
+            guard !Task.isCancelled, let self else { return }
+            self.reconnectTask = nil
+            guard self.reconnectSourceTaskId == sourceTaskId else { return }
+            self.reconnectSourceTaskId = nil
+            guard WebSocketReconnectPolicy.shouldRunScheduled(
                 isIntentionallyClosed: self.isIntentionallyClosed,
-                hasScheduledReconnect: self.reconnectWorkItem != nil,
                 currentGeneration: self.connectionGeneration,
-                context: context
+                scheduledGeneration: scheduledGeneration
             ) else { return }
-
-            self.logger.info("Scheduling reconnect in \(self.reconnectDelay)s")
-            let scheduledGeneration = context.generation
-            let workItem = DispatchWorkItem { [weak self] in
-                guard let self = self else { return }
-                self.reconnectWorkItem = nil
-                guard WebSocketReconnectPolicy.shouldRunScheduled(
-                    isIntentionallyClosed: self.isIntentionallyClosed,
-                    currentGeneration: self.connectionGeneration,
-                    scheduledGeneration: scheduledGeneration
-                ) else { return }
-                self.performConnect()
-            }
-            self.reconnectWorkItem = workItem
-            DispatchQueue.main.asyncAfter(
-                deadline: .now() + self.reconnectDelay,
-                execute: workItem
-            )
+            self.performConnect()
         }
     }
 
@@ -405,8 +597,11 @@ final class WebSocketClient: @unchecked Sendable {
     private func startDeviceAnnounceTimer() {
         stopDeviceAnnounceTimer()
         // Fire every 30 seconds on the main run loop
+        let delivery = eventDelivery
         deviceAnnounceTimer = Timer.scheduledTimer(withTimeInterval: 30.0, repeats: true) { [weak self] _ in
-            self?.sendDeviceAnnounce()
+            delivery.deliver { [weak self] in
+                self?.sendDeviceAnnounce()
+            }
         }
         // Also send immediately on connect
         sendDeviceAnnounce()
@@ -426,8 +621,11 @@ final class WebSocketClient: @unchecked Sendable {
     /// repeating timer kept the device awake on real hardware.
     func startPings() {
         stopPings()
+        let delivery = eventDelivery
         pingTimer = Timer.scheduledTimer(withTimeInterval: Self.pingInterval, repeats: true) { [weak self] _ in
-            self?.sendPing()
+            delivery.deliver { [weak self] in
+                self?.sendPing()
+            }
         }
     }
 
@@ -446,24 +644,19 @@ final class WebSocketClient: @unchecked Sendable {
     /// with an error rather than completing successfully.
     private func sendPing() {
         guard let task = task else { return }
-        let generation = connectionGeneration
+        let context = WebSocketConnectionContext(
+            generation: connectionGeneration,
+            roomId: roomId ?? ""
+        )
+        let taskId = ObjectIdentifier(task)
+        let delivery = eventDelivery
         task.sendPing { [weak self] error in
-            guard let self = self else { return }
-            // Ignore late callbacks from a prior connection generation -- those
-            // would cause us to tear down a healthy new connection or, worse,
-            // mistake a stale pong for proof of life on the new one.
-            DispatchQueue.main.async {
-                guard generation == self.connectionGeneration else { return }
-                if let error = error {
-                    self.logger.warning("Ping failed -- treating connection as dead: \(error.localizedDescription)")
-                    if let deadTask = self.task {
-                        let context = WebSocketConnectionContext(
-                            generation: generation,
-                            roomId: self.roomId ?? ""
-                        )
-                        self.handleDisconnect(for: deadTask, context: context)
-                    }
-                }
+            delivery.deliver { [weak self] in
+                guard let self,
+                      self.isCurrent(taskId: taskId, context: context),
+                      let error else { return }
+                self.logger.warning("Ping failed -- treating connection as dead: \(error.localizedDescription)")
+                self.handleDisconnect(taskId: taskId, context: context)
             }
         }
     }

--- a/packages/ios/NimbalystNative/Sources/Views/SessionListView.swift
+++ b/packages/ios/NimbalystNative/Sources/Views/SessionListView.swift
@@ -2,6 +2,31 @@ import SwiftUI
 import Combine
 import GRDB
 
+@MainActor
+final class SessionListObservationHandoff<Value> {
+    private var generation: UInt = 0
+    private var cancellable: AnyDatabaseCancellable?
+
+    func replace(
+        start: (@escaping (Value) -> Void) -> AnyDatabaseCancellable,
+        onChange: @escaping (Value) -> Void
+    ) {
+        cancellable?.cancel()
+        generation &+= 1
+        let acceptedGeneration = generation
+        cancellable = start { [weak self] value in
+            guard let self, self.generation == acceptedGeneration else { return }
+            onChange(value)
+        }
+    }
+
+    func cancel() {
+        cancellable?.cancel()
+        cancellable = nil
+        generation &+= 1
+    }
+}
+
 // MARK: - Time Period Grouping
 
 enum TimePeriod: String, CaseIterable {
@@ -159,7 +184,7 @@ public struct SessionListView: View {
     private var isIPadSidebar: Bool { selectedSession != nil }
 
     @State private var sessions: [Session] = []
-    @State private var cancellable: AnyDatabaseCancellable?
+    @State private var observationHandoff = SessionListObservationHandoff<[Session]>()
     @State private var expandedWorkstreams: Set<String> = []
     /// Meta-agent groups that are COLLAPSED. Stored as the inverse of expansion so the
     /// default state is expanded, mirroring desktop (see `MetaAgentExpansion`).
@@ -453,13 +478,14 @@ public struct SessionListView: View {
             resolveDefaultModel()
         }
         .onChange(of: project.id) { _ in
-            cancellable?.cancel()
+            observationHandoff.cancel()
+            sessions = []
             startObserving()
             loadExpandedState()
             loadMetaAgentExpansionState()
         }
         .onDisappear {
-            cancellable?.cancel()
+            observationHandoff.cancel()
         }
         // Refresh the meta-agent gate at the root so a desktop flip is caught even when the
         // user is on a non-Sessions tab. The creation menu's listener is only mounted while
@@ -819,14 +845,24 @@ public struct SessionListView: View {
                 .fetchAll(db)
         }
 
-        cancellable = observation.start(
-            in: db.writer,
-            onError: { error in
-                print("Session observation error: \(error)")
+        observationHandoff.replace(
+            start: { receive in
+                observation.start(
+                    in: db.writer,
+                    scheduling: .async(onQueue: .main),
+                    onError: { error in
+                        print("Session observation error: \(error)")
+                    },
+                    onChange: receive
+                )
             },
             onChange: { newSessions in
                 withAnimation {
                     sessions = newSessions
+                    if let selected = selectedSession?.wrappedValue,
+                       let authoritative = newSessions.first(where: { $0.id == selected.id }) {
+                        selectedSession?.wrappedValue = authoritative
+                    }
                 }
             }
         )

--- a/packages/ios/NimbalystNative/Tests/SessionFeedContinuityTests.swift
+++ b/packages/ios/NimbalystNative/Tests/SessionFeedContinuityTests.swift
@@ -1,0 +1,565 @@
+import XCTest
+import GRDB
+@testable import NimbalystNative
+
+private final class FakeSyncSocket: SyncWebSocketClient {
+    var sendsDeviceAnnounce = false
+    var onMessageWithContext: ((Data, WebSocketConnectionContext) -> Void)?
+    var onConnectionStateChangedWithContext: ((Bool, WebSocketConnectionContext) -> Void)?
+    var isConnected = false
+
+    private(set) var connectCount = 0
+    private(set) var reconnectCount = 0
+    private(set) var sentJSON: [String] = []
+    private(set) var currentContext: WebSocketConnectionContext?
+    var sendResults: [Error?] = []
+
+    private var generation = 0
+    private var serverUrl: String?
+    private var roomId: String?
+    private var authToken: String?
+
+    func reportActivity() {}
+    func setAppInForeground(_ inForeground: Bool) {}
+
+    func connect(serverUrl: String, roomId: String, authToken: String) {
+        self.serverUrl = serverUrl
+        self.roomId = roomId
+        self.authToken = authToken
+        connectCount += 1
+        openReplacementConnection()
+    }
+
+    func disconnect() {
+        let closed = currentContext
+        generation &+= 1
+        currentContext = nil
+        isConnected = false
+        if let closed {
+            onConnectionStateChangedWithContext?(false, closed)
+        }
+    }
+
+    func reconnect() {
+        reconnectCount += 1
+        guard serverUrl != nil, roomId != nil, authToken != nil else { return }
+        openReplacementConnection()
+    }
+
+    func sendRaw(_ json: String) {
+        sendRaw(json, completion: nil)
+    }
+
+    func sendRaw(_ json: String, completion: ((Error?) -> Void)?) {
+        sentJSON.append(json)
+        let result = sendResults.isEmpty ? nil : sendResults.removeFirst()
+        completion?(result)
+    }
+
+    func startPings() {}
+    func stopPings() {}
+
+    func emit(_ data: Data, context: WebSocketConnectionContext? = nil) {
+        guard let context = context ?? currentContext else { return }
+        onMessageWithContext?(data, context)
+    }
+
+    private func openReplacementConnection() {
+        generation &+= 1
+        let context = WebSocketConnectionContext(
+            generation: generation,
+            roomId: roomId ?? ""
+        )
+        currentContext = context
+        isConnected = true
+        onConnectionStateChangedWithContext?(true, context)
+    }
+}
+
+@MainActor
+private final class ControlledSyncScheduler: SyncScheduling {
+    private(set) var operations: [SyncScheduledOperation] = []
+
+    func schedule(after delay: TimeInterval, _ operation: @escaping SyncScheduledOperation) {
+        operations.append(operation)
+    }
+
+    func runNext() {
+        operations.removeFirst()()
+    }
+}
+
+private final class ControlledIndexExecutor: IndexWorkExecuting, @unchecked Sendable {
+    private var activeGeneration: Int?
+    private(set) var queued: [(Int, IndexWork)] = []
+
+    func setActiveGeneration(_ generation: Int?) {
+        activeGeneration = generation
+    }
+
+    func enqueue(generation: Int, _ work: @escaping IndexWork) {
+        queued.append((generation, work))
+    }
+
+    func runNext() {
+        let (generation, work) = queued.removeFirst()
+        let isCurrent: IndexGenerationCheck = { [weak self] in
+            self?.activeGeneration == generation
+        }
+        guard isCurrent() else { return }
+        work(isCurrent)
+    }
+
+    func runAll() {
+        while !queued.isEmpty {
+            runNext()
+        }
+    }
+}
+
+@MainActor
+final class SessionFeedContinuityTests: XCTestCase {
+    private let userId = "user-test-12345"
+    private let seed = "dGVzdC1lbmNyeXB0aW9uLWtleS1zZWVkLWZvci10ZXN0cw=="
+
+    private func makeCrypto() -> CryptoManager {
+        CryptoManager(seed: seed, userId: userId)
+    }
+
+    private func makeDatabaseWithSession(
+        id: String = "session-1",
+        title: String? = nil,
+        isPinned: Bool = false,
+        isExecuting: Bool = false,
+        updatedAt: Int = 1_000
+    ) throws -> DatabaseManager {
+        let database = try DatabaseManager()
+        try database.upsertProject(Project(id: "/project", name: "project"))
+        try database.upsertSession(Session(
+            id: id,
+            projectId: "/project",
+            titleDecrypted: title,
+            isPinned: isPinned,
+            isExecuting: isExecuting,
+            createdAt: 500,
+            updatedAt: updatedAt
+        ))
+        return database
+    }
+
+    private func makeManager(
+        database: DatabaseManager,
+        crypto: CryptoManager,
+        indexSocket: FakeSyncSocket,
+        sessionSocket: FakeSyncSocket,
+        scheduler: ControlledSyncScheduler = ControlledSyncScheduler(),
+        executor: ControlledIndexExecutor = ControlledIndexExecutor()
+    ) -> SyncManager {
+        SyncManager(
+            crypto: crypto,
+            database: database,
+            serverUrl: "https://example.invalid",
+            userId: userId,
+            indexClient: indexSocket,
+            sessionClient: sessionSocket,
+            scheduler: scheduler,
+            indexExecutor: executor
+        )
+    }
+
+    private func settleMainActor(_ count: Int = 12) async {
+        for _ in 0..<count {
+            await Task.yield()
+        }
+    }
+
+    private func serverMessage(sequence: Int, crypto: CryptoManager) throws -> ServerMessageEntry {
+        let encrypted = try crypto.encrypt(plaintext: "message \(sequence)")
+        return ServerMessageEntry(
+            id: "message-\(sequence)",
+            sequence: sequence,
+            createdAt: 1_000 + sequence,
+            source: sequence.isMultiple(of: 2) ? "assistant" : "user",
+            direction: sequence.isMultiple(of: 2) ? "output" : "input",
+            encryptedContent: encrypted.encrypted,
+            iv: encrypted.iv,
+            metadata: nil
+        )
+    }
+
+    private func serverSession(
+        crypto: CryptoManager,
+        title: String,
+        isPinned: Bool,
+        isExecuting: Bool,
+        updatedAt: Int
+    ) throws -> ServerSessionEntry {
+        let encryptedTitle = try crypto.encrypt(plaintext: title)
+        return ServerSessionEntry(
+            sessionId: "session-1",
+            encryptedProjectId: try crypto.encryptProjectId("/project"),
+            projectIdIv: CryptoManager.projectIdIvBase64,
+            encryptedTitle: encryptedTitle.encrypted,
+            titleIv: encryptedTitle.iv,
+            provider: "claude-code",
+            model: "opus",
+            mode: "agent",
+            sessionType: nil,
+            parentSessionId: nil,
+            agentRole: nil,
+            createdBySessionId: nil,
+            worktreeId: nil,
+            isArchived: false,
+            isPinned: isPinned,
+            branchedFromSessionId: nil,
+            branchPointMessageId: nil,
+            branchedAt: nil,
+            messageCount: 0,
+            lastMessageAt: nil,
+            createdAt: 500,
+            updatedAt: updatedAt,
+            pendingExecution: nil,
+            isExecuting: isExecuting,
+            queuedPromptCount: 0,
+            encryptedQueuedPrompts: nil,
+            hasPendingPrompt: false,
+            encryptedClientMetadata: nil,
+            clientMetadataIv: nil,
+            lastReadAt: nil
+        )
+    }
+
+    private func metadata(
+        crypto: CryptoManager,
+        title: String,
+        isExecuting: Bool,
+        updatedAt: Int
+    ) throws -> SessionRoomMetadata {
+        let encryptedTitle = try crypto.encrypt(plaintext: title)
+        return SessionRoomMetadata(
+            encryptedTitle: encryptedTitle.encrypted,
+            titleIv: encryptedTitle.iv,
+            provider: "claude-code",
+            model: "opus",
+            mode: "agent",
+            isExecuting: isExecuting,
+            createdAt: nil,
+            updatedAt: updatedAt,
+            encryptedProjectId: nil,
+            projectIdIv: nil,
+            encryptedClientMetadata: nil,
+            clientMetadataIv: nil
+        )
+    }
+
+    func testForegroundTransitionReplacesStaleRunningIndexAndSessionSockets() async throws {
+        let database = try makeDatabaseWithSession()
+        let crypto = makeCrypto()
+        let indexSocket = FakeSyncSocket()
+        let sessionSocket = FakeSyncSocket()
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: indexSocket,
+            sessionSocket: sessionSocket
+        )
+
+        manager.connect(authToken: "token", authUserId: userId, orgId: "org")
+        manager.joinSessionRoom(sessionId: "session-1")
+        await settleMainActor()
+        XCTAssertTrue(indexSocket.isConnected, "Fake deliberately reports stale .running state")
+        XCTAssertTrue(sessionSocket.isConnected)
+
+        manager.setAppInForeground(false)
+        manager.setAppInForeground(false)
+        manager.setAppInForeground(true)
+        await settleMainActor()
+
+        XCTAssertEqual(indexSocket.reconnectCount, 1)
+        XCTAssertEqual(sessionSocket.reconnectCount, 1)
+        XCTAssertGreaterThanOrEqual(indexSocket.sentJSON.count, 2, "replacement generation must catch up index")
+        XCTAssertGreaterThanOrEqual(sessionSocket.sentJSON.count, 2, "replacement generation must catch up transcript")
+
+        manager.setAppInForeground(true)
+        XCTAssertEqual(indexSocket.reconnectCount, 1, "foreground callbacks are transition-bounded")
+    }
+
+    func testSessionRetrySchedulerAndPaginatedRuntimeCallbackStoreLongHistory() async throws {
+        let database = try makeDatabaseWithSession()
+        let crypto = makeCrypto()
+        let indexSocket = FakeSyncSocket()
+        let sessionSocket = FakeSyncSocket()
+        let scheduler = ControlledSyncScheduler()
+        sessionSocket.sendResults = [NSError(domain: "test", code: 1), nil, nil]
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: indexSocket,
+            sessionSocket: sessionSocket,
+            scheduler: scheduler
+        )
+
+        manager.connect(authToken: "token", authUserId: userId, orgId: "org")
+        manager.joinSessionRoom(sessionId: "session-1")
+        await settleMainActor()
+        XCTAssertEqual(scheduler.operations.count, 1)
+        scheduler.runNext()
+        await settleMainActor()
+
+        let firstPage = SessionSyncResponse(
+            type: "syncResponse",
+            messages: try (1...256).map { try serverMessage(sequence: $0, crypto: crypto) },
+            metadata: nil,
+            hasMore: true,
+            cursor: "256"
+        )
+        sessionSocket.emit(try JSONEncoder().encode(firstPage))
+        await settleMainActor(300)
+
+        let secondPage = SessionSyncResponse(
+            type: "syncResponse",
+            messages: try (257...520).map { try serverMessage(sequence: $0, crypto: crypto) },
+            metadata: nil,
+            hasMore: false,
+            cursor: "520"
+        )
+        sessionSocket.emit(try JSONEncoder().encode(secondPage))
+        await settleMainActor(300)
+
+        let replay = MessageBroadcast(
+            type: "messageBroadcast",
+            message: try serverMessage(sequence: 520, crypto: crypto),
+            fromConnectionId: "desktop"
+        )
+        sessionSocket.emit(try JSONEncoder().encode(replay))
+        await settleMainActor()
+
+        let stored = try database.messages(forSession: "session-1")
+        XCTAssertEqual(stored.count, 520)
+        XCTAssertEqual(stored.map(\.sequence), Array(1...520))
+        XCTAssertEqual(try database.syncState(forRoom: "session-1")?.lastSequence, 520)
+        XCTAssertEqual(try database.session(byId: "session-1")?.lastSyncedSeq, 520)
+    }
+
+    func testOlderQueuedIndexResponseCannotSplitNewerMetadataAndCursor() async throws {
+        let database = try makeDatabaseWithSession(title: "initial")
+        let crypto = makeCrypto()
+        let indexSocket = FakeSyncSocket()
+        let executor = ControlledIndexExecutor()
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: indexSocket,
+            sessionSocket: FakeSyncSocket(),
+            executor: executor
+        )
+        manager.connect(authToken: "token", authUserId: userId, orgId: "org")
+        await settleMainActor()
+
+        let oldSnapshot = IndexSyncResponse(
+            type: "indexSyncResponse",
+            sessions: [try serverSession(
+                crypto: crypto,
+                title: "stale index title",
+                isPinned: true,
+                isExecuting: false,
+                updatedAt: 2_000
+            )],
+            projects: [],
+            totalSessionCount: 1,
+            since: nil
+        )
+        indexSocket.emit(try JSONEncoder().encode(oldSnapshot))
+        await settleMainActor()
+        XCTAssertEqual(executor.queued.count, 1)
+
+        manager.applySessionMetadata(
+            try metadata(crypto: crypto, title: "new room title", isExecuting: true, updatedAt: 3_000),
+            sessionId: "session-1"
+        )
+        executor.runAll()
+
+        let stored = try XCTUnwrap(database.session(byId: "session-1"))
+        XCTAssertEqual(stored.titleDecrypted, "new room title")
+        XCTAssertTrue(stored.isExecuting)
+        XCTAssertTrue(stored.isPinned, "index-owned fields still reconcile")
+        XCTAssertEqual(try database.syncState(forRoom: "session-1")?.lastCursor, "3000")
+    }
+
+    func testEqualTimestampSnapshotThenPinBroadcastAppliesInReceiveOrder() async throws {
+        let database = try makeDatabaseWithSession(isPinned: false)
+        let crypto = makeCrypto()
+        let indexSocket = FakeSyncSocket()
+        let executor = ControlledIndexExecutor()
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: indexSocket,
+            sessionSocket: FakeSyncSocket(),
+            executor: executor
+        )
+        manager.connect(authToken: "token", authUserId: userId, orgId: "org")
+        await settleMainActor()
+
+        let snapshotEntry = try serverSession(
+            crypto: crypto,
+            title: "session",
+            isPinned: false,
+            isExecuting: false,
+            updatedAt: 2_000
+        )
+        let snapshot = IndexSyncResponse(
+            type: "indexSyncResponse",
+            sessions: [snapshotEntry],
+            projects: [],
+            totalSessionCount: 1,
+            since: nil
+        )
+        let pin = IndexBroadcast(
+            type: "indexBroadcast",
+            session: try serverSession(
+                crypto: crypto,
+                title: "session",
+                isPinned: true,
+                isExecuting: false,
+                updatedAt: 2_000
+            ),
+            fromConnectionId: "desktop"
+        )
+
+        indexSocket.emit(try JSONEncoder().encode(snapshot))
+        indexSocket.emit(try JSONEncoder().encode(pin))
+        await settleMainActor()
+        XCTAssertEqual(executor.queued.count, 2)
+        executor.runAll()
+
+        XCTAssertTrue(try XCTUnwrap(database.session(byId: "session-1")).isPinned)
+    }
+
+    func testQueuedOldGenerationIndexWorkAndLateCallbackAreRejected() async throws {
+        let database = try makeDatabaseWithSession(title: "current")
+        let crypto = makeCrypto()
+        let indexSocket = FakeSyncSocket()
+        let executor = ControlledIndexExecutor()
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: indexSocket,
+            sessionSocket: FakeSyncSocket(),
+            executor: executor
+        )
+        manager.connect(authToken: "token", authUserId: userId, orgId: "org")
+        await settleMainActor()
+        let oldContext = try XCTUnwrap(indexSocket.currentContext)
+        let oldResponse = IndexSyncResponse(
+            type: "indexSyncResponse",
+            sessions: [try serverSession(
+                crypto: crypto,
+                title: "old generation",
+                isPinned: true,
+                isExecuting: false,
+                updatedAt: 2_000
+            )],
+            projects: [],
+            totalSessionCount: 1,
+            since: nil
+        )
+        let data = try JSONEncoder().encode(oldResponse)
+        indexSocket.emit(data, context: oldContext)
+        await settleMainActor()
+        XCTAssertEqual(executor.queued.count, 1)
+
+        manager.setAppInForeground(false)
+        manager.setAppInForeground(true)
+        await settleMainActor()
+        executor.runAll()
+        XCTAssertEqual(try database.session(byId: "session-1")?.titleDecrypted, "current")
+
+        let queuedAfterReconnect = executor.queued.count
+        indexSocket.emit(data, context: oldContext)
+        await settleMainActor()
+        XCTAssertEqual(executor.queued.count, queuedAfterReconnect)
+    }
+
+    func testMetadataProgressesWithoutTranscriptTrafficAndRejectsOlderReplay() throws {
+        let database = try makeDatabaseWithSession()
+        let crypto = makeCrypto()
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: FakeSyncSocket(),
+            sessionSocket: FakeSyncSocket()
+        )
+
+        manager.applySessionMetadata(
+            try metadata(crypto: crypto, title: "running", isExecuting: true, updatedAt: 2_000),
+            sessionId: "session-1"
+        )
+        manager.applySessionMetadata(
+            try metadata(crypto: crypto, title: "complete", isExecuting: false, updatedAt: 3_000),
+            sessionId: "session-1"
+        )
+        manager.applySessionMetadata(
+            try metadata(crypto: crypto, title: "stale", isExecuting: true, updatedAt: 2_500),
+            sessionId: "session-1"
+        )
+
+        let stored = try XCTUnwrap(database.session(byId: "session-1"))
+        XCTAssertFalse(stored.isExecuting)
+        XCTAssertEqual(stored.titleDecrypted, "complete")
+        XCTAssertEqual(try database.messages(forSession: "session-1").count, 0)
+        XCTAssertEqual(try database.syncState(forRoom: "session-1")?.lastCursor, "3000")
+    }
+
+    func testDatabaseObservationHandoffDropsAlreadyQueuedOldWatcherValue() async throws {
+        let database = try makeDatabaseWithSession()
+        try database.upsertProject(Project(id: "/other", name: "other"))
+        try database.upsertSession(Session(id: "session-2", projectId: "/other"))
+        let handoff = SessionListObservationHandoff<[Session]>()
+        var oldReceive: (([Session]) -> Void)?
+        var receivedIds: [[String]] = []
+
+        let firstObservation = ValueObservation.tracking { db in
+            try Session.filter(Session.Columns.projectId == "/project").fetchAll(db)
+        }
+        handoff.replace(
+            start: { receive in
+                oldReceive = receive
+                return firstObservation.start(
+                    in: database.writer,
+                    scheduling: .async(onQueue: .main),
+                    onError: { XCTFail("first observation failed: \($0)") },
+                    onChange: receive
+                )
+            },
+            onChange: { receivedIds.append($0.map(\.id)) }
+        )
+
+        let currentValue = expectation(description: "replacement watcher delivered")
+        let secondObservation = ValueObservation.tracking { db in
+            try Session.filter(Session.Columns.projectId == "/other").fetchAll(db)
+        }
+        handoff.replace(
+            start: { receive in
+                secondObservation.start(
+                    in: database.writer,
+                    scheduling: .async(onQueue: .main),
+                    onError: { XCTFail("second observation failed: \($0)") },
+                    onChange: receive
+                )
+            },
+            onChange: {
+                receivedIds.append($0.map(\.id))
+                if $0.map(\.id) == ["session-2"] {
+                    currentValue.fulfill()
+                }
+            }
+        )
+
+        oldReceive?([try XCTUnwrap(database.session(byId: "session-1"))])
+        await fulfillment(of: [currentValue], timeout: 2)
+        handoff.cancel()
+        XCTAssertFalse(receivedIds.contains(["session-1"]))
+        XCTAssertEqual(receivedIds.last, ["session-2"])
+    }
+}

--- a/packages/ios/NimbalystNative/Tests/SessionFeedContinuityTests.swift
+++ b/packages/ios/NimbalystNative/Tests/SessionFeedContinuityTests.swift
@@ -1,11 +1,13 @@
 import XCTest
 import GRDB
+import CryptoKit
 @testable import NimbalystNative
 
+@MainActor
 private final class FakeSyncSocket: SyncWebSocketClient {
     var sendsDeviceAnnounce = false
-    var onMessageWithContext: ((Data, WebSocketConnectionContext) -> Void)?
-    var onConnectionStateChangedWithContext: ((Bool, WebSocketConnectionContext) -> Void)?
+    var onMessageWithContext: WebSocketMessageHandler?
+    var onConnectionStateChangedWithContext: WebSocketConnectionHandler?
     var isConnected = false
 
     private(set) var connectCount = 0
@@ -50,7 +52,7 @@ private final class FakeSyncSocket: SyncWebSocketClient {
         sendRaw(json, completion: nil)
     }
 
-    func sendRaw(_ json: String, completion: ((Error?) -> Void)?) {
+    func sendRaw(_ json: String, completion: WebSocketSendCompletion?) {
         sentJSON.append(json)
         let result = sendResults.isEmpty ? nil : sendResults.removeFirst()
         completion?(result)
@@ -59,9 +61,13 @@ private final class FakeSyncSocket: SyncWebSocketClient {
     func startPings() {}
     func stopPings() {}
 
-    func emit(_ data: Data, context: WebSocketConnectionContext? = nil) {
+    func emit(_ data: Data, context: WebSocketConnectionContext? = nil) async {
         guard let context = context ?? currentContext else { return }
-        onMessageWithContext?(data, context)
+        await onMessageWithContext?(data, context)
+    }
+
+    func emitConnection(_ connected: Bool, context: WebSocketConnectionContext) {
+        onConnectionStateChangedWithContext?(connected, context)
     }
 
     private func openReplacementConnection() {
@@ -73,6 +79,192 @@ private final class FakeSyncSocket: SyncWebSocketClient {
         currentContext = context
         isConnected = true
         onConnectionStateChangedWithContext?(true, context)
+    }
+}
+
+private final class ControlledWebSocketEventDelivery: WebSocketEventDelivering, @unchecked Sendable {
+    private let lock = NSLock()
+    private var operations: [WebSocketEventOperation] = []
+
+    var count: Int {
+        lock.withLock { operations.count }
+    }
+
+    func deliver(_ operation: @escaping WebSocketEventOperation) {
+        lock.withLock {
+            operations.append(operation)
+        }
+    }
+
+    func run(at index: Int = 0) async {
+        let operation = lock.withLock { operations.remove(at: index) }
+        await operation()
+    }
+}
+
+private final class FakeWebSocketTransportTask: WebSocketTransportTask {
+    private let lock = NSLock()
+    private var taskState: URLSessionTask.State = .suspended
+    private var receiveCompletion: (@Sendable (
+        Result<WebSocketTransportMessage, Error>
+    ) -> Void)?
+    private var sendCompletions: [@Sendable (Error?) -> Void] = []
+
+    var state: URLSessionTask.State {
+        lock.withLock { taskState }
+    }
+
+    var hasPendingReceive: Bool {
+        lock.withLock { receiveCompletion != nil }
+    }
+
+    var pendingSendCount: Int {
+        lock.withLock { sendCompletions.count }
+    }
+
+    func resume() {
+        lock.withLock { taskState = .running }
+    }
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        lock.withLock { taskState = .canceling }
+    }
+
+    func send(
+        text: String,
+        completionHandler: @escaping @Sendable (Error?) -> Void
+    ) {
+        lock.withLock { sendCompletions.append(completionHandler) }
+    }
+
+    func receive(
+        completionHandler: @escaping @Sendable (
+            Result<WebSocketTransportMessage, Error>
+        ) -> Void
+    ) {
+        lock.withLock {
+            precondition(receiveCompletion == nil, "only one receive may be outstanding")
+            receiveCompletion = completionHandler
+        }
+    }
+
+    func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {}
+
+    @discardableResult
+    func completeReceive(
+        _ result: Result<WebSocketTransportMessage, Error>
+    ) -> Bool {
+        let completion = lock.withLock { () -> (@Sendable (
+            Result<WebSocketTransportMessage, Error>
+        ) -> Void)? in
+            defer { receiveCompletion = nil }
+            return receiveCompletion
+        }
+        guard let completion else { return false }
+        completion(result)
+        return true
+    }
+
+    func completeSend(at index: Int = 0, error: Error?) {
+        let completion = lock.withLock { sendCompletions.remove(at: index) }
+        completion(error)
+    }
+}
+
+@MainActor
+private final class FakeWebSocketTransportFactory: WebSocketTransportCreating {
+    private(set) var tasks: [FakeWebSocketTransportTask] = []
+
+    func makeTask(url: URL) -> any WebSocketTransportTask {
+        let task = FakeWebSocketTransportTask()
+        tasks.append(task)
+        return task
+    }
+}
+
+@MainActor
+private final class DocumentWebSocketClientQueue {
+    private var clients: [WebSocketClient]
+
+    init(_ clients: [WebSocketClient]) {
+        self.clients = clients
+    }
+
+    func next() -> WebSocketClient {
+        precondition(!clients.isEmpty, "document client factory exhausted")
+        return clients.removeFirst()
+    }
+}
+
+private enum DeterministicWebSocketError: Error, Sendable {
+    case receiveFailed
+}
+
+@MainActor
+private final class OneShotSuspension {
+    let reached: XCTestExpectation
+    private var shouldSuspend = true
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    init(description: String) {
+        reached = XCTestExpectation(description: description)
+    }
+
+    func suspendOnce() async {
+        guard shouldSuspend else { return }
+        shouldSuspend = false
+        reached.fulfill()
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func resume() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+@MainActor
+private final class ControlledSessionCatchUpYielder: SessionCatchUpYielding {
+    let suspension = OneShotSuspension(description: "session final chunk persisted")
+
+    func yieldAfterPersistedChunk() async {
+        await suspension.suspendOnce()
+    }
+}
+
+@MainActor
+private final class SuspendedMessageRecorder {
+    private(set) var messages: [String] = []
+    private(set) var secondaryMessages: [String] = []
+    private(set) var connectedGenerations: [Int] = []
+    private(set) var sendErrorCodes: [Int?] = []
+    let suspension = OneShotSuspension(description: "message callback suspended")
+    var suspendNext = false
+
+    func accept(_ data: Data) async {
+        if suspendNext {
+            suspendNext = false
+            await suspension.suspendOnce()
+        }
+        messages.append(String(data: data, encoding: .utf8) ?? "<binary>")
+    }
+
+    func resume() {
+        suspension.resume()
+    }
+
+    func recordConnection(_ connected: Bool, context: WebSocketConnectionContext) {
+        if connected {
+            connectedGenerations.append(context.generation)
+        }
+    }
+
+    func recordSend(error: Error?) {
+        sendErrorCodes.append(error.map { ($0 as NSError).code })
+    }
+
+    func recordSecondary(_ data: Data) {
+        secondaryMessages.append(String(data: data, encoding: .utf8) ?? "<binary>")
     }
 }
 
@@ -150,10 +342,11 @@ final class SessionFeedContinuityTests: XCTestCase {
     private func makeManager(
         database: DatabaseManager,
         crypto: CryptoManager,
-        indexSocket: FakeSyncSocket,
-        sessionSocket: FakeSyncSocket,
+        indexSocket: any SyncWebSocketClient,
+        sessionSocket: any SyncWebSocketClient,
         scheduler: ControlledSyncScheduler = ControlledSyncScheduler(),
-        executor: ControlledIndexExecutor = ControlledIndexExecutor()
+        executor: ControlledIndexExecutor = ControlledIndexExecutor(),
+        sessionCatchUpYielder: any SessionCatchUpYielding = TaskSessionCatchUpYielder()
     ) -> SyncManager {
         SyncManager(
             crypto: crypto,
@@ -163,7 +356,8 @@ final class SessionFeedContinuityTests: XCTestCase {
             indexClient: indexSocket,
             sessionClient: sessionSocket,
             scheduler: scheduler,
-            indexExecutor: executor
+            indexExecutor: executor,
+            sessionCatchUpYielder: sessionCatchUpYielder
         )
     }
 
@@ -171,6 +365,47 @@ final class SessionFeedContinuityTests: XCTestCase {
         for _ in 0..<count {
             await Task.yield()
         }
+    }
+
+    private func startTrackedOperation(
+        description: String,
+        operation: @escaping @MainActor @Sendable () async -> Void
+    ) -> (task: Task<Void, Never>, completion: XCTestExpectation) {
+        let completion = expectation(description: description)
+        let task = Task { @MainActor in
+            await operation()
+            completion.fulfill()
+        }
+        return (task, completion)
+    }
+
+    private func documentRoomId(projectId: String = "/project") -> String {
+        let digest = SHA256.hash(data: Data(projectId.utf8))
+        let hashedProjectId = digest.map { String(format: "%02x", $0) }.joined()
+        return "org:org:user:\(userId):project:\(hashedProjectId)"
+    }
+
+    private func documentContentBroadcast(
+        syncId: String,
+        content: String,
+        crypto: CryptoManager
+    ) throws -> FileContentBroadcast {
+        let encryptedContent = try crypto.encrypt(plaintext: content)
+        let encryptedPath = try crypto.encrypt(plaintext: "\(syncId).md")
+        let encryptedTitle = try crypto.encrypt(plaintext: syncId)
+        return FileContentBroadcast(
+            type: "fileContentBroadcast",
+            syncId: syncId,
+            encryptedContent: encryptedContent.encrypted,
+            contentIv: encryptedContent.iv,
+            contentHash: "hash-\(syncId)",
+            encryptedPath: encryptedPath.encrypted,
+            pathIv: encryptedPath.iv,
+            encryptedTitle: encryptedTitle.encrypted,
+            titleIv: encryptedTitle.iv,
+            lastModifiedAt: 2_000,
+            fromConnectionId: "desktop"
+        )
     }
 
     private func serverMessage(sequence: Int, crypto: CryptoManager) throws -> ServerMessageEntry {
@@ -252,6 +487,109 @@ final class SessionFeedContinuityTests: XCTestCase {
         )
     }
 
+    private func exerciseStaleFinalChunkSchedule(oldHasMore: Bool) async throws {
+        let database = try makeDatabaseWithSession(title: "initial")
+        let crypto = makeCrypto()
+        let delivery = ControlledWebSocketEventDelivery()
+        let factory = FakeWebSocketTransportFactory()
+        let sessionSocket = WebSocketClient(
+            transportFactory: factory,
+            eventDelivery: delivery
+        )
+        let yielder = ControlledSessionCatchUpYielder()
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: FakeSyncSocket(),
+            sessionSocket: sessionSocket,
+            sessionCatchUpYielder: yielder
+        )
+        var diagnostics: [SessionSyncDiagnostic] = []
+        manager.onSessionSyncDiagnostic = { _, diagnostic in
+            diagnostics.append(diagnostic)
+        }
+
+        manager.connect(authToken: "token", authUserId: userId, orgId: "org")
+        manager.joinSessionRoom(sessionId: "session-1")
+        await delivery.run()
+        let firstTask = try XCTUnwrap(factory.tasks.first)
+
+        let staleResponse = SessionSyncResponse(
+            type: "syncResponse",
+            messages: [try serverMessage(sequence: 1, crypto: crypto)],
+            metadata: try metadata(
+                crypto: crypto,
+                title: "stale generation",
+                isExecuting: true,
+                updatedAt: 2_000
+            ),
+            hasMore: oldHasMore,
+            cursor: oldHasMore ? "1" : nil
+        )
+        XCTAssertTrue(firstTask.completeReceive(.success(.data(
+            try JSONEncoder().encode(staleResponse)
+        ))))
+        let staleDelivery = startTrackedOperation(
+            description: "stale session delivery unwound"
+        ) {
+            await delivery.run()
+        }
+        await fulfillment(of: [yielder.suspension.reached], timeout: 1.0)
+
+        manager.setAppInForeground(false)
+        manager.setAppInForeground(true)
+        await delivery.run()
+        let replacementTask = try XCTUnwrap(factory.tasks.last)
+        let replacementSendCount = replacementTask.pendingSendCount
+
+        yielder.suspension.resume()
+        await fulfillment(of: [staleDelivery.completion], timeout: 1.0)
+        staleDelivery.task.cancel()
+
+        XCTAssertEqual(
+            try database.session(byId: "session-1")?.titleDecrypted,
+            "initial",
+            "generation N cannot apply metadata after N+1 owns catch-up"
+        )
+        XCTAssertTrue(diagnostics.isEmpty, "generation N cannot finish N+1 catch-up")
+        if oldHasMore {
+            XCTAssertEqual(
+                replacementTask.pendingSendCount,
+                replacementSendCount,
+                "generation N cannot paginate on N+1's socket"
+            )
+        }
+
+        let replacementResponse = SessionSyncResponse(
+            type: "syncResponse",
+            messages: [try serverMessage(sequence: 2, crypto: crypto)],
+            metadata: try metadata(
+                crypto: crypto,
+                title: "replacement generation",
+                isExecuting: false,
+                updatedAt: 3_000
+            ),
+            hasMore: false,
+            cursor: "2"
+        )
+        XCTAssertTrue(replacementTask.completeReceive(.success(.data(
+            try JSONEncoder().encode(replacementResponse)
+        ))))
+        await delivery.run()
+
+        XCTAssertEqual(try database.session(byId: "session-1")?.titleDecrypted, "replacement generation")
+        XCTAssertEqual(diagnostics.count, 1, "only generation N+1 may finish catch-up")
+        XCTAssertEqual(diagnostics.first?.totalServerMessages, 1)
+    }
+
+    func testStaleFinalChunkCannotFinishReplacementCatchUp() async throws {
+        try await exerciseStaleFinalChunkSchedule(oldHasMore: false)
+    }
+
+    func testStaleFinalChunkCannotApplyMetadataOrPaginateOnReplacementSocket() async throws {
+        try await exerciseStaleFinalChunkSchedule(oldHasMore: true)
+    }
+
     func testForegroundTransitionReplacesStaleRunningIndexAndSessionSockets() async throws {
         let database = try makeDatabaseWithSession()
         let crypto = makeCrypto()
@@ -313,7 +651,7 @@ final class SessionFeedContinuityTests: XCTestCase {
             hasMore: true,
             cursor: "256"
         )
-        sessionSocket.emit(try JSONEncoder().encode(firstPage))
+        await sessionSocket.emit(try JSONEncoder().encode(firstPage))
         await settleMainActor(300)
 
         let secondPage = SessionSyncResponse(
@@ -323,7 +661,7 @@ final class SessionFeedContinuityTests: XCTestCase {
             hasMore: false,
             cursor: "520"
         )
-        sessionSocket.emit(try JSONEncoder().encode(secondPage))
+        await sessionSocket.emit(try JSONEncoder().encode(secondPage))
         await settleMainActor(300)
 
         let replay = MessageBroadcast(
@@ -331,7 +669,7 @@ final class SessionFeedContinuityTests: XCTestCase {
             message: try serverMessage(sequence: 520, crypto: crypto),
             fromConnectionId: "desktop"
         )
-        sessionSocket.emit(try JSONEncoder().encode(replay))
+        await sessionSocket.emit(try JSONEncoder().encode(replay))
         await settleMainActor()
 
         let stored = try database.messages(forSession: "session-1")
@@ -369,7 +707,7 @@ final class SessionFeedContinuityTests: XCTestCase {
             totalSessionCount: 1,
             since: nil
         )
-        indexSocket.emit(try JSONEncoder().encode(oldSnapshot))
+        await indexSocket.emit(try JSONEncoder().encode(oldSnapshot))
         await settleMainActor()
         XCTAssertEqual(executor.queued.count, 1)
 
@@ -389,7 +727,12 @@ final class SessionFeedContinuityTests: XCTestCase {
     func testEqualTimestampSnapshotThenPinBroadcastAppliesInReceiveOrder() async throws {
         let database = try makeDatabaseWithSession(isPinned: false)
         let crypto = makeCrypto()
-        let indexSocket = FakeSyncSocket()
+        let delivery = ControlledWebSocketEventDelivery()
+        let factory = FakeWebSocketTransportFactory()
+        let indexSocket = WebSocketClient(
+            transportFactory: factory,
+            eventDelivery: delivery
+        )
         let executor = ControlledIndexExecutor()
         let manager = makeManager(
             database: database,
@@ -399,7 +742,8 @@ final class SessionFeedContinuityTests: XCTestCase {
             executor: executor
         )
         manager.connect(authToken: "token", authUserId: userId, orgId: "org")
-        await settleMainActor()
+        await delivery.run()
+        let transportTask = try XCTUnwrap(factory.tasks.first)
 
         let snapshotEntry = try serverSession(
             crypto: crypto,
@@ -427,13 +771,351 @@ final class SessionFeedContinuityTests: XCTestCase {
             fromConnectionId: "desktop"
         )
 
-        indexSocket.emit(try JSONEncoder().encode(snapshot))
-        indexSocket.emit(try JSONEncoder().encode(pin))
-        await settleMainActor()
+        XCTAssertTrue(transportTask.completeReceive(.success(.data(
+            try JSONEncoder().encode(snapshot)
+        ))))
+        await delivery.run()
+        XCTAssertTrue(transportTask.completeReceive(.success(.data(
+            try JSONEncoder().encode(pin)
+        ))))
+        await delivery.run()
         XCTAssertEqual(executor.queued.count, 2)
         executor.runAll()
 
         XCTAssertTrue(try XCTUnwrap(database.session(byId: "session-1")).isPinned)
+    }
+
+    func testSocketActorHopRejectsStaleConnectedAndCompetingOldTaskCallbacks() async throws {
+        let delivery = ControlledWebSocketEventDelivery()
+        let factory = FakeWebSocketTransportFactory()
+        let recorder = SuspendedMessageRecorder()
+        let client = WebSocketClient(
+            transportFactory: factory,
+            eventDelivery: delivery
+        )
+        client.onConnectionStateChangedWithContext = { connected, context in
+            recorder.recordConnection(connected, context: context)
+        }
+        client.onMessageWithContext = { data, _ in
+            await recorder.accept(data)
+        }
+
+        client.connect(
+            serverUrl: "https://example.invalid",
+            roomId: "index:user",
+            authToken: "token"
+        )
+        let firstTask = try XCTUnwrap(factory.tasks.first)
+        client.reconnect()
+        let secondTask = try XCTUnwrap(factory.tasks.last)
+
+        // Admit N+1 before the deliberately delayed N connected callback.
+        await delivery.run(at: 1)
+        await delivery.run(at: 0)
+        XCTAssertEqual(recorder.connectedGenerations, [2])
+        XCTAssertFalse(firstTask.hasPendingReceive)
+        XCTAssertTrue(secondTask.hasPendingReceive)
+
+        client.sendRaw("{\"type\":\"syncRequest\"}") { error in
+            recorder.recordSend(error: error)
+        }
+        XCTAssertEqual(secondTask.pendingSendCount, 1)
+
+        client.reconnect()
+        let thirdTask = try XCTUnwrap(factory.tasks.last)
+        XCTAssertTrue(secondTask.completeReceive(.success(.string("stale snapshot"))))
+        secondTask.completeSend(error: nil)
+
+        // Run the old receive and send completions ahead of N+2 admission.
+        // They may report a stale send to their caller, but have no socket or
+        // manager mutation authority.
+        await delivery.run(at: 1)
+        await delivery.run(at: 1)
+        XCTAssertTrue(recorder.messages.isEmpty)
+        XCTAssertEqual(recorder.sendErrorCodes, [-2])
+        XCTAssertFalse(thirdTask.hasPendingReceive)
+
+        await delivery.run()
+        XCTAssertEqual(recorder.connectedGenerations, [2, 3])
+        XCTAssertTrue(thirdTask.hasPendingReceive)
+    }
+
+    func testSocketDoesNotArmPinReceiveUntilSuspendedSnapshotDeliveryFinishes() async throws {
+        let delivery = ControlledWebSocketEventDelivery()
+        let factory = FakeWebSocketTransportFactory()
+        let recorder = SuspendedMessageRecorder()
+        recorder.suspendNext = true
+        let client = WebSocketClient(
+            transportFactory: factory,
+            eventDelivery: delivery
+        )
+        client.onMessageWithContext = { data, _ in
+            await recorder.accept(data)
+        }
+
+        client.connect(
+            serverUrl: "https://example.invalid",
+            roomId: "index:user",
+            authToken: "token"
+        )
+        await delivery.run()
+        let task = try XCTUnwrap(factory.tasks.first)
+        XCTAssertTrue(task.completeReceive(.success(.string("snapshot"))))
+
+        let snapshotDelivery = startTrackedOperation(
+            description: "snapshot delivery unwound"
+        ) {
+            await delivery.run()
+        }
+        await fulfillment(of: [recorder.suspension.reached], timeout: 1.0)
+
+        XCTAssertFalse(task.hasPendingReceive)
+        XCTAssertFalse(
+            task.completeReceive(.success(.string("pin"))),
+            "the next URLSession receive must not be armed while snapshot delivery is suspended"
+        )
+
+        recorder.resume()
+        await fulfillment(of: [snapshotDelivery.completion], timeout: 1.0)
+        snapshotDelivery.task.cancel()
+        XCTAssertTrue(task.hasPendingReceive)
+        XCTAssertTrue(task.completeReceive(.success(.string("pin"))))
+        await delivery.run()
+
+        XCTAssertEqual(recorder.messages, ["snapshot", "pin"])
+    }
+
+    func testReconnectDuringLegacyCallbackPreventsContextCallbackDelivery() async throws {
+        let delivery = ControlledWebSocketEventDelivery()
+        let factory = FakeWebSocketTransportFactory()
+        let recorder = SuspendedMessageRecorder()
+        recorder.suspendNext = true
+        let client = WebSocketClient(
+            transportFactory: factory,
+            eventDelivery: delivery
+        )
+        client.onMessage = { data in
+            await recorder.accept(data)
+        }
+        client.onMessageWithContext = { data, _ in
+            recorder.recordSecondary(data)
+        }
+
+        client.connect(
+            serverUrl: "https://example.invalid",
+            roomId: "index:user",
+            authToken: "token"
+        )
+        await delivery.run()
+        let firstTask = try XCTUnwrap(factory.tasks.first)
+        XCTAssertTrue(firstTask.completeReceive(.success(.string("generation N"))))
+
+        let messageDelivery = startTrackedOperation(
+            description: "legacy callback delivery unwound"
+        ) {
+            await delivery.run()
+        }
+        await fulfillment(of: [recorder.suspension.reached], timeout: 1.0)
+        client.reconnect()
+        recorder.resume()
+        await fulfillment(of: [messageDelivery.completion], timeout: 1.0)
+        messageDelivery.task.cancel()
+
+        XCTAssertEqual(recorder.messages, ["generation N"])
+        XCTAssertTrue(
+            recorder.secondaryMessages.isEmpty,
+            "authority must be revalidated between the two awaited callback surfaces"
+        )
+    }
+
+    func testDocumentCallbacksRemainOrderedAcrossSuspensionAndDelete() async throws {
+        let database = try makeDatabaseWithSession()
+        let crypto = makeCrypto()
+        let delivery = ControlledWebSocketEventDelivery()
+        let factory = FakeWebSocketTransportFactory()
+        let client = WebSocketClient(
+            transportFactory: factory,
+            eventDelivery: delivery
+        )
+        let suspension = OneShotSuspension(description: "document message handling suspended")
+        let manager = DocumentSyncManager(
+            crypto: crypto,
+            database: database,
+            serverUrl: "https://example.invalid",
+            userId: userId,
+            clientFactory: { client },
+            messageWillHandle: { _, _ in
+                await suspension.suspendOnce()
+            }
+        )
+        manager.setAuth(authToken: "token", authUserId: userId, orgId: "org")
+        manager.connectProject("/project")
+        await delivery.run()
+        let task = try XCTUnwrap(factory.tasks.first)
+
+        let encryptedContent = try crypto.encrypt(plaintext: "ordered content")
+        let encryptedPath = try crypto.encrypt(plaintext: "notes.md")
+        let encryptedTitle = try crypto.encrypt(plaintext: "Notes")
+        let content = FileContentBroadcast(
+            type: "fileContentBroadcast",
+            syncId: "doc-1",
+            encryptedContent: encryptedContent.encrypted,
+            contentIv: encryptedContent.iv,
+            contentHash: "hash-1",
+            encryptedPath: encryptedPath.encrypted,
+            pathIv: encryptedPath.iv,
+            encryptedTitle: encryptedTitle.encrypted,
+            titleIv: encryptedTitle.iv,
+            lastModifiedAt: 2_000,
+            fromConnectionId: "desktop"
+        )
+        XCTAssertTrue(task.completeReceive(.success(.data(
+            try JSONEncoder().encode(content)
+        ))))
+        let contentDelivery = startTrackedOperation(
+            description: "document content delivery unwound"
+        ) {
+            await delivery.run()
+        }
+        await fulfillment(of: [suspension.reached], timeout: 1.0)
+        XCTAssertFalse(
+            task.hasPendingReceive,
+            "DocumentSyncManager must keep the socket callback awaited while handling content"
+        )
+
+        suspension.resume()
+        await fulfillment(of: [contentDelivery.completion], timeout: 1.0)
+        contentDelivery.task.cancel()
+        XCTAssertNotNil(try database.document(byId: "doc-1"))
+        XCTAssertTrue(task.hasPendingReceive)
+
+        let deletion = FileDeleteBroadcast(
+            type: "fileDeleteBroadcast",
+            syncId: "doc-1",
+            fromConnectionId: "desktop"
+        )
+        XCTAssertTrue(task.completeReceive(.success(.data(
+            try JSONEncoder().encode(deletion)
+        ))))
+        await delivery.run()
+        XCTAssertNil(try database.document(byId: "doc-1"))
+    }
+
+    func testDocumentFreshClientGenerationOneRebindsAuthorityAndRejectsRetiredClientCallbacks() async throws {
+        let database = try makeDatabaseWithSession()
+        let crypto = makeCrypto()
+        let delivery = ControlledWebSocketEventDelivery()
+        let firstFactory = FakeWebSocketTransportFactory()
+        let secondFactory = FakeWebSocketTransportFactory()
+        let firstClient = WebSocketClient(
+            transportFactory: firstFactory,
+            eventDelivery: delivery
+        )
+        let secondClient = WebSocketClient(
+            transportFactory: secondFactory,
+            eventDelivery: delivery
+        )
+        let clients = DocumentWebSocketClientQueue([firstClient, secondClient])
+        let manager = DocumentSyncManager(
+            crypto: crypto,
+            database: database,
+            serverUrl: "https://example.invalid",
+            userId: userId,
+            clientFactory: { clients.next() },
+            messageWillHandle: { _, _ in }
+        )
+        manager.setAuth(authToken: "token", authUserId: userId, orgId: "org")
+        manager.connectProject("/project")
+        await delivery.run()
+
+        let firstTask = try XCTUnwrap(firstFactory.tasks.first)
+        let firstContext = WebSocketConnectionContext(
+            generation: 1,
+            roomId: documentRoomId()
+        )
+        let delayedConnection = try XCTUnwrap(firstClient.onConnectionStateChangedWithContext)
+        let delayedMessage = try XCTUnwrap(firstClient.onMessageWithContext)
+        XCTAssertTrue(manager.isConnected)
+        XCTAssertGreaterThanOrEqual(firstTask.pendingSendCount, 1)
+
+        XCTAssertTrue(firstTask.completeReceive(.failure(
+            DeterministicWebSocketError.receiveFailed
+        )))
+        await delivery.run()
+        XCTAssertFalse(manager.isConnected)
+
+        manager.connectProject("/project")
+        await delivery.run()
+        let secondTask = try XCTUnwrap(secondFactory.tasks.first)
+        XCTAssertTrue(manager.isConnected, "fresh client B generation 1 must be authoritative")
+        XCTAssertGreaterThanOrEqual(
+            secondTask.pendingSendCount,
+            1,
+            "fresh client B must send its initial sync request"
+        )
+        XCTAssertTrue(secondTask.hasPendingReceive)
+
+        let freshContent = try documentContentBroadcast(
+            syncId: "fresh-doc",
+            content: "fresh",
+            crypto: crypto
+        )
+        XCTAssertTrue(secondTask.completeReceive(.success(.data(
+            try JSONEncoder().encode(freshContent)
+        ))))
+        await delivery.run()
+        XCTAssertNotNil(try database.document(byId: "fresh-doc"))
+
+        let sendsBeforeRetiredCallbacks = secondTask.pendingSendCount
+        delayedConnection(true, firstContext)
+        let staleContent = try documentContentBroadcast(
+            syncId: "stale-doc",
+            content: "stale",
+            crypto: crypto
+        )
+        await delayedMessage(try JSONEncoder().encode(staleContent), firstContext)
+
+        XCTAssertTrue(manager.isConnected)
+        XCTAssertEqual(secondTask.pendingSendCount, sendsBeforeRetiredCallbacks)
+        XCTAssertNil(
+            try database.document(byId: "stale-doc"),
+            "retired client A callbacks must fail exact identity/context authority"
+        )
+    }
+
+    func testDocumentDisconnectRejectsDelayedLowerConnectedGenerationAtManagerGate() async throws {
+        let database = try makeDatabaseWithSession()
+        let crypto = makeCrypto()
+        let delivery = ControlledWebSocketEventDelivery()
+        let factory = FakeWebSocketTransportFactory()
+        let client = WebSocketClient(
+            transportFactory: factory,
+            eventDelivery: delivery
+        )
+        let manager = DocumentSyncManager(
+            crypto: crypto,
+            database: database,
+            serverUrl: "https://example.invalid",
+            userId: userId,
+            clientFactory: { client },
+            messageWillHandle: { _, _ in }
+        )
+        manager.setAuth(authToken: "token", authUserId: userId, orgId: "org")
+        manager.connectProject("/project")
+        client.reconnect()
+
+        await delivery.run(at: 1)
+        XCTAssertTrue(manager.isConnected)
+        let managerCallback = try XCTUnwrap(client.onConnectionStateChangedWithContext)
+        let roomId = documentRoomId()
+        managerCallback(false, WebSocketConnectionContext(generation: 2, roomId: roomId))
+        XCTAssertFalse(manager.isConnected)
+
+        managerCallback(true, WebSocketConnectionContext(generation: 1, roomId: roomId))
+        XCTAssertFalse(
+            manager.isConnected,
+            "the manager watermark must reject a delayed lower generation after disconnect"
+        )
     }
 
     func testQueuedOldGenerationIndexWorkAndLateCallbackAreRejected() async throws {
@@ -465,20 +1147,67 @@ final class SessionFeedContinuityTests: XCTestCase {
             since: nil
         )
         let data = try JSONEncoder().encode(oldResponse)
-        indexSocket.emit(data, context: oldContext)
+        await indexSocket.emit(data, context: oldContext)
         await settleMainActor()
         XCTAssertEqual(executor.queued.count, 1)
 
         manager.setAppInForeground(false)
         manager.setAppInForeground(true)
         await settleMainActor()
+        let replacementContext = try XCTUnwrap(indexSocket.currentContext)
         executor.runAll()
         XCTAssertEqual(try database.session(byId: "session-1")?.titleDecrypted, "current")
 
         let queuedAfterReconnect = executor.queued.count
-        indexSocket.emit(data, context: oldContext)
+        await indexSocket.emit(data, context: oldContext)
         await settleMainActor()
         XCTAssertEqual(executor.queued.count, queuedAfterReconnect)
+
+        let sendsAfterReconnect = indexSocket.sentJSON.count
+        indexSocket.emitConnection(true, context: oldContext)
+        XCTAssertEqual(
+            indexSocket.sentJSON.count,
+            sendsAfterReconnect,
+            "a stale connected callback must not replace newer manager context or trigger catch-up"
+        )
+
+        indexSocket.emitConnection(false, context: replacementContext)
+        let sendsAfterReplacementDisconnect = indexSocket.sentJSON.count
+        indexSocket.emitConnection(true, context: oldContext)
+        XCTAssertFalse(manager.isConnected)
+        XCTAssertEqual(
+            indexSocket.sentJSON.count,
+            sendsAfterReplacementDisconnect,
+            "disconnect must not erase the highest accepted index generation"
+        )
+    }
+
+    func testSessionDisconnectDoesNotEraseHighestAcceptedGeneration() async throws {
+        let database = try makeDatabaseWithSession()
+        let crypto = makeCrypto()
+        let sessionSocket = FakeSyncSocket()
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: FakeSyncSocket(),
+            sessionSocket: sessionSocket
+        )
+        manager.connect(authToken: "token", authUserId: userId, orgId: "org")
+        manager.joinSessionRoom(sessionId: "session-1")
+        let oldContext = try XCTUnwrap(sessionSocket.currentContext)
+
+        manager.setAppInForeground(false)
+        manager.setAppInForeground(true)
+        let replacementContext = try XCTUnwrap(sessionSocket.currentContext)
+        sessionSocket.emitConnection(false, context: replacementContext)
+        let sendsAfterReplacementDisconnect = sessionSocket.sentJSON.count
+
+        sessionSocket.emitConnection(true, context: oldContext)
+        XCTAssertEqual(
+            sessionSocket.sentJSON.count,
+            sendsAfterReplacementDisconnect,
+            "disconnect must not let an older session generation restart catch-up"
+        )
     }
 
     func testMetadataProgressesWithoutTranscriptTrafficAndRejectsOlderReplay() throws {

--- a/packages/ios/NimbalystNative/Tests/SessionFeedContinuityTests.swift
+++ b/packages/ios/NimbalystNative/Tests/SessionFeedContinuityTests.swift
@@ -740,6 +740,55 @@ final class SessionFeedContinuityTests: XCTestCase {
         XCTAssertEqual(diagnostics.last?.error, "Session sync response timed out")
     }
 
+    func testReceivedResponseInvalidatesTimeoutBeforeYieldingPersistedChunk() async throws {
+        let database = try makeDatabaseWithSession()
+        let crypto = makeCrypto()
+        let sessionSocket = FakeSyncSocket()
+        let scheduler = ControlledSyncScheduler()
+        let yielder = ControlledSessionCatchUpYielder()
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: FakeSyncSocket(),
+            sessionSocket: sessionSocket,
+            scheduler: scheduler,
+            sessionCatchUpYielder: yielder
+        )
+        var diagnostics: [SessionSyncDiagnostic] = []
+        manager.addSessionSyncDiagnosticHandler(sessionId: "session-1") { diagnostic in
+            diagnostics.append(diagnostic)
+        }
+
+        manager.connect(authToken: "token", authUserId: userId, orgId: "org")
+        manager.joinSessionRoom(sessionId: "session-1")
+        await settleMainActor()
+        XCTAssertEqual(scheduler.operations.count, 1)
+
+        let response = SessionSyncResponse(
+            type: "syncResponse",
+            messages: [try serverMessage(sequence: 1, crypto: crypto)],
+            metadata: nil,
+            hasMore: false,
+            cursor: nil
+        )
+        let responseData = try JSONEncoder().encode(response)
+        let delivery = startTrackedOperation(
+            description: "session response persists after timeout is invalidated"
+        ) {
+            await sessionSocket.emit(responseData)
+        }
+        await fulfillment(of: [yielder.suspension.reached], timeout: 1.0)
+
+        scheduler.runNext()
+        XCTAssertTrue(diagnostics.isEmpty, "an acknowledged response must invalidate its timeout before chunk persistence yields")
+
+        yielder.suspension.resume()
+        await fulfillment(of: [delivery.completion], timeout: 1.0)
+        delivery.task.cancel()
+        XCTAssertEqual(diagnostics.count, 1)
+        XCTAssertNil(diagnostics.last?.error)
+    }
+
     func testOlderQueuedIndexResponseCannotSplitNewerMetadataAndCursor() async throws {
         let database = try makeDatabaseWithSession(title: "initial")
         let crypto = makeCrypto()

--- a/packages/ios/NimbalystNative/Tests/SessionFeedContinuityTests.swift
+++ b/packages/ios/NimbalystNative/Tests/SessionFeedContinuityTests.swift
@@ -679,6 +679,67 @@ final class SessionFeedContinuityTests: XCTestCase {
         XCTAssertEqual(try database.session(byId: "session-1")?.lastSyncedSeq, 520)
     }
 
+    func testSessionServerErrorFinishesOwnedCatchUp() async throws {
+        let database = try makeDatabaseWithSession()
+        let crypto = makeCrypto()
+        let sessionSocket = FakeSyncSocket()
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: FakeSyncSocket(),
+            sessionSocket: sessionSocket
+        )
+        var diagnostics: [SessionSyncDiagnostic] = []
+        manager.addSessionSyncDiagnosticHandler(sessionId: "session-1") { diagnostic in
+            diagnostics.append(diagnostic)
+        }
+
+        manager.connect(authToken: "token", authUserId: userId, orgId: "org")
+        manager.joinSessionRoom(sessionId: "session-1")
+        await settleMainActor()
+        XCTAssertEqual(sessionSocket.sentJSON.count, 1)
+
+        let serverError = ServerError(
+            type: "error",
+            code: "sync_failed",
+            message: "session history unavailable"
+        )
+        await sessionSocket.emit(try JSONEncoder().encode(serverError))
+
+        XCTAssertEqual(
+            diagnostics.last?.error,
+            "Server sync error [sync_failed]: session history unavailable"
+        )
+    }
+
+    func testSessionSyncResponseTimeoutFinishesOwnedCatchUp() async throws {
+        let database = try makeDatabaseWithSession()
+        let crypto = makeCrypto()
+        let sessionSocket = FakeSyncSocket()
+        let scheduler = ControlledSyncScheduler()
+        let manager = makeManager(
+            database: database,
+            crypto: crypto,
+            indexSocket: FakeSyncSocket(),
+            sessionSocket: sessionSocket,
+            scheduler: scheduler
+        )
+        var diagnostics: [SessionSyncDiagnostic] = []
+        manager.addSessionSyncDiagnosticHandler(sessionId: "session-1") { diagnostic in
+            diagnostics.append(diagnostic)
+        }
+
+        manager.connect(authToken: "token", authUserId: userId, orgId: "org")
+        manager.joinSessionRoom(sessionId: "session-1")
+        await settleMainActor()
+        XCTAssertEqual(sessionSocket.sentJSON.count, 1)
+        XCTAssertEqual(scheduler.operations.count, 1)
+
+        scheduler.runNext()
+
+        XCTAssertEqual(diagnostics.last?.error, "Session sync response timed out")
+    }
+
     func testOlderQueuedIndexResponseCannotSplitNewerMetadataAndCursor() async throws {
         let database = try makeDatabaseWithSession(title: "initial")
         let crypto = makeCrypto()


### PR DESCRIPTION
## Summary
- Keep index and session feeds authoritative across reconnects and stale callbacks.
- Preserve metadata and catch-up ordering through reconnects.
- Add deterministic regression coverage for stale generations, delayed callbacks, and document-feed ordering.

## Verification
- `npm run typecheck:prepush`
- `npm run test:prepush-gate`
- Native iOS tests not run locally: this Windows host has no Swift/Xcode toolchain.

## Why this is worth merging

A reconnect should restore the authoritative session feed, not leave the phone frozen on an old snapshot or race a delayed catch-up against newer events. These bounded recovery and timer-invalidating changes keep iOS current after network transitions while preserving compatibility with existing session metadata.
