### PR TITLE
feat(meta-agent): add guarded cross-project session routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 <!-- Bug fixes go here -->
 - Agent-mode document embeds now recover when their target file is created after the document opens.
+- Orchestrator sessions can launch isolated worktree agents in another loaded project and retain status, result, queue, prompt, and reply control.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/mcp/__tests__/metaAgentServer.projectTargeting.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/metaAgentServer.projectTargeting.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { META_AGENT_TOOL_DEFS } from '../metaAgentServer';
+
+describe('spawn_session project-targeting schema (NIM-408)', () => {
+  it('exposes only the guarded target-project and base-branch inputs', () => {
+    const spawnSession = META_AGENT_TOOL_DEFS.find((tool) => tool.name === 'spawn_session');
+    const properties = spawnSession?.inputSchema.properties ?? {};
+
+    expect(properties).toHaveProperty('targetWorkspacePath');
+    expect(properties).toHaveProperty('baseBranch');
+    expect(properties).not.toHaveProperty('worktreeId');
+    expect(JSON.stringify(properties.targetWorkspacePath)).toContain('already-loaded');
+    expect(JSON.stringify(properties.targetWorkspacePath)).toContain('isolated');
+    expect(JSON.stringify(properties.targetWorkspacePath)).toContain('useWorktree');
+  });
+});

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -28,6 +28,8 @@ type SpawnSessionArgs = {
   title?: string;
   prompt: string;
   useWorktree?: boolean;
+  targetWorkspacePath?: string;
+  baseBranch?: string;
   model?: string;
   notifyOnComplete?: boolean;
   /**
@@ -249,6 +251,16 @@ export const META_AGENT_TOOL_DEFS: Array<{
           type: "boolean",
           description:
             "Default false. By default the spawned session inherits the caller's working directory: if the caller is in a worktree, the new session runs in that same worktree; if the caller is in the main checkout, the new session runs there too. Set true only when the user explicitly asks for the new session to get its OWN new worktree (separate branch and working directory) — this creates a fresh worktree rather than inheriting the caller's.",
+        },
+        targetWorkspacePath: {
+          type: "string",
+          description:
+            "Optional absolute path of an already-loaded canonical Nimbalyst project. Cross-project creation fails closed unless isolated=true and useWorktree=true, so the child is born as a top-level session in a fresh target-project worktree. This does not attach to an existing worktree or grant authority from an arbitrary path.",
+        },
+        baseBranch: {
+          type: "string",
+          description:
+            "Optional branch or ref for the fresh worktree created by useWorktree=true. With targetWorkspacePath, the ref is resolved inside that already-loaded target project.",
         },
         model: {
           type: "string",

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -19,6 +19,8 @@ import { setMetaAgentToolFns } from '../mcp/metaAgentServer';
 import { computeNotificationSignature } from './metaAgentNotificationSignature';
 import { extractMessageText, extractUserPrompts } from './metaAgentMessageText';
 import type { NotificationOptions, NotificationResult } from './NotificationService';
+import { resolveProjectPath } from '../utils/workspaceDetection';
+import { hasLiveWindowForWorkspace } from '../window/windowState';
 
 type SessionStatusValue = 'idle' | 'running' | 'waiting_for_input' | 'error' | 'interrupted';
 type PromptType = 'permission_request' | 'ask_user_question_request' | 'exit_plan_mode_request';
@@ -64,6 +66,7 @@ interface CreateChildSessionArgs {
   prompt?: string;
   useWorktree?: boolean;
   worktreeId?: string;
+  baseBranch?: string;
   toolScope?: string;
 }
 
@@ -90,6 +93,13 @@ interface SpawnSessionArgs {
   title?: string;
   prompt: string;
   useWorktree?: boolean;
+  /**
+   * An already-loaded canonical project to create the session in. Crossing
+   * project boundaries requires isolated=true and useWorktree=true.
+   */
+  targetWorkspacePath?: string;
+  /** Optional branch or ref for the fresh worktree. */
+  baseBranch?: string;
   model?: string;
   /**
    * When true and `model` is not explicitly set, the new session uses the
@@ -196,18 +206,18 @@ export class MetaAgentService {
           this.createChildSession(metaSessionId, workspaceId, args),
         spawnSession: (callerSessionId, workspaceId, args) =>
           this.spawnSession(callerSessionId, workspaceId, args),
-        getSessionStatus: (_metaSessionId, workspaceId, targetSessionId) =>
-          this.getSessionStatusJson(targetSessionId, workspaceId),
-        getSessionResult: (_metaSessionId, workspaceId, targetSessionId, options) =>
-          this.getSessionResultJson(targetSessionId, workspaceId, options),
-        listQueuedPrompts: (_metaSessionId, workspaceId, targetSessionId, options) =>
-          this.listQueuedPromptsJson(targetSessionId, workspaceId, options),
-        sendPrompt: (_metaSessionId, workspaceId, targetSessionId, prompt) =>
-          this.sendPromptToSession(targetSessionId, workspaceId, prompt),
+        getSessionStatus: (metaSessionId, workspaceId, targetSessionId) =>
+          this.getSessionStatusJson(metaSessionId, workspaceId, targetSessionId),
+        getSessionResult: (metaSessionId, workspaceId, targetSessionId, options) =>
+          this.getSessionResultJson(metaSessionId, workspaceId, targetSessionId, options),
+        listQueuedPrompts: (metaSessionId, workspaceId, targetSessionId, options) =>
+          this.listQueuedPromptsJson(metaSessionId, workspaceId, targetSessionId, options),
+        sendPrompt: (metaSessionId, workspaceId, targetSessionId, prompt) =>
+          this.sendPromptToSession(metaSessionId, workspaceId, targetSessionId, prompt),
         notifyUser: (callerSessionId, workspaceId, args) =>
           this.notifyUserJson(callerSessionId, workspaceId, args),
-        respondToPrompt: (_metaSessionId, workspaceId, args) =>
-          this.respondToPrompt(workspaceId, args),
+        respondToPrompt: (metaSessionId, workspaceId, args) =>
+          this.respondToPrompt(metaSessionId, workspaceId, args),
         listSpawnedSessions: (metaSessionId, workspaceId) =>
           this.listSpawnedSessionsJson(metaSessionId, workspaceId),
       });
@@ -511,7 +521,10 @@ export class MetaAgentService {
       for (const name of filesystemNames) existingNames.add(name);
       for (const name of branchNames) existingNames.add(name);
       const finalName = gitWorktreeService.generateUniqueWorktreeName(existingNames);
-      const worktree = await gitWorktreeService.createWorktree(workspaceId, { name: finalName });
+      const worktree = await gitWorktreeService.createWorktree(workspaceId, {
+        name: finalName,
+        ...(args.baseBranch ? { baseBranch: args.baseBranch } : {}),
+      });
       await worktreeStore.create(worktree);
       gitRefWatcher.start(worktree.path).catch((error: Error) => {
         console.error('[MetaAgentService] Failed to start GitRefWatcher for meta-agent worktree:', error);
@@ -675,6 +688,26 @@ export class MetaAgentService {
     }
 
     const isolated = args.isolated === true;
+    const requestedTargetWorkspace = args.targetWorkspacePath?.trim();
+    const targetWorkspaceId = requestedTargetWorkspace
+      ? resolveProjectPath(requestedTargetWorkspace)
+      : workspaceId;
+    const isCrossProject = targetWorkspaceId !== workspaceId;
+
+    if (isCrossProject) {
+      if (!isolated) {
+        throw new Error('Cross-project spawn_session requires isolated=true');
+      }
+      if (args.useWorktree !== true) {
+        throw new Error('Cross-project spawn_session requires useWorktree=true');
+      }
+
+      if (!hasLiveWindowForWorkspace(targetWorkspaceId)) {
+        throw new Error(
+          `Cross-project spawn_session requires an already-loaded target project: ${targetWorkspaceId}`
+        );
+      }
+    }
 
     // Sibling mode: resolve (or create) a workstream container so the new
     // session shares files-edited, tabs, and workstream overview with the
@@ -704,11 +737,12 @@ export class MetaAgentService {
     const effectiveModel =
       args.model ?? (args.inheritModel ? parent.model ?? undefined : undefined);
 
-    const childResult = await this.createChildSessionInternal(parentSessionId, workspaceId, {
+    const childResult = await this.createChildSessionInternal(parentSessionId, targetWorkspaceId, {
       title: args.title,
       prompt: args.prompt,
       useWorktree: !!args.useWorktree,
       worktreeId: inheritedWorktreeId,
+      baseBranch: args.baseBranch,
       model: effectiveModel,
       parentSessionIdOverride: workstreamId,
     });
@@ -725,6 +759,8 @@ export class MetaAgentService {
     return JSON.stringify({
       ...childResult,
       isolated,
+      sourceWorkspacePath: workspaceId,
+      targetWorkspacePath: targetWorkspaceId,
       workstreamId,
       promotedParent,
       notifyOnComplete,
@@ -826,8 +862,17 @@ export class MetaAgentService {
     return JSON.stringify(summaries, null, 2);
   }
 
-  private async getSessionStatusJson(sessionId: string, workspaceId: string): Promise<string> {
-    const row = await this.getSessionStatusRow(sessionId, workspaceId);
+  private async getSessionStatusJson(
+    callerSessionId: string,
+    callerWorkspaceId: string,
+    sessionId: string
+  ): Promise<string> {
+    const session = await this.resolveSessionForCaller(
+      callerSessionId,
+      callerWorkspaceId,
+      sessionId
+    );
+    const row = await this.getSessionStatusRow(sessionId, session.workspacePath);
     if (!row) {
       throw new Error(`Session ${sessionId} not found`);
     }
@@ -850,13 +895,19 @@ export class MetaAgentService {
   }
 
   private async getSessionResultJson(
+    callerSessionId: string,
+    callerWorkspaceId: string,
     sessionId: string,
-    workspaceId: string,
     options: { includeFullResponse?: boolean } = {}
   ): Promise<string> {
+    const session = await this.resolveSessionForCaller(
+      callerSessionId,
+      callerWorkspaceId,
+      sessionId
+    );
     const data = await this.buildSessionResultData(
       sessionId,
-      workspaceId,
+      session.workspacePath,
       undefined,
       options.includeFullResponse ?? true
     );
@@ -864,18 +915,16 @@ export class MetaAgentService {
   }
 
   private async listQueuedPromptsJson(
+    callerSessionId: string,
+    callerWorkspaceId: string,
     sessionId: string,
-    workspaceId: string,
     options: { includeCompleted?: boolean; includePromptText?: boolean } = {}
   ): Promise<string> {
     if (!sessionId) {
       throw new Error('sessionId is required');
     }
 
-    const session = await AISessionsRepository.get(sessionId);
-    if (!session || session.workspacePath !== workspaceId) {
-      throw new Error(`Session ${sessionId} not found`);
-    }
+    await this.resolveSessionForCaller(callerSessionId, callerWorkspaceId, sessionId);
 
     const { getQueuedPromptsStore } = await import('./RepositoryManager');
     const queueStore = getQueuedPromptsStore();
@@ -902,7 +951,12 @@ export class MetaAgentService {
     }, null, 2);
   }
 
-  private async sendPromptToSession(sessionId: string, workspaceId: string, prompt: string): Promise<string> {
+  private async sendPromptToSession(
+    callerSessionId: string,
+    callerWorkspaceId: string,
+    sessionId: string,
+    prompt: string
+  ): Promise<string> {
     if (!this.aiService) {
       throw new Error('AI service not initialized');
     }
@@ -910,14 +964,15 @@ export class MetaAgentService {
       throw new Error('prompt is required');
     }
 
-    const session = await AISessionsRepository.get(sessionId);
-    if (!session || session.workspacePath !== workspaceId) {
-      throw new Error(`Session ${sessionId} not found`);
-    }
+    const session = await this.resolveSessionForCaller(
+      callerSessionId,
+      callerWorkspaceId,
+      sessionId
+    );
 
     const normalizedPrompt = prompt.trim();
     const shouldBypassExecution = this.shouldBypassChildAgentExecutionForTests();
-    const statusRow = await this.getSessionStatusRow(sessionId, workspaceId);
+    const statusRow = await this.getSessionStatusRow(sessionId, session.workspacePath);
     const statusBeforeQueue = (statusRow?.status || 'idle') as SessionStatusValue;
 
     if (shouldBypassExecution) {
@@ -939,7 +994,7 @@ export class MetaAgentService {
     if (processingTriggered) {
       await this.aiService.triggerQueuedPromptProcessingForSession(
         sessionId,
-        session.worktreePath || session.workspacePath || workspaceId
+        session.worktreePath || session.workspacePath
       );
     }
 
@@ -967,10 +1022,11 @@ export class MetaAgentService {
     }
 
     const targetSessionId = args.sessionId?.trim() || callerSessionId;
-    const session = await AISessionsRepository.get(targetSessionId);
-    if (!session || session.workspacePath !== workspaceId) {
-      throw new Error(`Session ${targetSessionId} not found`);
-    }
+    const session = await this.resolveSessionForCaller(
+      callerSessionId,
+      workspaceId,
+      targetSessionId
+    );
 
     if (!this.showNotificationWithResult) {
       throw new Error('Notification delivery is not initialized');
@@ -998,7 +1054,7 @@ export class MetaAgentService {
     }, null, 2);
   }
 
-  private async respondToPrompt(workspaceId: string, args: {
+  private async respondToPrompt(callerSessionId: string, workspaceId: string, args: {
     sessionId: string;
     promptId: string;
     promptType: PromptType;
@@ -1008,10 +1064,7 @@ export class MetaAgentService {
       throw new Error('AI service not initialized');
     }
 
-    const session = await AISessionsRepository.get(args.sessionId);
-    if (!session || session.workspacePath !== workspaceId) {
-      throw new Error(`Session ${args.sessionId} not found`);
-    }
+    await this.resolveSessionForCaller(callerSessionId, workspaceId, args.sessionId);
 
     const result = await this.aiService.respondToInteractivePrompt({
       sessionId: args.sessionId,
@@ -1038,20 +1091,19 @@ export class MetaAgentService {
     return JSON.stringify(sessions, null, 2);
   }
 
-  private async getSpawnedSessions(metaSessionId: string, workspaceId: string): Promise<Array<Record<string, unknown>>> {
+  private async getSpawnedSessions(metaSessionId: string, _workspaceId: string): Promise<Array<Record<string, unknown>>> {
     const { rows } = await databaseWorker.query<any>(
-      `SELECT id, title, provider, model, status, last_activity, created_at, updated_at, worktree_id, agent_role, created_by_session_id
+      `SELECT id, title, provider, model, status, last_activity, created_at, updated_at, worktree_id, agent_role, created_by_session_id, workspace_id
        FROM ai_sessions
-       WHERE workspace_id = $1
-         AND created_by_session_id = $2
+       WHERE created_by_session_id = $1
          AND (is_archived = FALSE OR is_archived IS NULL)
        ORDER BY created_at DESC`,
-      [workspaceId, metaSessionId]
+      [metaSessionId]
     );
 
     const sessions: Array<Record<string, unknown>> = [];
     for (const row of rows) {
-      const data = await this.buildSessionResultData(row.id, workspaceId, {
+      const data = await this.buildSessionResultData(row.id, row.workspace_id, {
         title: row.title || 'Untitled Session',
         provider: row.provider,
         model: row.model || null,
@@ -1075,6 +1127,7 @@ export class MetaAgentService {
         createdAt: data.createdAt,
         updatedAt: data.updatedAt,
         worktreeId: data.worktreeId || null,
+        workspacePath: row.workspace_id,
       });
     }
 
@@ -1464,6 +1517,30 @@ export class MetaAgentService {
       [sessionId, workspaceId]
     );
     return rows[0] || null;
+  }
+
+  /**
+   * Preserve the existing same-workspace session surface while granting a
+   * caller a narrow cross-project capability over sessions it created.
+   * Possession of a path or unrelated session UUID never grants authority.
+   */
+  private async resolveSessionForCaller(
+    callerSessionId: string,
+    callerWorkspaceId: string,
+    targetSessionId: string
+  ): Promise<any> {
+    if (!targetSessionId) {
+      throw new Error('sessionId is required');
+    }
+
+    const session = await AISessionsRepository.get(targetSessionId);
+    const sameWorkspace = session?.workspacePath === callerWorkspaceId;
+    const createdByCaller = session?.createdBySessionId === callerSessionId;
+    if (!session || (!sameWorkspace && !createdByCaller)) {
+      throw new Error(`Session ${targetSessionId} not found`);
+    }
+
+    return session;
   }
 
   private async ensurePlanTrackerItem(workspaceId: string, sessionId: string, result: SessionResultData): Promise<void> {

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.getSessionResultCompact.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.getSessionResultCompact.test.ts
@@ -85,7 +85,7 @@ describe('MetaAgentService.getSessionResultJson includeFullResponse (FIX C)', ()
     ] as never);
 
     const service = MetaAgentService.getInstance();
-    const json = await (service as any).getSessionResultJson('child-1', '/ws');
+    const json = await (service as any).getSessionResultJson('caller', '/ws', 'child-1');
     const data = JSON.parse(json);
 
     expect(data.fullResponse).toBe(longReport);
@@ -99,7 +99,7 @@ describe('MetaAgentService.getSessionResultJson includeFullResponse (FIX C)', ()
     ] as never);
 
     const service = MetaAgentService.getInstance();
-    const json = await (service as any).getSessionResultJson('child-1', '/ws', {
+    const json = await (service as any).getSessionResultJson('caller', '/ws', 'child-1', {
       includeFullResponse: false,
     });
     const data = JSON.parse(json);
@@ -119,7 +119,7 @@ describe('MetaAgentService.getSessionResultJson includeFullResponse (FIX C)', ()
     ] as never);
 
     const service = MetaAgentService.getInstance();
-    const json = await (service as any).getSessionResultJson('child-1', '/ws', {
+    const json = await (service as any).getSessionResultJson('caller', '/ws', 'child-1', {
       includeFullResponse: true,
     });
     const data = JSON.parse(json);

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.projectTargeting.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.projectTargeting.test.ts
@@ -1,0 +1,497 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  hasLiveWindowForWorkspaceMock,
+  createWorktreeMock,
+  worktreeStoreCreateMock,
+  worktreeStoreListMock,
+  worktreeStoreGetMock,
+  worktreeStoreGetAllNamesMock,
+  worktreeStoreGetSessionsMock,
+  databaseQueryMock,
+  queuedPromptsListMock,
+  setMetaAgentToolFnsMock,
+} = vi.hoisted(() => ({
+  hasLiveWindowForWorkspaceMock: vi.fn(),
+  createWorktreeMock: vi.fn(),
+  worktreeStoreCreateMock: vi.fn(),
+  worktreeStoreListMock: vi.fn(),
+  worktreeStoreGetMock: vi.fn(),
+  worktreeStoreGetAllNamesMock: vi.fn(),
+  worktreeStoreGetSessionsMock: vi.fn(),
+  databaseQueryMock: vi.fn(),
+  queuedPromptsListMock: vi.fn(),
+  setMetaAgentToolFnsMock: vi.fn(),
+}));
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    create: vi.fn(),
+    updateMetadata: vi.fn(),
+    get: vi.fn(),
+  },
+  AgentMessagesRepository: {
+    create: vi.fn(),
+    list: vi.fn().mockResolvedValue([]),
+  },
+  SessionFilesRepository: {
+    getFilesBySession: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  SessionManager: class {
+    async initialize() {}
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: {
+    parse: (id: string) => {
+      const split = id.indexOf(':');
+      if (split <= 0) throw new Error(`invalid model: ${id}`);
+      return { provider: id.slice(0, split), model: id.slice(split + 1), combined: id };
+    },
+    tryParse: (id: string) => {
+      const split = typeof id === 'string' ? id.indexOf(':') : -1;
+      return split > 0
+        ? { provider: id.slice(0, split), model: id.slice(split + 1), combined: id }
+        : null;
+    },
+    getDefaultModelId: (provider: string) => `${provider}:default`,
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn(() => () => {}) }),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+vi.mock('../../window/windowState', () => ({
+  hasLiveWindowForWorkspace: hasLiveWindowForWorkspaceMock,
+}));
+
+vi.mock('../../utils/workspaceDetection', () => ({
+  resolveProjectPath: (workspacePath: string) => workspacePath,
+}));
+
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => 'openai-codex:gpt-5.6-terra' }));
+vi.mock('../../utils/timestampUtils', () => ({ toMillis: (value: unknown) => value }));
+vi.mock('../WorktreeStore', () => ({
+  createWorktreeStore: () => ({
+    create: worktreeStoreCreateMock,
+    list: worktreeStoreListMock,
+    get: worktreeStoreGetMock,
+    getAllNames: worktreeStoreGetAllNamesMock,
+    getWorktreeSessions: worktreeStoreGetSessionsMock,
+  }),
+}));
+vi.mock('../GitWorktreeService', () => ({
+  GitWorktreeService: class {
+    createWorktree = createWorktreeMock;
+    getExistingWorktreeDirectories = vi.fn(() => []);
+    getAllBranchNames = vi.fn(async () => []);
+    generateUniqueWorktreeName = vi.fn(() => 'safe-route');
+  },
+}));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({
+  database: { query: databaseQueryMock },
+}));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => ({}) }));
+vi.mock('../../file/GitRefWatcher', () => ({
+  gitRefWatcher: { start: vi.fn(async () => undefined) },
+}));
+vi.mock('../RepositoryManager', () => ({
+  getQueuedPromptsStore: () => ({ listForSession: queuedPromptsListMock }),
+}));
+vi.mock('../ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({ setMetaAgentToolFns: setMetaAgentToolFnsMock }));
+vi.mock('../metaAgentNotificationSignature', () => ({ computeNotificationSignature: vi.fn() }));
+vi.mock('../metaAgentMessageText', () => ({
+  extractMessageText: vi.fn(),
+  extractUserPrompts: vi.fn(() => []),
+}));
+
+import { AISessionsRepository } from '@nimbalyst/runtime';
+import { setMetaAgentToolFns } from '../../mcp/metaAgentServer';
+import { MetaAgentService } from '../MetaAgentService';
+
+const caller = {
+  id: 'caller',
+  workspacePath: '/project-a',
+  provider: 'openai-codex',
+  model: 'openai-codex:gpt-5.6-terra',
+  worktreeId: null,
+  parentSessionId: null,
+  sessionType: 'session',
+};
+
+const targetChild = {
+  id: 'target-child',
+  workspacePath: '/project-b',
+  provider: 'openai-codex',
+  model: 'openai-codex:gpt-5.6-terra',
+  createdBySessionId: 'caller',
+  worktreeId: 'target-worktree',
+  worktreePath: '/project-b_worktrees/safe-route',
+  title: 'Target child',
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+describe('MetaAgentService project-targeted session routing (NIM-408)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    hasLiveWindowForWorkspaceMock.mockReset();
+    createWorktreeMock.mockReset();
+    worktreeStoreCreateMock.mockReset();
+    worktreeStoreListMock.mockReset();
+    worktreeStoreGetMock.mockReset();
+    worktreeStoreGetAllNamesMock.mockReset().mockResolvedValue([]);
+    worktreeStoreGetSessionsMock.mockReset();
+    databaseQueryMock.mockReset().mockResolvedValue({ rows: [{ in_flight: '0', total: '0' }] });
+    queuedPromptsListMock.mockReset().mockResolvedValue([]);
+    setMetaAgentToolFnsMock.mockReset();
+    vi.mocked(AISessionsRepository.get).mockReset();
+    vi.mocked(AISessionsRepository.create).mockReset();
+    vi.mocked(AISessionsRepository.updateMetadata).mockReset();
+  });
+
+  it('creates an isolated fresh worktree session in an already-loaded target project', async () => {
+    const service = MetaAgentService.getInstance();
+    (service as any).aiService = {
+      queuePromptForSession: vi.fn(async () => ({ id: 'queue-1', prompt: 'Do the work' })),
+      triggerQueuedPromptProcessingForSession: vi.fn(async () => undefined),
+    };
+
+    vi.mocked(AISessionsRepository.get).mockImplementation(async (sessionId: string) =>
+      sessionId === 'caller' ? caller as any : null,
+    );
+    hasLiveWindowForWorkspaceMock.mockReturnValue(true);
+    createWorktreeMock.mockResolvedValue({
+      id: 'target-worktree',
+      name: 'safe-route',
+      path: '/project-b_worktrees/safe-route',
+      branch: 'worktree/safe-route',
+      baseBranch: 'integration/v12',
+      projectPath: '/project-b',
+      createdAt: 1,
+    });
+
+    const result = JSON.parse(await (service as any).spawnSession('caller', '/project-a', {
+      prompt: 'Do the work',
+      title: 'Project B owner',
+      isolated: true,
+      useWorktree: true,
+      targetWorkspacePath: '/project-b',
+      baseBranch: 'integration/v12',
+    }));
+
+    expect(hasLiveWindowForWorkspaceMock).toHaveBeenCalledWith('/project-b');
+    expect(createWorktreeMock).toHaveBeenCalledWith('/project-b', {
+      name: 'safe-route',
+      baseBranch: 'integration/v12',
+    });
+    expect(vi.mocked(AISessionsRepository.create)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: '/project-b',
+        worktreeId: 'target-worktree',
+        createdBySessionId: 'caller',
+        parentSessionId: null,
+      }),
+    );
+    expect(result).toMatchObject({
+      isolated: true,
+      sourceWorkspacePath: '/project-a',
+      targetWorkspacePath: '/project-b',
+      worktreeId: 'target-worktree',
+      worktreePath: '/project-b_worktrees/safe-route',
+      worktreeMode: 'new',
+    });
+  });
+
+  it.each([
+    [{ isolated: false, useWorktree: true }, 'isolated=true'],
+    [{ isolated: true, useWorktree: false }, 'useWorktree=true'],
+  ])('fails closed when cross-project creation omits a custody gate', async (flags, expected) => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(caller as any);
+    hasLiveWindowForWorkspaceMock.mockReturnValue(true);
+
+    await expect((service as any).spawnSession('caller', '/project-a', {
+      prompt: 'Do the work',
+      targetWorkspacePath: '/project-b',
+      ...flags,
+    })).rejects.toThrow(expected);
+  });
+
+  it('fails closed when the target project is not loaded in Nimbalyst', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(caller as any);
+    hasLiveWindowForWorkspaceMock.mockReturnValue(false);
+
+    await expect((service as any).spawnSession('caller', '/project-a', {
+      prompt: 'Do the work',
+      isolated: true,
+      useWorktree: true,
+      targetWorkspacePath: '/project-b',
+    })).rejects.toThrow('already-loaded target project');
+  });
+
+  it('allows the creator to supervise its cross-project child but hides unrelated sessions', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockImplementation(async (sessionId: string) => {
+      if (sessionId === 'target-child') return targetChild as any;
+      if (sessionId === 'unrelated') {
+        return { ...targetChild, id: 'unrelated', createdBySessionId: 'someone-else' } as any;
+      }
+      return null;
+    });
+    databaseQueryMock.mockResolvedValueOnce({
+      rows: [{
+        id: 'target-child',
+        title: 'Target child',
+        provider: 'openai-codex',
+        model: 'openai-codex:gpt-5.6-terra',
+        status: 'idle',
+        last_activity: 1,
+        updated_at: 2,
+        created_by_session_id: 'caller',
+        agent_role: 'standard',
+      }],
+    });
+
+    const status = JSON.parse(await (service as any).getSessionStatusJson(
+      'caller',
+      '/project-a',
+      'target-child',
+    ));
+    expect(status.sessionId).toBe('target-child');
+    expect(databaseQueryMock).toHaveBeenCalledWith(
+      expect.stringContaining('workspace_id = $2'),
+      ['target-child', '/project-b'],
+    );
+
+    await expect((service as any).getSessionStatusJson(
+      'caller',
+      '/project-a',
+      'unrelated',
+    )).rejects.toThrow('Session unrelated not found');
+  });
+
+  it('keeps result, queue, prompt, and interactive-reply custody in the target workspace', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.spyOn(service as any, 'shouldBypassChildAgentExecutionForTests').mockReturnValue(false);
+    const queuePromptForSession = vi.fn(async () => ({ id: 'queue-2', prompt: 'Continue' }));
+    const triggerQueuedPromptProcessingForSession = vi.fn(async () => undefined);
+    const respondToInteractivePrompt = vi.fn(async () => ({ success: true }));
+    (service as any).aiService = {
+      queuePromptForSession,
+      triggerQueuedPromptProcessingForSession,
+      respondToInteractivePrompt,
+    };
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(targetChild as any);
+    queuedPromptsListMock.mockResolvedValue([{
+      id: 'queue-1',
+      status: 'pending',
+      prompt: 'Initial',
+      createdAt: 1,
+    }]);
+
+    const buildResultSpy = vi.spyOn(service as any, 'buildSessionResultData').mockResolvedValue({
+      sessionId: 'target-child',
+      title: 'Target child',
+      provider: 'openai-codex',
+      model: 'openai-codex:gpt-5.6-terra',
+      status: 'idle',
+      lastActivity: 1,
+      originalPrompt: 'Initial',
+      userPrompts: ['Initial'],
+      lastResponse: null,
+      fullResponse: null,
+      recentMessages: [],
+      editedFiles: [],
+      pendingPrompt: null,
+      createdAt: 1,
+      updatedAt: 2,
+      worktreeId: 'target-worktree',
+      toolScope: null,
+    });
+
+    await (service as any).getSessionResultJson('caller', '/project-a', 'target-child', {
+      includeFullResponse: false,
+    });
+    expect(buildResultSpy).toHaveBeenCalledWith(
+      'target-child',
+      '/project-b',
+      undefined,
+      false,
+    );
+
+    const queue = JSON.parse(await (service as any).listQueuedPromptsJson(
+      'caller',
+      '/project-a',
+      'target-child',
+      {},
+    ));
+    expect(queue.prompts[0].id).toBe('queue-1');
+
+    databaseQueryMock.mockResolvedValueOnce({
+      rows: [{
+        id: 'target-child',
+        title: 'Target child',
+        provider: 'openai-codex',
+        model: 'openai-codex:gpt-5.6-terra',
+        status: 'idle',
+        last_activity: 1,
+        updated_at: 2,
+        created_by_session_id: 'caller',
+        agent_role: 'standard',
+      }],
+    });
+    const sent = JSON.parse(await (service as any).sendPromptToSession(
+      'caller',
+      '/project-a',
+      'target-child',
+      'Continue',
+    ));
+    expect(sent.processingTriggered).toBe(true);
+    expect(triggerQueuedPromptProcessingForSession).toHaveBeenCalledWith(
+      'target-child',
+      '/project-b_worktrees/safe-route',
+    );
+
+    await (service as any).respondToPrompt('caller', '/project-a', {
+      sessionId: 'target-child',
+      promptId: 'prompt-1',
+      promptType: 'ask_user_question_request',
+      response: { answers: { question: 'answer' } },
+    });
+    expect(respondToInteractivePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'target-child', promptId: 'prompt-1' }),
+    );
+  });
+
+  it('lists creator-owned children across project boundaries', async () => {
+    const service = MetaAgentService.getInstance();
+    databaseQueryMock.mockResolvedValueOnce({
+      rows: [{
+        id: 'target-child',
+        title: 'Target child',
+        provider: 'openai-codex',
+        model: 'openai-codex:gpt-5.6-terra',
+        status: 'idle',
+        last_activity: 1,
+        created_at: 1,
+        updated_at: 2,
+        worktree_id: 'target-worktree',
+        created_by_session_id: 'caller',
+        agent_role: 'standard',
+        workspace_id: '/project-b',
+      }],
+    });
+    vi.spyOn(service as any, 'buildSessionResultData').mockResolvedValue({
+      sessionId: 'target-child',
+      title: 'Target child',
+      provider: 'openai-codex',
+      model: 'openai-codex:gpt-5.6-terra',
+      status: 'idle',
+      lastActivity: 1,
+      originalPrompt: 'Initial',
+      userPrompts: ['Initial'],
+      lastResponse: null,
+      fullResponse: null,
+      recentMessages: [],
+      editedFiles: [],
+      pendingPrompt: null,
+      createdAt: 1,
+      updatedAt: 2,
+      worktreeId: 'target-worktree',
+      toolScope: null,
+    });
+
+    const sessions = await (service as any).getSpawnedSessions('caller', '/project-a');
+
+    expect(databaseQueryMock).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE created_by_session_id = $1'),
+      ['caller'],
+    );
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        sessionId: 'target-child',
+        workspacePath: '/project-b',
+      }),
+    ]);
+  });
+
+  it('exposes creation and supervision through the injected MCP tool route', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.spyOn(service as any, 'shouldBypassChildAgentExecutionForTests').mockReturnValue(false);
+    const aiService = {
+      queuePromptForSession: vi.fn(async (_sessionId: string, prompt: string) => ({
+        id: 'queue-public',
+        prompt,
+      })),
+      triggerQueuedPromptProcessingForSession: vi.fn(async () => undefined),
+    };
+    await service.start(aiService as any, vi.fn());
+
+    const fns = vi.mocked(setMetaAgentToolFns).mock.calls[0][0];
+    let createdSessionId = '';
+    vi.mocked(AISessionsRepository.get).mockImplementation(async (sessionId: string) => {
+      if (sessionId === 'caller') return caller as any;
+      if (sessionId === createdSessionId) {
+        return { ...targetChild, id: createdSessionId } as any;
+      }
+      return null;
+    });
+    vi.mocked(AISessionsRepository.create).mockImplementation(async (input: any) => {
+      createdSessionId = input.id;
+      return input;
+    });
+    hasLiveWindowForWorkspaceMock.mockReturnValue(true);
+    createWorktreeMock.mockResolvedValue({
+      id: 'target-worktree',
+      name: 'safe-route',
+      path: '/project-b_worktrees/safe-route',
+      branch: 'worktree/safe-route',
+      baseBranch: 'integration/v12',
+      projectPath: '/project-b',
+      createdAt: 1,
+    });
+
+    const spawned = JSON.parse(await fns.spawnSession('caller', '/project-a', {
+      prompt: 'Do the work',
+      isolated: true,
+      useWorktree: true,
+      targetWorkspacePath: '/project-b',
+      baseBranch: 'integration/v12',
+    }));
+    expect(spawned.sessionId).toBe(createdSessionId);
+    expect(spawned.targetWorkspacePath).toBe('/project-b');
+
+    databaseQueryMock.mockResolvedValueOnce({
+      rows: [{
+        id: createdSessionId,
+        title: 'Target child',
+        provider: 'openai-codex',
+        model: 'openai-codex:gpt-5.6-terra',
+        status: 'idle',
+        last_activity: 1,
+        updated_at: 2,
+        created_by_session_id: 'caller',
+        agent_role: 'standard',
+      }],
+    });
+    const status = JSON.parse(await fns.getSessionStatus(
+      'caller',
+      '/project-a',
+      createdSessionId,
+    ));
+    expect(status).toMatchObject({ sessionId: createdSessionId, status: 'idle' });
+  });
+});

--- a/packages/electron/src/main/window/__tests__/windowState.test.ts
+++ b/packages/electron/src/main/window/__tests__/windowState.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   windowStates,
+  windows,
   resolveActiveWorkspacePath,
   resolveActiveWorkspacePathForWindowId,
   resolveDocumentServicePath,
   windowReferencesWorkspace,
   anyWindowReferencesWorkspace,
+  hasLiveWindowForWorkspace,
 } from '../windowState';
 import type { WindowState } from '../../types';
 
@@ -22,6 +24,7 @@ function makeState(partial: Partial<WindowState> = {}): WindowState {
 describe('windowState helpers', () => {
   beforeEach(() => {
     windowStates.clear();
+    windows.clear();
   });
 
   describe('resolveActiveWorkspacePath', () => {
@@ -177,6 +180,23 @@ describe('windowState helpers', () => {
     it('returns false when the only references are excluded', () => {
       windowStates.set(1, makeState({ workspacePath: '/ws/lone' }));
       expect(anyWindowReferencesWorkspace('/ws/lone', 1)).toBe(false);
+    });
+  });
+
+  describe('hasLiveWindowForWorkspace', () => {
+    it('returns true only when a non-destroyed window references the path', () => {
+      windows.set(1, { isDestroyed: () => false } as any);
+      windowStates.set(1, makeState({ workspacePath: '/ws/a' }));
+
+      expect(hasLiveWindowForWorkspace('/ws/a')).toBe(true);
+      expect(hasLiveWindowForWorkspace('/ws/b')).toBe(false);
+    });
+
+    it('ignores stale state owned by a destroyed window', () => {
+      windows.set(1, { isDestroyed: () => true } as any);
+      windowStates.set(1, makeState({ workspacePath: '/ws/a' }));
+
+      expect(hasLiveWindowForWorkspace('/ws/a')).toBe(false);
     });
   });
 });

--- a/packages/electron/src/main/window/windowState.ts
+++ b/packages/electron/src/main/window/windowState.ts
@@ -88,3 +88,17 @@ export function anyWindowReferencesWorkspace(path: string, excludeWindowId?: num
     }
     return false;
 }
+
+/**
+ * Whether a live window currently references a workspace path.
+ *
+ * This is the lightweight loaded-project gate for services that must not pull
+ * in WindowManager's startup graph merely to verify routing custody.
+ */
+export function hasLiveWindowForWorkspace(path: string): boolean {
+    for (const [id, window] of windows) {
+        if (window.isDestroyed()) continue;
+        if (windowReferencesWorkspace(windowStates.get(id), path)) return true;
+    }
+    return false;
+}

--- a/scripts/__tests__/check-push-authors.test.mjs
+++ b/scripts/__tests__/check-push-authors.test.mjs
@@ -9,8 +9,15 @@ import { findForbiddenAuthors, parseGitLog } from '../check-push-authors.mjs';
 
 const CHECK_SCRIPT = fileURLToPath(new URL('../check-push-authors.mjs', import.meta.url));
 
+// Git exports repository-local GIT_* variables to hooks. If this test runs
+// inside pre-push and inherits those variables, `cwd` alone is not an isolation
+// boundary: scratch commits can mutate the repository that invoked the hook.
+const SCRATCH_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.toUpperCase().startsWith('GIT_')),
+);
+
 function git(cwd, ...args) {
-  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+  return execFileSync('git', args, { cwd, encoding: 'utf8', env: SCRATCH_ENV });
 }
 
 function commitAs(cwd, name, email, message) {
@@ -55,7 +62,11 @@ test('CLI rejects a range containing a fixture-authored commit', (t) => {
   commitAs(repo, 'Greg Hinkle', 'greghinkle@gmail.com', 'real work');
   commitAs(repo, 'Test User', 'test@example.com', 'seed');
   assert.throws(
-    () => execFileSync('node', [CHECK_SCRIPT, 'HEAD~1..HEAD'], { cwd: repo, encoding: 'utf8' }),
+    () => execFileSync(
+      'node',
+      [CHECK_SCRIPT, 'HEAD~1..HEAD'],
+      { cwd: repo, encoding: 'utf8', env: SCRATCH_ENV },
+    ),
     (error) => {
       assert.equal(error.status, 1);
       assert.match(error.stderr, /test-fixture authors/);
@@ -69,6 +80,10 @@ test('CLI passes a range of real commits', (t) => {
   const repo = makeScratchRepo(t);
   commitAs(repo, 'Greg Hinkle', 'greghinkle@gmail.com', 'first');
   commitAs(repo, 'Greg Hinkle', 'greghinkle@gmail.com', 'second');
-  const stdout = execFileSync('node', [CHECK_SCRIPT, 'HEAD~1..HEAD'], { cwd: repo, encoding: 'utf8' });
+  const stdout = execFileSync(
+    'node',
+    [CHECK_SCRIPT, 'HEAD~1..HEAD'],
+    { cwd: repo, encoding: 'utf8', env: SCRATCH_ENV },
+  );
   assert.match(stdout, /OK: no test-fixture authors/);
 });

--- a/scripts/check-push-authors.mjs
+++ b/scripts/check-push-authors.mjs
@@ -5,6 +5,8 @@
 // ("seed", "hook must reject", author "Test User") to public main. Any outgoing
 // commit with one of these identities is an escaped fixture, never real work.
 import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const FORBIDDEN_NAMES = new Set(['Test', 'Test User', 'Your Name']);
 const FORBIDDEN_EMAIL_PATTERN = /(^test@|@example\.(com|net|org)$|@test\.?$)/i;
@@ -57,6 +59,9 @@ function main() {
   console.log(`[check-push-authors] OK: no test-fixture authors in ${range}.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+const isMain = process.argv[1]
+  && path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1]);
+
+if (isMain) {
   main();
 }


### PR DESCRIPTION
## Summary

- add a guarded `targetWorkspacePath` / `baseBranch` route for spawning a fresh
  worktree session in another already-loaded canonical project;
- preserve creator-scoped cross-project list/status/result/queue/prompt/reply
  custody while keeping unrelated sessions invisible;
- keep `workspace_open` navigation-only and reject arbitrary project paths,
  same-root reuse, and existing-worktree attachment;
- isolate the pre-push author-guard scratch repositories from hook-exported
  `GIT_*` variables and make its CLI entrypoint work on Windows.

This complements the v0.70.5 / #933 fix: that change places an already-created
Claude CLI worktree session in its recorded cwd; this change supplies the
missing guarded project-A to loaded-project-B creation and supervision route.

## Safety contract

- Cross-project targeting requires `isolated: true` and `useWorktree: true`.
- The target must have a live Nimbalyst window.
- A new target-owned worktree is always created; no attachment/rebinding API is
  exposed.
- Cross-project control is restricted to children created by the calling
  session.
- Child prompt processing uses the child `worktreePath`.

## Validation

- 9 focused test files / 60 tests passed.
- Targeted ESLint passed.
- Electron TypeScript typecheck passed.
- `git diff --check` passed.
- Author-guard regression test passed under simulated hook-exported
  `GIT_DIR`/`GIT_WORK_TREE`, with before/after HEAD identical.
- Full prepush baseline before the guard repair: 808 files passed, 28 unrelated
  environment/runtime files failed, 7 skipped; 6404 tests passed, 106 unrelated
  tests failed, 26 skipped. No failed path overlaps the meta-agent patch.

The required downstream release gate is integration into the exact Yogi source
SHA, a new build, and a live project-A to project-B
create/query/queue/commit-custody smoke.

Fixes #964
Fixes #965

## Why this is worth merging

Teams often need to route a bounded task to a session in another already-loaded project. This patch adds that capability behind explicit project resolution and custody checks, so cross-project work can be directed without opening an unguarded global session lookup or creating duplicate projects and agents.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
