### PR TITLE
fix: keep tracker issue keys when copying from the agent transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 <!-- Bug fixes go here -->
 - Agent-mode document embeds now recover when their target file is created after the document opens.
+- Copying tracker references out of an agent session now keeps the issue key instead of dropping it.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
@@ -9,6 +9,7 @@ import { ProviderIcon } from '../../icons/ProviderIcons';
 import { MaterialSymbol } from '../../icons/MaterialSymbol';
 import { formatMessageTime, formatDuration, formatTurnFinishedAt } from '../../../utils/dateUtils';
 import { copyToClipboard } from '../../../utils/clipboard';
+import { serializeSelectionWithTrackerChips } from '../utils/trackerChipClipboard';
 import { JSONViewer } from './JSONViewer';
 import { formatToolArguments, extractFilePathFromArgs } from '../utils/pathResolver';
 import { EditToolResultCard } from './EditToolResultCard';
@@ -1196,6 +1197,35 @@ export const RichTranscriptView = React.forwardRef<
     );
     io.observe(el);
     return () => io.disconnect();
+  }, []);
+
+  // Preserve tracker-reference chips when copying from the transcript. The chips
+  // render with `user-select: none`, so a native selection copy drops their
+  // issue key entirely. When a copied selection includes a chip, rewrite the
+  // clipboard so each chip becomes "NIM-123" (text/plain) plus a nimbalyst://
+  // anchor (text/html). Selections without chips fall through to the browser's
+  // default copy untouched.
+  useEffect(() => {
+    const el = viewRootRef.current;
+    if (!el) return;
+    const handleCopy = (event: ClipboardEvent) => {
+      const selection = el.ownerDocument.getSelection();
+      if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+      if (!el.contains(selection.anchorNode) && !el.contains(selection.focusNode)) {
+        return;
+      }
+      const fragment = el.ownerDocument.createDocumentFragment();
+      for (let i = 0; i < selection.rangeCount; i++) {
+        fragment.appendChild(selection.getRangeAt(i).cloneContents());
+      }
+      const payload = serializeSelectionWithTrackerChips(fragment);
+      if (!payload || !event.clipboardData) return;
+      event.preventDefault();
+      event.clipboardData.setData('text/plain', payload.text);
+      event.clipboardData.setData('text/html', payload.html);
+    };
+    el.addEventListener('copy', handleCopy);
+    return () => el.removeEventListener('copy', handleCopy);
   }, []);
 
   useEffect(() => {

--- a/packages/runtime/src/ui/AgentTranscript/utils/__tests__/trackerChipClipboard.test.ts
+++ b/packages/runtime/src/ui/AgentTranscript/utils/__tests__/trackerChipClipboard.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+
+import { serializeSelectionWithTrackerChips } from '../trackerChipClipboard';
+
+/**
+ * Build a chip matching the real TrackerReferenceChip DOM: an icon, the issue
+ * key, a title, and a status badge, all nested under `.tracker-reference-chip`.
+ * The title/status text is exactly the noise that must NOT end up on the
+ * clipboard — only the issue key should.
+ */
+function chip(
+  key: string,
+  opts: { title?: string; status?: string; withAttr?: boolean } = {},
+): string {
+  const { title = 'Some title', status = 'In Progress', withAttr = true } = opts;
+  const attr = withAttr ? ` data-issue-key="${key}"` : '';
+  return (
+    `<span class="tracker-reference-chip"${attr} data-status="in-progress">` +
+    `<span class="material-symbols-outlined tracker-reference-chip-type-icon">bug_report</span>` +
+    `<span class="tracker-reference-chip-key">${key}</span>` +
+    `<span class="tracker-reference-chip-title">${title}</span>` +
+    `<span class="tracker-reference-chip-status">${status}</span>` +
+    `</span>`
+  );
+}
+
+/** Mirror a real Cmd+C: clone the contents of a selection over `html`. */
+function selectionFragment(html: string): DocumentFragment {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  const range = document.createRange();
+  range.selectNodeContents(container);
+  const fragment = range.cloneContents();
+  container.remove();
+  return fragment;
+}
+
+describe('serializeSelectionWithTrackerChips', () => {
+  it('returns null when the selection contains no tracker chips', () => {
+    const fragment = selectionFragment('<p>just some ordinary transcript text</p>');
+    expect(serializeSelectionWithTrackerChips(fragment)).toBeNull();
+  });
+
+  it('copies a single chip as its issue key with the hyphen intact', () => {
+    const result = serializeSelectionWithTrackerChips(selectionFragment(chip('NIM-2058')));
+    expect(result).not.toBeNull();
+    // Regression for the reported "NIM 2058" (space, no hyphen) symptom.
+    expect(result!.text).toBe('NIM-2058');
+    expect(result!.text).not.toContain('NIM 2058');
+    // And the title/status noise inside the chip must not leak out.
+    expect(result!.text).not.toContain('In Progress');
+    expect(result!.text).not.toContain('Some title');
+    // Rich text carries the nimbalyst:// reference so paste can rebuild a chip.
+    expect(result!.html).toContain('href="nimbalyst://NIM-2058"');
+    expect(result!.html).toContain('>NIM-2058</a>');
+  });
+
+  it('keeps both keys and line structure for a bulleted list of chips (reported case)', () => {
+    const html =
+      '<ul>' +
+      `<li>${chip('NIM-1745')} — Make onboarding modes and entry points discoverable <em>(Onboarding)</em></li>` +
+      `<li>${chip('NIM-2058')} — Offer a 15-minute learn-by-doing quickstart after onboarding <em>(Tutorial)</em></li>` +
+      '</ul>';
+    const result = serializeSelectionWithTrackerChips(selectionFragment(html));
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe(
+      'NIM-1745 — Make onboarding modes and entry points discoverable (Onboarding)\n' +
+        'NIM-2058 — Offer a 15-minute learn-by-doing quickstart after onboarding (Tutorial)',
+    );
+    // Both chips resolve to real references in the HTML payload.
+    expect(result!.html).toContain('href="nimbalyst://NIM-1745"');
+    expect(result!.html).toContain('href="nimbalyst://NIM-2058"');
+    // The status badge text is never copied.
+    expect(result!.text).not.toContain('In Progress');
+  });
+
+  it('falls back to the visible key span when data-issue-key is missing', () => {
+    const result = serializeSelectionWithTrackerChips(
+      selectionFragment(chip('NIM-9', { withAttr: false })),
+    );
+    expect(result!.text).toBe('NIM-9');
+  });
+});

--- a/packages/runtime/src/ui/AgentTranscript/utils/trackerChipClipboard.ts
+++ b/packages/runtime/src/ui/AgentTranscript/utils/trackerChipClipboard.ts
@@ -1,0 +1,106 @@
+/**
+ * Clipboard serialization for tracker-reference chips in the AI transcript.
+ *
+ * Transcript chips (`.tracker-reference-chip`, rendered by TrackerReferenceChip)
+ * carry `user-select: none`, so the browser's native selection copy drops the
+ * chip entirely — the issue key ("NIM-123") never reaches the clipboard, or
+ * leaks out mangled (e.g. "NIM 123") via inter-box boundary whitespace. The
+ * transcript has no copy handler, so the `nimbalyst://` reference is lost too.
+ *
+ * This helper rewrites a copied selection so every chip becomes its issue key in
+ * `text/plain` and a `nimbalyst://` anchor in `text/html`. It returns `null`
+ * when the selection contains no chips, so callers leave normal copies to the
+ * browser.
+ */
+
+/** Root class of a rendered tracker-reference chip. */
+export const TRACKER_CHIP_SELECTOR = '.tracker-reference-chip';
+
+// Keep in sync with TRACKER_REFERENCE_URN_SCHEME in
+// plugins/TrackerLinkPlugin/TrackerReferenceNode.tsx. Inlined so this pure DOM
+// util (and its test) stay free of the Lexical/React import chain.
+const TRACKER_REFERENCE_URN_SCHEME = 'nimbalyst://';
+
+/**
+ * Block-level tags that should introduce a line break when a cloned selection is
+ * flattened to plain text, so multi-line selections (lists, paragraphs) keep
+ * their line structure.
+ */
+const BLOCK_TAGS = new Set([
+  'ADDRESS', 'ARTICLE', 'ASIDE', 'BLOCKQUOTE', 'DD', 'DIV', 'DL', 'DT',
+  'FIGCAPTION', 'FIGURE', 'FOOTER', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
+  'HEADER', 'HR', 'LI', 'MAIN', 'NAV', 'OL', 'P', 'PRE', 'SECTION', 'TABLE',
+  'TR', 'UL',
+]);
+
+/** Resolve the issue key a chip should copy as, preferring the canonical attr. */
+function issueKeyFromChip(chip: Element): string {
+  const attr = chip.getAttribute('data-issue-key')?.trim();
+  if (attr) return attr;
+  const keySpan = chip.querySelector('.tracker-reference-chip-key');
+  return (keySpan?.textContent ?? chip.textContent ?? '').trim();
+}
+
+/** Flatten a node tree to plain text, emitting newlines around block elements. */
+function fragmentToPlainText(root: Node): string {
+  let out = '';
+  const visit = (node: Node): void => {
+    node.childNodes.forEach((child) => {
+      if (child.nodeType === Node.TEXT_NODE) {
+        out += child.textContent ?? '';
+        return;
+      }
+      if (child.nodeType !== Node.ELEMENT_NODE) return;
+      const el = child as Element;
+      if (el.tagName === 'BR') {
+        out += '\n';
+        return;
+      }
+      const isBlock = BLOCK_TAGS.has(el.tagName);
+      if (isBlock && out.length > 0 && !out.endsWith('\n')) out += '\n';
+      visit(el);
+      if (isBlock && !out.endsWith('\n')) out += '\n';
+    });
+  };
+  visit(root);
+  return out
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * Given a cloned selection fragment, produce clipboard payloads in which each
+ * tracker chip is replaced by its issue key (plain text) and a `nimbalyst://`
+ * anchor (HTML). Returns `null` when the fragment has no chips.
+ */
+export function serializeSelectionWithTrackerChips(
+  fragment: DocumentFragment,
+): { text: string; html: string } | null {
+  if (fragment.querySelector(TRACKER_CHIP_SELECTOR) == null) return null;
+
+  const doc = fragment.ownerDocument ?? document;
+
+  // Plain text: each chip becomes a bare "NIM-123" text node.
+  const textRoot = fragment.cloneNode(true) as DocumentFragment;
+  textRoot.querySelectorAll(TRACKER_CHIP_SELECTOR).forEach((chip) => {
+    chip.replaceWith(doc.createTextNode(issueKeyFromChip(chip)));
+  });
+  const text = fragmentToPlainText(textRoot);
+
+  // Rich text: each chip becomes a nimbalyst:// anchor so rich paste targets can
+  // rebuild a live reference.
+  const htmlRoot = fragment.cloneNode(true) as DocumentFragment;
+  htmlRoot.querySelectorAll(TRACKER_CHIP_SELECTOR).forEach((chip) => {
+    const key = issueKeyFromChip(chip);
+    const anchor = doc.createElement('a');
+    anchor.setAttribute('href', `${TRACKER_REFERENCE_URN_SCHEME}${key}`);
+    anchor.textContent = key;
+    chip.replaceWith(anchor);
+  });
+  const container = doc.createElement('div');
+  container.appendChild(htmlRoot);
+  const html = container.innerHTML;
+
+  return { text, html };
+}


### PR DESCRIPTION
## Problem

Selecting tracker pills in an agent session transcript and copying them silently loses the reference. Pasting a two-pill selection produced:

```
 — Make onboarding modes and entry points discoverable (Onboarding)
 — Offer a 15-minute learn-by-doing quickstart after onboarding (Tutorial)
```

The issue keys are gone entirely, leaving a dangling separator. In another paste one key degraded to `NIM 2058` (space instead of the hyphen, no link).

## Root cause

Transcript chips render via `TrackerReferenceChip`, whose root sets `user-select: none`. The transcript has no copy handler, so it relies on the browser's native selection serialization, and `user-select: none` removes the whole chip, issue key included, from the copied selection. Native selection copy is also plain-text only, so the `nimbalyst://` reference never survives either.

The Lexical document-editor path is not affected; it already copies keys correctly through `TrackerReferenceNode.getTextContent()`. This is transcript-only.

## Fix

Adds a `copy` handler on the transcript root. When a copied selection contains any `.tracker-reference-chip`, the clipboard is rewritten so each chip becomes:

- `text/plain`: the issue key, e.g. `NIM-2058`
- `text/html`: a `nimbalyst://NIM-2058` anchor, so rich paste targets can rebuild a live reference

Selections containing no chips return early and fall through to the browser's default copy, so ordinary transcript copying is unchanged. The serialization is a pure helper (`trackerChipClipboard.ts`) to keep it testable.

After the fix, the same selection copies as:

```
NIM-1745 — Make onboarding modes and entry points discoverable (Onboarding)
NIM-2058 — Offer a 15-minute learn-by-doing quickstart after onboarding (Tutorial)
```

## Tests

New unit tests in `trackerChipClipboard.test.ts` cover a single chip, the reported two-pill list, the `NIM 2058` hyphen regression, exclusion of chip title/status noise, and the no-chip passthrough.

- 24 tests pass across the new suite plus the existing chip and markdown-refs suites
- `tsc --noEmit` clean

Also verified live in a running renderer against the real `.rich-transcript-view` root: native copy dropped the keys entirely, and the patched path emitted both keys with hyphens intact and the `nimbalyst://` hrefs present.

Generated with Claude Code