### PR TITLE
feat(ai): expose explicit session launch configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Launched agent sessions now validate and display their model, reasoning, capability scope, and inheritance provenance before the first prompt runs.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/mcp/__tests__/metaAgentServer.launchConfiguration.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/metaAgentServer.launchConfiguration.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  SESSION_LAUNCH_EFFORT_LEVELS,
+  SESSION_LAUNCH_THINKING_MODES,
+  SESSION_LAUNCH_TOOL_SCOPES,
+} from '@nimbalyst/runtime/ai/server/sessionLaunchConfiguration';
+
+vi.mock('../../utils/workspaceDetection', () => ({
+  resolveProjectPath: (workspacePath: string) => workspacePath,
+}));
+
+import {
+  META_AGENT_TOOL_DEFS,
+  dispatchMetaAgentTool,
+  setMetaAgentToolFns,
+} from '../metaAgentServer';
+
+describe('meta-agent launch configuration schemas', () => {
+  const createSession = vi.fn().mockResolvedValue('{"created":true}');
+  const spawnSession = vi.fn().mockResolvedValue('{"spawned":true}');
+
+  beforeEach(() => {
+    createSession.mockClear();
+    spawnSession.mockClear();
+    setMetaAgentToolFns({
+      listWorktrees: vi.fn().mockResolvedValue('[]'),
+      createSession,
+      spawnSession,
+      getSessionStatus: vi.fn().mockResolvedValue('{}'),
+      getSessionResult: vi.fn().mockResolvedValue('{}'),
+      listQueuedPrompts: vi.fn().mockResolvedValue('[]'),
+      sendPrompt: vi.fn().mockResolvedValue('{}'),
+      notifyUser: vi.fn().mockResolvedValue('{}'),
+      respondToPrompt: vi.fn().mockResolvedValue('{}'),
+      listSpawnedSessions: vi.fn().mockResolvedValue('[]'),
+    });
+  });
+
+  it('exposes the same provider-aware controls on create_session and spawn_session', () => {
+    for (const toolName of ['create_session', 'spawn_session']) {
+      const tool = META_AGENT_TOOL_DEFS.find(candidate => candidate.name === toolName);
+      const properties = tool?.inputSchema.properties as Record<
+        string,
+        { enum?: string[] }
+      >;
+
+      expect(properties.effortLevel.enum).toEqual(SESSION_LAUNCH_EFFORT_LEVELS);
+      expect(properties.thinkingMode.enum).toEqual(SESSION_LAUNCH_THINKING_MODES);
+      expect(properties.toolScope.enum).toEqual(SESSION_LAUNCH_TOOL_SCOPES);
+    }
+  });
+
+  it('forwards launch controls unchanged through both dispatch paths', async () => {
+    const launch = {
+      provider: 'claude-code',
+      model: 'claude-code:opus',
+      effortLevel: 'high',
+      thinkingMode: 'disabled',
+      toolScope: 'write',
+    };
+    await dispatchMetaAgentTool('create_session', 'parent-1', '/workspace', {
+      prompt: 'create child',
+      ...launch,
+    });
+    await dispatchMetaAgentTool('spawn_session', 'parent-1', '/workspace', {
+      prompt: 'spawn sibling',
+      ...launch,
+    });
+
+    expect(createSession).toHaveBeenCalledWith('parent-1', '/workspace', {
+      prompt: 'create child',
+      ...launch,
+    });
+    expect(spawnSession).toHaveBeenCalledWith('parent-1', '/workspace', {
+      prompt: 'spawn sibling',
+      ...launch,
+    });
+  });
+});

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -13,6 +13,16 @@
  */
 
 import { resolveProjectPath } from "../utils/workspaceDetection";
+import {
+  SESSION_LAUNCH_EFFORT_LEVELS,
+  SESSION_LAUNCH_THINKING_MODES,
+  SESSION_LAUNCH_TOOL_SCOPES,
+  type SessionLaunchToolScope,
+} from "@nimbalyst/runtime/ai/server/sessionLaunchConfiguration";
+import type {
+  EffortLevel,
+  ThinkingMode,
+} from "@nimbalyst/runtime/ai/server/effortLevels";
 
 type CreateSessionArgs = {
   title?: string;
@@ -21,14 +31,20 @@ type CreateSessionArgs = {
   prompt?: string;
   useWorktree?: boolean;
   worktreeId?: string;
-  toolScope?: string;
+  toolScope?: SessionLaunchToolScope;
+  effortLevel?: EffortLevel;
+  thinkingMode?: ThinkingMode;
 };
 
 type SpawnSessionArgs = {
   title?: string;
   prompt: string;
   useWorktree?: boolean;
+  provider?: string;
   model?: string;
+  toolScope?: SessionLaunchToolScope;
+  effortLevel?: EffortLevel;
+  thinkingMode?: ThinkingMode;
   notifyOnComplete?: boolean;
   /**
    * When true, the new session is created at the top level — no parent,
@@ -217,9 +233,21 @@ export const META_AGENT_TOOL_DEFS: Array<{
         },
         toolScope: {
           type: "string",
-          enum: ["read", "write", "full"],
+          enum: [...SESSION_LAUNCH_TOOL_SCOPES],
           description:
             "Capability scope for the child. \"read\" = read_file/list_files/search_files only (pure investigation). \"write\" = those plus write_file but NO run_command, so the child can save a file deliverable (e.g. a report) yet cannot build/test/run anything. \"full\" (default) = all tools including run_command. Use read or write for analyze/research tasks so the child physically cannot run a build, and reserve full for tasks that must build/test.",
+        },
+        effortLevel: {
+          type: "string",
+          enum: [...SESSION_LAUNCH_EFFORT_LEVELS],
+          description:
+            "Optional requested reasoning effort for this child only. Accepted only when the resolved provider/model supports that exact value; unsupported combinations fail before session creation.",
+        },
+        thinkingMode: {
+          type: "string",
+          enum: [...SESSION_LAUNCH_THINKING_MODES],
+          description:
+            "Optional Claude adaptive-thinking toggle for this child only. Accepted only for Claude Agent models whose transport implements the toggle; unsupported combinations fail before session creation.",
         },
       },
     },
@@ -250,15 +278,38 @@ export const META_AGENT_TOOL_DEFS: Array<{
           description:
             "Default false. By default the spawned session inherits the caller's working directory: if the caller is in a worktree, the new session runs in that same worktree; if the caller is in the main checkout, the new session runs there too. Set true only when the user explicitly asks for the new session to get its OWN new worktree (separate branch and working directory) — this creates a fresh worktree rather than inheriting the caller's.",
         },
+        provider: {
+          type: "string",
+          description:
+            "Optional explicit provider. When set, model must either be omitted or carry the same provider prefix.",
+        },
         model: {
           type: "string",
           description:
-            "Optional explicit model identifier (e.g. 'claude-code:opus'). When omitted, the new session uses the global default model unless inheritModel=true. Wins over inheritModel when both are set.",
+            "Optional explicit model identifier (e.g. 'claude-code:opus'). When omitted, the new session inherits the caller's provider/model. Wins over inheritModel when both are set.",
         },
         inheritModel: {
           type: "boolean",
           description:
-            "Default false. When true and `model` is not set, the spawned session uses the caller's model so it stays on the same provider/model (e.g. opus stays on opus). Ignored when `model` is provided explicitly.",
+            "Optional explicit inheritance intent retained in launch provenance. When model is omitted, the spawned session inherits the caller's provider/model either way; an explicit model wins.",
+        },
+        toolScope: {
+          type: "string",
+          enum: [...SESSION_LAUNCH_TOOL_SCOPES],
+          description:
+            "Capability scope for the spawned session. \"read\" and \"write\" restrict tools; \"full\" (default) grants the complete tool surface.",
+        },
+        effortLevel: {
+          type: "string",
+          enum: [...SESSION_LAUNCH_EFFORT_LEVELS],
+          description:
+            "Optional requested reasoning effort for this session only. Accepted only when the resolved provider/model supports that exact value; unsupported combinations fail before session creation.",
+        },
+        thinkingMode: {
+          type: "string",
+          enum: [...SESSION_LAUNCH_THINKING_MODES],
+          description:
+            "Optional Claude adaptive-thinking toggle for this session only. Accepted only for Claude Agent models whose transport implements the toggle; unsupported combinations fail before session creation.",
         },
         notifyOnComplete: {
           type: "boolean",

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -5,9 +5,19 @@ import { safeHandle } from '../utils/ipcRegistry';
 import { SessionManager } from '@nimbalyst/runtime/ai/server';
 import type { AIProviderType } from '@nimbalyst/runtime/ai/server/types';
 import { ModelIdentifier } from '@nimbalyst/runtime/ai/server/types';
+import type { EffortLevel, ThinkingMode } from '@nimbalyst/runtime/ai/server/effortLevels';
+import {
+  isSessionLaunchConfiguration,
+  parseSessionLaunchToolScope,
+  resolveSessionReasoningConfiguration,
+  type SessionLaunchConfiguration,
+  type SessionLaunchToolScope,
+  type SessionLaunchValueSource,
+  type SessionLaunchWorktreeMode,
+} from '@nimbalyst/runtime/ai/server/sessionLaunchConfiguration';
 import { AISessionsRepository, AgentMessagesRepository, SessionFilesRepository } from '@nimbalyst/runtime';
 import { getSessionStateManager } from '@nimbalyst/runtime/ai/server/SessionStateManager';
-import { getDefaultAIModel } from '../utils/store';
+import { getDefaultAIModel, getDefaultEffortLevel } from '../utils/store';
 import { toMillis } from '../utils/timestampUtils';
 import { createWorktreeStore } from './WorktreeStore';
 import { GitWorktreeService } from './GitWorktreeService';
@@ -55,6 +65,7 @@ interface SessionResultData {
   /** Capability scope the child was granted (read|write|full). The objective
    *  record of what the child COULD do; null/full means all tools. */
   toolScope?: string | null;
+  launchConfiguration?: SessionLaunchConfiguration;
 }
 
 interface CreateChildSessionArgs {
@@ -64,7 +75,17 @@ interface CreateChildSessionArgs {
   prompt?: string;
   useWorktree?: boolean;
   worktreeId?: string;
-  toolScope?: string;
+  toolScope?: SessionLaunchToolScope;
+  effortLevel?: EffortLevel;
+  thinkingMode?: ThinkingMode;
+}
+
+interface ChildLaunchContext {
+  inheritModel?: boolean;
+  isolated?: boolean;
+  notifyOnComplete?: boolean;
+  notifyOnCompleteRequested?: boolean | null;
+  worktreeMode?: SessionLaunchWorktreeMode;
 }
 
 function normalizeStoredChildModelIdentifier(
@@ -86,15 +107,128 @@ function normalizeStoredChildModelIdentifier(
   return model;
 }
 
+interface ResolvedChildModel {
+  provider: AIProviderType;
+  normalizedModel: string;
+  providerSource: SessionLaunchValueSource;
+  modelSource: SessionLaunchValueSource;
+}
+
+async function resolveChildSessionModelAndProvider(
+  parentSessionId: string,
+  args: Pick<CreateChildSessionArgs, 'provider' | 'model'>
+): Promise<ResolvedChildModel> {
+  let parentProvider: string | null = null;
+  let parentModel: string | null = null;
+  try {
+    const parentSession = await AISessionsRepository.get(parentSessionId);
+    if (parentSession) {
+      parentProvider = parentSession.provider ?? null;
+      parentModel = normalizeStoredChildModelIdentifier(parentProvider, parentSession.model ?? null);
+    }
+  } catch {
+    // Orphan callers fall through to the configured/default model.
+  }
+
+  const configuredDefaultModel = normalizeStoredChildModelIdentifier(null, getDefaultAIModel());
+  const defaultModel = parentModel || configuredDefaultModel || 'claude-code:opus';
+  const parsedExplicitModel = args.model ? ModelIdentifier.tryParse(args.model) : null;
+  if (
+    args.provider
+    && parsedExplicitModel?.provider
+    && parsedExplicitModel.provider !== args.provider
+  ) {
+    throw new Error(
+      `provider ${args.provider} does not match model provider ${parsedExplicitModel.provider}`
+    );
+  }
+
+  const explicitModelProvider =
+    args.provider
+    ?? parsedExplicitModel?.provider
+    ?? parentProvider;
+  const explicitModel = normalizeStoredChildModelIdentifier(
+    explicitModelProvider,
+    args.model ?? null
+  );
+  const model = explicitModel || defaultModel;
+  const parsed = ModelIdentifier.tryParse(model);
+  const configuredDefaultProvider = configuredDefaultModel
+    ? ModelIdentifier.tryParse(configuredDefaultModel)?.provider ?? null
+    : null;
+  const provider = (
+    args.provider
+    || parsed?.provider
+    || parentProvider
+    || configuredDefaultProvider
+    || 'claude-code'
+  ) as AIProviderType;
+  const parentModelProvider = parentModel
+    ? (ModelIdentifier.tryParse(parentModel)?.provider ?? parentProvider)
+    : null;
+  const normalizedModel =
+    explicitModel
+    || (parentModel && parentModelProvider === provider ? parentModel : null)
+    || (
+      configuredDefaultModel
+      && configuredDefaultProvider === provider
+        ? configuredDefaultModel
+        : null
+    )
+    || ModelIdentifier.getDefaultModelId(provider);
+
+  const providerSource: SessionLaunchValueSource = args.provider || parsedExplicitModel
+    ? 'requested'
+    : parentProvider
+      ? 'inherited'
+      : configuredDefaultProvider
+        ? 'app-default'
+        : 'default';
+  const modelSource: SessionLaunchValueSource = explicitModel
+    ? 'requested'
+    : parentModel && parentModelProvider === provider
+      ? 'inherited'
+      : configuredDefaultModel && configuredDefaultProvider === provider
+        ? 'app-default'
+        : 'default';
+
+  return { provider, normalizedModel, providerSource, modelSource };
+}
+
+function readSessionMetadata(metadata: unknown): Record<string, unknown> | null {
+  let parsed = metadata;
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  return parsed as Record<string, unknown>;
+}
+
+function readSessionLaunchConfiguration(
+  metadata: unknown
+): SessionLaunchConfiguration | undefined {
+  const launchConfiguration = readSessionMetadata(metadata)?.launchConfiguration;
+  return isSessionLaunchConfiguration(launchConfiguration)
+    ? launchConfiguration
+    : undefined;
+}
+
 interface SpawnSessionArgs {
   title?: string;
   prompt: string;
   useWorktree?: boolean;
+  provider?: string;
   model?: string;
+  toolScope?: SessionLaunchToolScope;
+  effortLevel?: EffortLevel;
+  thinkingMode?: ThinkingMode;
   /**
-   * When true and `model` is not explicitly set, the new session uses the
-   * caller's model instead of the global app default. Ignored if `model` is
-   * provided explicitly.
+   * Records explicit inheritance intent in launch provenance. The current
+   * default also inherits the caller when model is omitted.
    */
   inheritModel?: boolean;
   /**
@@ -377,7 +511,10 @@ export class MetaAgentService {
   private async createChildSessionInternal(
     metaSessionId: string,
     workspaceId: string,
-    args: CreateChildSessionArgs & { parentSessionIdOverride?: string | null }
+    args: CreateChildSessionArgs & {
+      parentSessionIdOverride?: string | null;
+      launchContext?: ChildLaunchContext;
+    }
   ): Promise<{
     sessionId: string;
     title: string;
@@ -389,6 +526,7 @@ export class MetaAgentService {
     createdBySessionId: string;
     queuedInitialPrompt: boolean;
     parentSessionId: string | null;
+    launchConfiguration: SessionLaunchConfiguration;
   }> {
     if (!this.aiService) {
       throw new Error('AI service not initialized');
@@ -413,57 +551,20 @@ export class MetaAgentService {
       );
     }
 
-    // Inherit the calling session's provider+model as the primary fallback so a
-    // non-Claude parent (Gemini, OpenAI-Codex, LM Studio, etc.) spawning a child
-    // via the meta-agent tools without an explicit model does NOT silently land
-    // on the hardcoded Opus default and bill the user's Anthropic pool. Only fall
-    // through to getDefaultAIModel() / the last-resort default when the parent
-    // session cannot be loaded (orphan call) or carries no usable provider+model.
-    // An explicit args.provider/args.model still wins; that is what they are for.
-    let parentProvider: string | null = null;
-    let parentModel: string | null = null;
-    try {
-      const parentSession = await AISessionsRepository.get(metaSessionId);
-      if (parentSession) {
-        parentProvider = parentSession.provider ?? null;
-        parentModel = normalizeStoredChildModelIdentifier(parentProvider, parentSession.model ?? null);
-      }
-    } catch {
-      // Best-effort lookup; fall through to the hardcoded default below.
-    }
-
-    const defaultModel =
-      parentModel
-      || normalizeStoredChildModelIdentifier(null, getDefaultAIModel())
-      || 'claude-code:opus';
-    // For an explicit model, the model's own "provider:" prefix is
-    // authoritative (e.g. a claude-code parent launching an
-    // "openai-codex:gpt-5.5" action). Only fall back to the parent's provider
-    // for a bare, prefix-less variant; passing the parent provider for a
-    // self-describing identifier wrongly trips the claude-code mismatch guard.
-    const explicitModelProvider =
-      args.provider
-      ?? (args.model?.includes(':') ? ModelIdentifier.tryParse(args.model)?.provider ?? null : null)
-      ?? parentProvider;
-    const explicitModel = normalizeStoredChildModelIdentifier(explicitModelProvider, args.model ?? null);
-    const model = explicitModel || defaultModel;
-    const parsed = ModelIdentifier.tryParse(model);
-    const provider = (args.provider ||
-      parsed?.provider ||
-      parentProvider ||
-      'claude-code') as AIProviderType;
-    // Provider and model MUST agree. Otherwise a child is persisted with, e.g.,
-    // provider=claude-code + an antigravity-gemini model, gets routed to the
-    // Claude Code provider, is rejected ("requires a claude-code:* identifier"),
-    // and dies with no output. Only reuse the parent model when it actually
-    // belongs to the resolved provider; otherwise use that provider default.
-    const parentModelProvider = parentModel
-      ? (ModelIdentifier.tryParse(parentModel)?.provider ?? parentProvider)
-      : null;
-    const normalizedModel =
-      explicitModel
-      || (parentModel && parentModelProvider === provider ? parentModel : null)
-      || ModelIdentifier.getDefaultModelId(provider);
+    const {
+      provider,
+      normalizedModel,
+      providerSource,
+      modelSource,
+    } = await resolveChildSessionModelAndProvider(metaSessionId, args);
+    const toolScope = parseSessionLaunchToolScope(args.toolScope);
+    const reasoning = resolveSessionReasoningConfiguration({
+      provider,
+      model: normalizedModel,
+      effortLevel: args.effortLevel,
+      thinkingMode: args.thinkingMode,
+      appDefaultEffortLevel: getDefaultEffortLevel(),
+    });
 
     const callerProvidedTitle = !!args.title?.trim();
     const title = (args.title || this.deriveTitleFromPrompt(args.prompt) || 'Meta Task').trim();
@@ -597,14 +698,54 @@ export class MetaAgentService {
       hasBeenNamed: callerProvidedTitle,
     } as any);
 
-    // Read-only tool segregation: persist a restricted capability scope so the
-    // child is granted only the matching dev tools at turn time (an analyze
-    // child physically cannot run_command, so it cannot build or claim to).
-    const childToolScope =
-      args.toolScope === 'read' || args.toolScope === 'write' ? args.toolScope : undefined;
-    if (childToolScope) {
-      await AISessionsRepository.updateMetadata(sessionId, { metadata: { toolScope: childToolScope } });
-    }
+    const worktreeMode: SessionLaunchWorktreeMode =
+      args.launchContext?.worktreeMode
+      ?? (args.worktreeId ? 'existing' : args.useWorktree ? 'new' : 'none');
+    const notifyOnComplete = args.launchContext?.notifyOnComplete ?? true;
+    const launchConfiguration: SessionLaunchConfiguration = {
+      requested: {
+        provider: args.provider ?? null,
+        model: args.model ?? null,
+        effortLevel: reasoning.requestedEffortLevel,
+        thinkingMode: reasoning.requestedThinkingMode,
+        toolScope: args.toolScope ?? null,
+        inheritModel: args.launchContext?.inheritModel === true,
+        isolated: args.launchContext?.isolated === true,
+        useWorktree: args.useWorktree === true,
+        notifyOnComplete: args.launchContext?.notifyOnCompleteRequested ?? null,
+      },
+      resolved: {
+        provider,
+        model: normalizedModel,
+        effortLevel: reasoning.effortLevel,
+        thinkingMode: reasoning.thinkingMode,
+        toolScope,
+        isolated: args.launchContext?.isolated === true,
+        worktreeMode,
+        notifyOnComplete,
+        sources: {
+          provider: providerSource,
+          model: modelSource,
+          effortLevel: reasoning.effortLevelSource,
+          thinkingMode: reasoning.thinkingModeSource,
+          toolScope: args.toolScope ? 'requested' : 'default',
+        },
+      },
+      effectiveness: 'not-provider-confirmed',
+    };
+
+    // Persist the complete launch snapshot before the initial prompt is queued.
+    // Runtime fields remain top-level for existing provider/tool-scope readers;
+    // launchConfiguration is the truthful requested/resolved audit contract.
+    await AISessionsRepository.updateMetadata(sessionId, {
+      metadata: {
+        launchConfiguration,
+        ...(toolScope !== 'full' ? { toolScope } : {}),
+        ...(reasoning.effortLevel ? { effortLevel: reasoning.effortLevel } : {}),
+        ...(reasoning.thinkingMode ? { thinkingMode: reasoning.thinkingMode } : {}),
+        ...(!notifyOnComplete ? { notifyParent: false } : {}),
+      },
+    });
 
     const initialPrompt = args.prompt?.trim();
     const shouldBypassExecution = this.shouldBypassChildAgentExecutionForTests();
@@ -657,6 +798,7 @@ export class MetaAgentService {
       createdBySessionId: metaSessionId,
       queuedInitialPrompt: !!initialPrompt,
       parentSessionId: args.parentSessionIdOverride ?? null,
+      launchConfiguration,
     };
   }
 
@@ -673,6 +815,23 @@ export class MetaAgentService {
     if (!parent || parent.workspacePath !== workspaceId) {
       throw new Error(`Parent session ${parentSessionId} not found in this workspace`);
     }
+
+    // Validate the complete requested configuration before workstream
+    // resolution can create a container or reparent the caller.
+    const effectiveModel =
+      args.model ?? (args.inheritModel ? parent.model ?? undefined : undefined);
+    const previewResolution = await resolveChildSessionModelAndProvider(parentSessionId, {
+      provider: args.provider,
+      model: effectiveModel,
+    });
+    parseSessionLaunchToolScope(args.toolScope);
+    resolveSessionReasoningConfiguration({
+      provider: previewResolution.provider,
+      model: previewResolution.normalizedModel,
+      effortLevel: args.effortLevel,
+      thinkingMode: args.thinkingMode,
+      appDefaultEffortLevel: getDefaultEffortLevel(),
+    });
 
     const isolated = args.isolated === true;
 
@@ -697,31 +856,33 @@ export class MetaAgentService {
     const inheritedWorktreeId =
       !args.useWorktree && parent.worktreeId ? parent.worktreeId : undefined;
 
-    // Resolve effective model: explicit `model` wins; otherwise `inheritModel`
-    // copies the caller's model so the new session keeps the same provider/model
-    // (e.g. opus stays on opus). Falling through to undefined lets
-    // createChildSessionInternal use the global default.
-    const effectiveModel =
-      args.model ?? (args.inheritModel ? parent.model ?? undefined : undefined);
-
+    const notifyOnComplete = args.notifyOnComplete === true;
     const childResult = await this.createChildSessionInternal(parentSessionId, workspaceId, {
       title: args.title,
       prompt: args.prompt,
       useWorktree: !!args.useWorktree,
       worktreeId: inheritedWorktreeId,
+      provider: args.provider,
       model: effectiveModel,
+      toolScope: args.toolScope,
+      effortLevel: args.effortLevel,
+      thinkingMode: args.thinkingMode,
       parentSessionIdOverride: workstreamId,
+      launchContext: {
+        inheritModel: args.inheritModel,
+        isolated,
+        notifyOnComplete,
+        notifyOnCompleteRequested: args.notifyOnComplete ?? null,
+        worktreeMode: args.useWorktree
+          ? 'new'
+          : inheritedWorktreeId
+            ? 'inherited'
+            : 'none',
+      },
     });
 
     // Default is fire-and-forget: kicking off work in a fresh session is the
     // common /launch-new-session use case (escape a long parent context).
-    const notifyOnComplete = args.notifyOnComplete === true;
-    if (!notifyOnComplete) {
-      await AISessionsRepository.updateMetadata(childResult.sessionId, {
-        metadata: { notifyParent: false },
-      });
-    }
-
     return JSON.stringify({
       ...childResult,
       isolated,
@@ -845,6 +1006,10 @@ export class MetaAgentService {
       agentRole: row.agent_role || 'standard',
       waitingForInput: status === 'waiting_for_input',
     };
+    const launchConfiguration = readSessionLaunchConfiguration(row.metadata);
+    if (launchConfiguration) {
+      result.launchConfiguration = launchConfiguration;
+    }
 
     return JSON.stringify(result, null, 2);
   }
@@ -1040,7 +1205,7 @@ export class MetaAgentService {
 
   private async getSpawnedSessions(metaSessionId: string, workspaceId: string): Promise<Array<Record<string, unknown>>> {
     const { rows } = await databaseWorker.query<any>(
-      `SELECT id, title, provider, model, status, last_activity, created_at, updated_at, worktree_id, agent_role, created_by_session_id
+      `SELECT id, title, provider, model, status, last_activity, created_at, updated_at, worktree_id, agent_role, created_by_session_id, metadata
        FROM ai_sessions
        WHERE workspace_id = $1
          AND created_by_session_id = $2
@@ -1060,6 +1225,7 @@ export class MetaAgentService {
         createdAt: toMillis(row.created_at)!,
         updatedAt: toMillis(row.updated_at)!,
         worktreeId: row.worktree_id || null,
+        metadata: row.metadata,
       }, false);
       sessions.push({
         sessionId: data.sessionId,
@@ -1075,6 +1241,9 @@ export class MetaAgentService {
         createdAt: data.createdAt,
         updatedAt: data.updatedAt,
         worktreeId: data.worktreeId || null,
+        ...(data.launchConfiguration
+          ? { launchConfiguration: data.launchConfiguration }
+          : {}),
       });
     }
 
@@ -1250,7 +1419,17 @@ export class MetaAgentService {
   private async buildSessionResultData(
     sessionId: string,
     workspaceId: string,
-    prefetchedSession?: { title: string; provider: string; model: string | null; status: string; lastActivity: number | null; createdAt: number; updatedAt: number; worktreeId: string | null },
+    prefetchedSession?: {
+      title: string;
+      provider: string;
+      model: string | null;
+      status: string;
+      lastActivity: number | null;
+      createdAt: number;
+      updatedAt: number;
+      worktreeId: string | null;
+      metadata?: unknown;
+    },
     // Skip the heavier full-turn extract when the caller only needs preview
     // fields (the list and notification paths discard fullResponse).
     includeFullResponse: boolean = true
@@ -1264,6 +1443,7 @@ export class MetaAgentService {
     let sessionUpdatedAt: number;
     let sessionWorktreeId: string | null;
     let sessionToolScope: string | null = null;
+    let launchConfiguration: SessionLaunchConfiguration | undefined;
 
     if (prefetchedSession) {
       sessionTitle = prefetchedSession.title;
@@ -1274,6 +1454,11 @@ export class MetaAgentService {
       sessionCreatedAt = prefetchedSession.createdAt;
       sessionUpdatedAt = prefetchedSession.updatedAt;
       sessionWorktreeId = prefetchedSession.worktreeId;
+      const metadata = readSessionMetadata(prefetchedSession.metadata);
+      launchConfiguration = readSessionLaunchConfiguration(metadata);
+      sessionToolScope = typeof metadata?.toolScope === 'string'
+        ? metadata.toolScope
+        : launchConfiguration?.resolved.toolScope ?? null;
     } else {
       const session = await AISessionsRepository.get(sessionId);
       if (!session || session.workspacePath !== workspaceId) {
@@ -1288,8 +1473,11 @@ export class MetaAgentService {
       sessionCreatedAt = session.createdAt;
       sessionUpdatedAt = session.updatedAt;
       sessionWorktreeId = session.worktreeId || null;
-      sessionToolScope =
-        ((session.metadata as Record<string, unknown> | undefined)?.toolScope as string | undefined) ?? null;
+      const metadata = readSessionMetadata(session.metadata);
+      launchConfiguration = readSessionLaunchConfiguration(metadata);
+      sessionToolScope = typeof metadata?.toolScope === 'string'
+        ? metadata.toolScope
+        : launchConfiguration?.resolved.toolScope ?? null;
     }
 
     const messages = await AgentMessagesRepository.list(sessionId, { limit: 500 });
@@ -1324,6 +1512,7 @@ export class MetaAgentService {
       updatedAt: sessionUpdatedAt,
       worktreeId: sessionWorktreeId,
       toolScope: sessionToolScope,
+      ...(launchConfiguration ? { launchConfiguration } : {}),
     };
   }
 
@@ -1457,7 +1646,7 @@ export class MetaAgentService {
 
   private async getSessionStatusRow(sessionId: string, workspaceId: string): Promise<any | null> {
     const { rows } = await databaseWorker.query<any>(
-      `SELECT id, title, provider, model, status, last_activity, updated_at, created_by_session_id, agent_role
+      `SELECT id, title, provider, model, status, last_activity, updated_at, created_by_session_id, agent_role, metadata
        FROM ai_sessions
        WHERE id = $1 AND workspace_id = $2
        LIMIT 1`,

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.launchConfiguration.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.launchConfiguration.test.ts
@@ -1,0 +1,433 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    create: vi.fn(),
+    updateMetadata: vi.fn(),
+    get: vi.fn(),
+  },
+  AgentMessagesRepository: {
+    create: vi.fn(),
+    list: vi.fn(),
+  },
+  SessionFilesRepository: {
+    getFilesBySession: vi.fn(),
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  SessionManager: class {
+    async initialize() {}
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: {
+    parse: (id: string) => {
+      const separator = id.indexOf(':');
+      if (separator <= 0) throw new Error(`invalid model: ${id}`);
+      return {
+        provider: id.slice(0, separator),
+        model: id.slice(separator + 1),
+        combined: id,
+      };
+    },
+    tryParse: (id: string) => {
+      const separator = typeof id === 'string' ? id.indexOf(':') : -1;
+      return separator > 0
+        ? { provider: id.slice(0, separator), model: id.slice(separator + 1) }
+        : null;
+    },
+    getDefaultModelId: (provider: string) => `${provider}:default`,
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn() }),
+}));
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({
+  getDefaultAIModel: () => null,
+  getDefaultEffortLevel: () => 'high',
+}));
+vi.mock('../../utils/timestampUtils', () => ({ toMillis: (value: unknown) => value }));
+vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
+vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({
+  database: { query: vi.fn() },
+}));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => null }));
+vi.mock('../../file/GitRefWatcher', () => ({ gitRefWatcher: {} }));
+vi.mock('./ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({ setMetaAgentToolFns: vi.fn() }));
+vi.mock('../metaAgentNotificationSignature', () => ({ computeNotificationSignature: vi.fn() }));
+vi.mock('../metaAgentMessageText', () => ({
+  extractMessageText: (content: unknown) => (typeof content === 'string' ? content : ''),
+  extractUserPrompts: () => [],
+}));
+
+import {
+  AISessionsRepository,
+  AgentMessagesRepository,
+  SessionFilesRepository,
+} from '@nimbalyst/runtime';
+import { database as databaseWorker } from '../../database/PGLiteDatabaseWorker';
+import { MetaAgentService } from '../MetaAgentService';
+
+const WORKSPACE = '/workspace/path';
+const CODEX_PARENT = {
+  id: 'parent-codex-session',
+  provider: 'openai-codex',
+  model: 'openai-codex:gpt-5.6-sol',
+  title: 'Codex parent',
+  workspacePath: WORKSPACE,
+  worktreeId: null,
+  parentSessionId: null,
+  sessionType: 'session',
+};
+const CLAUDE_PARENT = {
+  ...CODEX_PARENT,
+  id: 'parent-claude-session',
+  provider: 'claude-code',
+  model: 'claude-code:opus',
+  title: 'Claude parent',
+};
+const STORED_LAUNCH_CONFIGURATION = {
+  requested: {
+    provider: null,
+    model: null,
+    effortLevel: 'max',
+    thinkingMode: null,
+    toolScope: null,
+    inheritModel: false,
+    isolated: false,
+    useWorktree: false,
+    notifyOnComplete: null,
+  },
+  resolved: {
+    provider: 'openai-codex',
+    model: CODEX_PARENT.model,
+    effortLevel: 'max',
+    thinkingMode: null,
+    toolScope: 'full',
+    isolated: false,
+    worktreeMode: 'none',
+    notifyOnComplete: true,
+    sources: {
+      provider: 'inherited',
+      model: 'inherited',
+      effortLevel: 'requested',
+      thinkingMode: null,
+      toolScope: 'default',
+    },
+  },
+  effectiveness: 'not-provider-confirmed',
+};
+
+function installAIService(service: MetaAgentService) {
+  const queuePromptForSession = vi.fn().mockResolvedValue({ id: 'queued-1' });
+  const triggerQueuedPromptProcessingForSession = vi.fn().mockResolvedValue(undefined);
+  (service as any).aiService = {
+    queuePromptForSession,
+    triggerQueuedPromptProcessingForSession,
+  };
+  return { queuePromptForSession, triggerQueuedPromptProcessingForSession };
+}
+
+describe('MetaAgentService launch configuration', () => {
+  beforeEach(() => {
+    vi.mocked(AISessionsRepository.create).mockReset().mockResolvedValue(undefined);
+    vi.mocked(AISessionsRepository.updateMetadata).mockReset().mockResolvedValue(undefined);
+    vi.mocked(AISessionsRepository.get).mockReset();
+    vi.mocked(AgentMessagesRepository.create).mockReset().mockResolvedValue(undefined);
+    vi.mocked(AgentMessagesRepository.list).mockReset().mockResolvedValue([] as never);
+    vi.mocked(SessionFilesRepository.getFilesBySession)
+      .mockReset()
+      .mockResolvedValue([] as never);
+    vi.mocked(databaseWorker.query)
+      .mockReset()
+      .mockResolvedValue({ rows: [{ in_flight: '0', total: '0' }] } as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists requested/resolved Codex configuration before queue and trigger', async () => {
+    const service = MetaAgentService.getInstance();
+    const { queuePromptForSession, triggerQueuedPromptProcessingForSession } =
+      installAIService(service);
+    vi.spyOn(service as any, 'shouldBypassChildAgentExecutionForTests')
+      .mockReturnValue(false);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    const result = JSON.parse(await (service as any).createChildSession(
+      CODEX_PARENT.id,
+      WORKSPACE,
+      {
+        prompt: 'Implement the focused fix',
+        effortLevel: 'max',
+        toolScope: 'write',
+      },
+    ));
+
+    expect(result.launchConfiguration).toMatchObject({
+      requested: {
+        effortLevel: 'max',
+        toolScope: 'write',
+      },
+      resolved: {
+        provider: 'openai-codex',
+        model: CODEX_PARENT.model,
+        effortLevel: 'max',
+        toolScope: 'write',
+        sources: {
+          provider: 'inherited',
+          model: 'inherited',
+          effortLevel: 'requested',
+          toolScope: 'requested',
+        },
+      },
+      effectiveness: 'not-provider-confirmed',
+    });
+    expect(result.effectiveEffortLevel).toBeUndefined();
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(
+      result.sessionId,
+      {
+        metadata: expect.objectContaining({
+          effortLevel: 'max',
+          toolScope: 'write',
+          launchConfiguration: result.launchConfiguration,
+        }),
+      },
+    );
+
+    const persistOrder =
+      vi.mocked(AISessionsRepository.updateMetadata).mock.invocationCallOrder[0];
+    expect(persistOrder).toBeLessThan(
+      queuePromptForSession.mock.invocationCallOrder[0],
+    );
+    expect(queuePromptForSession.mock.invocationCallOrder[0]).toBeLessThan(
+      triggerQueuedPromptProcessingForSession.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('persists supported Claude effort and thinking configuration', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CLAUDE_PARENT as any);
+
+    const result = await (service as any).createChildSessionInternal(
+      CLAUDE_PARENT.id,
+      WORKSPACE,
+      {
+        effortLevel: 'xhigh',
+        thinkingMode: 'disabled',
+      },
+    );
+
+    expect(result.launchConfiguration.resolved).toMatchObject({
+      effortLevel: 'xhigh',
+      thinkingMode: 'disabled',
+    });
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(
+      result.sessionId,
+      {
+        metadata: expect.objectContaining({
+          effortLevel: 'xhigh',
+          thinkingMode: 'disabled',
+        }),
+      },
+    );
+  });
+
+  it('snapshots supported app defaults with explicit default provenance', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    const result = await (service as any).createChildSessionInternal(
+      CODEX_PARENT.id,
+      WORKSPACE,
+      {},
+    );
+
+    expect(result.launchConfiguration.resolved.effortLevel).toBe('high');
+    expect(result.launchConfiguration.resolved.sources.effortLevel).toBe(
+      'app-default',
+    );
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(
+      result.sessionId,
+      {
+        metadata: expect.objectContaining({ effortLevel: 'high' }),
+      },
+    );
+  });
+
+  it('rejects unsupported reasoning before creating a session', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      ...CLAUDE_PARENT,
+      model: 'claude-code:haiku',
+    } as any);
+
+    await expect((service as any).createChildSessionInternal(
+      CLAUDE_PARENT.id,
+      WORKSPACE,
+      { effortLevel: 'high' },
+    )).rejects.toThrow('Supported values: none');
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects provider/model mismatches before creating a session', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CLAUDE_PARENT as any);
+
+    await expect((service as any).createChildSessionInternal(
+      CLAUDE_PARENT.id,
+      WORKSPACE,
+      {
+        provider: 'claude-code',
+        model: 'openai-codex:gpt-5.6-sol',
+      },
+    )).rejects.toThrow(
+      'provider claude-code does not match model provider openai-codex',
+    );
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid spawn configuration before workstream mutation', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+    const resolveWorkstream = vi.spyOn(service as any, 'resolveOrCreateWorkstream');
+
+    await expect((service as any).spawnSession(
+      CODEX_PARENT.id,
+      WORKSPACE,
+      {
+        prompt: 'Spawn with invalid scope',
+        toolScope: 'admin',
+      },
+    )).rejects.toThrow('Invalid toolScope "admin"');
+    expect(resolveWorkstream).not.toHaveBeenCalled();
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported spawn reasoning before workstream mutation', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      ...CODEX_PARENT,
+      provider: 'openai-codex-acp',
+      model: 'openai-codex-acp:gpt-5.6-sol',
+    } as any);
+    const resolveWorkstream = vi.spyOn(service as any, 'resolveOrCreateWorkstream');
+
+    await expect((service as any).spawnSession(
+      CODEX_PARENT.id,
+      WORKSPACE,
+      {
+        prompt: 'Spawn with unsupported effort',
+        effortLevel: 'max',
+      },
+    )).rejects.toThrow('Supported values: none');
+    expect(resolveWorkstream).not.toHaveBeenCalled();
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('persists spawn topology, scope, and notification behavior before queueing', async () => {
+    const service = MetaAgentService.getInstance();
+    const { queuePromptForSession } = installAIService(service);
+    vi.spyOn(service as any, 'shouldBypassChildAgentExecutionForTests')
+      .mockReturnValue(false);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    const result = JSON.parse(await (service as any).spawnSession(
+      CODEX_PARENT.id,
+      WORKSPACE,
+      {
+        prompt: 'Continue independently',
+        isolated: true,
+        toolScope: 'read',
+        notifyOnComplete: false,
+      },
+    ));
+
+    expect(result.launchConfiguration.resolved).toMatchObject({
+      isolated: true,
+      worktreeMode: 'none',
+      toolScope: 'read',
+      notifyOnComplete: false,
+    });
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(
+      result.sessionId,
+      {
+        metadata: expect.objectContaining({
+          notifyParent: false,
+          toolScope: 'read',
+        }),
+      },
+    );
+    expect(
+      vi.mocked(AISessionsRepository.updateMetadata).mock.invocationCallOrder[0],
+    ).toBeLessThan(queuePromptForSession.mock.invocationCallOrder[0]);
+  });
+
+  it('returns persisted launch provenance from get_session_status', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(databaseWorker.query).mockResolvedValueOnce({
+      rows: [{
+        id: 'child-1',
+        title: 'Launch child',
+        status: 'idle',
+        last_activity: 10,
+        updated_at: 11,
+        provider: 'openai-codex',
+        model: CODEX_PARENT.model,
+        created_by_session_id: CODEX_PARENT.id,
+        agent_role: 'standard',
+        metadata: { launchConfiguration: STORED_LAUNCH_CONFIGURATION },
+      }],
+    } as any);
+
+    const status = JSON.parse(await (service as any).getSessionStatusJson(
+      'child-1',
+      WORKSPACE,
+    ));
+    expect(status.launchConfiguration).toEqual(STORED_LAUNCH_CONFIGURATION);
+    expect(status.effectiveEffortLevel).toBeUndefined();
+  });
+
+  it('returns persisted launch provenance from get_session_result', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      id: 'child-1',
+      title: 'Launch child',
+      provider: 'openai-codex',
+      model: CODEX_PARENT.model,
+      workspacePath: WORKSPACE,
+      worktreeId: null,
+      createdAt: 1,
+      updatedAt: 2,
+      metadata: { launchConfiguration: STORED_LAUNCH_CONFIGURATION },
+    } as any);
+    vi.mocked(databaseWorker.query)
+      .mockResolvedValueOnce({
+        rows: [{ status: 'idle', last_activity: 3 }],
+      } as any)
+      .mockResolvedValueOnce({ rows: [] } as any);
+
+    const result = JSON.parse(await (service as any).getSessionResultJson(
+      'child-1',
+      WORKSPACE,
+    ));
+    expect(result.launchConfiguration).toEqual(STORED_LAUNCH_CONFIGURATION);
+    expect(result.effectiveEffortLevel).toBeUndefined();
+  });
+});

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.parentPromotion.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.parentPromotion.test.ts
@@ -57,7 +57,10 @@ vi.mock('electron', () => ({
 
 vi.mock('../SyncManager', () => ({ getSyncProvider: () => ({ pushChange: vi.fn() }) }));
 vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
-vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => null }));
+vi.mock('../../utils/store', () => ({
+  getDefaultAIModel: () => null,
+  getDefaultEffortLevel: () => 'high',
+}));
 vi.mock('../../utils/timestampUtils', () => ({ toMillis: (v: unknown) => v }));
 vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
 vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.providerInheritance.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.providerInheritance.test.ts
@@ -72,7 +72,10 @@ vi.mock('electron', () => ({
 
 vi.mock('../SyncManager', () => ({ getSyncProvider: () => ({ pushChange: vi.fn() }) }));
 vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
-vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => null }));
+vi.mock('../../utils/store', () => ({
+  getDefaultAIModel: () => null,
+  getDefaultEffortLevel: () => 'high',
+}));
 vi.mock('../../utils/timestampUtils', () => ({ toMillis: (v: unknown) => v }));
 vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
 vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -42,6 +42,10 @@
       "import": "./dist/ai/server/effortLevels.js",
       "types": "./dist/ai/server/effortLevels.d.ts"
     },
+    "./ai/server/sessionLaunchConfiguration": {
+      "import": "./dist/ai/server/sessionLaunchConfiguration.js",
+      "types": "./dist/ai/server/sessionLaunchConfiguration.d.ts"
+    },
     "./ai/types": {
       "import": "./dist/ai/types.js",
       "types": "./dist/ai/types.d.ts"

--- a/packages/runtime/src/ai/server/__tests__/sessionLaunchConfiguration.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/sessionLaunchConfiguration.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSessionLaunchToolScope,
+  resolveSessionReasoningConfiguration,
+} from '../sessionLaunchConfiguration';
+
+describe('session launch reasoning configuration', () => {
+  it('accepts explicit Codex effort without claiming provider effectiveness', () => {
+    expect(resolveSessionReasoningConfiguration({
+      provider: 'openai-codex',
+      model: 'openai-codex:gpt-5.6-sol',
+      effortLevel: 'max',
+      appDefaultEffortLevel: 'high',
+    })).toEqual({
+      requestedEffortLevel: 'max',
+      requestedThinkingMode: null,
+      effortLevel: 'max',
+      thinkingMode: null,
+      effortLevelSource: 'requested',
+      thinkingModeSource: null,
+    });
+  });
+
+  it('accepts supported Claude effort and adaptive-thinking requests', () => {
+    expect(resolveSessionReasoningConfiguration({
+      provider: 'claude-code',
+      model: 'claude-code:opus',
+      effortLevel: 'xhigh',
+      thinkingMode: 'disabled',
+      appDefaultEffortLevel: 'medium',
+    })).toMatchObject({
+      effortLevel: 'xhigh',
+      thinkingMode: 'disabled',
+      effortLevelSource: 'requested',
+      thinkingModeSource: 'requested',
+    });
+  });
+
+  it('normalizes an app default for the selected model but rejects that value when explicit', () => {
+    expect(resolveSessionReasoningConfiguration({
+      provider: 'claude-code',
+      model: 'claude-code:sonnet-4-6',
+      appDefaultEffortLevel: 'xhigh',
+    }).effortLevel).toBe('high');
+
+    expect(() => resolveSessionReasoningConfiguration({
+      provider: 'claude-code',
+      model: 'claude-code:sonnet-4-6',
+      effortLevel: 'xhigh',
+      appDefaultEffortLevel: 'high',
+    })).toThrow('Supported values: low, medium, high, max');
+  });
+
+  it.each([
+    ['openai-codex-acp', 'openai-codex-acp:gpt-5.6-sol'],
+    ['claude-code-cli', 'claude-code-cli:opus'],
+    ['claude-code', 'claude-code:haiku'],
+    ['opencode', 'opencode:default'],
+  ])('rejects effort for unsupported %s models', (provider, model) => {
+    expect(() => resolveSessionReasoningConfiguration({
+      provider,
+      model,
+      effortLevel: 'high',
+      appDefaultEffortLevel: 'high',
+    })).toThrow('Supported values: none');
+  });
+
+  it('rejects thinking toggles for fixed-adaptive Fable', () => {
+    expect(() => resolveSessionReasoningConfiguration({
+      provider: 'claude-code',
+      model: 'claude-code:fable',
+      thinkingMode: 'disabled',
+      appDefaultEffortLevel: 'high',
+    })).toThrow('thinkingMode is not supported');
+  });
+
+  it('validates tool scopes instead of silently treating unknown values as full', () => {
+    expect(parseSessionLaunchToolScope(undefined)).toBe('full');
+    expect(parseSessionLaunchToolScope('write')).toBe('write');
+    expect(() => parseSessionLaunchToolScope('admin')).toThrow(
+      'Invalid toolScope "admin"'
+    );
+  });
+});

--- a/packages/runtime/src/ai/server/effortLevels.ts
+++ b/packages/runtime/src/ai/server/effortLevels.ts
@@ -17,13 +17,79 @@ export const EFFORT_LEVELS: { key: EffortLevel; label: string }[] = [
 ];
 
 export const DEFAULT_EFFORT_LEVEL: EffortLevel = 'high';
-// Default to 'enabled' so the app omits the SDK thinking option and preserves
-// the SDK's default adaptive thinking (Claude decides depth) on supported
-// Opus/Sonnet models. Users can opt into 'disabled' (Extended: Off) per session.
+// "enabled" is the persisted compatibility value for adaptive thinking. The
+// provider translates it to `thinking: { type: 'adaptive' }`; it must not be
+// presented as manual "extended thinking", which is a different API mode.
 export const DEFAULT_THINKING_MODE: ThinkingMode = 'enabled';
 
 const VALID_EFFORT_LEVELS = new Set<string>(['low', 'medium', 'high', 'xhigh', 'max']);
 const VALID_THINKING_MODES = new Set<string>(['enabled', 'disabled']);
+
+const CLAUDE_EFFORT_LEVELS = {
+  current: EFFORT_LEVELS,
+  legacyAdaptive: EFFORT_LEVELS.filter(level => level.key !== 'xhigh'),
+} as const;
+
+function normalizedModelId(modelId: string | undefined | null): string {
+  return (modelId ?? '').toLowerCase().replace(/-1m$/, '').replace(/\[1m\]$/, '');
+}
+
+/**
+ * Return only the effort values the selected model accepts.
+ *
+ * Claude Sonnet 5, Fable 5, Opus 4.8, and Opus 4.7 support the complete
+ * low/medium/high/xhigh/max ladder. Opus 4.6 and Sonnet 4.6 support the same
+ * ladder except xhigh. Haiku has no adaptive-effort control in this surface.
+ * Other providers keep their existing transport-owned ladder.
+ */
+export function supportedEffortLevelsForModel(
+  modelId: string | undefined | null
+): { key: EffortLevel; label: string }[] {
+  const id = normalizedModelId(modelId);
+  if (id.startsWith('claude-code-cli:') || id.startsWith('openai-codex-acp:')) return [];
+  if (id.startsWith('claude-code:')) {
+    if (id.includes('haiku')) return [];
+    if (id.includes('opus-4-6') || id.includes('sonnet-4-6')) {
+      return [...CLAUDE_EFFORT_LEVELS.legacyAdaptive];
+    }
+  }
+  return [...CLAUDE_EFFORT_LEVELS.current];
+}
+
+/**
+ * Whether the selected model supports an explicit adaptive-thinking toggle.
+ *
+ * Fable is intentionally excluded: it is always adaptive and cannot be
+ * disabled. Claude CLI and non-Claude transports do not forward this setting.
+ */
+export function supportsThinkingModeForModel(
+  modelId: string | undefined | null
+): boolean {
+  const id = normalizedModelId(modelId);
+  if (!id.startsWith('claude-code:')) return false;
+  const variant = id.slice('claude-code:'.length);
+  return variant.startsWith('opus') || variant.startsWith('sonnet');
+}
+
+/**
+ * Normalize a stored/global effort to a value the selected model accepts.
+ * Unsupported intermediate levels step down rather than silently upgrading
+ * capability or cost (for example xhigh -> high on Sonnet 4.6).
+ */
+export function normalizeEffortForModel(
+  modelId: string | undefined | null,
+  effort: EffortLevel
+): EffortLevel {
+  const supported = supportedEffortLevelsForModel(modelId);
+  if (supported.length === 0 || supported.some(level => level.key === effort)) return effort;
+
+  const requestedIndex = EFFORT_LEVELS.findIndex(level => level.key === effort);
+  for (let index = requestedIndex - 1; index >= 0; index -= 1) {
+    const candidate = EFFORT_LEVELS[index].key;
+    if (supported.some(level => level.key === candidate)) return candidate;
+  }
+  return supported[0].key;
+}
 
 /**
  * Validate and return a valid EffortLevel, or the default if invalid.
@@ -49,12 +115,19 @@ export function parseEffortLevel(value: unknown): EffortLevel {
  */
 export function resolveEffortLevel(
   sessionEffortLevel: unknown,
-  appDefaultEffortLevel: EffortLevel | undefined
+  appDefaultEffortLevel: EffortLevel | undefined,
+  modelId?: string | null,
 ): EffortLevel | undefined {
+  let resolved: EffortLevel | undefined;
   if (sessionEffortLevel != null && sessionEffortLevel !== '') {
-    return parseEffortLevel(sessionEffortLevel);
+    resolved = parseEffortLevel(sessionEffortLevel);
+  } else {
+    resolved = appDefaultEffortLevel;
   }
-  return appDefaultEffortLevel;
+  if (resolved === undefined) return undefined;
+  const supported = supportedEffortLevelsForModel(modelId);
+  if (supported.length === 0) return undefined;
+  return normalizeEffortForModel(modelId, resolved);
 }
 
 /**

--- a/packages/runtime/src/ai/server/sessionLaunchConfiguration.ts
+++ b/packages/runtime/src/ai/server/sessionLaunchConfiguration.ts
@@ -1,0 +1,205 @@
+import {
+  DEFAULT_THINKING_MODE,
+  EFFORT_LEVELS,
+  normalizeEffortForModel,
+  supportedEffortLevelsForModel,
+  supportsThinkingModeForModel,
+  type EffortLevel,
+  type ThinkingMode,
+} from './effortLevels';
+
+export const SESSION_LAUNCH_TOOL_SCOPES = ['read', 'write', 'full'] as const;
+export const SESSION_LAUNCH_EFFORT_LEVELS = EFFORT_LEVELS.map(({ key }) => key);
+export const SESSION_LAUNCH_THINKING_MODES = ['enabled', 'disabled'] as const;
+
+export type SessionLaunchToolScope = (typeof SESSION_LAUNCH_TOOL_SCOPES)[number];
+export type SessionLaunchValueSource =
+  | 'requested'
+  | 'inherited'
+  | 'app-default'
+  | 'provider-default'
+  | 'default';
+export type SessionLaunchWorktreeMode = 'existing' | 'new' | 'inherited' | 'none';
+
+export interface RequestedSessionLaunchConfiguration {
+  provider: string | null;
+  model: string | null;
+  effortLevel: EffortLevel | null;
+  thinkingMode: ThinkingMode | null;
+  toolScope: SessionLaunchToolScope | null;
+  inheritModel: boolean;
+  isolated: boolean;
+  useWorktree: boolean;
+  notifyOnComplete: boolean | null;
+}
+
+export interface ResolvedSessionLaunchConfiguration {
+  provider: string;
+  model: string;
+  effortLevel: EffortLevel | null;
+  thinkingMode: ThinkingMode | null;
+  toolScope: SessionLaunchToolScope;
+  isolated: boolean;
+  worktreeMode: SessionLaunchWorktreeMode;
+  notifyOnComplete: boolean;
+  sources: {
+    provider: SessionLaunchValueSource;
+    model: SessionLaunchValueSource;
+    effortLevel: SessionLaunchValueSource | null;
+    thinkingMode: SessionLaunchValueSource | null;
+    toolScope: SessionLaunchValueSource;
+  };
+}
+
+export interface SessionLaunchConfiguration {
+  requested: RequestedSessionLaunchConfiguration;
+  resolved: ResolvedSessionLaunchConfiguration;
+  effectiveness: 'not-provider-confirmed';
+}
+
+export interface ResolveSessionReasoningInput {
+  provider: string;
+  model: string;
+  effortLevel?: unknown;
+  thinkingMode?: unknown;
+  appDefaultEffortLevel?: EffortLevel;
+}
+
+export interface ResolvedSessionReasoning {
+  requestedEffortLevel: EffortLevel | null;
+  requestedThinkingMode: ThinkingMode | null;
+  effortLevel: EffortLevel | null;
+  thinkingMode: ThinkingMode | null;
+  effortLevelSource: SessionLaunchValueSource | null;
+  thinkingModeSource: SessionLaunchValueSource | null;
+}
+
+function parseOptionalEffortLevel(value: unknown): EffortLevel | null {
+  if (value === undefined || value === null) return null;
+  if (
+    typeof value !== 'string'
+    || !SESSION_LAUNCH_EFFORT_LEVELS.includes(value as EffortLevel)
+  ) {
+    throw new Error(
+      `Invalid effortLevel ${JSON.stringify(value)}. Expected one of: ${SESSION_LAUNCH_EFFORT_LEVELS.join(', ')}`
+    );
+  }
+  return value as EffortLevel;
+}
+
+function parseOptionalThinkingMode(value: unknown): ThinkingMode | null {
+  if (value === undefined || value === null) return null;
+  if (
+    typeof value !== 'string'
+    || !SESSION_LAUNCH_THINKING_MODES.includes(value as ThinkingMode)
+  ) {
+    throw new Error(
+      `Invalid thinkingMode ${JSON.stringify(value)}. Expected one of: ${SESSION_LAUNCH_THINKING_MODES.join(', ')}`
+    );
+  }
+  return value as ThinkingMode;
+}
+
+export function parseSessionLaunchToolScope(value: unknown): SessionLaunchToolScope {
+  if (value === undefined || value === null) return 'full';
+  if (
+    typeof value !== 'string'
+    || !SESSION_LAUNCH_TOOL_SCOPES.includes(value as SessionLaunchToolScope)
+  ) {
+    throw new Error(
+      `Invalid toolScope ${JSON.stringify(value)}. Expected one of: ${SESSION_LAUNCH_TOOL_SCOPES.join(', ')}`
+    );
+  }
+  return value as SessionLaunchToolScope;
+}
+
+/**
+ * Validate requested reasoning controls against the resolved provider/model,
+ * then resolve application defaults without claiming provider effectiveness.
+ */
+export function resolveSessionReasoningConfiguration(
+  input: ResolveSessionReasoningInput
+): ResolvedSessionReasoning {
+  const requestedEffortLevel = parseOptionalEffortLevel(input.effortLevel);
+  const requestedThinkingMode = parseOptionalThinkingMode(input.thinkingMode);
+  const supportsEffort =
+    input.provider === 'openai-codex' || input.provider === 'claude-code';
+  const supportedEffortLevels = supportsEffort
+    ? supportedEffortLevelsForModel(input.model)
+    : [];
+
+  if (
+    requestedEffortLevel
+    && !supportedEffortLevels.some(({ key }) => key === requestedEffortLevel)
+  ) {
+    const supportedDescription = supportedEffortLevels.length > 0
+      ? supportedEffortLevels.map(({ key }) => key).join(', ')
+      : 'none';
+    throw new Error(
+      `effortLevel ${JSON.stringify(requestedEffortLevel)} is not supported for ${input.provider} model ${input.model}. Supported values: ${supportedDescription}`
+    );
+  }
+
+  const supportsThinkingMode =
+    input.provider === 'claude-code' && supportsThinkingModeForModel(input.model);
+  if (requestedThinkingMode && !supportsThinkingMode) {
+    throw new Error(
+      `thinkingMode is not supported for ${input.provider} model ${input.model}`
+    );
+  }
+
+  let effortLevel: EffortLevel | null = null;
+  let effortLevelSource: SessionLaunchValueSource | null = null;
+  if (requestedEffortLevel) {
+    effortLevel = requestedEffortLevel;
+    effortLevelSource = 'requested';
+  } else if (supportedEffortLevels.length > 0 && input.appDefaultEffortLevel) {
+    effortLevel = normalizeEffortForModel(input.model, input.appDefaultEffortLevel);
+    effortLevelSource = 'app-default';
+  }
+
+  const thinkingMode = supportsThinkingMode
+    ? requestedThinkingMode ?? DEFAULT_THINKING_MODE
+    : null;
+  const thinkingModeSource = supportsThinkingMode
+    ? requestedThinkingMode
+      ? 'requested' as const
+      : 'provider-default' as const
+    : null;
+
+  return {
+    requestedEffortLevel,
+    requestedThinkingMode,
+    effortLevel,
+    thinkingMode,
+    effortLevelSource,
+    thinkingModeSource,
+  };
+}
+
+export function isSessionLaunchConfiguration(
+  value: unknown
+): value is SessionLaunchConfiguration {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const candidate = value as Partial<SessionLaunchConfiguration>;
+  if (
+    !candidate.requested
+    || typeof candidate.requested !== 'object'
+    || !candidate.resolved
+    || typeof candidate.resolved !== 'object'
+    || candidate.effectiveness !== 'not-provider-confirmed'
+  ) {
+    return false;
+  }
+  const resolved = candidate.resolved as Partial<ResolvedSessionLaunchConfiguration>;
+  return Boolean(
+    typeof resolved.provider === 'string'
+    && typeof resolved.model === 'string'
+    && typeof resolved.toolScope === 'string'
+    && typeof resolved.isolated === 'boolean'
+    && typeof resolved.worktreeMode === 'string'
+    && typeof resolved.notifyOnComplete === 'boolean'
+    && resolved.sources
+    && typeof resolved.sources === 'object'
+  );
+}

--- a/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/CrossSessionToolWidget.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/CrossSessionToolWidget.tsx
@@ -14,6 +14,9 @@
 import React from 'react';
 import type { CustomToolWidgetProps } from './index';
 import { SessionReferenceChip } from '../../session/SessionReferenceChip';
+import {
+  isSessionLaunchConfiguration,
+} from '../../../../ai/server/sessionLaunchConfiguration';
 
 interface ActionMeta {
   label: string;
@@ -26,7 +29,7 @@ const ACTIONS: Record<string, ActionMeta> = {
   send_prompt: { label: 'Send prompt', icon: 'send', detailArg: 'prompt' },
   respond_to_prompt: { label: 'Respond to prompt', icon: 'reply', detailArg: 'response' },
   spawn_session: { label: 'Spawn session', icon: 'rocket_launch', detailArg: 'prompt' },
-  create_session: { label: 'Create session', icon: 'add_circle', detailArg: 'initialPrompt' },
+  create_session: { label: 'Create session', icon: 'add_circle', detailArg: 'prompt' },
   get_session_status: { label: 'Get session status', icon: 'query_stats' },
   get_session_result: { label: 'Get session result', icon: 'task_alt' },
   list_queued_prompts: { label: 'List queued prompts', icon: 'list' },
@@ -66,16 +69,23 @@ function getResultText(result: unknown): string | null {
   return null;
 }
 
+function parseResultJson(result: unknown): Record<string, unknown> | null {
+  const text = getResultText(result);
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Collect distinct session ids referenced by the result JSON. */
 function collectResultSessionIds(result: unknown): string[] {
-  const text = getResultText(result);
-  if (!text) return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch {
-    return [];
-  }
+  const parsed = parseResultJson(result);
+  if (!parsed) return [];
   const ids: string[] = [];
   const add = (v: unknown) => {
     if (isUuid(v) && !ids.includes(v)) ids.push(v);
@@ -93,6 +103,87 @@ function collectResultSessionIds(result: unknown): string[] {
   };
   visit(parsed);
   return ids;
+}
+
+interface LaunchSummaryItem {
+  label: string;
+  value: string;
+  source?: string | null;
+}
+
+function launchSummaryItems(
+  toolName: string,
+  args: Record<string, unknown>,
+  result: unknown,
+): LaunchSummaryItem[] {
+  const parsedResult = parseResultJson(result);
+  const launchConfiguration = parsedResult?.launchConfiguration;
+  const config = isSessionLaunchConfiguration(launchConfiguration)
+    ? launchConfiguration
+    : null;
+
+  if (config) {
+    const { resolved } = config;
+    const items: LaunchSummaryItem[] = [
+      {
+        label: 'Model',
+        value: resolved.model,
+        source: resolved.sources.model,
+      },
+    ];
+    if (resolved.effortLevel) {
+      items.push({
+        label: 'Effort',
+        value: resolved.effortLevel,
+        source: resolved.sources.effortLevel,
+      });
+    }
+    if (resolved.thinkingMode) {
+      items.push({
+        label: 'Thinking',
+        value: resolved.thinkingMode === 'enabled' ? 'Adaptive' : 'Off',
+        source: resolved.sources.thinkingMode,
+      });
+    }
+    items.push({
+      label: 'Scope',
+      value: resolved.toolScope,
+      source: resolved.sources.toolScope,
+    });
+    items.push({
+      label: 'Workspace',
+      value: resolved.isolated
+        ? 'isolated'
+        : resolved.worktreeMode === 'none'
+          ? 'shared'
+          : `${resolved.worktreeMode} worktree`,
+    });
+    items.push({
+      label: 'Notify',
+      value: resolved.notifyOnComplete ? 'on' : 'off',
+    });
+    return items;
+  }
+
+  if (toolName !== 'create_session' && toolName !== 'spawn_session') return [];
+  const items: LaunchSummaryItem[] = [];
+  if (typeof args.model === 'string') {
+    items.push({ label: 'Model', value: args.model, source: 'requested' });
+  }
+  if (typeof args.effortLevel === 'string') {
+    items.push({ label: 'Effort', value: args.effortLevel, source: 'requested' });
+  }
+  if (typeof args.thinkingMode === 'string') {
+    items.push({
+      label: 'Thinking',
+      value: args.thinkingMode === 'enabled' ? 'Adaptive' : 'Off',
+      source: 'requested',
+    });
+  }
+  if (typeof args.toolScope === 'string') {
+    items.push({ label: 'Scope', value: args.toolScope, source: 'requested' });
+  }
+  return items;
 }
 
 function truncate(text: string, max = 120): string {
@@ -124,6 +215,7 @@ export const CrossSessionToolWidget: React.FC<CustomToolWidgetProps> = ({
     action.detailArg && typeof args[action.detailArg] === 'string'
       ? (args[action.detailArg] as string)
       : null;
+  const launchSummary = launchSummaryItems(bare, args, tool.result);
 
   const canExpand = Boolean(detail || tool.result);
   const isError = tool.isError || tool.status === 'error';
@@ -193,6 +285,37 @@ export const CrossSessionToolWidget: React.FC<CustomToolWidgetProps> = ({
           </button>
         ) : null}
       </div>
+
+      {launchSummary.length > 0 ? (
+        <div
+          className="cross-session-tool-widget-launch-summary"
+          aria-label="Launch configuration"
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '4px',
+            marginTop: '6px',
+          }}
+        >
+          {launchSummary.map((item) => (
+            <span
+              key={`${item.label}:${item.value}`}
+              className="cross-session-tool-widget-launch-item"
+              title={item.source ? `${item.label} source: ${item.source}` : undefined}
+              style={{
+                padding: '2px 6px',
+                borderRadius: '999px',
+                background: 'var(--nim-bg-tertiary)',
+                color: 'var(--nim-text-muted)',
+                fontSize: '11px',
+              }}
+            >
+              {item.label}: {truncate(item.value, 42)}
+              {item.source ? ` · ${item.source}` : ''}
+            </span>
+          ))}
+        </div>
+      ) : null}
 
       {detail && !isExpanded ? (
         <div

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/CrossSessionToolWidget.test.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/CrossSessionToolWidget.test.tsx
@@ -3,7 +3,15 @@
  */
 
 import React from 'react';
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+  describe,
+  expect,
+  it,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
 import * as rtl from '@testing-library/react';
 import { createStore, Provider as JotaiProvider } from 'jotai';
 import type { TranscriptViewMessage } from '../../../../ai/server/transcript/TranscriptProjector';
@@ -54,6 +62,7 @@ function renderWidget(
   message: TranscriptViewMessage,
   meta?: SessionRefMeta,
   onToggle = () => {},
+  isExpanded = false,
 ) {
   const store = createStore();
   if (meta) store.set(sessionRefMapAtom, new Map([[meta.id, meta]]));
@@ -61,7 +70,7 @@ function renderWidget(
     <JotaiProvider store={store}>
       <CrossSessionToolWidget
         message={message}
-        isExpanded={false}
+        isExpanded={isExpanded}
         onToggle={onToggle}
         sessionId="host"
       />
@@ -70,7 +79,7 @@ function renderWidget(
 }
 
 describe('CrossSessionToolWidget', () => {
-  let dispatchSpy: ReturnType<typeof vi.spyOn>;
+  let dispatchSpy: MockInstance<(event: Event) => boolean>;
   beforeEach(() => {
     dispatchSpy = vi.spyOn(window, 'dispatchEvent');
   });
@@ -102,6 +111,96 @@ describe('CrossSessionToolWidget', () => {
     );
     expect(screen.getByText('Spawn session')).toBeDefined();
     expect(screen.getByText('Child A')).toBeDefined();
+  });
+
+  it('shows resolved launch settings and provenance at a glance', () => {
+    renderWidget(
+      toolMessage(
+        'spawn_session',
+        {
+          prompt: 'Do the thing',
+          effortLevel: 'max',
+        },
+        {
+          sessionId: CHILD,
+          launchConfiguration: {
+            requested: {
+              provider: null,
+              model: null,
+              effortLevel: 'max',
+              thinkingMode: null,
+              toolScope: null,
+              inheritModel: false,
+              isolated: true,
+              useWorktree: false,
+              notifyOnComplete: false,
+            },
+            resolved: {
+              provider: 'openai-codex',
+              model: 'openai-codex:gpt-5.6-sol',
+              effortLevel: 'max',
+              thinkingMode: null,
+              toolScope: 'full',
+              isolated: true,
+              worktreeMode: 'none',
+              notifyOnComplete: false,
+              sources: {
+                provider: 'inherited',
+                model: 'inherited',
+                effortLevel: 'requested',
+                thinkingMode: null,
+                toolScope: 'default',
+              },
+            },
+            effectiveness: 'not-provider-confirmed',
+          },
+        },
+      ),
+    );
+
+    expect(screen.getByText('Model: openai-codex:gpt-5.6-sol · inherited')).toBeDefined();
+    expect(screen.getByText('Effort: max · requested')).toBeDefined();
+    expect(screen.getByText('Scope: full · default')).toBeDefined();
+    expect(screen.getByText('Workspace: isolated')).toBeDefined();
+    expect(screen.getByText('Notify: off')).toBeDefined();
+  });
+
+  it('keeps the full launch receipt in expanded details', () => {
+    renderWidget(
+      toolMessage(
+        'create_session',
+        { prompt: 'Create a child', thinkingMode: 'disabled' },
+        {
+          sessionId: CHILD,
+          launchConfiguration: {
+            requested: {},
+            resolved: {
+              provider: 'claude-code',
+              model: 'claude-code:opus',
+              effortLevel: 'high',
+              thinkingMode: 'disabled',
+              toolScope: 'full',
+              isolated: false,
+              worktreeMode: 'none',
+              notifyOnComplete: true,
+              sources: {
+                provider: 'requested',
+                model: 'requested',
+                effortLevel: 'app-default',
+                thinkingMode: 'requested',
+                toolScope: 'default',
+              },
+            },
+            effectiveness: 'not-provider-confirmed',
+          },
+        },
+      ),
+      undefined,
+      () => {},
+      true,
+    );
+
+    expect(screen.getByText(/not-provider-confirmed/)).toBeDefined();
   });
 
   it('opens the session via open-ai-session when the chip is clicked', () => {


### PR DESCRIPTION
## Summary

Expose explicit session launch configuration allowing control over provider, model selection, tool-scope, effort levels, and extended thinking modes. The implementation includes:

- **sessionLaunchConfiguration**: New server-side module for launch configuration with validation and provenance tracking
- **MetaAgentService enhancements**: Extended to expose launch configuration from session metadata, handle provider/model inheritance from parent sessions, and support parent session promotion
- **metaAgentServer integration**: Wired launch configuration into the MCP endpoint routing for external agent access
- **CrossSessionToolWidget**: Updated to display launch provider and model configuration
- **effortLevels**: Extended with structured validation for thinking/extended-thinking effort levels

## Verification

- **Tests**: 43 passing (MetaAgentService: 26, metaAgentServer: 2, CrossSessionToolWidget + effortLevels: 13, plus 85 from ai/server suite)
- **TypeScript**: Both runtime and electron packages pass `tsc --noEmit`
- **Pre-push gate**: All checks passed (lockfile sync, override/dep sync, typecheck, test gate)

## Test Coverage

11 affected test suites with 60+ tests passing:
- metaAgentServer.launchConfiguration.test.ts
- MetaAgentService.launchConfiguration.test.ts  
- MetaAgentService.parentPromotion.test.ts
- MetaAgentService.providerInheritance.test.ts
- sessionLaunchConfiguration.test.ts
- effortLevels.test.ts
- CrossSessionToolWidget.test.tsx
- Plus supporting test suites in ai/server package

## Why this is worth merging

Provider, model, effort, and inheritance rules determine what a delegated session can do and how much it costs. Exposing the exact launch configuration through the service, MCP surface, persistence, and transcript UI makes delegation reproducible and reviewable instead of requiring investigators to reconstruct hidden defaults after a failure.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
