### PR TITLE
fix(ai): show only supported model reasoning controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Model controls now expose only supported reasoning options and distinguish adaptive thinking from context size.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -588,7 +588,11 @@ export class AIService {
     const effectiveWorkspacePath = session.workspacePath || workspacePath;
     const apiKey = this.getApiKeyForProvider('claude-code', effectiveWorkspacePath);
 
-    const effortLevel = resolveEffortLevel((session.metadata as any)?.effortLevel, getDefaultEffortLevel());
+    const effortLevel = resolveEffortLevel(
+      (session.metadata as any)?.effortLevel,
+      getDefaultEffortLevel(),
+      session.model || session.providerConfig?.model,
+    );
     const config: ProviderConfig = {
       maxTokens: (session.providerConfig as any)?.maxTokens,
       temperature: (session.providerConfig as any)?.temperature,
@@ -1969,7 +1973,11 @@ export class AIService {
         }
         // Effort level: explicit session value, else the app-wide default the
         // selector displays (Opus 4.6 adaptive reasoning).
-        const effortLevel = resolveEffortLevel((session.metadata as any)?.effortLevel, getDefaultEffortLevel());
+        const effortLevel = resolveEffortLevel(
+          (session.metadata as any)?.effortLevel,
+          getDefaultEffortLevel(),
+          session.model || session.providerConfig?.model,
+        );
         if (effortLevel) {
           initConfig.effortLevel = effortLevel;
         }
@@ -1978,7 +1986,11 @@ export class AIService {
 
       // Pass effort level for OpenAI Codex
       if (provider === 'openai-codex') {
-        const effortLevel = resolveEffortLevel((session.metadata as any)?.effortLevel, getDefaultEffortLevel());
+        const effortLevel = resolveEffortLevel(
+          (session.metadata as any)?.effortLevel,
+          getDefaultEffortLevel(),
+          session.model || session.providerConfig?.model,
+        );
         if (effortLevel) {
           initConfig.effortLevel = effortLevel;
         }

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -569,7 +569,11 @@ export class MessageStreamingHandler {
       if (isProviderClaudeCode) {
       }
 
-      const reinitEffortLevel = resolveEffortLevel((session.metadata as any)?.effortLevel, getDefaultEffortLevel());
+      const reinitEffortLevel = resolveEffortLevel(
+        (session.metadata as any)?.effortLevel,
+        getDefaultEffortLevel(),
+        session.model || session.providerConfig?.model,
+      );
       const reinitConfig: any = {
         apiKey,
         maxTokens: (session.providerConfig as any)?.maxTokens,
@@ -1235,7 +1239,11 @@ export class MessageStreamingHandler {
       } else {
         // Refresh credentials every turn for all providers so key changes in settings apply immediately.
         const freshApiKey = this.svc.getApiKeyForProvider(session.provider, effectiveWorkspacePath);
-        const turnEffortLevel = resolveEffortLevel((session.metadata as any)?.effortLevel, getDefaultEffortLevel());
+        const turnEffortLevel = resolveEffortLevel(
+          (session.metadata as any)?.effortLevel,
+          getDefaultEffortLevel(),
+          session.model || session.providerConfig?.model,
+        );
         const turnConfig: any = {
           apiKey: freshApiKey,
           maxTokens: (session.providerConfig as any)?.maxTokens,

--- a/packages/electron/src/renderer/components/UnifiedAI/AIInput.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/AIInput.tsx
@@ -89,6 +89,7 @@ interface AIInputProps {
   effortLevel?: EffortLevel;
   onEffortLevelChange?: (level: EffortLevel) => void;
   showEffortLevel?: boolean;
+  supportedEffortLevels?: ReadonlyArray<{ key: EffortLevel; label: string }>;
   thinkingMode?: ThinkingMode;
   onThinkingModeChange?: (mode: ThinkingMode) => void;
   showThinkingToggle?: boolean;
@@ -176,6 +177,7 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
     effortLevel,
     onEffortLevelChange,
     showEffortLevel,
+    supportedEffortLevels,
     thinkingMode,
     onThinkingModeChange,
     showThinkingToggle,
@@ -1407,6 +1409,7 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
               <EffortLevelSelector
                 level={effortLevel}
                 onLevelChange={onEffortLevelChange}
+                levels={supportedEffortLevels}
                 disabled={reasoningControlsDisabled}
                 disabledTitle={reasoningControlsDisabledTitle}
               />

--- a/packages/electron/src/renderer/components/UnifiedAI/EffortLevelSelector.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/EffortLevelSelector.tsx
@@ -2,15 +2,23 @@ import React, { useState, useRef, useEffect } from 'react';
 import { MaterialSymbol } from '@nimbalyst/runtime';
 import type { EffortLevel } from '../../utils/modelUtils';
 import { EFFORT_LEVELS, DEFAULT_EFFORT_LEVEL } from '../../utils/modelUtils';
+import { HelpTooltip } from '../../help';
 
 interface EffortLevelSelectorProps {
   level: EffortLevel;
   onLevelChange: (level: EffortLevel) => void;
+  levels?: ReadonlyArray<{ key: EffortLevel; label: string }>;
   disabled?: boolean;
   disabledTitle?: string;
 }
 
-export function EffortLevelSelector({ level, onLevelChange, disabled = false, disabledTitle }: EffortLevelSelectorProps) {
+export function EffortLevelSelector({
+  level,
+  onLevelChange,
+  levels = EFFORT_LEVELS,
+  disabled = false,
+  disabledTitle,
+}: EffortLevelSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -40,28 +48,33 @@ export function EffortLevelSelector({ level, onLevelChange, disabled = false, di
     }
   }, [disabled]);
 
-  const currentLevel = EFFORT_LEVELS.find(l => l.key === level) ?? EFFORT_LEVELS.find(l => l.key === DEFAULT_EFFORT_LEVEL)!;
+  const currentLevel = levels.find(l => l.key === level)
+    ?? levels.find(l => l.key === DEFAULT_EFFORT_LEVEL)
+    ?? levels[0];
+  if (!currentLevel) return null;
 
   return (
     <div className="relative inline-block" ref={dropdownRef}>
-      <button
-        data-testid="effort-level-selector"
-        className={`flex items-center gap-1 px-2 py-[3px] rounded-xl text-[11px] font-medium transition-all duration-200 outline-none whitespace-nowrap bg-[var(--nim-bg-secondary)] text-[var(--nim-text-muted)] border border-[var(--nim-border)] ${disabled ? 'opacity-45 cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--nim-bg-hover)] hover:border-[var(--nim-primary)]'}`}
-        onClick={() => {
-          if (!disabled) setIsOpen(!isOpen);
-        }}
-        aria-label={`Effort level: ${currentLevel.label}`}
-        disabled={disabled}
-        title={disabled ? disabledTitle : undefined}
-      >
-        <MaterialSymbol icon="psychology" size={12} />
-        <span>{currentLevel.label}</span>
-        <MaterialSymbol icon="expand_more" size={14} className={`transition-transform duration-200 shrink-0 ${isOpen ? 'rotate-180' : ''}`} />
-      </button>
+      <HelpTooltip testId="effort-level-selector">
+        <button
+          data-testid="effort-level-selector"
+          className={`flex items-center gap-1 px-2 py-[3px] rounded-xl text-[11px] font-medium transition-all duration-200 outline-none whitespace-nowrap bg-[var(--nim-bg-secondary)] text-[var(--nim-text-muted)] border border-[var(--nim-border)] ${disabled ? 'opacity-45 cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--nim-bg-hover)] hover:border-[var(--nim-primary)]'}`}
+          onClick={() => {
+            if (!disabled) setIsOpen(!isOpen);
+          }}
+          aria-label={`Effort level: ${currentLevel.label}`}
+          disabled={disabled}
+          title={disabled ? disabledTitle : undefined}
+        >
+          <MaterialSymbol icon="psychology" size={12} />
+          <span>{currentLevel.label}</span>
+          <MaterialSymbol icon="expand_more" size={14} className={`transition-transform duration-200 shrink-0 ${isOpen ? 'rotate-180' : ''}`} />
+        </button>
+      </HelpTooltip>
 
       {isOpen && (
         <div className="absolute bottom-full left-0 mb-1 min-w-[120px] rounded-lg p-1 z-[1000] bg-[var(--nim-bg)] border border-[var(--nim-border)] shadow-[0_4px_12px_rgba(0,0,0,0.15)]">
-          {EFFORT_LEVELS.map(l => (
+          {levels.map(l => (
             <button
               key={l.key}
               className={`flex items-center justify-between gap-2 px-2 py-1.5 w-full border-none rounded text-xs cursor-pointer transition-[background] duration-150 text-left text-[var(--nim-text)] hover:bg-[var(--nim-bg-hover)] ${l.key === level ? 'bg-[var(--nim-bg-secondary)] text-[var(--nim-primary)]' : ''}`}

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionLaunchPopup.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionLaunchPopup.tsx
@@ -30,7 +30,9 @@ import {
 } from '../../store/atoms/sessionLaunchPopup';
 import { sessionRegistryAtom } from '../../store/atoms/sessions';
 import {
+  normalizeEffortForModel,
   parseThinkingMode,
+  supportedEffortLevelsForModel,
   supportsEffortLevel,
   supportsThinkingToggle,
   type EffortLevel,
@@ -134,8 +136,17 @@ export const SessionLaunchPopup: React.FC<SessionLaunchPopupProps> = ({ workspac
   const selectedModel = draft.model ?? defaultModel;
   const parsedModel = selectedModel ? ModelIdentifier.tryParse(selectedModel) : null;
   const provider = parsedModel?.provider ?? 'claude-code';
-  const effortLevel = draft.effortLevel ?? defaultEffortLevel;
+  const supportedEffortLevels = useMemo(
+    () => supportedEffortLevelsForModel(selectedModel),
+    [selectedModel],
+  );
+  const effortLevel = normalizeEffortForModel(
+    selectedModel,
+    draft.effortLevel ?? defaultEffortLevel,
+  );
   const thinkingMode = draft.thinkingMode ?? parseThinkingMode(undefined);
+  const showEffortLevel = supportsEffortLevel(selectedModel);
+  const showThinkingToggle = developerMode && supportsThinkingToggle(selectedModel);
 
   const virtualReference = useMemo<VirtualElement>(() => ({
     getBoundingClientRect: () => DOMRect.fromRect({
@@ -305,8 +316,8 @@ export const SessionLaunchPopup: React.FC<SessionLaunchPopupProps> = ({ workspac
           mode: launchMode,
           selectSession: false,
           metadata: {
-            effortLevel,
-            thinkingMode,
+            ...(showEffortLevel ? { effortLevel } : {}),
+            ...(showThinkingToggle ? { thinkingMode } : {}),
           },
         }) ?? null;
         if (!sessionId) throw new Error('Failed to create the session.');
@@ -350,6 +361,8 @@ export const SessionLaunchPopup: React.FC<SessionLaunchPopupProps> = ({ workspac
     selectedModel,
     sessionRegistry,
     setDraft,
+    showEffortLevel,
+    showThinkingToggle,
     thinkingMode,
     workspacePath,
   ]);
@@ -419,10 +432,11 @@ export const SessionLaunchPopup: React.FC<SessionLaunchPopupProps> = ({ workspac
           currentProvider={provider}
           effortLevel={effortLevel}
           onEffortLevelChange={handleEffortLevelChange}
-          showEffortLevel={supportsEffortLevel(selectedModel)}
+          showEffortLevel={showEffortLevel}
+          supportedEffortLevels={supportedEffortLevels}
           thinkingMode={thinkingMode}
           onThinkingModeChange={handleThinkingModeChange}
-          showThinkingToggle={developerMode && supportsThinkingToggle(selectedModel)}
+          showThinkingToggle={showThinkingToggle}
           provider={provider}
           testId="session-launch-popup-input"
         />

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -108,7 +108,7 @@ import {
 import { scrollToTeammateAtom, scrollToMessageAtom, requestOpenSessionAtom } from '../../store/atoms/agentMode';
 import { usePostHog } from 'posthog-js/react';
 import { setAgentModeSettingsAtom, showPromptAdditionsAtom, hasExternalEditorAtom, externalEditorNameAtom, openInExternalEditorAtom, defaultAgentModelAtom, defaultEffortLevelAtom, chatShowToolCallsAtom, developerModeAtom } from '../../store/atoms/appSettings';
-import { supportsEffortLevel, supportsThinkingToggle, parseEffortLevel, parseThinkingMode, type EffortLevel, type ThinkingMode } from '../../utils/modelUtils';
+import { normalizeEffortForModel, supportedEffortLevelsForModel, supportsEffortLevel, supportsThinkingToggle, parseEffortLevel, parseThinkingMode, type EffortLevel, type ThinkingMode } from '../../utils/modelUtils';
 import { buildPlanImplementationPrompt, resolvePlanFilePath } from '../../utils/pathUtils';
 import { resolveTranscriptClickPath } from '../../utils/resolveTranscriptClickPath';
 import { autoCommitEnabledAtom, setAutoCommitEnabledAtom } from '../../store/atoms/autoCommitAtoms';
@@ -518,10 +518,15 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
 
   // Effort level: read from session metadata, fall back to global default
   const showEffortLevel = useMemo(() => supportsEffortLevel(currentModel), [currentModel]);
+  const supportedEffortLevels = useMemo(
+    () => supportedEffortLevelsForModel(currentModel),
+    [currentModel],
+  );
   const effortLevel = useMemo(() => {
-    return rawEffortLevel != null ? parseEffortLevel(rawEffortLevel) : defaultEffortLevel;
-  }, [rawEffortLevel, defaultEffortLevel]);
-  // Extended-thinking is a power-user control: only surface the selector in
+    const selectedEffort = rawEffortLevel != null ? parseEffortLevel(rawEffortLevel) : defaultEffortLevel;
+    return normalizeEffortForModel(currentModel, selectedEffort);
+  }, [rawEffortLevel, defaultEffortLevel, currentModel]);
+  // Adaptive thinking is a power-user control: only surface the selector in
   // developer mode. When hidden, thinkingMode is never set, so the default
   // (adaptive/enabled) applies.
   const developerMode = useAtomValue(developerModeAtom);
@@ -2606,6 +2611,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
         effortLevel={effortLevel}
         onEffortLevelChange={handleEffortLevelChange}
         showEffortLevel={isClaudeCliTerminalSession(provider) && cliSessionCommitted ? false : showEffortLevel}
+        supportedEffortLevels={supportedEffortLevels}
         thinkingMode={thinkingMode}
         onThinkingModeChange={handleThinkingModeChange}
         showThinkingToggle={isClaudeCliTerminalSession(provider) && cliSessionCommitted ? false : showThinkingToggle}

--- a/packages/electron/src/renderer/components/UnifiedAI/ThinkingModeSelector.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/ThinkingModeSelector.tsx
@@ -2,10 +2,11 @@ import React, { useState, useRef, useEffect } from 'react';
 import { MaterialSymbol } from '@nimbalyst/runtime';
 import type { ThinkingMode } from '../../utils/modelUtils';
 import { DEFAULT_THINKING_MODE } from '../../utils/modelUtils';
+import { HelpTooltip } from '../../help';
 
 const THINKING_MODE_OPTIONS: Array<{ key: ThinkingMode; label: string }> = [
-  { key: 'enabled', label: 'Extended: On' },
-  { key: 'disabled', label: 'Extended: Off' },
+  { key: 'enabled', label: 'Thinking: Adaptive' },
+  { key: 'disabled', label: 'Thinking: Off' },
 ];
 
 interface ThinkingModeSelectorProps {
@@ -56,20 +57,22 @@ export function ThinkingModeSelector({
 
   return (
     <div className="relative inline-block" ref={dropdownRef}>
-      <button
-        data-testid="thinking-mode-selector"
-        className={`thinking-mode-selector flex items-center gap-1 px-2 py-[3px] rounded-xl text-[11px] font-medium transition-all duration-200 outline-none whitespace-nowrap bg-[var(--nim-bg-secondary)] text-[var(--nim-text-muted)] border border-[var(--nim-border)] ${disabled ? 'opacity-45 cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--nim-bg-hover)] hover:border-[var(--nim-primary)]'}`}
-        onClick={() => {
-          if (!disabled) setIsOpen(!isOpen);
-        }}
-        aria-label={`Extended thinking: ${currentMode.label}`}
-        disabled={disabled}
-        title={disabled ? disabledTitle : undefined}
-      >
-        <MaterialSymbol icon="psychology_alt" size={12} />
-        <span>{currentMode.label}</span>
-        <MaterialSymbol icon="expand_more" size={14} className={`transition-transform duration-200 shrink-0 ${isOpen ? 'rotate-180' : ''}`} />
-      </button>
+      <HelpTooltip testId="thinking-mode-selector">
+        <button
+          data-testid="thinking-mode-selector"
+          className={`thinking-mode-selector flex items-center gap-1 px-2 py-[3px] rounded-xl text-[11px] font-medium transition-all duration-200 outline-none whitespace-nowrap bg-[var(--nim-bg-secondary)] text-[var(--nim-text-muted)] border border-[var(--nim-border)] ${disabled ? 'opacity-45 cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--nim-bg-hover)] hover:border-[var(--nim-primary)]'}`}
+          onClick={() => {
+            if (!disabled) setIsOpen(!isOpen);
+          }}
+          aria-label={currentMode.label}
+          disabled={disabled}
+          title={disabled ? disabledTitle : undefined}
+        >
+          <MaterialSymbol icon="psychology_alt" size={12} />
+          <span>{currentMode.label}</span>
+          <MaterialSymbol icon="expand_more" size={14} className={`transition-transform duration-200 shrink-0 ${isOpen ? 'rotate-180' : ''}`} />
+        </button>
+      </HelpTooltip>
 
       {isOpen && (
         <div className="absolute bottom-full left-0 mb-1 min-w-[140px] rounded-lg p-1 z-[1000] bg-[var(--nim-bg)] border border-[var(--nim-border)] shadow-[0_4px_12px_rgba(0,0,0,0.15)]">

--- a/packages/electron/src/renderer/components/UnifiedAI/__tests__/ReasoningControls.test.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/__tests__/ReasoningControls.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getHelpContent } from '../../../help/HelpContent';
+import { EffortLevelSelector } from '../EffortLevelSelector';
+import { ThinkingModeSelector } from '../ThinkingModeSelector';
+
+describe('model reasoning controls', () => {
+  afterEach(cleanup);
+
+  it('renders only the effort values supported by the selected model', () => {
+    render(
+      <EffortLevelSelector
+        level="high"
+        onLevelChange={vi.fn()}
+        levels={[
+          { key: 'low', label: 'Low' },
+          { key: 'medium', label: 'Medium' },
+          { key: 'high', label: 'High' },
+          { key: 'max', label: 'Max' },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('effort-level-selector'));
+
+    expect(screen.getByRole('button', { name: 'Max' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Extra High' })).toBeNull();
+  });
+
+  it('labels adaptive thinking without calling it extended thinking', () => {
+    render(<ThinkingModeSelector mode="enabled" onModeChange={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Thinking: Adaptive' })).toBeTruthy();
+    fireEvent.click(screen.getByTestId('thinking-mode-selector'));
+    expect(screen.getByRole('button', { name: 'Thinking: Off' })).toBeTruthy();
+    expect(screen.queryByText(/extended/i)).toBeNull();
+  });
+
+  it('defines each exposed degree of freedom in the help registry', () => {
+    expect(getHelpContent('effort-level-selector')).toMatchObject({
+      title: 'Reasoning Effort',
+      body: expect.stringMatching(/reasoning depth and response work/i),
+    });
+    expect(getHelpContent('thinking-mode-selector')).toMatchObject({
+      title: 'Adaptive Thinking',
+      body: expect.stringMatching(/does not change context size/i),
+    });
+  });
+});

--- a/packages/electron/src/renderer/components/UnifiedAI/__tests__/SessionLaunchPopup.test.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/__tests__/SessionLaunchPopup.test.tsx
@@ -136,7 +136,7 @@ describe('SessionLaunchPopup', () => {
         provider: 'claude-code',
         model: 'claude-code:sonnet',
         mode: 'agent',
-        metadata: { effortLevel: 'high', thinkingMode: 'enabled' },
+        metadata: { effortLevel: 'high' },
       },
     });
     const createdId = createCall?.[1].session.id;
@@ -165,6 +165,36 @@ describe('SessionLaunchPopup', () => {
     await act(async () => {
       resolveBackgroundLaunch({ success: true });
       await backgroundLaunchPending;
+    });
+  });
+
+  it('does not persist reasoning metadata hidden by the selected transport', async () => {
+    const testStore = createStore();
+    testStore.set(activeWorkspacePathAtom, '/workspace');
+    initWorkstreamState('/workspace');
+    testStore.set(agentModeSettingsAtom, {
+      defaultModel: 'openai-codex-acp:gpt-5.4',
+      defaultEffortLevel: 'max',
+    });
+    render(
+      <Provider store={testStore}>
+        <SessionLaunchPopup workspacePath="/workspace" />
+      </Provider>,
+    );
+
+    act(() => testStore.set(sessionLaunchPopupRequestAtom, 1));
+    fireEvent.change(await screen.findByTestId('session-launch-popup-input'), {
+      target: { value: 'Inspect this session' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Start Session' }));
+
+    await waitFor(() => {
+      const createCall = invoke.mock.calls.find(([channel]) => channel === 'sessions:create');
+      expect(createCall?.[1]?.session).toMatchObject({
+        provider: 'openai-codex-acp',
+        model: 'openai-codex-acp:gpt-5.4',
+        metadata: {},
+      });
     });
   });
 

--- a/packages/electron/src/renderer/help/HelpContent.ts
+++ b/packages/electron/src/renderer/help/HelpContent.ts
@@ -244,6 +244,14 @@ export const HelpContent: Record<string, HelpEntry> = {
     title: 'Select AI Model',
     body: 'Choose which AI model to use. Different models have different capabilities and speeds.',
   },
+  'effort-level-selector': {
+    title: 'Reasoning Effort',
+    body: 'Sets how much reasoning depth and response work the selected model applies. Available levels depend on the model.',
+  },
+  'thinking-mode-selector': {
+    title: 'Adaptive Thinking',
+    body: 'Adaptive lets the model decide when and how deeply to reason; Off disables adaptive thinking. This does not change context size or assign a fixed reasoning budget.',
+  },
   'model-picker-provider-claude-code': {
     title: 'Claude Agent (Claude Code Based)',
     body: 'The in-app agent built on Claude Code with full Nimbalyst integration: it sees your active document and selection, renders the rich inline transcript, and tracks every file it edits. Uses your configured Anthropic API key.',

--- a/packages/electron/src/renderer/utils/__tests__/modelUtils.effort.test.ts
+++ b/packages/electron/src/renderer/utils/__tests__/modelUtils.effort.test.ts
@@ -7,27 +7,25 @@ describe('supportsEffortLevel', () => {
     'claude-code:opus-4-6',
     'claude-code:sonnet',
     'claude-code:fable',
-    'claude-code-cli:fable-1m',
     'claude-code:opus-4-7',
-    'claude-code-cli:opus-4-7-1m',
     'claude-code:sonnet-4-6',
-    'claude-code-cli:sonnet-4-6-1m',
   ])('supports current Claude Code effort-capable variants: %s', (modelId) => {
     expect(supportsEffortLevel(modelId)).toBe(true);
   });
 
-  it.each([
-    'openai-codex:gpt-5.4',
-    'openai-codex-acp:gpt-5.4',
-  ])('supports effort for both Codex providers: %s', (modelId) => {
+  it('supports effort for the Codex SDK transport', () => {
+    const modelId = 'openai-codex:gpt-5.4';
     expect(supportsEffortLevel(modelId)).toBe(true);
   });
 
   it.each([
     undefined,
     'claude-code:haiku',
+    'claude-code-cli:fable',
+    'claude-code-cli:opus-4-7',
     'claude-code:unknown',
     'claude:claude-fable-5',
+    'openai-codex-acp:gpt-5.4',
   ])('does not expose effort for unsupported models: %s', (modelId) => {
     expect(supportsEffortLevel(modelId)).toBe(false);
   });

--- a/packages/electron/src/renderer/utils/__tests__/supportsThinkingToggle.test.ts
+++ b/packages/electron/src/renderer/utils/__tests__/supportsThinkingToggle.test.ts
@@ -24,5 +24,7 @@ describe('supportsThinkingToggle', () => {
   it('disables the toggle for non-claude-code and missing models', () => {
     expect(supportsThinkingToggle(undefined)).toBe(false);
     expect(supportsThinkingToggle('gpt-5.5')).toBe(false);
+    expect(supportsThinkingToggle('claude-code-cli:opus')).toBe(false);
+    expect(supportsThinkingToggle('claude-code-cli:sonnet')).toBe(false);
   });
 });

--- a/packages/electron/src/renderer/utils/modelUtils.ts
+++ b/packages/electron/src/renderer/utils/modelUtils.ts
@@ -29,8 +29,10 @@ export {
   EFFORT_LEVELS,
   DEFAULT_EFFORT_LEVEL,
   DEFAULT_THINKING_MODE,
+  normalizeEffortForModel,
   parseEffortLevel,
   parseThinkingMode,
+  supportedEffortLevelsForModel,
 } from '@nimbalyst/runtime/ai/server/effortLevels';
 
 interface ModelInfo {
@@ -254,6 +256,12 @@ export function getModelShortName(provider: string, modelId: string): string {
  */
 export function supportsEffortLevel(modelId?: string): boolean {
   if (!modelId) return false;
+  const parsed = ModelIdentifier.tryParse(modelId);
+  // Only expose controls on transports that actually forward them. The
+  // terminal Claude CLI and Codex ACP launch paths currently do not.
+  if (parsed?.provider === 'claude-code-cli' || parsed?.provider === 'openai-codex-acp') {
+    return false;
+  }
   const variant = extractClaudeCodeVariant(modelId);
   if (
     variant === 'fable' ||
@@ -263,10 +271,9 @@ export function supportsEffortLevel(modelId?: string): boolean {
     variant === 'sonnet' ||
     variant === 'sonnet-4-6'
   ) return true;
-  // OpenAI Codex models support reasoning effort (both SDK and ACP transports)
-  const parsed = ModelIdentifier.tryParse(modelId);
-  if (parsed?.provider === 'openai-codex' || parsed?.provider === 'openai-codex-acp') return true;
-  if (modelId.startsWith('openai-codex:') || modelId.startsWith('openai-codex-acp:')) return true;
+  // The Codex SDK transport forwards reasoning effort.
+  if (parsed?.provider === 'openai-codex') return true;
+  if (modelId.startsWith('openai-codex:')) return true;
   return false;
 }
 
@@ -281,6 +288,8 @@ export function supportsEffortLevel(modelId?: string): boolean {
  */
 export function supportsThinkingToggle(modelId?: string): boolean {
   if (!modelId) return false;
+  const parsed = ModelIdentifier.tryParse(modelId);
+  if (parsed?.provider !== 'claude-code') return false;
   const variant = extractClaudeCodeVariant(modelId);
   if (!variant) return false;
   return variant.startsWith('opus') || variant.startsWith('sonnet');

--- a/packages/runtime/src/ai/server/__tests__/effortLevels.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/effortLevels.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_EFFORT_LEVEL,
   DEFAULT_THINKING_MODE,
+  normalizeEffortForModel,
   parseThinkingMode,
   resolveEffortLevel,
+  supportedEffortLevelsForModel,
 } from '../effortLevels';
 
 describe('resolveEffortLevel', () => {
@@ -27,6 +29,45 @@ describe('resolveEffortLevel', () => {
 
   it('coerces an invalid stored session value to the default level', () => {
     expect(resolveEffortLevel('bogus', 'max')).toBe(DEFAULT_EFFORT_LEVEL);
+  });
+
+  it('normalizes unsupported Claude effort without upgrading it', () => {
+    expect(resolveEffortLevel('xhigh', 'max', 'claude-code:sonnet-4-6')).toBe('high');
+    expect(resolveEffortLevel(undefined, 'xhigh', 'claude-code:opus-4-6')).toBe('high');
+    expect(resolveEffortLevel('max', 'low', 'claude-code:sonnet-4-6')).toBe('max');
+  });
+
+  it.each([
+    'claude-code:haiku',
+    'claude-code-cli:sonnet',
+    'openai-codex-acp:gpt-5.4',
+  ])('omits effort entirely when %s cannot forward that degree of freedom', (modelId) => {
+    expect(resolveEffortLevel('high', 'max', modelId)).toBeUndefined();
+  });
+});
+
+describe('Claude effort capabilities', () => {
+  it.each([
+    'claude-code:fable',
+    'claude-code:opus',
+    'claude-code:opus-4-7',
+    'claude-code:sonnet',
+  ])('offers the full current-generation ladder for %s', (modelId) => {
+    expect(supportedEffortLevelsForModel(modelId).map(level => level.key))
+      .toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+  });
+
+  it.each([
+    'claude-code:opus-4-6',
+    'claude-code:sonnet-4-6',
+  ])('omits xhigh for legacy adaptive model %s', (modelId) => {
+    expect(supportedEffortLevelsForModel(modelId).map(level => level.key))
+      .toEqual(['low', 'medium', 'high', 'max']);
+    expect(normalizeEffortForModel(modelId, 'xhigh')).toBe('high');
+  });
+
+  it('declares no adaptive-effort control for Haiku', () => {
+    expect(supportedEffortLevelsForModel('claude-code:haiku')).toEqual([]);
   });
 });
 

--- a/packages/runtime/src/ai/server/effortLevels.ts
+++ b/packages/runtime/src/ai/server/effortLevels.ts
@@ -17,13 +17,64 @@ export const EFFORT_LEVELS: { key: EffortLevel; label: string }[] = [
 ];
 
 export const DEFAULT_EFFORT_LEVEL: EffortLevel = 'high';
-// Default to 'enabled' so the app omits the SDK thinking option and preserves
-// the SDK's default adaptive thinking (Claude decides depth) on supported
-// Opus/Sonnet models. Users can opt into 'disabled' (Extended: Off) per session.
+// "enabled" is the persisted compatibility value for adaptive thinking. The
+// provider translates it to `thinking: { type: 'adaptive' }`; it must not be
+// presented as manual "extended thinking", which is a different API mode.
 export const DEFAULT_THINKING_MODE: ThinkingMode = 'enabled';
 
 const VALID_EFFORT_LEVELS = new Set<string>(['low', 'medium', 'high', 'xhigh', 'max']);
 const VALID_THINKING_MODES = new Set<string>(['enabled', 'disabled']);
+
+const CLAUDE_EFFORT_LEVELS = {
+  current: EFFORT_LEVELS,
+  legacyAdaptive: EFFORT_LEVELS.filter(level => level.key !== 'xhigh'),
+} as const;
+
+function normalizedModelId(modelId: string | undefined | null): string {
+  return (modelId ?? '').toLowerCase().replace(/-1m$/, '').replace(/\[1m\]$/, '');
+}
+
+/**
+ * Return only the effort values the selected model accepts.
+ *
+ * Claude Sonnet 5, Fable 5, Opus 4.8, and Opus 4.7 support the complete
+ * low/medium/high/xhigh/max ladder. Opus 4.6 and Sonnet 4.6 support the same
+ * ladder except xhigh. Haiku has no adaptive-effort control in this surface.
+ * Other providers keep their existing transport-owned ladder.
+ */
+export function supportedEffortLevelsForModel(
+  modelId: string | undefined | null
+): { key: EffortLevel; label: string }[] {
+  const id = normalizedModelId(modelId);
+  if (id.startsWith('claude-code-cli:') || id.startsWith('openai-codex-acp:')) return [];
+  if (id.startsWith('claude-code:')) {
+    if (id.includes('haiku')) return [];
+    if (id.includes('opus-4-6') || id.includes('sonnet-4-6')) {
+      return [...CLAUDE_EFFORT_LEVELS.legacyAdaptive];
+    }
+  }
+  return [...CLAUDE_EFFORT_LEVELS.current];
+}
+
+/**
+ * Normalize a stored/global effort to a value the selected model accepts.
+ * Unsupported intermediate levels step down rather than silently upgrading
+ * capability or cost (for example xhigh -> high on Sonnet 4.6).
+ */
+export function normalizeEffortForModel(
+  modelId: string | undefined | null,
+  effort: EffortLevel
+): EffortLevel {
+  const supported = supportedEffortLevelsForModel(modelId);
+  if (supported.length === 0 || supported.some(level => level.key === effort)) return effort;
+
+  const requestedIndex = EFFORT_LEVELS.findIndex(level => level.key === effort);
+  for (let index = requestedIndex - 1; index >= 0; index -= 1) {
+    const candidate = EFFORT_LEVELS[index].key;
+    if (supported.some(level => level.key === candidate)) return candidate;
+  }
+  return supported[0].key;
+}
 
 /**
  * Validate and return a valid EffortLevel, or the default if invalid.
@@ -49,12 +100,19 @@ export function parseEffortLevel(value: unknown): EffortLevel {
  */
 export function resolveEffortLevel(
   sessionEffortLevel: unknown,
-  appDefaultEffortLevel: EffortLevel | undefined
+  appDefaultEffortLevel: EffortLevel | undefined,
+  modelId?: string | null,
 ): EffortLevel | undefined {
+  let resolved: EffortLevel | undefined;
   if (sessionEffortLevel != null && sessionEffortLevel !== '') {
-    return parseEffortLevel(sessionEffortLevel);
+    resolved = parseEffortLevel(sessionEffortLevel);
+  } else {
+    resolved = appDefaultEffortLevel;
   }
-  return appDefaultEffortLevel;
+  if (resolved === undefined) return undefined;
+  const supported = supportedEffortLevelsForModel(modelId);
+  if (supported.length === 0) return undefined;
+  return normalizeEffortForModel(modelId, resolved);
 }
 
 /**

--- a/packages/runtime/src/ai/server/providers/__tests__/sdkOptionsBuilder.envKeys.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/sdkOptionsBuilder.envKeys.test.ts
@@ -180,7 +180,27 @@ describe('buildSdkOptions env-key hardening', () => {
     expect(options.env.CLAUDE_CODE_EFFORT_LEVEL).toBe('high');
   });
 
-  it('disables SDK extended thinking for supported Claude Agent models', async () => {
+  it('normalizes effort against the resolved Claude model before spawning', async () => {
+    const legacyOptions = await buildSdkOptions(
+      makeDeps({
+        resolveModelVariant: () => 'sonnet-4-6',
+        config: { effortLevel: 'xhigh' },
+      }),
+      makeParams()
+    );
+    const haikuOptions = await buildSdkOptions(
+      makeDeps({
+        resolveModelVariant: () => 'haiku',
+        config: { effortLevel: 'high' },
+      }),
+      makeParams()
+    );
+
+    expect(legacyOptions.options.env.CLAUDE_CODE_EFFORT_LEVEL).toBe('high');
+    expect(haikuOptions.options.env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
+  });
+
+  it('disables SDK adaptive thinking for supported Claude Agent models', async () => {
     const { options } = await buildSdkOptions(
       makeDeps({ config: { thinkingMode: 'disabled' } }),
       makeParams()
@@ -189,16 +209,16 @@ describe('buildSdkOptions env-key hardening', () => {
     expect(options.thinking).toEqual({ type: 'disabled' });
   });
 
-  it('omits the SDK thinking option when extended thinking is enabled', async () => {
+  it('explicitly enables adaptive thinking instead of relying on model-specific defaults', async () => {
     const { options } = await buildSdkOptions(
       makeDeps({ config: { thinkingMode: 'enabled' } }),
       makeParams()
     );
 
-    expect(options.thinking).toBeUndefined();
+    expect(options.thinking).toEqual({ type: 'adaptive' });
   });
 
-  it('omits the SDK thinking option for unsupported Claude Agent models', async () => {
+  it('keeps Fable adaptive but refuses a stored off value', async () => {
     const { options } = await buildSdkOptions(
       makeDeps({
         resolveModelVariant: () => 'claude-fable-4-6-20260615',
@@ -208,6 +228,18 @@ describe('buildSdkOptions env-key hardening', () => {
     );
 
     expect(options.thinking).toBeUndefined();
+  });
+
+  it('explicitly enables Fable adaptive thinking', async () => {
+    const { options } = await buildSdkOptions(
+      makeDeps({
+        resolveModelVariant: () => 'claude-fable-5',
+        config: { thinkingMode: 'enabled' },
+      }),
+      makeParams()
+    );
+
+    expect(options.thinking).toEqual({ type: 'adaptive' });
   });
 
   it('disables the CLI self-updater by default on every spawn (NIM-1573)', async () => {

--- a/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import { app } from 'electron';
 import { ClaudeCodeDeps } from './dependencyInjection';
 import { resolveClaudeAgentCliPath } from './cliPathResolver';
-import { type ThinkingMode } from '../../effortLevels';
+import { resolveEffortLevel, type ThinkingMode } from '../../effortLevels';
 
 type SessionMode = 'planning' | 'agent' | 'auto' | undefined;
 
@@ -89,12 +89,15 @@ export interface BuildSdkOptionsResult {
   helperMethod: 'native' | 'custom';
 }
 
+function supportsAdaptiveThinkingForModel(model: string | undefined): boolean {
+  const normalized = model?.toLowerCase() ?? '';
+  if (!normalized || normalized.includes('haiku')) return false;
+  return normalized.includes('fable') || normalized.includes('opus') || normalized.includes('sonnet');
+}
+
 function canDisableThinkingForModel(model: string | undefined): boolean {
   const normalized = model?.toLowerCase() ?? '';
-  if (!normalized || normalized.includes('fable') || normalized.includes('haiku')) {
-    return false;
-  }
-  return normalized.includes('opus') || normalized.includes('sonnet');
+  return supportsAdaptiveThinkingForModel(model) && !normalized.includes('fable');
 }
 
 export function createPersistentPromptStream(
@@ -228,6 +231,11 @@ export async function buildSdkOptions(
   const effectivePath = customPath || resolvedBinaryPath;
   // console.log(`[CLAUDE-CODE] Binary path: custom=${customPath || '(none)'} resolved=${resolvedBinaryPath ?? '(none)'} effective=${effectivePath ?? '(none)'}`);
   const resolvedModel = resolveModelVariant();
+  const resolvedEffortLevel = resolveEffortLevel(
+    config.effortLevel,
+    undefined,
+    `claude-code:${resolvedModel}`,
+  );
 
   const options: any = {
     pathToClaudeCodeExecutable: effectivePath,
@@ -298,11 +306,15 @@ export async function buildSdkOptions(
     },
   };
 
-  if (config.thinkingMode === 'disabled') {
+  if (config.thinkingMode === 'enabled' && supportsAdaptiveThinkingForModel(resolvedModel)) {
+    // Omitting this field is not portable across models: Sonnet 5 defaults to
+    // adaptive, while Opus 4.7/4.8 and Sonnet 4.6 default to thinking off.
+    options.thinking = { type: 'adaptive' as const };
+  } else if (config.thinkingMode === 'disabled') {
     if (canDisableThinkingForModel(resolvedModel)) {
       options.thinking = { type: 'disabled' as const };
     } else {
-      console.warn(`[CLAUDE-CODE] Extended thinking cannot be disabled for model "${resolvedModel}"; omitting SDK thinking option.`);
+      console.warn(`[CLAUDE-CODE] Adaptive thinking cannot be disabled for model "${resolvedModel}"; omitting SDK thinking option.`);
     }
   }
 
@@ -390,8 +402,8 @@ export async function buildSdkOptions(
     // The Claude CLI currently defaults to xhigh when this variable is absent.
     // Always forward a resolved Nimbalyst selection, including "high", so the
     // effort shown in the selector matches the request sent to the CLI.
-    ...(config.effortLevel && {
-      CLAUDE_CODE_EFFORT_LEVEL: config.effortLevel
+    ...(resolvedEffortLevel && {
+      CLAUDE_CODE_EFFORT_LEVEL: resolvedEffortLevel
     }),
     // The bundled claude binary runs a per-tool idle-timeout watchdog (default
     // 300s) over MCP servers whose transport is http/sse/ws. ALL Nimbalyst


### PR DESCRIPTION
## Problem

The model launch/transcript controls exposed reasoning settings that some selected models or transports do not support or forward. Hidden controls could also leak default metadata into a session, and Claude adaptive thinking was presented as extended thinking rather than as its own capability.

## Capability matrix

- Supported Sonnet and Opus models expose `Thinking: Adaptive / Off`.
- Fable 5 stays adaptive and exposes no thinking toggle because adaptive thinking cannot be disabled.
- Haiku exposes no effort selector.
- Opus 4.6 and Sonnet 4.6 omit `xhigh`; stale `xhigh` values normalize down to `high` rather than up.
- Claude CLI and Codex ACP hide reasoning controls their transports do not forward.
- Codex SDK keeps its forwarded effort control.

## Request and persistence correction

- Model capability helpers drive the values rendered in both launch and transcript surfaces.
- Hidden launch controls no longer write reasoning metadata.
- Main-process initialization and turn reinitialization normalize effort against the selected model.
- Claude SDK requests serialize adaptive thinking explicitly where supported, refuse unsupported stored `Off` for Fable, and forward only supported effort values.
- This does not change model names, context-window selection, or expose raw `budget_tokens`.

## Help and labels

Both exposed degrees of freedom use the Nimbalyst `HelpTooltip` registry. The help text distinguishes adaptive thinking from context size and fixed reasoning budgets.

## Validation

- 56 focused tests passed across 6 files covering capability helpers, launch persistence, rendered controls, help entries, main effort normalization, and Claude SDK serialization.
- `git diff --check` passed.
- No dependency or generated-file changes.

Full typecheck remains red on the current unrelated upstream/dependency-artifact baseline in `OpenAIProvider.ts` and missing `nimbalyst-memory` engine/dist artifacts. No patch-file typecheck errors were reported in the prepared verification, and this PR does not claim the full baseline passed.

Refs NIM-407

## Why this is worth merging

Showing an effort control that the selected provider or model cannot honor creates false configuration: the UI accepts a choice that is ignored, rejected later, or silently changed. This patch derives the visible choices from supported capabilities, preserving honest user control and reducing provider-specific launch failures.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
