### PR TITLE
feat(ai): preserve auditable cross-project session custody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Bug fixes go here -->
 - Delegated agent sessions now report their resolved launch model and reasoning settings, accept auditable priority prompts without stale-turn interrupts, and automatically resume ordinary queued prompts after turns and restarts.
 - Agent-mode document embeds now recover when their target file is created after the document opens.
+- Orchestrator sessions can launch isolated worktree agents in another loaded project and retain status, result, queue, prompt, and reply control.
 - Automations no longer rerun the same scheduled occurrence after restarting while a run is waiting or fails.
 - Voice Mode now explains blocked or missing microphones on Windows and links directly to microphone privacy settings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added a `Claude agent - DeepSeek` model with High/Max effort and reasoning controls.
+
 - Fixed delayed queued prompts after a long-running session's original window closes or reloads.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed delayed queued prompts after a long-running session's original window closes or reloads.
+
 ### Added
 <!-- New features go here -->
 - Sharing a markdown document to your team now offers to share the documents it embeds, and teammates see those embeds live inline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
-- Delegated agent sessions now report their resolved launch model and reasoning settings, accept auditable priority prompts without stale-turn interrupts, and automatically resume ordinary queued prompts after turns and restarts without overlapping an interrupted priority turn.
+- Delegated agent sessions now report their resolved launch model and reasoning settings, accept auditable priority prompts without stale-turn interrupts, and automatically resume ordinary queued prompts after turns, restarts, and interactive replies without overlapping an interrupted priority turn.
 - Agent-mode document embeds now recover when their target file is created after the document opens.
 - Orchestrator sessions can launch isolated worktree agents from their source project into another loaded project and retain status, result, queue, prompt, and reply control.
 - Automations no longer rerun the same scheduled occurrence after restarting while a run is waiting or fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed saved Claude Agent Sonnet 5 defaults resolving as invalid model names.
 - Added a `Claude agent - DeepSeek` model with High/Max effort and reasoning controls.
 
 - Fixed delayed queued prompts after a long-running session's original window closes or reloads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Bug fixes go here -->
 - Delegated agent sessions now report their resolved launch model and reasoning settings, accept auditable priority prompts without stale-turn interrupts, and automatically resume ordinary queued prompts after turns and restarts.
 - Agent-mode document embeds now recover when their target file is created after the document opens.
-- Orchestrator sessions can launch isolated worktree agents in another loaded project and retain status, result, queue, prompt, and reply control.
+- Orchestrator sessions can launch isolated worktree agents from their source project into another loaded project and retain status, result, queue, prompt, and reply control.
 - Automations no longer rerun the same scheduled occurrence after restarting while a run is waiting or fails.
 - Voice Mode now explains blocked or missing microphones on Windows and links directly to microphone privacy settings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
-- Delegated agent sessions now report their resolved launch model and reasoning settings, accept auditable priority prompts without stale-turn interrupts, and automatically resume ordinary queued prompts after turns and restarts.
+- Delegated agent sessions now report their resolved launch model and reasoning settings, accept auditable priority prompts without stale-turn interrupts, and automatically resume ordinary queued prompts after turns and restarts without overlapping an interrupted priority turn.
 - Agent-mode document embeds now recover when their target file is created after the document opens.
 - Orchestrator sessions can launch isolated worktree agents from their source project into another loaded project and retain status, result, queue, prompt, and reply control.
 - Automations no longer rerun the same scheduled occurrence after restarting while a run is waiting or fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Delegated agent sessions now report their resolved launch model and reasoning settings, accept auditable priority prompts without stale-turn interrupts, and automatically resume ordinary queued prompts after turns and restarts.
 - Agent-mode document embeds now recover when their target file is created after the document opens.
 - Automations no longer rerun the same scheduled occurrence after restarting while a run is waiting or fails.
 - Voice Mode now explains blocked or missing microphones on Windows and links directly to microphone privacy settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Structured agent prompts now retain their actionable state until exactly one answer settles.
 - Delegated agent sessions now report their resolved launch model and reasoning settings, accept auditable priority prompts without stale-turn interrupts, and automatically resume ordinary queued prompts after turns, restarts, and interactive replies without overlapping an interrupted priority turn.
 - Agent-mode document embeds now recover when their target file is created after the document opens.
 - Orchestrator sessions can launch isolated worktree agents from their source project into another loaded project and retain status, result, queue, prompt, and reply control.

--- a/packages/electron/src/main/database/sqlite/MigrationRunner.ts
+++ b/packages/electron/src/main/database/sqlite/MigrationRunner.ts
@@ -176,6 +176,11 @@ export function getMigrations(schemaDir: string): Migration[] {
       name: 'tool_usage_backfill_state',
       sqlFile: path.join(schemaDir, '0027_tool_usage_backfill_state.sql'),
     },
+    {
+      version: 28,
+      name: 'queued_prompt_priority_control',
+      sqlFile: path.join(schemaDir, '0028_queued_prompt_priority_control.sql'),
+    },
   ];
 }
 

--- a/packages/electron/src/main/database/sqlite/__tests__/MigrationRunner.test.ts
+++ b/packages/electron/src/main/database/sqlite/__tests__/MigrationRunner.test.ts
@@ -85,6 +85,7 @@ describe('runMigrations', () => {
     fs.writeFileSync(path.join(tmp, '0025_account_org_bindings.sql'), '-- noop\n');
     fs.writeFileSync(path.join(tmp, '0026_tool_usage_counters.sql'), '-- noop\n');
     fs.writeFileSync(path.join(tmp, '0027_tool_usage_backfill_state.sql'), '-- noop\n');
+    fs.writeFileSync(path.join(tmp, '0028_queued_prompt_priority_control.sql'), '-- noop\n');
 
     const db = new FakeDb();
     // Hack: inject our own migration list via reflection-equivalent. Re-using
@@ -98,13 +99,13 @@ describe('runMigrations', () => {
     // a stand-in implementation; for now, test the file-backed path with the
     // bundled migrations.
     const result = runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
-    expect(result.applied).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]);
+    expect(result.applied).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]);
     expect(result.skipped).toEqual([]);
 
     // Second invocation: nothing to apply, all skipped.
     const result2 = runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
     expect(result2.applied).toEqual([]);
-    expect(result2.skipped).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]);
+    expect(result2.skipped).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]);
 
     // Anti-flake: unused locals lint silencer.
     void customs;
@@ -217,6 +218,10 @@ describe('runMigrations', () => {
     );
     fs.writeFileSync(
       path.join(tmp, '0027_tool_usage_backfill_state.sql'),
+      '-- noop\n',
+    );
+    fs.writeFileSync(
+      path.join(tmp, '0028_queued_prompt_priority_control.sql'),
       '-- noop\n',
     );
     const db = new FakeDb();

--- a/packages/electron/src/main/database/sqlite/schemas/0028_queued_prompt_priority_control.sql
+++ b/packages/electron/src/main/database/sqlite/schemas/0028_queued_prompt_priority_control.sql
@@ -1,0 +1,21 @@
+-- Durable priority/control delivery metadata for agent-to-agent prompts.
+-- Ordinary rows retain priority_rank=0 and preserve FIFO ordering.
+
+ALTER TABLE queued_prompts ADD COLUMN delivery_class TEXT NOT NULL DEFAULT 'ordinary'
+  CHECK (delivery_class IN ('ordinary', 'control'));
+ALTER TABLE queued_prompts ADD COLUMN priority_rank INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE queued_prompts ADD COLUMN delivery_ready INTEGER NOT NULL DEFAULT 1
+  CHECK (delivery_ready IN (0, 1));
+ALTER TABLE queued_prompts ADD COLUMN producer TEXT;
+ALTER TABLE queued_prompts ADD COLUMN idempotency_key TEXT;
+ALTER TABLE queued_prompts ADD COLUMN request_digest TEXT;
+ALTER TABLE queued_prompts ADD COLUMN control_operation TEXT;
+ALTER TABLE queued_prompts ADD COLUMN interrupt_target_generation TEXT;
+ALTER TABLE queued_prompts ADD COLUMN interrupt_reservation_owner TEXT;
+ALTER TABLE queued_prompts ADD COLUMN interrupt_receipt TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_control_idempotency
+  ON queued_prompts(session_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_queued_prompts_priority_pending
+  ON queued_prompts(session_id, status, delivery_ready, priority_rank DESC, created_at ASC);

--- a/packages/electron/src/main/database/worker.js
+++ b/packages/electron/src/main/database/worker.js
@@ -1686,6 +1686,17 @@ class PGLiteWorker {
           claimed_at TIMESTAMPTZ,
           completed_at TIMESTAMPTZ,
           error_message TEXT,
+          delivery_class TEXT NOT NULL DEFAULT 'ordinary'
+            CHECK (delivery_class IN ('ordinary', 'control')),
+          priority_rank INTEGER NOT NULL DEFAULT 0,
+          delivery_ready BOOLEAN NOT NULL DEFAULT TRUE,
+          producer TEXT,
+          idempotency_key TEXT,
+          request_digest TEXT,
+          control_operation TEXT,
+          interrupt_target_generation TEXT,
+          interrupt_reservation_owner TEXT,
+          interrupt_receipt JSONB,
           CONSTRAINT fk_queued_prompts_session
             FOREIGN KEY (session_id)
             REFERENCES ai_sessions(id)
@@ -1696,6 +1707,23 @@ class PGLiteWorker {
         CREATE INDEX IF NOT EXISTS idx_queued_prompts_status ON queued_prompts(status);
         CREATE INDEX IF NOT EXISTS idx_queued_prompts_session_status ON queued_prompts(session_id, status);
         CREATE INDEX IF NOT EXISTS idx_queued_prompts_created ON queued_prompts(created_at);
+
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS delivery_class TEXT NOT NULL DEFAULT 'ordinary';
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS priority_rank INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS delivery_ready BOOLEAN NOT NULL DEFAULT TRUE;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS producer TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS request_digest TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS control_operation TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS interrupt_target_generation TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS interrupt_reservation_owner TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS interrupt_receipt JSONB;
+
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_control_idempotency
+          ON queued_prompts(session_id, idempotency_key)
+          WHERE idempotency_key IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_queued_prompts_priority_pending
+          ON queued_prompts(session_id, status, delivery_ready, priority_rank DESC, created_at ASC);
       `);
       console.log('[PGLite Worker] queued_prompts table created successfully');
     } catch (error) {

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -2584,6 +2584,22 @@ app.whenReady().then(async () => {
         await openFileWithWorkspaceDetection(fileToOpen);
     }
 
+    // Windows and their workspace routes now exist. Automatically resume
+    // ordinary FIFO work that survived a process restart. Atomic claims make
+    // this safe if another trigger races startup; control rows stay fenced
+    // until send_prompt_now records their delivery decision.
+    try {
+        const { discovered, triggered, skipped } =
+            await aiService.drainPendingOrdinaryPromptsOnStartup();
+        if (discovered > 0) {
+            logger.main.info(
+                `[Main] Startup queue drain: discovered ${discovered} session(s), triggered ${triggered}, skipped ${skipped}`
+            );
+        }
+    } catch (drainErr) {
+        logger.main.error('[Main] Startup queue drain failed:', drainErr);
+    }
+
     // Handle pending deep link URL (e.g., auth callback)
     if (pendingDeepLinkUrl) {
         const urlToHandle = pendingDeepLinkUrl;

--- a/packages/electron/src/main/mcp/__tests__/metaAgentServer.launchConfiguration.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/metaAgentServer.launchConfiguration.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  SESSION_LAUNCH_EFFORT_LEVELS,
+  SESSION_LAUNCH_THINKING_MODES,
+  SESSION_LAUNCH_TOOL_SCOPES,
+} from '@nimbalyst/runtime/ai/server/sessionLaunchConfiguration';
+
+vi.mock('../../utils/workspaceDetection', () => ({
+  resolveProjectPath: (workspacePath: string) => workspacePath,
+}));
+
+import {
+  META_AGENT_TOOL_DEFS,
+  dispatchMetaAgentTool,
+  setMetaAgentToolFns,
+} from '../metaAgentServer';
+
+describe('meta-agent launch configuration schemas', () => {
+  const createSession = vi.fn().mockResolvedValue('{"created":true}');
+  const spawnSession = vi.fn().mockResolvedValue('{"spawned":true}');
+
+  beforeEach(() => {
+    createSession.mockClear();
+    spawnSession.mockClear();
+    setMetaAgentToolFns({
+      listWorktrees: vi.fn().mockResolvedValue('[]'),
+      createSession,
+      spawnSession,
+      getSessionStatus: vi.fn().mockResolvedValue('{}'),
+      getSessionResult: vi.fn().mockResolvedValue('{}'),
+      listQueuedPrompts: vi.fn().mockResolvedValue('[]'),
+      sendPrompt: vi.fn().mockResolvedValue('{}'),
+      sendPromptNow: vi.fn().mockResolvedValue('{}'),
+      notifyUser: vi.fn().mockResolvedValue('{}'),
+      respondToPrompt: vi.fn().mockResolvedValue('{}'),
+      listSpawnedSessions: vi.fn().mockResolvedValue('[]'),
+    });
+  });
+
+  it('exposes the same provider-aware controls on create_session and spawn_session', () => {
+    for (const toolName of ['create_session', 'spawn_session']) {
+      const tool = META_AGENT_TOOL_DEFS.find(candidate => candidate.name === toolName);
+      const properties = tool?.inputSchema.properties as Record<
+        string,
+        { enum?: string[] }
+      >;
+
+      expect(properties.effortLevel.enum).toEqual(SESSION_LAUNCH_EFFORT_LEVELS);
+      expect(properties.thinkingMode.enum).toEqual(SESSION_LAUNCH_THINKING_MODES);
+      expect(properties.toolScope.enum).toEqual(SESSION_LAUNCH_TOOL_SCOPES);
+    }
+  });
+
+  it('forwards launch controls unchanged through both dispatch paths', async () => {
+    const launch = {
+      provider: 'claude-code',
+      model: 'claude-code:opus',
+      effortLevel: 'high',
+      thinkingMode: 'disabled',
+      toolScope: 'write',
+    };
+    await dispatchMetaAgentTool('create_session', 'parent-1', '/workspace', {
+      prompt: 'create child',
+      ...launch,
+    });
+    await dispatchMetaAgentTool('spawn_session', 'parent-1', '/workspace', {
+      prompt: 'spawn sibling',
+      ...launch,
+    });
+
+    expect(createSession).toHaveBeenCalledWith('parent-1', '/workspace', {
+      prompt: 'create child',
+      ...launch,
+    });
+    expect(spawnSession).toHaveBeenCalledWith('parent-1', '/workspace', {
+      prompt: 'spawn sibling',
+      ...launch,
+    });
+  });
+});

--- a/packages/electron/src/main/mcp/__tests__/metaAgentServer.priorityDelivery.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/metaAgentServer.priorityDelivery.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/workspaceDetection', () => ({
+  resolveProjectPath: (workspacePath: string) => workspacePath,
+}));
+
+import {
+  META_AGENT_TOOL_DEFS,
+  dispatchMetaAgentTool,
+  getMetaAgentOpenAITools,
+  setMetaAgentToolFns,
+} from '../metaAgentServer';
+
+describe('send_prompt_now MCP parity', () => {
+  const sendPromptNow = vi.fn();
+
+  beforeEach(() => {
+    sendPromptNow.mockReset();
+    sendPromptNow.mockResolvedValue('{"ok":true}');
+    setMetaAgentToolFns({ sendPromptNow } as any);
+  });
+
+  it('appears exactly once on both surfaces with explicit waiting authority', () => {
+    const builtIn = META_AGENT_TOOL_DEFS.filter((tool) => tool.name === 'send_prompt_now');
+    const extension = getMetaAgentOpenAITools().filter(
+      (tool) => tool.function.name === 'send_prompt_now',
+    );
+
+    expect(builtIn).toHaveLength(1);
+    expect(extension).toHaveLength(1);
+    expect(builtIn[0].inputSchema.required).toEqual(['sessionId', 'prompt']);
+    expect(Object.keys(builtIn[0].inputSchema.properties)).toEqual([
+      'sessionId',
+      'prompt',
+      'idempotencyKey',
+      'controlOperation',
+      'interruptWaitingForInput',
+    ]);
+    expect(builtIn[0].description).toMatch(/priority/i);
+    expect(builtIn[0].description).toMatch(/interrupt/i);
+    expect(builtIn[0].description).toMatch(/FIFO send_prompt/i);
+  });
+
+  it('dispatches the raw argument object to the sendPromptNow binding', async () => {
+    const args = {
+      sessionId: 'target-session',
+      prompt: 'Act now',
+      idempotencyKey: 'control:key-1',
+      controlOperation: 'operator_directive',
+      interruptWaitingForInput: true,
+      producer: 'forged-producer',
+      priorityRank: -1,
+    };
+
+    await expect(dispatchMetaAgentTool(
+      'mcp__nimbalyst-host__send_prompt_now',
+      'caller-session',
+      'D:\\repo',
+      args,
+    )).resolves.toBe('{"ok":true}');
+
+    expect(sendPromptNow).toHaveBeenCalledWith(
+      'caller-session',
+      'D:\\repo',
+      args,
+    );
+  });
+});

--- a/packages/electron/src/main/mcp/__tests__/metaAgentServer.projectTargeting.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/metaAgentServer.projectTargeting.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { META_AGENT_TOOL_DEFS } from '../metaAgentServer';
+
+describe('spawn_session project-targeting schema (NIM-408)', () => {
+  it('exposes only the guarded target-project and base-branch inputs', () => {
+    const spawnSession = META_AGENT_TOOL_DEFS.find((tool) => tool.name === 'spawn_session');
+    const properties = spawnSession?.inputSchema.properties ?? {};
+
+    expect(properties).toHaveProperty('targetWorkspacePath');
+    expect(properties).toHaveProperty('baseBranch');
+    expect(properties).not.toHaveProperty('worktreeId');
+    expect(JSON.stringify(properties.targetWorkspacePath)).toContain('already-loaded');
+    expect(JSON.stringify(properties.targetWorkspacePath)).toContain('isolated');
+    expect(JSON.stringify(properties.targetWorkspacePath)).toContain('useWorktree');
+  });
+});

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -13,6 +13,16 @@
  */
 
 import { resolveProjectPath } from "../utils/workspaceDetection";
+import {
+  SESSION_LAUNCH_EFFORT_LEVELS,
+  SESSION_LAUNCH_THINKING_MODES,
+  SESSION_LAUNCH_TOOL_SCOPES,
+  type SessionLaunchToolScope,
+} from "@nimbalyst/runtime/ai/server/sessionLaunchConfiguration";
+import type {
+  EffortLevel,
+  ThinkingMode,
+} from "@nimbalyst/runtime/ai/server/effortLevels";
 
 type CreateSessionArgs = {
   title?: string;
@@ -21,14 +31,20 @@ type CreateSessionArgs = {
   prompt?: string;
   useWorktree?: boolean;
   worktreeId?: string;
-  toolScope?: string;
+  toolScope?: SessionLaunchToolScope;
+  effortLevel?: EffortLevel;
+  thinkingMode?: ThinkingMode;
 };
 
 type SpawnSessionArgs = {
   title?: string;
   prompt: string;
   useWorktree?: boolean;
+  provider?: string;
   model?: string;
+  toolScope?: SessionLaunchToolScope;
+  effortLevel?: EffortLevel;
+  thinkingMode?: ThinkingMode;
   notifyOnComplete?: boolean;
   /**
    * When true, the new session is created at the top level — no parent,
@@ -77,6 +93,14 @@ type ListQueuedPromptsArgs = {
   includePromptText?: boolean;
 };
 
+type SendPromptNowArgs = {
+  sessionId: string;
+  prompt: string;
+  idempotencyKey?: string;
+  controlOperation?: string;
+  interruptWaitingForInput?: boolean;
+};
+
 type NotifyUserArgs = {
   title: string;
   body: string;
@@ -123,6 +147,11 @@ interface MetaAgentToolFns {
     workspaceId: string,
     targetSessionId: string,
     prompt: string
+  ) => Promise<string>;
+  sendPromptNow: (
+    metaSessionId: string,
+    workspaceId: string,
+    args: SendPromptNowArgs
   ) => Promise<string>;
   notifyUser: (
     metaSessionId: string,
@@ -217,9 +246,21 @@ export const META_AGENT_TOOL_DEFS: Array<{
         },
         toolScope: {
           type: "string",
-          enum: ["read", "write", "full"],
+          enum: [...SESSION_LAUNCH_TOOL_SCOPES],
           description:
             "Capability scope for the child. \"read\" = read_file/list_files/search_files only (pure investigation). \"write\" = those plus write_file but NO run_command, so the child can save a file deliverable (e.g. a report) yet cannot build/test/run anything. \"full\" (default) = all tools including run_command. Use read or write for analyze/research tasks so the child physically cannot run a build, and reserve full for tasks that must build/test.",
+        },
+        effortLevel: {
+          type: "string",
+          enum: [...SESSION_LAUNCH_EFFORT_LEVELS],
+          description:
+            "Optional requested reasoning effort for this child only. Accepted only when the resolved provider/model supports that exact value; unsupported combinations fail before session creation.",
+        },
+        thinkingMode: {
+          type: "string",
+          enum: [...SESSION_LAUNCH_THINKING_MODES],
+          description:
+            "Optional Claude adaptive-thinking toggle for this child only. Accepted only for Claude Agent models whose transport implements the toggle; unsupported combinations fail before session creation.",
         },
       },
     },
@@ -250,15 +291,38 @@ export const META_AGENT_TOOL_DEFS: Array<{
           description:
             "Default false. By default the spawned session inherits the caller's working directory: if the caller is in a worktree, the new session runs in that same worktree; if the caller is in the main checkout, the new session runs there too. Set true only when the user explicitly asks for the new session to get its OWN new worktree (separate branch and working directory) — this creates a fresh worktree rather than inheriting the caller's.",
         },
+        provider: {
+          type: "string",
+          description:
+            "Optional explicit provider. When set, model must either be omitted or carry the same provider prefix.",
+        },
         model: {
           type: "string",
           description:
-            "Optional explicit model identifier (e.g. 'claude-code:opus'). When omitted, the new session uses the global default model unless inheritModel=true. Wins over inheritModel when both are set.",
+            "Optional explicit model identifier (e.g. 'claude-code:opus'). When omitted, the new session inherits the caller's provider/model. Wins over inheritModel when both are set.",
         },
         inheritModel: {
           type: "boolean",
           description:
-            "Default false. When true and `model` is not set, the spawned session uses the caller's model so it stays on the same provider/model (e.g. opus stays on opus). Ignored when `model` is provided explicitly.",
+            "Optional explicit inheritance intent retained in launch provenance. When model is omitted, the spawned session inherits the caller's provider/model either way; an explicit model wins.",
+        },
+        toolScope: {
+          type: "string",
+          enum: [...SESSION_LAUNCH_TOOL_SCOPES],
+          description:
+            "Capability scope for the spawned session. \"read\" and \"write\" restrict tools; \"full\" (default) grants the complete tool surface.",
+        },
+        effortLevel: {
+          type: "string",
+          enum: [...SESSION_LAUNCH_EFFORT_LEVELS],
+          description:
+            "Optional requested reasoning effort for this session only. Accepted only when the resolved provider/model supports that exact value; unsupported combinations fail before session creation.",
+        },
+        thinkingMode: {
+          type: "string",
+          enum: [...SESSION_LAUNCH_THINKING_MODES],
+          description:
+            "Optional Claude adaptive-thinking toggle for this session only. Accepted only for Claude Agent models whose transport implements the toggle; unsupported combinations fail before session creation.",
         },
         notifyOnComplete: {
           type: "boolean",
@@ -343,6 +407,40 @@ export const META_AGENT_TOOL_DEFS: Array<{
         prompt: {
           type: "string",
           description: "The follow-up prompt to send.",
+        },
+      },
+      required: ["sessionId", "prompt"],
+    },
+  },
+  {
+    name: "send_prompt_now",
+    description:
+      "Durably queue a priority control prompt and, when authorized, interrupt the target's current ordinary turn so the prompt becomes agent-visible immediately. Use interruptWaitingForInput only for an ordinary-text waiting session; structured prompts must use respond_to_prompt. Use FIFO send_prompt for normal follow-ups that should not preempt active work.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description: "The target child session ID.",
+        },
+        prompt: {
+          type: "string",
+          description: "The priority control prompt to deliver.",
+        },
+        idempotencyKey: {
+          type: "string",
+          description:
+            "Optional stable request key. Reusing it with the same request replays the durable receipt; reusing it with different content fails.",
+        },
+        controlOperation: {
+          type: "string",
+          description:
+            "Optional audit label for the control action, such as waiting_reply or operator_directive.",
+        },
+        interruptWaitingForInput: {
+          type: "boolean",
+          description:
+            "Explicit authority to interrupt an ordinary-text waiting session. Has no effect on structured prompts, which require respond_to_prompt.",
         },
       },
       required: ["sessionId", "prompt"],
@@ -454,6 +552,7 @@ const EXTENSION_META_AGENT_ALLOWED_TOOLS = new Set<string>([
   "get_session_result",
   "list_queued_prompts",
   "send_prompt",
+  "send_prompt_now",
   "notify_user",
   "respond_to_prompt",
   "list_spawned_sessions",
@@ -534,6 +633,12 @@ export async function dispatchMetaAgentTool(
         effectiveWorkspaceId,
         (args?.sessionId as string) ?? "",
         (args?.prompt as string) ?? ""
+      );
+    case "send_prompt_now":
+      return toolFns.sendPromptNow(
+        aiSessionId,
+        effectiveWorkspaceId,
+        (args ?? {}) as SendPromptNowArgs
       );
     case "notify_user":
       return toolFns.notifyUser(aiSessionId, effectiveWorkspaceId, (args ?? {}) as NotifyUserArgs);

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -40,6 +40,8 @@ type SpawnSessionArgs = {
   title?: string;
   prompt: string;
   useWorktree?: boolean;
+  targetWorkspacePath?: string;
+  baseBranch?: string;
   provider?: string;
   model?: string;
   toolScope?: SessionLaunchToolScope;
@@ -290,6 +292,16 @@ export const META_AGENT_TOOL_DEFS: Array<{
           type: "boolean",
           description:
             "Default false. By default the spawned session inherits the caller's working directory: if the caller is in a worktree, the new session runs in that same worktree; if the caller is in the main checkout, the new session runs there too. Set true only when the user explicitly asks for the new session to get its OWN new worktree (separate branch and working directory) — this creates a fresh worktree rather than inheriting the caller's.",
+        },
+        targetWorkspacePath: {
+          type: "string",
+          description:
+            "Optional absolute path of an already-loaded canonical Nimbalyst project. Cross-project creation fails closed unless isolated=true and useWorktree=true, so the child is born as a top-level session in a fresh target-project worktree. This does not attach to an existing worktree or grant authority from an arbitrary path.",
+        },
+        baseBranch: {
+          type: "string",
+          description:
+            "Optional branch or ref for the fresh worktree created by useWorktree=true. With targetWorkspacePath, the ref is resolved inside that already-loaded target project.",
         },
         provider: {
           type: "string",

--- a/packages/electron/src/main/mcp/tools/__tests__/interactivePromptLifecycleRetention.test.ts
+++ b/packages/electron/src/main/mcp/tools/__tests__/interactivePromptLifecycleRetention.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { buildInteractivePromptToolUseContent } from '../interactivePromptTranscript';
+
+describe('structured prompt lifecycle retention', () => {
+  it('persists an answerable AskUserQuestion identity and payload before the turn can settle', () => {
+    const content = JSON.parse(buildInteractivePromptToolUseContent({
+      toolUseId: 'question-1',
+      toolName: 'AskUserQuestion',
+      input: {
+        questions: [{
+          header: 'Acceptance',
+          question: 'Complete the artifact-bound V13 acceptance?',
+          options: [{ label: 'Continue', description: 'continue' }],
+        }],
+      },
+    }));
+
+    expect(content).toEqual({
+      type: 'nimbalyst_tool_use',
+      id: 'question-1',
+      name: 'AskUserQuestion',
+      input: expect.objectContaining({ questions: expect.any(Array) }),
+    });
+  });
+});

--- a/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
@@ -269,8 +269,21 @@ export async function handleAskUserQuestion(
     });
   }
 
-  // NIM-806: we deliberately do NOT persist a synthetic nimbalyst_tool_use row
-  // here. The proxy observation bridge already persists the CLI's whole assistant
+  // Persist this before waiting. The proxy observation bridge normally persists
+  // the provider turn too, but its terminal notification can race that projection.
+  // This row is the durable prompt identity used by get_session_result; transcript
+  // parsing deduplicates the later provider observation by tool-use id.
+  if (sessionId) {
+    await persistInteractivePromptToolUse({
+      sessionId,
+      toolUseId: questionId,
+      toolName: "AskUserQuestion",
+      input: { questions: normalizedQuestions },
+    });
+    await setSessionPendingPrompt(sessionId, true);
+  }
+
+  // NIM-806: the proxy observation bridge also persists the CLI's whole assistant
   // turn (source 'claude-code') INCLUDING this AskUserQuestion tool_use block, so
   // ClaudeCodeRawParser renders the answerable widget from it (keyed by the same
   // claudecode/toolUseId == questionId, so the answer still reaches our response
@@ -293,7 +306,6 @@ export async function handleAskUserQuestion(
   // windows (the renderer handler keys by sessionId); handleAskUserQuestion only
   // runs for the MCP-routed CLI path, so SDK sessions are unaffected.
   if (isCliSession && sessionId) {
-    void setSessionPendingPrompt(sessionId, true);
     for (const w of BrowserWindow.getAllWindows()) {
       if (!w.isDestroyed()) {
         w.webContents.send("ai:askUserQuestion", {

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -841,7 +841,13 @@ export class MetaAgentService {
     }
 
     const parent = await AISessionsRepository.get(parentSessionId);
-    if (!parent || parent.workspacePath !== workspaceId) {
+    if (!parent?.workspacePath) {
+      throw new Error(`Parent session ${parentSessionId} not found in this workspace`);
+    }
+    const sourceWorkspaceId = resolveProjectPath(parent.workspacePath);
+    const requestWorkspaceId = resolveProjectPath(workspaceId);
+    const requestedTargetWorkspace = args.targetWorkspacePath?.trim();
+    if (!requestedTargetWorkspace && sourceWorkspaceId !== requestWorkspaceId) {
       throw new Error(`Parent session ${parentSessionId} not found in this workspace`);
     }
 
@@ -862,11 +868,10 @@ export class MetaAgentService {
     });
 
     const isolated = args.isolated === true;
-    const requestedTargetWorkspace = args.targetWorkspacePath?.trim();
     const targetWorkspaceId = requestedTargetWorkspace
       ? resolveProjectPath(requestedTargetWorkspace)
-      : workspaceId;
-    const isCrossProject = targetWorkspaceId !== workspaceId;
+      : sourceWorkspaceId;
+    const isCrossProject = targetWorkspaceId !== sourceWorkspaceId;
 
     if (isCrossProject) {
       if (!isolated) {
@@ -891,7 +896,7 @@ export class MetaAgentService {
     let workstreamId: string | null = null;
     let promotedParent = false;
     if (!isolated) {
-      const resolved = await this.resolveOrCreateWorkstream(parent, workspaceId);
+      const resolved = await this.resolveOrCreateWorkstream(parent, sourceWorkspaceId);
       workstreamId = resolved.workstreamId;
       promotedParent = resolved.promotedParent;
     }
@@ -935,7 +940,7 @@ export class MetaAgentService {
     return JSON.stringify({
       ...childResult,
       isolated,
-      sourceWorkspacePath: workspaceId,
+      sourceWorkspacePath: sourceWorkspaceId,
       targetWorkspacePath: targetWorkspaceId,
       workstreamId,
       promotedParent,

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -5,9 +5,19 @@ import { safeHandle } from '../utils/ipcRegistry';
 import { SessionManager } from '@nimbalyst/runtime/ai/server';
 import type { AIProviderType } from '@nimbalyst/runtime/ai/server/types';
 import { ModelIdentifier } from '@nimbalyst/runtime/ai/server/types';
+import type { EffortLevel, ThinkingMode } from '@nimbalyst/runtime/ai/server/effortLevels';
+import {
+  isSessionLaunchConfiguration,
+  parseSessionLaunchToolScope,
+  resolveSessionReasoningConfiguration,
+  type SessionLaunchConfiguration,
+  type SessionLaunchToolScope,
+  type SessionLaunchValueSource,
+  type SessionLaunchWorktreeMode,
+} from '@nimbalyst/runtime/ai/server/sessionLaunchConfiguration';
 import { AISessionsRepository, AgentMessagesRepository, SessionFilesRepository } from '@nimbalyst/runtime';
 import { getSessionStateManager } from '@nimbalyst/runtime/ai/server/SessionStateManager';
-import { getDefaultAIModel } from '../utils/store';
+import { getDefaultAIModel, getDefaultEffortLevel } from '../utils/store';
 import { toMillis } from '../utils/timestampUtils';
 import { createWorktreeStore } from './WorktreeStore';
 import { GitWorktreeService } from './GitWorktreeService';
@@ -19,6 +29,12 @@ import { setMetaAgentToolFns } from '../mcp/metaAgentServer';
 import { computeNotificationSignature } from './metaAgentNotificationSignature';
 import { extractMessageText, extractUserPrompts } from './metaAgentMessageText';
 import type { NotificationOptions, NotificationResult } from './NotificationService';
+import {
+  createPriorityPromptDeliveryService,
+  createPriorityTargetGeneration,
+  type PriorityControlPrompt,
+  type PriorityTargetState,
+} from './PriorityPromptDeliveryService';
 
 type SessionStatusValue = 'idle' | 'running' | 'waiting_for_input' | 'error' | 'interrupted';
 type PromptType = 'permission_request' | 'ask_user_question_request' | 'exit_plan_mode_request';
@@ -55,6 +71,7 @@ interface SessionResultData {
   /** Capability scope the child was granted (read|write|full). The objective
    *  record of what the child COULD do; null/full means all tools. */
   toolScope?: string | null;
+  launchConfiguration?: SessionLaunchConfiguration;
 }
 
 interface CreateChildSessionArgs {
@@ -64,7 +81,25 @@ interface CreateChildSessionArgs {
   prompt?: string;
   useWorktree?: boolean;
   worktreeId?: string;
-  toolScope?: string;
+  toolScope?: SessionLaunchToolScope;
+  effortLevel?: EffortLevel;
+  thinkingMode?: ThinkingMode;
+}
+
+interface SendPromptNowArgs {
+  sessionId: string;
+  prompt: string;
+  idempotencyKey?: string;
+  controlOperation?: string;
+  interruptWaitingForInput?: boolean;
+}
+
+interface ChildLaunchContext {
+  inheritModel?: boolean;
+  isolated?: boolean;
+  notifyOnComplete?: boolean;
+  notifyOnCompleteRequested?: boolean | null;
+  worktreeMode?: SessionLaunchWorktreeMode;
 }
 
 function normalizeStoredChildModelIdentifier(
@@ -86,15 +121,128 @@ function normalizeStoredChildModelIdentifier(
   return model;
 }
 
+interface ResolvedChildModel {
+  provider: AIProviderType;
+  normalizedModel: string;
+  providerSource: SessionLaunchValueSource;
+  modelSource: SessionLaunchValueSource;
+}
+
+async function resolveChildSessionModelAndProvider(
+  parentSessionId: string,
+  args: Pick<CreateChildSessionArgs, 'provider' | 'model'>
+): Promise<ResolvedChildModel> {
+  let parentProvider: string | null = null;
+  let parentModel: string | null = null;
+  try {
+    const parentSession = await AISessionsRepository.get(parentSessionId);
+    if (parentSession) {
+      parentProvider = parentSession.provider ?? null;
+      parentModel = normalizeStoredChildModelIdentifier(parentProvider, parentSession.model ?? null);
+    }
+  } catch {
+    // Orphan callers fall through to the configured/default model.
+  }
+
+  const configuredDefaultModel = normalizeStoredChildModelIdentifier(null, getDefaultAIModel());
+  const defaultModel = parentModel || configuredDefaultModel || 'claude-code:opus';
+  const parsedExplicitModel = args.model ? ModelIdentifier.tryParse(args.model) : null;
+  if (
+    args.provider
+    && parsedExplicitModel?.provider
+    && parsedExplicitModel.provider !== args.provider
+  ) {
+    throw new Error(
+      `provider ${args.provider} does not match model provider ${parsedExplicitModel.provider}`
+    );
+  }
+
+  const explicitModelProvider =
+    args.provider
+    ?? parsedExplicitModel?.provider
+    ?? parentProvider;
+  const explicitModel = normalizeStoredChildModelIdentifier(
+    explicitModelProvider,
+    args.model ?? null
+  );
+  const model = explicitModel || defaultModel;
+  const parsed = ModelIdentifier.tryParse(model);
+  const configuredDefaultProvider = configuredDefaultModel
+    ? ModelIdentifier.tryParse(configuredDefaultModel)?.provider ?? null
+    : null;
+  const provider = (
+    args.provider
+    || parsed?.provider
+    || parentProvider
+    || configuredDefaultProvider
+    || 'claude-code'
+  ) as AIProviderType;
+  const parentModelProvider = parentModel
+    ? (ModelIdentifier.tryParse(parentModel)?.provider ?? parentProvider)
+    : null;
+  const normalizedModel =
+    explicitModel
+    || (parentModel && parentModelProvider === provider ? parentModel : null)
+    || (
+      configuredDefaultModel
+      && configuredDefaultProvider === provider
+        ? configuredDefaultModel
+        : null
+    )
+    || ModelIdentifier.getDefaultModelId(provider);
+
+  const providerSource: SessionLaunchValueSource = args.provider || parsedExplicitModel
+    ? 'requested'
+    : parentProvider
+      ? 'inherited'
+      : configuredDefaultProvider
+        ? 'app-default'
+        : 'default';
+  const modelSource: SessionLaunchValueSource = explicitModel
+    ? 'requested'
+    : parentModel && parentModelProvider === provider
+      ? 'inherited'
+      : configuredDefaultModel && configuredDefaultProvider === provider
+        ? 'app-default'
+        : 'default';
+
+  return { provider, normalizedModel, providerSource, modelSource };
+}
+
+function readSessionMetadata(metadata: unknown): Record<string, unknown> | null {
+  let parsed = metadata;
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  return parsed as Record<string, unknown>;
+}
+
+function readSessionLaunchConfiguration(
+  metadata: unknown
+): SessionLaunchConfiguration | undefined {
+  const launchConfiguration = readSessionMetadata(metadata)?.launchConfiguration;
+  return isSessionLaunchConfiguration(launchConfiguration)
+    ? launchConfiguration
+    : undefined;
+}
+
 interface SpawnSessionArgs {
   title?: string;
   prompt: string;
   useWorktree?: boolean;
+  provider?: string;
   model?: string;
+  toolScope?: SessionLaunchToolScope;
+  effortLevel?: EffortLevel;
+  thinkingMode?: ThinkingMode;
   /**
-   * When true and `model` is not explicitly set, the new session uses the
-   * caller's model instead of the global app default. Ignored if `model` is
-   * provided explicitly.
+   * Records explicit inheritance intent in launch provenance. The current
+   * default also inherits the caller when model is omitted.
    */
   inheritModel?: boolean;
   /**
@@ -204,6 +352,8 @@ export class MetaAgentService {
           this.listQueuedPromptsJson(targetSessionId, workspaceId, options),
         sendPrompt: (_metaSessionId, workspaceId, targetSessionId, prompt) =>
           this.sendPromptToSession(targetSessionId, workspaceId, prompt),
+        sendPromptNow: (metaSessionId, workspaceId, args) =>
+          this.sendPromptNowToSession(metaSessionId, workspaceId, args),
         notifyUser: (callerSessionId, workspaceId, args) =>
           this.notifyUserJson(callerSessionId, workspaceId, args),
         respondToPrompt: (_metaSessionId, workspaceId, args) =>
@@ -377,7 +527,10 @@ export class MetaAgentService {
   private async createChildSessionInternal(
     metaSessionId: string,
     workspaceId: string,
-    args: CreateChildSessionArgs & { parentSessionIdOverride?: string | null }
+    args: CreateChildSessionArgs & {
+      parentSessionIdOverride?: string | null;
+      launchContext?: ChildLaunchContext;
+    }
   ): Promise<{
     sessionId: string;
     title: string;
@@ -389,6 +542,7 @@ export class MetaAgentService {
     createdBySessionId: string;
     queuedInitialPrompt: boolean;
     parentSessionId: string | null;
+    launchConfiguration: SessionLaunchConfiguration;
   }> {
     if (!this.aiService) {
       throw new Error('AI service not initialized');
@@ -413,57 +567,20 @@ export class MetaAgentService {
       );
     }
 
-    // Inherit the calling session's provider+model as the primary fallback so a
-    // non-Claude parent (Gemini, OpenAI-Codex, LM Studio, etc.) spawning a child
-    // via the meta-agent tools without an explicit model does NOT silently land
-    // on the hardcoded Opus default and bill the user's Anthropic pool. Only fall
-    // through to getDefaultAIModel() / the last-resort default when the parent
-    // session cannot be loaded (orphan call) or carries no usable provider+model.
-    // An explicit args.provider/args.model still wins; that is what they are for.
-    let parentProvider: string | null = null;
-    let parentModel: string | null = null;
-    try {
-      const parentSession = await AISessionsRepository.get(metaSessionId);
-      if (parentSession) {
-        parentProvider = parentSession.provider ?? null;
-        parentModel = normalizeStoredChildModelIdentifier(parentProvider, parentSession.model ?? null);
-      }
-    } catch {
-      // Best-effort lookup; fall through to the hardcoded default below.
-    }
-
-    const defaultModel =
-      parentModel
-      || normalizeStoredChildModelIdentifier(null, getDefaultAIModel())
-      || 'claude-code:opus';
-    // For an explicit model, the model's own "provider:" prefix is
-    // authoritative (e.g. a claude-code parent launching an
-    // "openai-codex:gpt-5.5" action). Only fall back to the parent's provider
-    // for a bare, prefix-less variant; passing the parent provider for a
-    // self-describing identifier wrongly trips the claude-code mismatch guard.
-    const explicitModelProvider =
-      args.provider
-      ?? (args.model?.includes(':') ? ModelIdentifier.tryParse(args.model)?.provider ?? null : null)
-      ?? parentProvider;
-    const explicitModel = normalizeStoredChildModelIdentifier(explicitModelProvider, args.model ?? null);
-    const model = explicitModel || defaultModel;
-    const parsed = ModelIdentifier.tryParse(model);
-    const provider = (args.provider ||
-      parsed?.provider ||
-      parentProvider ||
-      'claude-code') as AIProviderType;
-    // Provider and model MUST agree. Otherwise a child is persisted with, e.g.,
-    // provider=claude-code + an antigravity-gemini model, gets routed to the
-    // Claude Code provider, is rejected ("requires a claude-code:* identifier"),
-    // and dies with no output. Only reuse the parent model when it actually
-    // belongs to the resolved provider; otherwise use that provider default.
-    const parentModelProvider = parentModel
-      ? (ModelIdentifier.tryParse(parentModel)?.provider ?? parentProvider)
-      : null;
-    const normalizedModel =
-      explicitModel
-      || (parentModel && parentModelProvider === provider ? parentModel : null)
-      || ModelIdentifier.getDefaultModelId(provider);
+    const {
+      provider,
+      normalizedModel,
+      providerSource,
+      modelSource,
+    } = await resolveChildSessionModelAndProvider(metaSessionId, args);
+    const toolScope = parseSessionLaunchToolScope(args.toolScope);
+    const reasoning = resolveSessionReasoningConfiguration({
+      provider,
+      model: normalizedModel,
+      effortLevel: args.effortLevel,
+      thinkingMode: args.thinkingMode,
+      appDefaultEffortLevel: getDefaultEffortLevel(),
+    });
 
     const callerProvidedTitle = !!args.title?.trim();
     const title = (args.title || this.deriveTitleFromPrompt(args.prompt) || 'Meta Task').trim();
@@ -597,14 +714,54 @@ export class MetaAgentService {
       hasBeenNamed: callerProvidedTitle,
     } as any);
 
-    // Read-only tool segregation: persist a restricted capability scope so the
-    // child is granted only the matching dev tools at turn time (an analyze
-    // child physically cannot run_command, so it cannot build or claim to).
-    const childToolScope =
-      args.toolScope === 'read' || args.toolScope === 'write' ? args.toolScope : undefined;
-    if (childToolScope) {
-      await AISessionsRepository.updateMetadata(sessionId, { metadata: { toolScope: childToolScope } });
-    }
+    const worktreeMode: SessionLaunchWorktreeMode =
+      args.launchContext?.worktreeMode
+      ?? (args.worktreeId ? 'existing' : args.useWorktree ? 'new' : 'none');
+    const notifyOnComplete = args.launchContext?.notifyOnComplete ?? true;
+    const launchConfiguration: SessionLaunchConfiguration = {
+      requested: {
+        provider: args.provider ?? null,
+        model: args.model ?? null,
+        effortLevel: reasoning.requestedEffortLevel,
+        thinkingMode: reasoning.requestedThinkingMode,
+        toolScope: args.toolScope ?? null,
+        inheritModel: args.launchContext?.inheritModel === true,
+        isolated: args.launchContext?.isolated === true,
+        useWorktree: args.useWorktree === true,
+        notifyOnComplete: args.launchContext?.notifyOnCompleteRequested ?? null,
+      },
+      resolved: {
+        provider,
+        model: normalizedModel,
+        effortLevel: reasoning.effortLevel,
+        thinkingMode: reasoning.thinkingMode,
+        toolScope,
+        isolated: args.launchContext?.isolated === true,
+        worktreeMode,
+        notifyOnComplete,
+        sources: {
+          provider: providerSource,
+          model: modelSource,
+          effortLevel: reasoning.effortLevelSource,
+          thinkingMode: reasoning.thinkingModeSource,
+          toolScope: args.toolScope ? 'requested' : 'default',
+        },
+      },
+      effectiveness: 'not-provider-confirmed',
+    };
+
+    // Persist the complete launch snapshot before the initial prompt is queued.
+    // Runtime fields remain top-level for existing provider/tool-scope readers;
+    // launchConfiguration is the truthful requested/resolved audit contract.
+    await AISessionsRepository.updateMetadata(sessionId, {
+      metadata: {
+        launchConfiguration,
+        ...(toolScope !== 'full' ? { toolScope } : {}),
+        ...(reasoning.effortLevel ? { effortLevel: reasoning.effortLevel } : {}),
+        ...(reasoning.thinkingMode ? { thinkingMode: reasoning.thinkingMode } : {}),
+        ...(!notifyOnComplete ? { notifyParent: false } : {}),
+      },
+    });
 
     const initialPrompt = args.prompt?.trim();
     const shouldBypassExecution = this.shouldBypassChildAgentExecutionForTests();
@@ -657,6 +814,7 @@ export class MetaAgentService {
       createdBySessionId: metaSessionId,
       queuedInitialPrompt: !!initialPrompt,
       parentSessionId: args.parentSessionIdOverride ?? null,
+      launchConfiguration,
     };
   }
 
@@ -673,6 +831,23 @@ export class MetaAgentService {
     if (!parent || parent.workspacePath !== workspaceId) {
       throw new Error(`Parent session ${parentSessionId} not found in this workspace`);
     }
+
+    // Validate the complete requested configuration before workstream
+    // resolution can create a container or reparent the caller.
+    const effectiveModel =
+      args.model ?? (args.inheritModel ? parent.model ?? undefined : undefined);
+    const previewResolution = await resolveChildSessionModelAndProvider(parentSessionId, {
+      provider: args.provider,
+      model: effectiveModel,
+    });
+    parseSessionLaunchToolScope(args.toolScope);
+    resolveSessionReasoningConfiguration({
+      provider: previewResolution.provider,
+      model: previewResolution.normalizedModel,
+      effortLevel: args.effortLevel,
+      thinkingMode: args.thinkingMode,
+      appDefaultEffortLevel: getDefaultEffortLevel(),
+    });
 
     const isolated = args.isolated === true;
 
@@ -697,31 +872,33 @@ export class MetaAgentService {
     const inheritedWorktreeId =
       !args.useWorktree && parent.worktreeId ? parent.worktreeId : undefined;
 
-    // Resolve effective model: explicit `model` wins; otherwise `inheritModel`
-    // copies the caller's model so the new session keeps the same provider/model
-    // (e.g. opus stays on opus). Falling through to undefined lets
-    // createChildSessionInternal use the global default.
-    const effectiveModel =
-      args.model ?? (args.inheritModel ? parent.model ?? undefined : undefined);
-
+    const notifyOnComplete = args.notifyOnComplete === true;
     const childResult = await this.createChildSessionInternal(parentSessionId, workspaceId, {
       title: args.title,
       prompt: args.prompt,
       useWorktree: !!args.useWorktree,
       worktreeId: inheritedWorktreeId,
+      provider: args.provider,
       model: effectiveModel,
+      toolScope: args.toolScope,
+      effortLevel: args.effortLevel,
+      thinkingMode: args.thinkingMode,
       parentSessionIdOverride: workstreamId,
+      launchContext: {
+        inheritModel: args.inheritModel,
+        isolated,
+        notifyOnComplete,
+        notifyOnCompleteRequested: args.notifyOnComplete ?? null,
+        worktreeMode: args.useWorktree
+          ? 'new'
+          : inheritedWorktreeId
+            ? 'inherited'
+            : 'none',
+      },
     });
 
     // Default is fire-and-forget: kicking off work in a fresh session is the
     // common /launch-new-session use case (escape a long parent context).
-    const notifyOnComplete = args.notifyOnComplete === true;
-    if (!notifyOnComplete) {
-      await AISessionsRepository.updateMetadata(childResult.sessionId, {
-        metadata: { notifyParent: false },
-      });
-    }
-
     return JSON.stringify({
       ...childResult,
       isolated,
@@ -845,6 +1022,10 @@ export class MetaAgentService {
       agentRole: row.agent_role || 'standard',
       waitingForInput: status === 'waiting_for_input',
     };
+    const launchConfiguration = readSessionLaunchConfiguration(row.metadata);
+    if (launchConfiguration) {
+      result.launchConfiguration = launchConfiguration;
+    }
 
     return JSON.stringify(result, null, 2);
   }
@@ -894,6 +1075,14 @@ export class MetaAgentService {
         claimedAt: prompt.claimedAt ?? null,
         completedAt: prompt.completedAt ?? null,
         errorMessage: prompt.errorMessage ?? null,
+        deliveryClass: prompt.deliveryClass,
+        priorityRank: prompt.priorityRank,
+        deliveryReady: prompt.deliveryReady,
+        producer: prompt.producer ?? null,
+        idempotencyKey: prompt.idempotencyKey ?? null,
+        controlOperation: prompt.controlOperation ?? null,
+        interruptTargetGeneration: prompt.interruptTargetGeneration ?? null,
+        interruptReceipt: prompt.interruptReceipt ?? null,
         promptPreview: prompt.prompt.length > 300
           ? `${prompt.prompt.slice(0, 300)}...`
           : prompt.prompt,
@@ -1040,7 +1229,7 @@ export class MetaAgentService {
 
   private async getSpawnedSessions(metaSessionId: string, workspaceId: string): Promise<Array<Record<string, unknown>>> {
     const { rows } = await databaseWorker.query<any>(
-      `SELECT id, title, provider, model, status, last_activity, created_at, updated_at, worktree_id, agent_role, created_by_session_id
+      `SELECT id, title, provider, model, status, last_activity, created_at, updated_at, worktree_id, agent_role, created_by_session_id, metadata
        FROM ai_sessions
        WHERE workspace_id = $1
          AND created_by_session_id = $2
@@ -1060,6 +1249,7 @@ export class MetaAgentService {
         createdAt: toMillis(row.created_at)!,
         updatedAt: toMillis(row.updated_at)!,
         worktreeId: row.worktree_id || null,
+        metadata: row.metadata,
       }, false);
       sessions.push({
         sessionId: data.sessionId,
@@ -1075,6 +1265,9 @@ export class MetaAgentService {
         createdAt: data.createdAt,
         updatedAt: data.updatedAt,
         worktreeId: data.worktreeId || null,
+        ...(data.launchConfiguration
+          ? { launchConfiguration: data.launchConfiguration }
+          : {}),
       });
     }
 
@@ -1250,7 +1443,17 @@ export class MetaAgentService {
   private async buildSessionResultData(
     sessionId: string,
     workspaceId: string,
-    prefetchedSession?: { title: string; provider: string; model: string | null; status: string; lastActivity: number | null; createdAt: number; updatedAt: number; worktreeId: string | null },
+    prefetchedSession?: {
+      title: string;
+      provider: string;
+      model: string | null;
+      status: string;
+      lastActivity: number | null;
+      createdAt: number;
+      updatedAt: number;
+      worktreeId: string | null;
+      metadata?: unknown;
+    },
     // Skip the heavier full-turn extract when the caller only needs preview
     // fields (the list and notification paths discard fullResponse).
     includeFullResponse: boolean = true
@@ -1264,6 +1467,7 @@ export class MetaAgentService {
     let sessionUpdatedAt: number;
     let sessionWorktreeId: string | null;
     let sessionToolScope: string | null = null;
+    let launchConfiguration: SessionLaunchConfiguration | undefined;
 
     if (prefetchedSession) {
       sessionTitle = prefetchedSession.title;
@@ -1274,6 +1478,11 @@ export class MetaAgentService {
       sessionCreatedAt = prefetchedSession.createdAt;
       sessionUpdatedAt = prefetchedSession.updatedAt;
       sessionWorktreeId = prefetchedSession.worktreeId;
+      const metadata = readSessionMetadata(prefetchedSession.metadata);
+      launchConfiguration = readSessionLaunchConfiguration(metadata);
+      sessionToolScope = typeof metadata?.toolScope === 'string'
+        ? metadata.toolScope
+        : launchConfiguration?.resolved.toolScope ?? null;
     } else {
       const session = await AISessionsRepository.get(sessionId);
       if (!session || session.workspacePath !== workspaceId) {
@@ -1288,8 +1497,11 @@ export class MetaAgentService {
       sessionCreatedAt = session.createdAt;
       sessionUpdatedAt = session.updatedAt;
       sessionWorktreeId = session.worktreeId || null;
-      sessionToolScope =
-        ((session.metadata as Record<string, unknown> | undefined)?.toolScope as string | undefined) ?? null;
+      const metadata = readSessionMetadata(session.metadata);
+      launchConfiguration = readSessionLaunchConfiguration(metadata);
+      sessionToolScope = typeof metadata?.toolScope === 'string'
+        ? metadata.toolScope
+        : launchConfiguration?.resolved.toolScope ?? null;
     }
 
     const messages = await AgentMessagesRepository.list(sessionId, { limit: 500 });
@@ -1324,7 +1536,74 @@ export class MetaAgentService {
       updatedAt: sessionUpdatedAt,
       worktreeId: sessionWorktreeId,
       toolScope: sessionToolScope,
+      ...(launchConfiguration ? { launchConfiguration } : {}),
     };
+  }
+
+  private async sendPromptNowToSession(
+    callerSessionId: string,
+    workspaceId: string,
+    args: SendPromptNowArgs,
+  ): Promise<string> {
+    if (!this.aiService) {
+      throw new Error('AI service not initialized');
+    }
+    const sessionId = args.sessionId?.trim();
+    const prompt = args.prompt?.trim();
+    if (!sessionId) {
+      throw new Error('sessionId is required');
+    }
+    if (!prompt) {
+      throw new Error('prompt is required');
+    }
+
+    const session = await AISessionsRepository.get(sessionId);
+    if (!session || session.workspacePath !== workspaceId) {
+      throw new Error(`Session ${sessionId} not found`);
+    }
+
+    const { getQueuedPromptsStore } = await import('./RepositoryManager');
+    const queueStore = getQueuedPromptsStore();
+    const service = createPriorityPromptDeliveryService({
+      createControlPrompt: async (input) => {
+        const created = await queueStore.createPriorityControlPrompt(input);
+        return {
+          row: created.row as unknown as PriorityControlPrompt,
+          replayed: created.replayed,
+        };
+      },
+      getTargetState: (targetSessionId) =>
+        this.getPriorityTargetState(targetSessionId, workspaceId),
+      hasStructuredPendingPrompt: async (targetSessionId) =>
+        (await this.getPendingInteractivePrompt(targetSessionId)) !== null,
+      reserveInterrupt: async (input) => {
+        const reserved = await queueStore.reservePriorityInterrupt(input);
+        return {
+          row: reserved.row as unknown as PriorityControlPrompt,
+          reserved: reserved.reserved,
+        };
+      },
+      recordInterruptReceipt: async (input) =>
+        await queueStore.recordPriorityInterruptReceipt(input) as unknown as PriorityControlPrompt,
+      interruptCurrentTurn: (targetSessionId, expectedState) =>
+        this.aiService!.interruptCurrentTurnForSession(targetSessionId, expectedState),
+      triggerProcessing: (targetSessionId, targetWorkspaceId) =>
+        this.aiService!.triggerQueuedPromptProcessingForSession(targetSessionId, targetWorkspaceId),
+      getControlPrompt: async (promptId) =>
+        await queueStore.get(promptId) as unknown as PriorityControlPrompt | null,
+    });
+
+    const receipt = await service.deliver({
+      sessionId,
+      workspacePath: session.worktreePath || session.workspacePath || workspaceId,
+      prompt,
+      idempotencyKey: args.idempotencyKey?.trim()
+        || `send_prompt_now:${callerSessionId}:${randomUUID()}`,
+      producer: `send_prompt_now:${callerSessionId}`,
+      controlOperation: args.controlOperation?.trim() || 'agent_priority_prompt',
+      interruptWaitingForInput: args.interruptWaitingForInput === true,
+    });
+    return JSON.stringify(receipt, null, 2);
   }
 
   private async getPendingInteractivePrompt(sessionId: string): Promise<PendingInteractivePrompt | null> {
@@ -1457,13 +1736,37 @@ export class MetaAgentService {
 
   private async getSessionStatusRow(sessionId: string, workspaceId: string): Promise<any | null> {
     const { rows } = await databaseWorker.query<any>(
-      `SELECT id, title, provider, model, status, last_activity, updated_at, created_by_session_id, agent_role
+      `SELECT id, title, provider, model, status, last_activity, updated_at, created_by_session_id, agent_role, metadata
        FROM ai_sessions
        WHERE id = $1 AND workspace_id = $2
        LIMIT 1`,
       [sessionId, workspaceId]
     );
     return rows[0] || null;
+  }
+
+  private async getPriorityTargetState(
+    sessionId: string,
+    workspaceId: string,
+  ): Promise<PriorityTargetState> {
+    const row = await this.getSessionStatusRow(sessionId, workspaceId);
+    if (!row) {
+      return {
+        status: 'missing',
+        generation: createPriorityTargetGeneration('missing', null, null),
+        lastActivity: null,
+        updatedAt: null,
+      };
+    }
+    const status = row.status as PriorityTargetState['status'];
+    const lastActivity = toMillis(row.last_activity);
+    const updatedAt = toMillis(row.updated_at);
+    return {
+      status,
+      generation: createPriorityTargetGeneration(status, lastActivity, updatedAt),
+      lastActivity,
+      updatedAt,
+    };
   }
 
   private async ensurePlanTrackerItem(workspaceId: string, sessionId: string, result: SessionResultData): Promise<void> {

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -29,6 +29,8 @@ import { setMetaAgentToolFns } from '../mcp/metaAgentServer';
 import { computeNotificationSignature } from './metaAgentNotificationSignature';
 import { extractMessageText, extractUserPrompts } from './metaAgentMessageText';
 import type { NotificationOptions, NotificationResult } from './NotificationService';
+import { resolveProjectPath } from '../utils/workspaceDetection';
+import { hasLiveWindowForWorkspace } from '../window/windowState';
 import {
   createPriorityPromptDeliveryService,
   createPriorityTargetGeneration,
@@ -81,6 +83,7 @@ interface CreateChildSessionArgs {
   prompt?: string;
   useWorktree?: boolean;
   worktreeId?: string;
+  baseBranch?: string;
   toolScope?: SessionLaunchToolScope;
   effortLevel?: EffortLevel;
   thinkingMode?: ThinkingMode;
@@ -235,6 +238,13 @@ interface SpawnSessionArgs {
   title?: string;
   prompt: string;
   useWorktree?: boolean;
+  /**
+   * An already-loaded canonical project to create the session in. Crossing
+   * project boundaries requires isolated=true and useWorktree=true.
+   */
+  targetWorkspacePath?: string;
+  /** Optional branch or ref for the fresh worktree. */
+  baseBranch?: string;
   provider?: string;
   model?: string;
   toolScope?: SessionLaunchToolScope;
@@ -344,20 +354,20 @@ export class MetaAgentService {
           this.createChildSession(metaSessionId, workspaceId, args),
         spawnSession: (callerSessionId, workspaceId, args) =>
           this.spawnSession(callerSessionId, workspaceId, args),
-        getSessionStatus: (_metaSessionId, workspaceId, targetSessionId) =>
-          this.getSessionStatusJson(targetSessionId, workspaceId),
-        getSessionResult: (_metaSessionId, workspaceId, targetSessionId, options) =>
-          this.getSessionResultJson(targetSessionId, workspaceId, options),
-        listQueuedPrompts: (_metaSessionId, workspaceId, targetSessionId, options) =>
-          this.listQueuedPromptsJson(targetSessionId, workspaceId, options),
-        sendPrompt: (_metaSessionId, workspaceId, targetSessionId, prompt) =>
-          this.sendPromptToSession(targetSessionId, workspaceId, prompt),
+        getSessionStatus: (metaSessionId, workspaceId, targetSessionId) =>
+          this.getSessionStatusJson(metaSessionId, workspaceId, targetSessionId),
+        getSessionResult: (metaSessionId, workspaceId, targetSessionId, options) =>
+          this.getSessionResultJson(metaSessionId, workspaceId, targetSessionId, options),
+        listQueuedPrompts: (metaSessionId, workspaceId, targetSessionId, options) =>
+          this.listQueuedPromptsJson(metaSessionId, workspaceId, targetSessionId, options),
+        sendPrompt: (metaSessionId, workspaceId, targetSessionId, prompt) =>
+          this.sendPromptToSession(metaSessionId, workspaceId, targetSessionId, prompt),
         sendPromptNow: (metaSessionId, workspaceId, args) =>
           this.sendPromptNowToSession(metaSessionId, workspaceId, args),
         notifyUser: (callerSessionId, workspaceId, args) =>
           this.notifyUserJson(callerSessionId, workspaceId, args),
-        respondToPrompt: (_metaSessionId, workspaceId, args) =>
-          this.respondToPrompt(workspaceId, args),
+        respondToPrompt: (metaSessionId, workspaceId, args) =>
+          this.respondToPrompt(metaSessionId, workspaceId, args),
         listSpawnedSessions: (metaSessionId, workspaceId) =>
           this.listSpawnedSessionsJson(metaSessionId, workspaceId),
       });
@@ -628,7 +638,10 @@ export class MetaAgentService {
       for (const name of filesystemNames) existingNames.add(name);
       for (const name of branchNames) existingNames.add(name);
       const finalName = gitWorktreeService.generateUniqueWorktreeName(existingNames);
-      const worktree = await gitWorktreeService.createWorktree(workspaceId, { name: finalName });
+      const worktree = await gitWorktreeService.createWorktree(workspaceId, {
+        name: finalName,
+        ...(args.baseBranch ? { baseBranch: args.baseBranch } : {}),
+      });
       await worktreeStore.create(worktree);
       gitRefWatcher.start(worktree.path).catch((error: Error) => {
         console.error('[MetaAgentService] Failed to start GitRefWatcher for meta-agent worktree:', error);
@@ -834,8 +847,7 @@ export class MetaAgentService {
 
     // Validate the complete requested configuration before workstream
     // resolution can create a container or reparent the caller.
-    const effectiveModel =
-      args.model ?? (args.inheritModel ? parent.model ?? undefined : undefined);
+    const effectiveModel = args.model?.trim() || undefined;
     const previewResolution = await resolveChildSessionModelAndProvider(parentSessionId, {
       provider: args.provider,
       model: effectiveModel,
@@ -850,6 +862,26 @@ export class MetaAgentService {
     });
 
     const isolated = args.isolated === true;
+    const requestedTargetWorkspace = args.targetWorkspacePath?.trim();
+    const targetWorkspaceId = requestedTargetWorkspace
+      ? resolveProjectPath(requestedTargetWorkspace)
+      : workspaceId;
+    const isCrossProject = targetWorkspaceId !== workspaceId;
+
+    if (isCrossProject) {
+      if (!isolated) {
+        throw new Error('Cross-project spawn_session requires isolated=true');
+      }
+      if (args.useWorktree !== true) {
+        throw new Error('Cross-project spawn_session requires useWorktree=true');
+      }
+
+      if (!hasLiveWindowForWorkspace(targetWorkspaceId)) {
+        throw new Error(
+          `Cross-project spawn_session requires an already-loaded target project: ${targetWorkspaceId}`
+        );
+      }
+    }
 
     // Sibling mode: resolve (or create) a workstream container so the new
     // session shares files-edited, tabs, and workstream overview with the
@@ -873,11 +905,12 @@ export class MetaAgentService {
       !args.useWorktree && parent.worktreeId ? parent.worktreeId : undefined;
 
     const notifyOnComplete = args.notifyOnComplete === true;
-    const childResult = await this.createChildSessionInternal(parentSessionId, workspaceId, {
+    const childResult = await this.createChildSessionInternal(parentSessionId, targetWorkspaceId, {
       title: args.title,
       prompt: args.prompt,
       useWorktree: !!args.useWorktree,
       worktreeId: inheritedWorktreeId,
+      baseBranch: args.baseBranch,
       provider: args.provider,
       model: effectiveModel,
       toolScope: args.toolScope,
@@ -902,6 +935,8 @@ export class MetaAgentService {
     return JSON.stringify({
       ...childResult,
       isolated,
+      sourceWorkspacePath: workspaceId,
+      targetWorkspacePath: targetWorkspaceId,
       workstreamId,
       promotedParent,
       notifyOnComplete,
@@ -1003,8 +1038,17 @@ export class MetaAgentService {
     return JSON.stringify(summaries, null, 2);
   }
 
-  private async getSessionStatusJson(sessionId: string, workspaceId: string): Promise<string> {
-    const row = await this.getSessionStatusRow(sessionId, workspaceId);
+  private async getSessionStatusJson(
+    callerSessionId: string,
+    callerWorkspaceId: string,
+    sessionId: string
+  ): Promise<string> {
+    const session = await this.resolveSessionForCaller(
+      callerSessionId,
+      callerWorkspaceId,
+      sessionId
+    );
+    const row = await this.getSessionStatusRow(sessionId, session.workspacePath);
     if (!row) {
       throw new Error(`Session ${sessionId} not found`);
     }
@@ -1031,13 +1075,19 @@ export class MetaAgentService {
   }
 
   private async getSessionResultJson(
+    callerSessionId: string,
+    callerWorkspaceId: string,
     sessionId: string,
-    workspaceId: string,
     options: { includeFullResponse?: boolean } = {}
   ): Promise<string> {
+    const session = await this.resolveSessionForCaller(
+      callerSessionId,
+      callerWorkspaceId,
+      sessionId
+    );
     const data = await this.buildSessionResultData(
       sessionId,
-      workspaceId,
+      session.workspacePath,
       undefined,
       options.includeFullResponse ?? true
     );
@@ -1045,18 +1095,16 @@ export class MetaAgentService {
   }
 
   private async listQueuedPromptsJson(
+    callerSessionId: string,
+    callerWorkspaceId: string,
     sessionId: string,
-    workspaceId: string,
     options: { includeCompleted?: boolean; includePromptText?: boolean } = {}
   ): Promise<string> {
     if (!sessionId) {
       throw new Error('sessionId is required');
     }
 
-    const session = await AISessionsRepository.get(sessionId);
-    if (!session || session.workspacePath !== workspaceId) {
-      throw new Error(`Session ${sessionId} not found`);
-    }
+    await this.resolveSessionForCaller(callerSessionId, callerWorkspaceId, sessionId);
 
     const { getQueuedPromptsStore } = await import('./RepositoryManager');
     const queueStore = getQueuedPromptsStore();
@@ -1091,7 +1139,12 @@ export class MetaAgentService {
     }, null, 2);
   }
 
-  private async sendPromptToSession(sessionId: string, workspaceId: string, prompt: string): Promise<string> {
+  private async sendPromptToSession(
+    callerSessionId: string,
+    callerWorkspaceId: string,
+    sessionId: string,
+    prompt: string
+  ): Promise<string> {
     if (!this.aiService) {
       throw new Error('AI service not initialized');
     }
@@ -1099,14 +1152,15 @@ export class MetaAgentService {
       throw new Error('prompt is required');
     }
 
-    const session = await AISessionsRepository.get(sessionId);
-    if (!session || session.workspacePath !== workspaceId) {
-      throw new Error(`Session ${sessionId} not found`);
-    }
+    const session = await this.resolveSessionForCaller(
+      callerSessionId,
+      callerWorkspaceId,
+      sessionId
+    );
 
     const normalizedPrompt = prompt.trim();
     const shouldBypassExecution = this.shouldBypassChildAgentExecutionForTests();
-    const statusRow = await this.getSessionStatusRow(sessionId, workspaceId);
+    const statusRow = await this.getSessionStatusRow(sessionId, session.workspacePath);
     const statusBeforeQueue = (statusRow?.status || 'idle') as SessionStatusValue;
 
     if (shouldBypassExecution) {
@@ -1128,7 +1182,7 @@ export class MetaAgentService {
     if (processingTriggered) {
       await this.aiService.triggerQueuedPromptProcessingForSession(
         sessionId,
-        session.worktreePath || session.workspacePath || workspaceId
+        session.worktreePath || session.workspacePath
       );
     }
 
@@ -1156,10 +1210,11 @@ export class MetaAgentService {
     }
 
     const targetSessionId = args.sessionId?.trim() || callerSessionId;
-    const session = await AISessionsRepository.get(targetSessionId);
-    if (!session || session.workspacePath !== workspaceId) {
-      throw new Error(`Session ${targetSessionId} not found`);
-    }
+    const session = await this.resolveSessionForCaller(
+      callerSessionId,
+      workspaceId,
+      targetSessionId
+    );
 
     if (!this.showNotificationWithResult) {
       throw new Error('Notification delivery is not initialized');
@@ -1187,7 +1242,7 @@ export class MetaAgentService {
     }, null, 2);
   }
 
-  private async respondToPrompt(workspaceId: string, args: {
+  private async respondToPrompt(callerSessionId: string, workspaceId: string, args: {
     sessionId: string;
     promptId: string;
     promptType: PromptType;
@@ -1197,10 +1252,7 @@ export class MetaAgentService {
       throw new Error('AI service not initialized');
     }
 
-    const session = await AISessionsRepository.get(args.sessionId);
-    if (!session || session.workspacePath !== workspaceId) {
-      throw new Error(`Session ${args.sessionId} not found`);
-    }
+    await this.resolveSessionForCaller(callerSessionId, workspaceId, args.sessionId);
 
     const result = await this.aiService.respondToInteractivePrompt({
       sessionId: args.sessionId,
@@ -1227,20 +1279,19 @@ export class MetaAgentService {
     return JSON.stringify(sessions, null, 2);
   }
 
-  private async getSpawnedSessions(metaSessionId: string, workspaceId: string): Promise<Array<Record<string, unknown>>> {
+  private async getSpawnedSessions(metaSessionId: string, _workspaceId: string): Promise<Array<Record<string, unknown>>> {
     const { rows } = await databaseWorker.query<any>(
-      `SELECT id, title, provider, model, status, last_activity, created_at, updated_at, worktree_id, agent_role, created_by_session_id, metadata
+      `SELECT id, title, provider, model, status, last_activity, created_at, updated_at, worktree_id, agent_role, created_by_session_id, workspace_id, metadata
        FROM ai_sessions
-       WHERE workspace_id = $1
-         AND created_by_session_id = $2
+       WHERE created_by_session_id = $1
          AND (is_archived = FALSE OR is_archived IS NULL)
        ORDER BY created_at DESC`,
-      [workspaceId, metaSessionId]
+      [metaSessionId]
     );
 
     const sessions: Array<Record<string, unknown>> = [];
     for (const row of rows) {
-      const data = await this.buildSessionResultData(row.id, workspaceId, {
+      const data = await this.buildSessionResultData(row.id, row.workspace_id, {
         title: row.title || 'Untitled Session',
         provider: row.provider,
         model: row.model || null,
@@ -1265,6 +1316,7 @@ export class MetaAgentService {
         createdAt: data.createdAt,
         updatedAt: data.updatedAt,
         worktreeId: data.worktreeId || null,
+        workspacePath: row.workspace_id,
         ...(data.launchConfiguration
           ? { launchConfiguration: data.launchConfiguration }
           : {}),
@@ -1557,10 +1609,12 @@ export class MetaAgentService {
       throw new Error('prompt is required');
     }
 
-    const session = await AISessionsRepository.get(sessionId);
-    if (!session || session.workspacePath !== workspaceId) {
-      throw new Error(`Session ${sessionId} not found`);
-    }
+    const session = await this.resolveSessionForCaller(
+      callerSessionId,
+      workspaceId,
+      sessionId
+    );
+    const targetWorkspaceId = session.workspacePath;
 
     const { getQueuedPromptsStore } = await import('./RepositoryManager');
     const queueStore = getQueuedPromptsStore();
@@ -1573,7 +1627,7 @@ export class MetaAgentService {
         };
       },
       getTargetState: (targetSessionId) =>
-        this.getPriorityTargetState(targetSessionId, workspaceId),
+        this.getPriorityTargetState(targetSessionId, targetWorkspaceId),
       hasStructuredPendingPrompt: async (targetSessionId) =>
         (await this.getPendingInteractivePrompt(targetSessionId)) !== null,
       reserveInterrupt: async (input) => {
@@ -1595,7 +1649,7 @@ export class MetaAgentService {
 
     const receipt = await service.deliver({
       sessionId,
-      workspacePath: session.worktreePath || session.workspacePath || workspaceId,
+      workspacePath: session.worktreePath || targetWorkspaceId,
       prompt,
       idempotencyKey: args.idempotencyKey?.trim()
         || `send_prompt_now:${callerSessionId}:${randomUUID()}`,
@@ -1743,6 +1797,30 @@ export class MetaAgentService {
       [sessionId, workspaceId]
     );
     return rows[0] || null;
+  }
+
+  /**
+   * Preserve the existing same-workspace session surface while granting a
+   * caller a narrow cross-project capability over sessions it created.
+   * Possession of a path or unrelated session UUID never grants authority.
+   */
+  private async resolveSessionForCaller(
+    callerSessionId: string,
+    callerWorkspaceId: string,
+    targetSessionId: string
+  ): Promise<any> {
+    if (!targetSessionId) {
+      throw new Error('sessionId is required');
+    }
+
+    const session = await AISessionsRepository.get(targetSessionId);
+    const sameWorkspace = session?.workspacePath === callerWorkspaceId;
+    const createdByCaller = session?.createdBySessionId === callerSessionId;
+    if (!session || (!sameWorkspace && !createdByCaller)) {
+      throw new Error(`Session ${targetSessionId} not found`);
+    }
+
+    return session;
   }
 
   private async getPriorityTargetState(

--- a/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
+++ b/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
@@ -24,6 +24,26 @@ export interface QueuedPrompt {
   claimedAt?: number; // epoch ms
   completedAt?: number; // epoch ms
   errorMessage?: string;
+  deliveryClass: 'ordinary' | 'control';
+  priorityRank: number;
+  deliveryReady: boolean;
+  producer?: string;
+  idempotencyKey?: string;
+  requestDigest?: string;
+  controlOperation?: string;
+  interruptTargetGeneration?: string;
+  interruptReservationOwner?: string;
+  interruptReceipt?: QueuedPromptInterruptReceipt;
+}
+
+export interface QueuedPromptInterruptReceipt {
+  generation: string;
+  attempted: boolean;
+  success: boolean;
+  method: string | null;
+  error: string | null;
+  nativeEntered: boolean;
+  recordedAt: number;
 }
 
 export interface CreateQueuedPromptInput {
@@ -40,9 +60,25 @@ export interface CreateQueuedPromptInput {
   };
 }
 
+export interface CreatePriorityControlQueuedPromptInput {
+  id: string;
+  sessionId: string;
+  prompt: string;
+  producer: string;
+  idempotencyKey: string;
+  requestDigest: string;
+  controlOperation: string;
+}
+
 export interface QueuedPromptsStore {
   /** Create a new queued prompt */
   create(input: CreateQueuedPromptInput): Promise<QueuedPrompt>;
+
+  /** Create or replay an idempotent high-priority control prompt. */
+  createPriorityControlPrompt(input: CreatePriorityControlQueuedPromptInput): Promise<{
+    row: QueuedPrompt;
+    replayed: boolean;
+  }>;
 
   /** Get a specific queued prompt by ID */
   get(id: string): Promise<QueuedPrompt | null>;
@@ -52,6 +88,23 @@ export interface QueuedPromptsStore {
 
   /** List pending prompts for a session (ready to execute) */
   listPending(sessionId: string): Promise<QueuedPrompt[]>;
+
+  /** Discover pending work after a process restart without changing row state. */
+  listPendingSessionIds(options?: { deliveryClass?: 'ordinary' | 'control' }): Promise<string[]>;
+
+  /** Atomically reserve the one native interrupt allowed for a control row. */
+  reservePriorityInterrupt(input: {
+    promptId: string;
+    generation: string;
+    owner: string;
+  }): Promise<{ row: QueuedPrompt; reserved: boolean }>;
+
+  /** Persist the native interrupt result before queue processing is triggered. */
+  recordPriorityInterruptReceipt(input: {
+    promptId: string;
+    generation: string;
+    receipt: QueuedPromptInterruptReceipt;
+  }): Promise<QueuedPrompt>;
 
   /**
    * Atomically claim a pending prompt for execution.
@@ -162,6 +215,15 @@ function rowToQueuedPrompt(row: any): QueuedPrompt {
     }
   }
 
+  let interruptReceipt = row.interrupt_receipt;
+  if (typeof interruptReceipt === 'string') {
+    try {
+      interruptReceipt = JSON.parse(interruptReceipt);
+    } catch {
+      interruptReceipt = undefined;
+    }
+  }
+
   return {
     id: row.id,
     sessionId: row.session_id,
@@ -173,6 +235,16 @@ function rowToQueuedPrompt(row: any): QueuedPrompt {
     claimedAt: toMillis(row.claimed_at) ?? undefined,
     completedAt: toMillis(row.completed_at) ?? undefined,
     errorMessage: row.error_message || undefined,
+    deliveryClass: row.delivery_class === 'control' ? 'control' : 'ordinary',
+    priorityRank: Number(row.priority_rank ?? 0),
+    deliveryReady: row.delivery_ready !== false && row.delivery_ready !== 0,
+    producer: row.producer || undefined,
+    idempotencyKey: row.idempotency_key || undefined,
+    requestDigest: row.request_digest || undefined,
+    controlOperation: row.control_operation || undefined,
+    interruptTargetGeneration: row.interrupt_target_generation || undefined,
+    interruptReservationOwner: row.interrupt_reservation_owner || undefined,
+    interruptReceipt: interruptReceipt || undefined,
   };
 }
 
@@ -211,6 +283,51 @@ export function createPGLiteQueuedPromptsStore(
       return rowToQueuedPrompt(rows[0]);
     },
 
+    async createPriorityControlPrompt(
+      input: CreatePriorityControlQueuedPromptInput
+    ): Promise<{ row: QueuedPrompt; replayed: boolean }> {
+      await ensureReady();
+
+      const { rows } = await db.query<any>(
+        `INSERT INTO queued_prompts (
+           id, session_id, prompt, delivery_class, priority_rank, delivery_ready, producer,
+           idempotency_key, request_digest, control_operation
+         )
+         VALUES ($1, $2, $3, 'control', 100, FALSE, $4, $5, $6, $7)
+         ON CONFLICT (session_id, idempotency_key)
+           WHERE idempotency_key IS NOT NULL
+         DO NOTHING
+         RETURNING *`,
+        [
+          input.id,
+          input.sessionId,
+          input.prompt,
+          input.producer,
+          input.idempotencyKey,
+          input.requestDigest,
+          input.controlOperation,
+        ]
+      );
+
+      if (rows.length > 0) {
+        return { row: rowToQueuedPrompt(rows[0]), replayed: false };
+      }
+
+      const existing = await db.query<any>(
+        `SELECT * FROM queued_prompts
+         WHERE session_id = $1 AND idempotency_key = $2
+         LIMIT 1`,
+        [input.sessionId, input.idempotencyKey]
+      );
+      if (existing.rows.length === 0) {
+        throw new Error('Failed to create or replay priority control prompt');
+      }
+      if (existing.rows[0].request_digest !== input.requestDigest) {
+        throw new Error('idempotency_conflict: key was already used for a different request');
+      }
+      return { row: rowToQueuedPrompt(existing.rows[0]), replayed: true };
+    },
+
     async get(id: string): Promise<QueuedPrompt | null> {
       await ensureReady();
 
@@ -234,7 +351,7 @@ export function createPGLiteQueuedPromptsStore(
       if (!includeCompleted) {
         query += ` AND status NOT IN ('completed', 'failed')`;
       }
-      query += ` ORDER BY created_at ASC`;
+      query += ` ORDER BY priority_rank DESC, created_at ASC, id ASC`;
 
       const { rows } = await db.query<any>(query, [sessionId]);
       return rows.map(rowToQueuedPrompt);
@@ -245,12 +362,95 @@ export function createPGLiteQueuedPromptsStore(
 
       const { rows } = await db.query<any>(
         `SELECT * FROM queued_prompts
-         WHERE session_id = $1 AND status = 'pending'
-         ORDER BY created_at ASC`,
+         WHERE session_id = $1 AND status = 'pending' AND delivery_ready = TRUE
+         ORDER BY priority_rank DESC, created_at ASC, id ASC`,
         [sessionId]
       );
 
       return rows.map(rowToQueuedPrompt);
+    },
+
+    async listPendingSessionIds(
+      options?: { deliveryClass?: 'ordinary' | 'control' }
+    ): Promise<string[]> {
+      await ensureReady();
+
+      const deliveryClass = options?.deliveryClass;
+      const { rows } = await db.query<{ session_id: string }>(
+        `SELECT session_id
+         FROM queued_prompts
+         WHERE status = 'pending' AND delivery_ready = TRUE
+           AND ($1 IS NULL OR delivery_class = $1)
+         GROUP BY session_id
+         ORDER BY MIN(created_at) ASC, session_id ASC`,
+        [deliveryClass ?? null]
+      );
+      return rows.map((row) => row.session_id);
+    },
+
+    async reservePriorityInterrupt(input): Promise<{ row: QueuedPrompt; reserved: boolean }> {
+      await ensureReady();
+
+      const { rows } = await db.query<any>(
+        `UPDATE queued_prompts
+         SET interrupt_target_generation = $2,
+             interrupt_reservation_owner = $3
+         WHERE id = $1
+           AND delivery_class = 'control'
+           AND interrupt_receipt IS NULL
+           AND interrupt_reservation_owner IS NULL
+         RETURNING *`,
+        [input.promptId, input.generation, input.owner]
+      );
+      if (rows.length > 0) {
+        return { row: rowToQueuedPrompt(rows[0]), reserved: true };
+      }
+      const existing = await db.query<any>(
+        `SELECT * FROM queued_prompts WHERE id = $1 LIMIT 1`,
+        [input.promptId]
+      );
+      if (existing.rows.length === 0) {
+        throw new Error(`Priority control prompt ${input.promptId} not found`);
+      }
+      return { row: rowToQueuedPrompt(existing.rows[0]), reserved: false };
+    },
+
+    async recordPriorityInterruptReceipt(input): Promise<QueuedPrompt> {
+      await ensureReady();
+
+      const { rows } = await db.query<any>(
+        `UPDATE queued_prompts
+         SET interrupt_receipt = $3,
+             delivery_ready = $4
+         WHERE id = $1
+           AND interrupt_target_generation = $2
+           AND interrupt_receipt IS NULL
+         RETURNING *`,
+        [
+          input.promptId,
+          input.generation,
+          JSON.stringify(input.receipt),
+          input.receipt.success,
+        ]
+      );
+      if (rows.length > 0) {
+        return rowToQueuedPrompt(rows[0]);
+      }
+      const existing = await db.query<any>(
+        `SELECT * FROM queued_prompts WHERE id = $1 LIMIT 1`,
+        [input.promptId]
+      );
+      if (existing.rows.length === 0) {
+        throw new Error(`Priority control prompt ${input.promptId} not found`);
+      }
+      const row = rowToQueuedPrompt(existing.rows[0]);
+      if (
+        row.interruptTargetGeneration !== input.generation
+        || !row.interruptReceipt
+      ) {
+        throw new Error('Failed to record priority interrupt receipt');
+      }
+      return row;
     },
 
     async claim(id: string): Promise<QueuedPrompt | null> {
@@ -261,7 +461,7 @@ export function createPGLiteQueuedPromptsStore(
       const { rows } = await db.query<any>(
         `UPDATE queued_prompts
          SET status = 'executing', claimed_at = CURRENT_TIMESTAMP
-         WHERE id = $1 AND status = 'pending'
+         WHERE id = $1 AND status = 'pending' AND delivery_ready = TRUE
          RETURNING *`,
         [id]
       );

--- a/packages/electron/src/main/services/PriorityPromptDeliveryService.ts
+++ b/packages/electron/src/main/services/PriorityPromptDeliveryService.ts
@@ -1,0 +1,345 @@
+import { createHash, randomUUID } from 'crypto';
+
+export type PriorityTargetStatus =
+  | 'idle'
+  | 'running'
+  | 'waiting_for_input'
+  | 'error'
+  | 'interrupted'
+  | 'missing';
+
+export interface PriorityTargetState {
+  status: PriorityTargetStatus;
+  generation: string;
+  lastActivity: number | null;
+  updatedAt: number | null;
+}
+
+export function createPriorityTargetGeneration(
+  status: PriorityTargetStatus,
+  lastActivity: number | null,
+  updatedAt: number | null,
+): string {
+  return `${status}:${lastActivity ?? 'none'}:${updatedAt ?? 'none'}`;
+}
+
+export interface PriorityInterruptReceipt {
+  generation: string;
+  attempted: boolean;
+  success: boolean;
+  method: string | null;
+  error: string | null;
+  nativeEntered: boolean;
+  recordedAt: number;
+}
+
+export interface PriorityControlPrompt {
+  id: string;
+  sessionId: string;
+  status: 'pending' | 'executing' | 'completed' | 'failed';
+  deliveryClass: 'control';
+  priorityRank: number;
+  deliveryReady?: boolean;
+  interruptTargetGeneration: string | null;
+  interruptReservationOwner: string | null;
+  interruptReceipt: PriorityInterruptReceipt | null;
+}
+
+interface CreateControlPromptInput {
+  id: string;
+  sessionId: string;
+  prompt: string;
+  producer: string;
+  idempotencyKey: string;
+  requestDigest: string;
+  controlOperation: string;
+}
+
+interface PriorityPromptDeliveryDependencies {
+  createControlPrompt(input: CreateControlPromptInput): Promise<{
+    row: PriorityControlPrompt;
+    replayed: boolean;
+  }>;
+  getTargetState(sessionId: string, workspacePath: string): Promise<PriorityTargetState>;
+  hasStructuredPendingPrompt(sessionId: string): Promise<boolean>;
+  reserveInterrupt(input: {
+    promptId: string;
+    generation: string;
+    owner: string;
+  }): Promise<{ row: PriorityControlPrompt; reserved: boolean }>;
+  recordInterruptReceipt(input: {
+    promptId: string;
+    generation: string;
+    receipt: PriorityInterruptReceipt;
+  }): Promise<PriorityControlPrompt>;
+  interruptCurrentTurn(
+    sessionId: string,
+    expectedState: PriorityTargetState,
+  ): Promise<{
+    success: boolean;
+    method?: string;
+    error?: string;
+    nativeEntered?: boolean;
+  }>;
+  triggerProcessing(sessionId: string, workspacePath: string): Promise<boolean>;
+  getControlPrompt(promptId: string): Promise<PriorityControlPrompt | null>;
+  createReservationOwner?(): string;
+  createControlPromptId?(): string;
+}
+
+export interface DeliverPriorityPromptInput {
+  sessionId: string;
+  workspacePath: string;
+  prompt: string;
+  idempotencyKey: string;
+  producer: string;
+  controlOperation: string;
+  interruptWaitingForInput: boolean;
+}
+
+export interface PriorityPromptDeliveryReceipt {
+  sessionId: string;
+  queuedPromptId: string;
+  deliveryClass: 'control';
+  priorityRank: number;
+  idempotencyKey: string;
+  producer: string;
+  controlOperation: string;
+  replayed: boolean;
+  action:
+    | 'processing_triggered'
+    | 'queued_waiting_for_authority'
+    | 'structured_prompt_requires_response'
+    | 'interrupt_attempted'
+    | 'interrupt_receipt_replayed'
+    | 'interrupt_already_reserved'
+    | 'stale_generation_rejected';
+  targetBefore: PriorityTargetState;
+  targetAfter: PriorityTargetState;
+  processingTriggerCalled: boolean;
+  processingTriggerAccepted: boolean;
+  interrupt: {
+    attempted: boolean;
+    success: boolean | null;
+    method: string | null;
+    error: string | null;
+    nativeEntered: boolean;
+    targetGeneration: string | null;
+    reservationOwner: string | null;
+  };
+}
+
+function requireNonEmpty(value: string, field: string): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new Error(`${field} is required`);
+  }
+  return normalized;
+}
+
+function requestDigest(input: {
+  sessionId: string;
+  prompt: string;
+  producer: string;
+  controlOperation: string;
+}): string {
+  return createHash('sha256')
+    .update(JSON.stringify(input))
+    .digest('hex');
+}
+
+function receiptInterrupt(
+  row: PriorityControlPrompt,
+  receipt: PriorityInterruptReceipt | null,
+) {
+  return {
+    attempted: receipt?.attempted ?? false,
+    success: receipt?.success ?? null,
+    method: receipt?.method ?? null,
+    error: receipt?.error ?? null,
+    nativeEntered: receipt?.nativeEntered ?? false,
+    targetGeneration: row.interruptTargetGeneration,
+    reservationOwner: row.interruptReservationOwner,
+  };
+}
+
+export function createPriorityPromptDeliveryService(
+  deps: PriorityPromptDeliveryDependencies,
+) {
+  return {
+    async deliver(raw: DeliverPriorityPromptInput): Promise<PriorityPromptDeliveryReceipt> {
+      const sessionId = requireNonEmpty(raw.sessionId, 'sessionId');
+      const workspacePath = requireNonEmpty(raw.workspacePath, 'workspacePath');
+      const prompt = requireNonEmpty(raw.prompt, 'prompt');
+      const idempotencyKey = requireNonEmpty(raw.idempotencyKey, 'idempotencyKey');
+      const producer = requireNonEmpty(raw.producer, 'producer');
+      const controlOperation = requireNonEmpty(raw.controlOperation, 'controlOperation');
+
+      const created = await deps.createControlPrompt({
+        id: deps.createControlPromptId?.() ?? `control-${randomUUID()}`,
+        sessionId,
+        prompt,
+        producer,
+        idempotencyKey,
+        requestDigest: requestDigest({ sessionId, prompt, producer, controlOperation }),
+        controlOperation,
+      });
+      let row = created.row;
+      const targetBefore = await deps.getTargetState(sessionId, workspacePath);
+
+      const result = (
+        action: PriorityPromptDeliveryReceipt['action'],
+        targetAfter: PriorityTargetState,
+        processingTriggerCalled: boolean,
+        processingTriggerAccepted: boolean,
+      ): PriorityPromptDeliveryReceipt => ({
+        sessionId,
+        queuedPromptId: row.id,
+        deliveryClass: 'control',
+        priorityRank: row.priorityRank,
+        idempotencyKey,
+        producer,
+        controlOperation,
+        replayed: created.replayed,
+        action,
+        targetBefore,
+        targetAfter,
+        processingTriggerCalled,
+        processingTriggerAccepted,
+        interrupt: receiptInterrupt(row, row.interruptReceipt),
+      });
+
+      if (row.interruptReceipt) {
+        const shouldRetryTrigger = row.status === 'pending' && row.interruptReceipt.success;
+        const accepted = shouldRetryTrigger
+          ? await deps.triggerProcessing(sessionId, workspacePath)
+          : false;
+        const targetAfter = shouldRetryTrigger
+          ? await deps.getTargetState(sessionId, workspacePath)
+          : targetBefore;
+        return result(
+          'interrupt_receipt_replayed',
+          targetAfter,
+          shouldRetryTrigger,
+          accepted,
+        );
+      }
+
+      if (targetBefore.status === 'waiting_for_input') {
+        if (await deps.hasStructuredPendingPrompt(sessionId)) {
+          return result('structured_prompt_requires_response', targetBefore, false, false);
+        }
+        if (!raw.interruptWaitingForInput) {
+          return result('queued_waiting_for_authority', targetBefore, false, false);
+        }
+      }
+
+      if (targetBefore.status === 'missing') {
+        throw new Error(`Session ${sessionId} disappeared before priority delivery`);
+      }
+
+      const needsInterrupt =
+        targetBefore.status === 'running'
+        || targetBefore.status === 'waiting_for_input';
+      const reservationOwner = deps.createReservationOwner?.() ?? randomUUID();
+      const reservation = await deps.reserveInterrupt({
+        promptId: row.id,
+        generation: targetBefore.generation,
+        owner: reservationOwner,
+      });
+      row = reservation.row;
+      if (!reservation.reserved) {
+        const durable = await deps.getControlPrompt(row.id);
+        if (durable) {
+          row = durable;
+        }
+        const shouldRetryTrigger = Boolean(
+          row.interruptReceipt?.success && row.status === 'pending'
+        );
+        const accepted = shouldRetryTrigger
+          ? await deps.triggerProcessing(sessionId, workspacePath)
+          : false;
+        const targetAfter = await deps.getTargetState(sessionId, workspacePath);
+        return result(
+          row.interruptReceipt ? 'interrupt_receipt_replayed' : 'interrupt_already_reserved',
+          targetAfter,
+          shouldRetryTrigger,
+          accepted,
+        );
+      }
+
+      const stateAtInterrupt = await deps.getTargetState(sessionId, workspacePath);
+      if (
+        stateAtInterrupt.generation !== targetBefore.generation
+        || stateAtInterrupt.status !== targetBefore.status
+      ) {
+        const staleReceipt: PriorityInterruptReceipt = {
+          generation: targetBefore.generation,
+          attempted: false,
+          success: false,
+          method: null,
+          error: 'stale lifecycle generation',
+          nativeEntered: false,
+          recordedAt: Date.now(),
+        };
+        row = await deps.recordInterruptReceipt({
+          promptId: row.id,
+          generation: targetBefore.generation,
+          receipt: staleReceipt,
+        });
+        const targetAfter = await deps.getTargetState(sessionId, workspacePath);
+        return result('stale_generation_rejected', targetAfter, false, false);
+      }
+
+      if (!needsInterrupt) {
+        const releaseReceipt: PriorityInterruptReceipt = {
+          generation: targetBefore.generation,
+          attempted: false,
+          success: true,
+          method: 'not-required',
+          error: null,
+          nativeEntered: false,
+          recordedAt: Date.now(),
+        };
+        row = await deps.recordInterruptReceipt({
+          promptId: row.id,
+          generation: targetBefore.generation,
+          receipt: releaseReceipt,
+        });
+        const accepted = await deps.triggerProcessing(sessionId, workspacePath);
+        const targetAfter = await deps.getTargetState(sessionId, workspacePath);
+        return result('processing_triggered', targetAfter, true, accepted);
+      }
+
+      const interruptResult = await deps.interruptCurrentTurn(sessionId, targetBefore);
+      const durableReceipt: PriorityInterruptReceipt = {
+        generation: targetBefore.generation,
+        attempted: true,
+        success: interruptResult.success,
+        method: interruptResult.method ?? null,
+        error: interruptResult.error ?? null,
+        nativeEntered: interruptResult.nativeEntered === true,
+        recordedAt: Date.now(),
+      };
+      row = await deps.recordInterruptReceipt({
+        promptId: row.id,
+        generation: targetBefore.generation,
+        receipt: durableReceipt,
+      });
+
+      let processingTriggerCalled = false;
+      let processingTriggerAccepted = false;
+      if (interruptResult.success) {
+        processingTriggerCalled = true;
+        processingTriggerAccepted = await deps.triggerProcessing(sessionId, workspacePath);
+      }
+      const targetAfter = await deps.getTargetState(sessionId, workspacePath);
+      return result(
+        'interrupt_attempted',
+        targetAfter,
+        processingTriggerCalled,
+        processingTriggerAccepted,
+      );
+    },
+  };
+}

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.getSessionResultCompact.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.getSessionResultCompact.test.ts
@@ -85,7 +85,7 @@ describe('MetaAgentService.getSessionResultJson includeFullResponse (FIX C)', ()
     ] as never);
 
     const service = MetaAgentService.getInstance();
-    const json = await (service as any).getSessionResultJson('child-1', '/ws');
+    const json = await (service as any).getSessionResultJson('caller', '/ws', 'child-1');
     const data = JSON.parse(json);
 
     expect(data.fullResponse).toBe(longReport);
@@ -99,7 +99,7 @@ describe('MetaAgentService.getSessionResultJson includeFullResponse (FIX C)', ()
     ] as never);
 
     const service = MetaAgentService.getInstance();
-    const json = await (service as any).getSessionResultJson('child-1', '/ws', {
+    const json = await (service as any).getSessionResultJson('caller', '/ws', 'child-1', {
       includeFullResponse: false,
     });
     const data = JSON.parse(json);
@@ -119,7 +119,7 @@ describe('MetaAgentService.getSessionResultJson includeFullResponse (FIX C)', ()
     ] as never);
 
     const service = MetaAgentService.getInstance();
-    const json = await (service as any).getSessionResultJson('child-1', '/ws', {
+    const json = await (service as any).getSessionResultJson('caller', '/ws', 'child-1', {
       includeFullResponse: true,
     });
     const data = JSON.parse(json);

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.launchConfiguration.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.launchConfiguration.test.ts
@@ -1,0 +1,433 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    create: vi.fn(),
+    updateMetadata: vi.fn(),
+    get: vi.fn(),
+  },
+  AgentMessagesRepository: {
+    create: vi.fn(),
+    list: vi.fn(),
+  },
+  SessionFilesRepository: {
+    getFilesBySession: vi.fn(),
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  SessionManager: class {
+    async initialize() {}
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: {
+    parse: (id: string) => {
+      const separator = id.indexOf(':');
+      if (separator <= 0) throw new Error(`invalid model: ${id}`);
+      return {
+        provider: id.slice(0, separator),
+        model: id.slice(separator + 1),
+        combined: id,
+      };
+    },
+    tryParse: (id: string) => {
+      const separator = typeof id === 'string' ? id.indexOf(':') : -1;
+      return separator > 0
+        ? { provider: id.slice(0, separator), model: id.slice(separator + 1) }
+        : null;
+    },
+    getDefaultModelId: (provider: string) => `${provider}:default`,
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn() }),
+}));
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({
+  getDefaultAIModel: () => null,
+  getDefaultEffortLevel: () => 'high',
+}));
+vi.mock('../../utils/timestampUtils', () => ({ toMillis: (value: unknown) => value }));
+vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
+vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({
+  database: { query: vi.fn() },
+}));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => null }));
+vi.mock('../../file/GitRefWatcher', () => ({ gitRefWatcher: {} }));
+vi.mock('./ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({ setMetaAgentToolFns: vi.fn() }));
+vi.mock('../metaAgentNotificationSignature', () => ({ computeNotificationSignature: vi.fn() }));
+vi.mock('../metaAgentMessageText', () => ({
+  extractMessageText: (content: unknown) => (typeof content === 'string' ? content : ''),
+  extractUserPrompts: () => [],
+}));
+
+import {
+  AISessionsRepository,
+  AgentMessagesRepository,
+  SessionFilesRepository,
+} from '@nimbalyst/runtime';
+import { database as databaseWorker } from '../../database/PGLiteDatabaseWorker';
+import { MetaAgentService } from '../MetaAgentService';
+
+const WORKSPACE = '/workspace/path';
+const CODEX_PARENT = {
+  id: 'parent-codex-session',
+  provider: 'openai-codex',
+  model: 'openai-codex:gpt-5.6-sol',
+  title: 'Codex parent',
+  workspacePath: WORKSPACE,
+  worktreeId: null,
+  parentSessionId: null,
+  sessionType: 'session',
+};
+const CLAUDE_PARENT = {
+  ...CODEX_PARENT,
+  id: 'parent-claude-session',
+  provider: 'claude-code',
+  model: 'claude-code:opus',
+  title: 'Claude parent',
+};
+const STORED_LAUNCH_CONFIGURATION = {
+  requested: {
+    provider: null,
+    model: null,
+    effortLevel: 'max',
+    thinkingMode: null,
+    toolScope: null,
+    inheritModel: false,
+    isolated: false,
+    useWorktree: false,
+    notifyOnComplete: null,
+  },
+  resolved: {
+    provider: 'openai-codex',
+    model: CODEX_PARENT.model,
+    effortLevel: 'max',
+    thinkingMode: null,
+    toolScope: 'full',
+    isolated: false,
+    worktreeMode: 'none',
+    notifyOnComplete: true,
+    sources: {
+      provider: 'inherited',
+      model: 'inherited',
+      effortLevel: 'requested',
+      thinkingMode: null,
+      toolScope: 'default',
+    },
+  },
+  effectiveness: 'not-provider-confirmed',
+};
+
+function installAIService(service: MetaAgentService) {
+  const queuePromptForSession = vi.fn().mockResolvedValue({ id: 'queued-1' });
+  const triggerQueuedPromptProcessingForSession = vi.fn().mockResolvedValue(undefined);
+  (service as any).aiService = {
+    queuePromptForSession,
+    triggerQueuedPromptProcessingForSession,
+  };
+  return { queuePromptForSession, triggerQueuedPromptProcessingForSession };
+}
+
+describe('MetaAgentService launch configuration', () => {
+  beforeEach(() => {
+    vi.mocked(AISessionsRepository.create).mockReset().mockResolvedValue(undefined);
+    vi.mocked(AISessionsRepository.updateMetadata).mockReset().mockResolvedValue(undefined);
+    vi.mocked(AISessionsRepository.get).mockReset();
+    vi.mocked(AgentMessagesRepository.create).mockReset().mockResolvedValue(undefined);
+    vi.mocked(AgentMessagesRepository.list).mockReset().mockResolvedValue([] as never);
+    vi.mocked(SessionFilesRepository.getFilesBySession)
+      .mockReset()
+      .mockResolvedValue([] as never);
+    vi.mocked(databaseWorker.query)
+      .mockReset()
+      .mockResolvedValue({ rows: [{ in_flight: '0', total: '0' }] } as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists requested/resolved Codex configuration before queue and trigger', async () => {
+    const service = MetaAgentService.getInstance();
+    const { queuePromptForSession, triggerQueuedPromptProcessingForSession } =
+      installAIService(service);
+    vi.spyOn(service as any, 'shouldBypassChildAgentExecutionForTests')
+      .mockReturnValue(false);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    const result = JSON.parse(await (service as any).createChildSession(
+      CODEX_PARENT.id,
+      WORKSPACE,
+      {
+        prompt: 'Implement the focused fix',
+        effortLevel: 'max',
+        toolScope: 'write',
+      },
+    ));
+
+    expect(result.launchConfiguration).toMatchObject({
+      requested: {
+        effortLevel: 'max',
+        toolScope: 'write',
+      },
+      resolved: {
+        provider: 'openai-codex',
+        model: CODEX_PARENT.model,
+        effortLevel: 'max',
+        toolScope: 'write',
+        sources: {
+          provider: 'inherited',
+          model: 'inherited',
+          effortLevel: 'requested',
+          toolScope: 'requested',
+        },
+      },
+      effectiveness: 'not-provider-confirmed',
+    });
+    expect(result.effectiveEffortLevel).toBeUndefined();
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(
+      result.sessionId,
+      {
+        metadata: expect.objectContaining({
+          effortLevel: 'max',
+          toolScope: 'write',
+          launchConfiguration: result.launchConfiguration,
+        }),
+      },
+    );
+
+    const persistOrder =
+      vi.mocked(AISessionsRepository.updateMetadata).mock.invocationCallOrder[0];
+    expect(persistOrder).toBeLessThan(
+      queuePromptForSession.mock.invocationCallOrder[0],
+    );
+    expect(queuePromptForSession.mock.invocationCallOrder[0]).toBeLessThan(
+      triggerQueuedPromptProcessingForSession.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('persists supported Claude effort and thinking configuration', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CLAUDE_PARENT as any);
+
+    const result = await (service as any).createChildSessionInternal(
+      CLAUDE_PARENT.id,
+      WORKSPACE,
+      {
+        effortLevel: 'xhigh',
+        thinkingMode: 'disabled',
+      },
+    );
+
+    expect(result.launchConfiguration.resolved).toMatchObject({
+      effortLevel: 'xhigh',
+      thinkingMode: 'disabled',
+    });
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(
+      result.sessionId,
+      {
+        metadata: expect.objectContaining({
+          effortLevel: 'xhigh',
+          thinkingMode: 'disabled',
+        }),
+      },
+    );
+  });
+
+  it('snapshots supported app defaults with explicit default provenance', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    const result = await (service as any).createChildSessionInternal(
+      CODEX_PARENT.id,
+      WORKSPACE,
+      {},
+    );
+
+    expect(result.launchConfiguration.resolved.effortLevel).toBe('high');
+    expect(result.launchConfiguration.resolved.sources.effortLevel).toBe(
+      'app-default',
+    );
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(
+      result.sessionId,
+      {
+        metadata: expect.objectContaining({ effortLevel: 'high' }),
+      },
+    );
+  });
+
+  it('rejects unsupported reasoning before creating a session', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      ...CLAUDE_PARENT,
+      model: 'claude-code:haiku',
+    } as any);
+
+    await expect((service as any).createChildSessionInternal(
+      CLAUDE_PARENT.id,
+      WORKSPACE,
+      { effortLevel: 'high' },
+    )).rejects.toThrow('Supported values: none');
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects provider/model mismatches before creating a session', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CLAUDE_PARENT as any);
+
+    await expect((service as any).createChildSessionInternal(
+      CLAUDE_PARENT.id,
+      WORKSPACE,
+      {
+        provider: 'claude-code',
+        model: 'openai-codex:gpt-5.6-sol',
+      },
+    )).rejects.toThrow(
+      'provider claude-code does not match model provider openai-codex',
+    );
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid spawn configuration before workstream mutation', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+    const resolveWorkstream = vi.spyOn(service as any, 'resolveOrCreateWorkstream');
+
+    await expect((service as any).spawnSession(
+      CODEX_PARENT.id,
+      WORKSPACE,
+      {
+        prompt: 'Spawn with invalid scope',
+        toolScope: 'admin',
+      },
+    )).rejects.toThrow('Invalid toolScope "admin"');
+    expect(resolveWorkstream).not.toHaveBeenCalled();
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported spawn reasoning before workstream mutation', async () => {
+    const service = MetaAgentService.getInstance();
+    installAIService(service);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      ...CODEX_PARENT,
+      provider: 'openai-codex-acp',
+      model: 'openai-codex-acp:gpt-5.6-sol',
+    } as any);
+    const resolveWorkstream = vi.spyOn(service as any, 'resolveOrCreateWorkstream');
+
+    await expect((service as any).spawnSession(
+      CODEX_PARENT.id,
+      WORKSPACE,
+      {
+        prompt: 'Spawn with unsupported effort',
+        effortLevel: 'max',
+      },
+    )).rejects.toThrow('Supported values: none');
+    expect(resolveWorkstream).not.toHaveBeenCalled();
+    expect(AISessionsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('persists spawn topology, scope, and notification behavior before queueing', async () => {
+    const service = MetaAgentService.getInstance();
+    const { queuePromptForSession } = installAIService(service);
+    vi.spyOn(service as any, 'shouldBypassChildAgentExecutionForTests')
+      .mockReturnValue(false);
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(CODEX_PARENT as any);
+
+    const result = JSON.parse(await (service as any).spawnSession(
+      CODEX_PARENT.id,
+      WORKSPACE,
+      {
+        prompt: 'Continue independently',
+        isolated: true,
+        toolScope: 'read',
+        notifyOnComplete: false,
+      },
+    ));
+
+    expect(result.launchConfiguration.resolved).toMatchObject({
+      isolated: true,
+      worktreeMode: 'none',
+      toolScope: 'read',
+      notifyOnComplete: false,
+    });
+    expect(AISessionsRepository.updateMetadata).toHaveBeenCalledWith(
+      result.sessionId,
+      {
+        metadata: expect.objectContaining({
+          notifyParent: false,
+          toolScope: 'read',
+        }),
+      },
+    );
+    expect(
+      vi.mocked(AISessionsRepository.updateMetadata).mock.invocationCallOrder[0],
+    ).toBeLessThan(queuePromptForSession.mock.invocationCallOrder[0]);
+  });
+
+  it('returns persisted launch provenance from get_session_status', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(databaseWorker.query).mockResolvedValueOnce({
+      rows: [{
+        id: 'child-1',
+        title: 'Launch child',
+        status: 'idle',
+        last_activity: 10,
+        updated_at: 11,
+        provider: 'openai-codex',
+        model: CODEX_PARENT.model,
+        created_by_session_id: CODEX_PARENT.id,
+        agent_role: 'standard',
+        metadata: { launchConfiguration: STORED_LAUNCH_CONFIGURATION },
+      }],
+    } as any);
+
+    const status = JSON.parse(await (service as any).getSessionStatusJson(
+      'child-1',
+      WORKSPACE,
+    ));
+    expect(status.launchConfiguration).toEqual(STORED_LAUNCH_CONFIGURATION);
+    expect(status.effectiveEffortLevel).toBeUndefined();
+  });
+
+  it('returns persisted launch provenance from get_session_result', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      id: 'child-1',
+      title: 'Launch child',
+      provider: 'openai-codex',
+      model: CODEX_PARENT.model,
+      workspacePath: WORKSPACE,
+      worktreeId: null,
+      createdAt: 1,
+      updatedAt: 2,
+      metadata: { launchConfiguration: STORED_LAUNCH_CONFIGURATION },
+    } as any);
+    vi.mocked(databaseWorker.query)
+      .mockResolvedValueOnce({
+        rows: [{ status: 'idle', last_activity: 3 }],
+      } as any)
+      .mockResolvedValueOnce({ rows: [] } as any);
+
+    const result = JSON.parse(await (service as any).getSessionResultJson(
+      'child-1',
+      WORKSPACE,
+    ));
+    expect(result.launchConfiguration).toEqual(STORED_LAUNCH_CONFIGURATION);
+    expect(result.effectiveEffortLevel).toBeUndefined();
+  });
+});

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.launchConfiguration.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.launchConfiguration.test.ts
@@ -381,6 +381,11 @@ describe('MetaAgentService launch configuration', () => {
 
   it('returns persisted launch provenance from get_session_status', async () => {
     const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      id: 'child-1',
+      workspacePath: WORKSPACE,
+      createdBySessionId: CODEX_PARENT.id,
+    } as any);
     vi.mocked(databaseWorker.query).mockResolvedValueOnce({
       rows: [{
         id: 'child-1',
@@ -397,8 +402,9 @@ describe('MetaAgentService launch configuration', () => {
     } as any);
 
     const status = JSON.parse(await (service as any).getSessionStatusJson(
-      'child-1',
+      CODEX_PARENT.id,
       WORKSPACE,
+      'child-1',
     ));
     expect(status.launchConfiguration).toEqual(STORED_LAUNCH_CONFIGURATION);
     expect(status.effectiveEffortLevel).toBeUndefined();
@@ -424,8 +430,9 @@ describe('MetaAgentService launch configuration', () => {
       .mockResolvedValueOnce({ rows: [] } as any);
 
     const result = JSON.parse(await (service as any).getSessionResultJson(
-      'child-1',
+      CODEX_PARENT.id,
       WORKSPACE,
+      'child-1',
     ));
     expect(result.launchConfiguration).toEqual(STORED_LAUNCH_CONFIGURATION);
     expect(result.effectiveEffortLevel).toBeUndefined();

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.parentPromotion.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.parentPromotion.test.ts
@@ -57,7 +57,10 @@ vi.mock('electron', () => ({
 
 vi.mock('../SyncManager', () => ({ getSyncProvider: () => ({ pushChange: vi.fn() }) }));
 vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
-vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => null }));
+vi.mock('../../utils/store', () => ({
+  getDefaultAIModel: () => null,
+  getDefaultEffortLevel: () => 'high',
+}));
 vi.mock('../../utils/timestampUtils', () => ({ toMillis: (v: unknown) => v }));
 vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
 vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.projectTargeting.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.projectTargeting.test.ts
@@ -266,6 +266,66 @@ describe('MetaAgentService project-targeted session routing (NIM-408)', () => {
     });
   });
 
+  it('creates a target-project child when the creator row exists only in the source project', async () => {
+    const service = MetaAgentService.getInstance();
+    (service as any).aiService = {
+      queuePromptForSession: vi.fn(async () => ({ id: 'queue-1', prompt: 'Do the work' })),
+      triggerQueuedPromptProcessingForSession: vi.fn(async () => undefined),
+    };
+
+    vi.mocked(AISessionsRepository.get).mockImplementation(async (sessionId: string) =>
+      sessionId === 'caller' ? caller as any : null,
+    );
+    hasLiveWindowForWorkspaceMock.mockReturnValue(true);
+    createWorktreeMock.mockResolvedValue({
+      id: 'target-worktree',
+      name: 'safe-route',
+      path: '/project-b_worktrees/safe-route',
+      branch: 'worktree/safe-route',
+      baseBranch: 'integration/v12',
+      projectPath: '/project-b',
+      createdAt: 1,
+    });
+
+    const result = JSON.parse(await (service as any).spawnSession('caller', '/project-b', {
+      prompt: 'Do the work',
+      title: 'Project B owner',
+      isolated: true,
+      useWorktree: true,
+      targetWorkspacePath: '/project-b',
+      baseBranch: 'integration/v12',
+    }));
+
+    expect(hasLiveWindowForWorkspaceMock).toHaveBeenCalledWith('/project-b');
+    expect(vi.mocked(AISessionsRepository.create)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: '/project-b',
+        worktreeId: 'target-worktree',
+        createdBySessionId: 'caller',
+        parentSessionId: null,
+      }),
+    );
+    expect(result).toMatchObject({
+      isolated: true,
+      sourceWorkspacePath: '/project-a',
+      targetWorkspacePath: '/project-b',
+      worktreeId: 'target-worktree',
+      worktreePath: '/project-b_worktrees/safe-route',
+      worktreeMode: 'new',
+    });
+  });
+
+  it('fails closed when host routing differs from the creator and no target is explicit', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(caller as any);
+
+    await expect((service as any).spawnSession('caller', '/project-b', {
+      prompt: 'Do the work',
+      isolated: true,
+      useWorktree: true,
+    })).rejects.toThrow('Parent session caller not found in this workspace');
+  });
+
   it.each([
     [{ isolated: false, useWorktree: true }, 'isolated=true'],
     [{ isolated: true, useWorktree: false }, 'useWorktree=true'],

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.projectTargeting.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.projectTargeting.test.ts
@@ -1,0 +1,630 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  hasLiveWindowForWorkspaceMock,
+  createWorktreeMock,
+  worktreeStoreCreateMock,
+  worktreeStoreListMock,
+  worktreeStoreGetMock,
+  worktreeStoreGetAllNamesMock,
+  worktreeStoreGetSessionsMock,
+  databaseQueryMock,
+  queuedPromptsListMock,
+  createPriorityControlPromptMock,
+  reservePriorityInterruptMock,
+  recordPriorityInterruptReceiptMock,
+  getQueuedPromptMock,
+  setMetaAgentToolFnsMock,
+} = vi.hoisted(() => ({
+  hasLiveWindowForWorkspaceMock: vi.fn(),
+  createWorktreeMock: vi.fn(),
+  worktreeStoreCreateMock: vi.fn(),
+  worktreeStoreListMock: vi.fn(),
+  worktreeStoreGetMock: vi.fn(),
+  worktreeStoreGetAllNamesMock: vi.fn(),
+  worktreeStoreGetSessionsMock: vi.fn(),
+  databaseQueryMock: vi.fn(),
+  queuedPromptsListMock: vi.fn(),
+  createPriorityControlPromptMock: vi.fn(),
+  reservePriorityInterruptMock: vi.fn(),
+  recordPriorityInterruptReceiptMock: vi.fn(),
+  getQueuedPromptMock: vi.fn(),
+  setMetaAgentToolFnsMock: vi.fn(),
+}));
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    create: vi.fn(),
+    updateMetadata: vi.fn(),
+    get: vi.fn(),
+  },
+  AgentMessagesRepository: {
+    create: vi.fn(),
+    list: vi.fn().mockResolvedValue([]),
+  },
+  SessionFilesRepository: {
+    getFilesBySession: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  SessionManager: class {
+    async initialize() {}
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: {
+    parse: (id: string) => {
+      const split = id.indexOf(':');
+      if (split <= 0) throw new Error(`invalid model: ${id}`);
+      return { provider: id.slice(0, split), model: id.slice(split + 1), combined: id };
+    },
+    tryParse: (id: string) => {
+      const split = typeof id === 'string' ? id.indexOf(':') : -1;
+      return split > 0
+        ? { provider: id.slice(0, split), model: id.slice(split + 1), combined: id }
+        : null;
+    },
+    getDefaultModelId: (provider: string) => `${provider}:default`,
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn(() => () => {}) }),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+vi.mock('../../window/windowState', () => ({
+  hasLiveWindowForWorkspace: hasLiveWindowForWorkspaceMock,
+}));
+
+vi.mock('../../utils/workspaceDetection', () => ({
+  resolveProjectPath: (workspacePath: string) => workspacePath,
+}));
+
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({
+  getDefaultAIModel: () => 'openai-codex:gpt-5.6-terra',
+  getDefaultEffortLevel: () => undefined,
+}));
+vi.mock('../../utils/timestampUtils', () => ({ toMillis: (value: unknown) => value }));
+vi.mock('../WorktreeStore', () => ({
+  createWorktreeStore: () => ({
+    create: worktreeStoreCreateMock,
+    list: worktreeStoreListMock,
+    get: worktreeStoreGetMock,
+    getAllNames: worktreeStoreGetAllNamesMock,
+    getWorktreeSessions: worktreeStoreGetSessionsMock,
+  }),
+}));
+vi.mock('../GitWorktreeService', () => ({
+  GitWorktreeService: class {
+    createWorktree = createWorktreeMock;
+    getExistingWorktreeDirectories = vi.fn(() => []);
+    getAllBranchNames = vi.fn(async () => []);
+    generateUniqueWorktreeName = vi.fn(() => 'safe-route');
+  },
+}));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({
+  database: { query: databaseQueryMock },
+}));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => ({}) }));
+vi.mock('../../file/GitRefWatcher', () => ({
+  gitRefWatcher: { start: vi.fn(async () => undefined) },
+}));
+vi.mock('../RepositoryManager', () => ({
+  getQueuedPromptsStore: () => ({
+    listForSession: queuedPromptsListMock,
+    createPriorityControlPrompt: createPriorityControlPromptMock,
+    reservePriorityInterrupt: reservePriorityInterruptMock,
+    recordPriorityInterruptReceipt: recordPriorityInterruptReceiptMock,
+    get: getQueuedPromptMock,
+  }),
+}));
+vi.mock('../ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({ setMetaAgentToolFns: setMetaAgentToolFnsMock }));
+vi.mock('../metaAgentNotificationSignature', () => ({ computeNotificationSignature: vi.fn() }));
+vi.mock('../metaAgentMessageText', () => ({
+  extractMessageText: vi.fn(),
+  extractUserPrompts: vi.fn(() => []),
+}));
+
+import { AISessionsRepository } from '@nimbalyst/runtime';
+import { setMetaAgentToolFns } from '../../mcp/metaAgentServer';
+import { MetaAgentService } from '../MetaAgentService';
+
+const caller = {
+  id: 'caller',
+  workspacePath: '/project-a',
+  provider: 'openai-codex',
+  model: 'openai-codex:gpt-5.6-terra',
+  worktreeId: null,
+  parentSessionId: null,
+  sessionType: 'session',
+};
+
+const targetChild = {
+  id: 'target-child',
+  workspacePath: '/project-b',
+  provider: 'openai-codex',
+  model: 'openai-codex:gpt-5.6-terra',
+  createdBySessionId: 'caller',
+  worktreeId: 'target-worktree',
+  worktreePath: '/project-b_worktrees/safe-route',
+  title: 'Target child',
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+describe('MetaAgentService project-targeted session routing (NIM-408)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    hasLiveWindowForWorkspaceMock.mockReset();
+    createWorktreeMock.mockReset();
+    worktreeStoreCreateMock.mockReset();
+    worktreeStoreListMock.mockReset();
+    worktreeStoreGetMock.mockReset();
+    worktreeStoreGetAllNamesMock.mockReset().mockResolvedValue([]);
+    worktreeStoreGetSessionsMock.mockReset();
+    databaseQueryMock.mockReset().mockResolvedValue({ rows: [{ in_flight: '0', total: '0' }] });
+    queuedPromptsListMock.mockReset().mockResolvedValue([]);
+    const priorityRow = {
+      id: 'control-project-b',
+      sessionId: 'target-child',
+      status: 'pending',
+      deliveryClass: 'control',
+      priorityRank: 100,
+      deliveryReady: false,
+      interruptTargetGeneration: null,
+      interruptReservationOwner: null,
+      interruptReceipt: null,
+    };
+    createPriorityControlPromptMock.mockReset().mockResolvedValue({
+      row: priorityRow,
+      replayed: false,
+    });
+    reservePriorityInterruptMock.mockReset().mockImplementation(
+      async ({ generation, owner }) => ({
+        row: {
+          ...priorityRow,
+          interruptTargetGeneration: generation,
+          interruptReservationOwner: owner,
+        },
+        reserved: true,
+      }),
+    );
+    recordPriorityInterruptReceiptMock.mockReset().mockImplementation(
+      async ({ generation, receipt }) => ({
+        ...priorityRow,
+        status: 'executing',
+        interruptTargetGeneration: generation,
+        interruptReservationOwner: 'owner-project-b',
+        interruptReceipt: receipt,
+      }),
+    );
+    getQueuedPromptMock.mockReset().mockResolvedValue(priorityRow);
+    setMetaAgentToolFnsMock.mockReset();
+    vi.mocked(AISessionsRepository.get).mockReset();
+    vi.mocked(AISessionsRepository.create).mockReset();
+    vi.mocked(AISessionsRepository.updateMetadata).mockReset();
+  });
+
+  it('creates an isolated fresh worktree session in an already-loaded target project', async () => {
+    const service = MetaAgentService.getInstance();
+    (service as any).aiService = {
+      queuePromptForSession: vi.fn(async () => ({ id: 'queue-1', prompt: 'Do the work' })),
+      triggerQueuedPromptProcessingForSession: vi.fn(async () => undefined),
+    };
+
+    vi.mocked(AISessionsRepository.get).mockImplementation(async (sessionId: string) =>
+      sessionId === 'caller' ? caller as any : null,
+    );
+    hasLiveWindowForWorkspaceMock.mockReturnValue(true);
+    createWorktreeMock.mockResolvedValue({
+      id: 'target-worktree',
+      name: 'safe-route',
+      path: '/project-b_worktrees/safe-route',
+      branch: 'worktree/safe-route',
+      baseBranch: 'integration/v12',
+      projectPath: '/project-b',
+      createdAt: 1,
+    });
+
+    const result = JSON.parse(await (service as any).spawnSession('caller', '/project-a', {
+      prompt: 'Do the work',
+      title: 'Project B owner',
+      isolated: true,
+      useWorktree: true,
+      targetWorkspacePath: '/project-b',
+      baseBranch: 'integration/v12',
+    }));
+
+    expect(hasLiveWindowForWorkspaceMock).toHaveBeenCalledWith('/project-b');
+    expect(createWorktreeMock).toHaveBeenCalledWith('/project-b', {
+      name: 'safe-route',
+      baseBranch: 'integration/v12',
+    });
+    expect(vi.mocked(AISessionsRepository.create)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: '/project-b',
+        worktreeId: 'target-worktree',
+        createdBySessionId: 'caller',
+        parentSessionId: null,
+      }),
+    );
+    expect(result).toMatchObject({
+      isolated: true,
+      sourceWorkspacePath: '/project-a',
+      targetWorkspacePath: '/project-b',
+      worktreeId: 'target-worktree',
+      worktreePath: '/project-b_worktrees/safe-route',
+      worktreeMode: 'new',
+    });
+  });
+
+  it.each([
+    [{ isolated: false, useWorktree: true }, 'isolated=true'],
+    [{ isolated: true, useWorktree: false }, 'useWorktree=true'],
+  ])('fails closed when cross-project creation omits a custody gate', async (flags, expected) => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(caller as any);
+    hasLiveWindowForWorkspaceMock.mockReturnValue(true);
+
+    await expect((service as any).spawnSession('caller', '/project-a', {
+      prompt: 'Do the work',
+      targetWorkspacePath: '/project-b',
+      ...flags,
+    })).rejects.toThrow(expected);
+  });
+
+  it('fails closed when the target project is not loaded in Nimbalyst', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(caller as any);
+    hasLiveWindowForWorkspaceMock.mockReturnValue(false);
+
+    await expect((service as any).spawnSession('caller', '/project-a', {
+      prompt: 'Do the work',
+      isolated: true,
+      useWorktree: true,
+      targetWorkspacePath: '/project-b',
+    })).rejects.toThrow('already-loaded target project');
+  });
+
+  it('allows the creator to supervise its cross-project child but hides unrelated sessions', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.mocked(AISessionsRepository.get).mockImplementation(async (sessionId: string) => {
+      if (sessionId === 'target-child') return targetChild as any;
+      if (sessionId === 'unrelated') {
+        return { ...targetChild, id: 'unrelated', createdBySessionId: 'someone-else' } as any;
+      }
+      return null;
+    });
+    databaseQueryMock.mockResolvedValueOnce({
+      rows: [{
+        id: 'target-child',
+        title: 'Target child',
+        provider: 'openai-codex',
+        model: 'openai-codex:gpt-5.6-terra',
+        status: 'idle',
+        last_activity: 1,
+        updated_at: 2,
+        created_by_session_id: 'caller',
+        agent_role: 'standard',
+      }],
+    });
+
+    const status = JSON.parse(await (service as any).getSessionStatusJson(
+      'caller',
+      '/project-a',
+      'target-child',
+    ));
+    expect(status.sessionId).toBe('target-child');
+    expect(databaseQueryMock).toHaveBeenCalledWith(
+      expect.stringContaining('workspace_id = $2'),
+      ['target-child', '/project-b'],
+    );
+
+    await expect((service as any).getSessionStatusJson(
+      'caller',
+      '/project-a',
+      'unrelated',
+    )).rejects.toThrow('Session unrelated not found');
+  });
+
+  it('keeps result, queue, prompt, and interactive-reply custody in the target workspace', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.spyOn(service as any, 'shouldBypassChildAgentExecutionForTests').mockReturnValue(false);
+    const queuePromptForSession = vi.fn(async () => ({ id: 'queue-2', prompt: 'Continue' }));
+    const triggerQueuedPromptProcessingForSession = vi.fn(async () => undefined);
+    const respondToInteractivePrompt = vi.fn(async () => ({ success: true }));
+    (service as any).aiService = {
+      queuePromptForSession,
+      triggerQueuedPromptProcessingForSession,
+      respondToInteractivePrompt,
+    };
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(targetChild as any);
+    queuedPromptsListMock.mockResolvedValue([{
+      id: 'queue-1',
+      status: 'pending',
+      prompt: 'Initial',
+      createdAt: 1,
+    }]);
+
+    const buildResultSpy = vi.spyOn(service as any, 'buildSessionResultData').mockResolvedValue({
+      sessionId: 'target-child',
+      title: 'Target child',
+      provider: 'openai-codex',
+      model: 'openai-codex:gpt-5.6-terra',
+      status: 'idle',
+      lastActivity: 1,
+      originalPrompt: 'Initial',
+      userPrompts: ['Initial'],
+      lastResponse: null,
+      fullResponse: null,
+      recentMessages: [],
+      editedFiles: [],
+      pendingPrompt: null,
+      createdAt: 1,
+      updatedAt: 2,
+      worktreeId: 'target-worktree',
+      toolScope: null,
+    });
+
+    await (service as any).getSessionResultJson('caller', '/project-a', 'target-child', {
+      includeFullResponse: false,
+    });
+    expect(buildResultSpy).toHaveBeenCalledWith(
+      'target-child',
+      '/project-b',
+      undefined,
+      false,
+    );
+
+    const queue = JSON.parse(await (service as any).listQueuedPromptsJson(
+      'caller',
+      '/project-a',
+      'target-child',
+      {},
+    ));
+    expect(queue.prompts[0].id).toBe('queue-1');
+
+    databaseQueryMock.mockResolvedValueOnce({
+      rows: [{
+        id: 'target-child',
+        title: 'Target child',
+        provider: 'openai-codex',
+        model: 'openai-codex:gpt-5.6-terra',
+        status: 'idle',
+        last_activity: 1,
+        updated_at: 2,
+        created_by_session_id: 'caller',
+        agent_role: 'standard',
+      }],
+    });
+    const sent = JSON.parse(await (service as any).sendPromptToSession(
+      'caller',
+      '/project-a',
+      'target-child',
+      'Continue',
+    ));
+    expect(sent.processingTriggered).toBe(true);
+    expect(triggerQueuedPromptProcessingForSession).toHaveBeenCalledWith(
+      'target-child',
+      '/project-b_worktrees/safe-route',
+    );
+
+    await (service as any).respondToPrompt('caller', '/project-a', {
+      sessionId: 'target-child',
+      promptId: 'prompt-1',
+      promptType: 'ask_user_question_request',
+      response: { answers: { question: 'answer' } },
+    });
+    expect(respondToInteractivePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'target-child', promptId: 'prompt-1' }),
+    );
+  });
+
+  it('routes send_prompt_now to the creator-owned project-B child and hides unrelated sessions', async () => {
+    const service = MetaAgentService.getInstance();
+    const targetState = {
+      status: 'idle',
+      generation: 'idle:1:2',
+      lastActivity: 1,
+      updatedAt: 2,
+    };
+    const getPriorityTargetStateSpy = vi.spyOn(
+      service as any,
+      'getPriorityTargetState',
+    ).mockResolvedValue(targetState);
+    vi.spyOn(service as any, 'getPendingInteractivePrompt').mockResolvedValue(null);
+    const triggerQueuedPromptProcessingForSession = vi.fn(async () => true);
+    (service as any).aiService = {
+      interruptCurrentTurnForSession: vi.fn(),
+      triggerQueuedPromptProcessingForSession,
+    };
+    vi.mocked(AISessionsRepository.get).mockImplementation(async (sessionId: string) => {
+      if (sessionId === 'target-child') return targetChild as any;
+      if (sessionId === 'unrelated') {
+        return { ...targetChild, id: 'unrelated', createdBySessionId: 'someone-else' } as any;
+      }
+      return null;
+    });
+
+    const receipt = JSON.parse(await (service as any).sendPromptNowToSession(
+      'caller',
+      '/project-a',
+      {
+        sessionId: 'target-child',
+        prompt: 'Priority directive',
+        idempotencyKey: 'project-b-priority-1',
+      },
+    ));
+
+    expect(receipt).toMatchObject({
+      sessionId: 'target-child',
+      action: 'processing_triggered',
+      processingTriggerCalled: true,
+      processingTriggerAccepted: true,
+    });
+    expect(getPriorityTargetStateSpy).toHaveBeenCalledWith(
+      'target-child',
+      '/project-b',
+    );
+    expect(triggerQueuedPromptProcessingForSession).toHaveBeenCalledWith(
+      'target-child',
+      '/project-b_worktrees/safe-route',
+    );
+
+    await expect((service as any).sendPromptNowToSession(
+      'caller',
+      '/project-a',
+      {
+        sessionId: 'unrelated',
+        prompt: 'Unauthorized directive',
+        idempotencyKey: 'project-b-priority-2',
+      },
+    )).rejects.toThrow('Session unrelated not found');
+  });
+
+  it('lists creator-owned children across projects with workspace and launch provenance', async () => {
+    const service = MetaAgentService.getInstance();
+    const launchConfiguration = {
+      requested: { model: null },
+      resolved: { model: 'openai-codex:gpt-5.6-terra' },
+      effectiveness: 'not-provider-confirmed',
+    };
+    databaseQueryMock.mockResolvedValueOnce({
+      rows: [{
+        id: 'target-child',
+        title: 'Target child',
+        provider: 'openai-codex',
+        model: 'openai-codex:gpt-5.6-terra',
+        status: 'idle',
+        last_activity: 1,
+        created_at: 1,
+        updated_at: 2,
+        worktree_id: 'target-worktree',
+        created_by_session_id: 'caller',
+        agent_role: 'standard',
+        workspace_id: '/project-b',
+        metadata: JSON.stringify({ launchConfiguration }),
+      }],
+    });
+    const buildResultSpy = vi.spyOn(
+      service as any,
+      'buildSessionResultData',
+    ).mockResolvedValue({
+      sessionId: 'target-child',
+      title: 'Target child',
+      provider: 'openai-codex',
+      model: 'openai-codex:gpt-5.6-terra',
+      status: 'idle',
+      lastActivity: 1,
+      originalPrompt: 'Initial',
+      userPrompts: ['Initial'],
+      lastResponse: null,
+      fullResponse: null,
+      recentMessages: [],
+      editedFiles: [],
+      pendingPrompt: null,
+      createdAt: 1,
+      updatedAt: 2,
+      worktreeId: 'target-worktree',
+      toolScope: null,
+      launchConfiguration,
+    });
+
+    const sessions = await (service as any).getSpawnedSessions('caller', '/project-a');
+
+    expect(databaseQueryMock).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE created_by_session_id = $1'),
+      ['caller'],
+    );
+    expect(buildResultSpy).toHaveBeenCalledWith(
+      'target-child',
+      '/project-b',
+      expect.objectContaining({
+        metadata: JSON.stringify({ launchConfiguration }),
+      }),
+      false,
+    );
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        sessionId: 'target-child',
+        workspacePath: '/project-b',
+        launchConfiguration,
+      }),
+    ]);
+  });
+
+  it('exposes creation and supervision through the injected MCP tool route', async () => {
+    const service = MetaAgentService.getInstance();
+    vi.spyOn(service as any, 'shouldBypassChildAgentExecutionForTests').mockReturnValue(false);
+    const aiService = {
+      queuePromptForSession: vi.fn(async (_sessionId: string, prompt: string) => ({
+        id: 'queue-public',
+        prompt,
+      })),
+      triggerQueuedPromptProcessingForSession: vi.fn(async () => undefined),
+    };
+    await service.start(aiService as any, vi.fn());
+
+    const fns = vi.mocked(setMetaAgentToolFns).mock.calls[0][0];
+    let createdSessionId = '';
+    vi.mocked(AISessionsRepository.get).mockImplementation(async (sessionId: string) => {
+      if (sessionId === 'caller') return caller as any;
+      if (sessionId === createdSessionId) {
+        return { ...targetChild, id: createdSessionId } as any;
+      }
+      return null;
+    });
+    vi.mocked(AISessionsRepository.create).mockImplementation(async (input: any) => {
+      createdSessionId = input.id;
+      return input;
+    });
+    hasLiveWindowForWorkspaceMock.mockReturnValue(true);
+    createWorktreeMock.mockResolvedValue({
+      id: 'target-worktree',
+      name: 'safe-route',
+      path: '/project-b_worktrees/safe-route',
+      branch: 'worktree/safe-route',
+      baseBranch: 'integration/v12',
+      projectPath: '/project-b',
+      createdAt: 1,
+    });
+
+    const spawned = JSON.parse(await fns.spawnSession('caller', '/project-a', {
+      prompt: 'Do the work',
+      isolated: true,
+      useWorktree: true,
+      targetWorkspacePath: '/project-b',
+      baseBranch: 'integration/v12',
+    }));
+    expect(spawned.sessionId).toBe(createdSessionId);
+    expect(spawned.targetWorkspacePath).toBe('/project-b');
+
+    databaseQueryMock.mockResolvedValueOnce({
+      rows: [{
+        id: createdSessionId,
+        title: 'Target child',
+        provider: 'openai-codex',
+        model: 'openai-codex:gpt-5.6-terra',
+        status: 'idle',
+        last_activity: 1,
+        updated_at: 2,
+        created_by_session_id: 'caller',
+        agent_role: 'standard',
+      }],
+    });
+    const status = JSON.parse(await fns.getSessionStatus(
+      'caller',
+      '/project-a',
+      createdSessionId,
+    ));
+    expect(status).toMatchObject({ sessionId: createdSessionId, status: 'idle' });
+  });
+});

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.providerInheritance.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.providerInheritance.test.ts
@@ -72,7 +72,10 @@ vi.mock('electron', () => ({
 
 vi.mock('../SyncManager', () => ({ getSyncProvider: () => ({ pushChange: vi.fn() }) }));
 vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
-vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => null }));
+vi.mock('../../utils/store', () => ({
+  getDefaultAIModel: () => null,
+  getDefaultEffortLevel: () => 'high',
+}));
 vi.mock('../../utils/timestampUtils', () => ({ toMillis: (v: unknown) => v }));
 vi.mock('../WorktreeStore', () => ({ createWorktreeStore: vi.fn() }));
 vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));

--- a/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.priorityControl.sqlite.test.ts
+++ b/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.priorityControl.sqlite.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SQLiteDatabase } from '../../database/sqlite/SQLiteDatabase';
+import { createSQLiteStoreAdapter } from '../../database/sqlite/SQLiteStoreAdapter';
+import { createPGLiteQueuedPromptsStore } from '../PGLiteQueuedPromptsStore';
+
+describe('PGLiteQueuedPromptsStore priority control rows on SQLite', () => {
+  let tmpDir: string;
+  let database: SQLiteDatabase;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nim-priority-queue-'));
+    database = new SQLiteDatabase({
+      dbDir: tmpDir,
+      schemaDir: path.resolve(__dirname, '../../database/sqlite/schemas'),
+      slowQueryThresholdMs: 1000,
+      sampleRate: 0,
+    });
+    await database.initialize();
+    await database.query(
+      `INSERT INTO ai_sessions (id, workspace_id, provider, title)
+       VALUES ($1, $2, $3, $4)`,
+      ['session-1', 'D:\\repo', 'openai-codex', 'Target'],
+    );
+  });
+
+  afterEach(async () => {
+    await database.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('keeps ordinary prompts FIFO while control rows sort first', async () => {
+    const store = createPGLiteQueuedPromptsStore(createSQLiteStoreAdapter(database));
+    await store.create({ id: 'ordinary-1', sessionId: 'session-1', prompt: 'first' });
+    await store.create({ id: 'ordinary-2', sessionId: 'session-1', prompt: 'second' });
+    await store.createPriorityControlPrompt({
+      id: 'control-1',
+      sessionId: 'session-1',
+      prompt: 'priority',
+      producer: 'send_prompt_now:caller',
+      idempotencyKey: 'priority:key-1',
+      requestDigest: 'digest-1',
+      controlOperation: 'operator_directive',
+    });
+
+    expect((await store.listPending('session-1')).map((row) => row.id)).toEqual([
+      'ordinary-1',
+      'ordinary-2',
+    ]);
+    await expect(store.claim('control-1')).resolves.toBeNull();
+    await store.reservePriorityInterrupt({
+      promptId: 'control-1',
+      generation: 'idle:10:20',
+      owner: 'owner-1',
+    });
+    await store.recordPriorityInterruptReceipt({
+      promptId: 'control-1',
+      generation: 'idle:10:20',
+      receipt: {
+        generation: 'idle:10:20',
+        attempted: false,
+        success: true,
+        method: 'not-required',
+        error: null,
+        nativeEntered: false,
+        recordedAt: 30,
+      },
+    });
+    expect((await store.listPending('session-1')).map((row) => row.id)).toEqual([
+      'control-1',
+      'ordinary-1',
+      'ordinary-2',
+    ]);
+    expect(await store.listPendingSessionIds({ deliveryClass: 'ordinary' }))
+      .toEqual(['session-1']);
+  });
+
+  it('replays the same durable row and rejects idempotency-key reuse', async () => {
+    const store = createPGLiteQueuedPromptsStore(createSQLiteStoreAdapter(database));
+    const input = {
+      id: 'control-1',
+      sessionId: 'session-1',
+      prompt: 'priority',
+      producer: 'send_prompt_now:caller',
+      idempotencyKey: 'priority:key-1',
+      requestDigest: 'digest-1',
+      controlOperation: 'operator_directive',
+    };
+
+    await expect(store.createPriorityControlPrompt(input)).resolves.toMatchObject({
+      replayed: false,
+      row: { id: 'control-1', deliveryClass: 'control', priorityRank: 100 },
+    });
+    await expect(store.createPriorityControlPrompt({ ...input, id: 'control-2' }))
+      .resolves.toMatchObject({
+        replayed: true,
+        row: { id: 'control-1' },
+      });
+    await expect(store.createPriorityControlPrompt({
+      ...input,
+      id: 'control-3',
+      requestDigest: 'different-digest',
+    })).rejects.toThrow(/idempotency_conflict/);
+  });
+
+  it('reserves and records one interrupt receipt durably', async () => {
+    const store = createPGLiteQueuedPromptsStore(createSQLiteStoreAdapter(database));
+    await store.createPriorityControlPrompt({
+      id: 'control-1',
+      sessionId: 'session-1',
+      prompt: 'priority',
+      producer: 'send_prompt_now:caller',
+      idempotencyKey: 'priority:key-1',
+      requestDigest: 'digest-1',
+      controlOperation: 'operator_directive',
+    });
+
+    await expect(store.reservePriorityInterrupt({
+      promptId: 'control-1',
+      generation: 'running:10:20',
+      owner: 'owner-1',
+    })).resolves.toMatchObject({
+      reserved: true,
+      row: {
+        interruptTargetGeneration: 'running:10:20',
+        interruptReservationOwner: 'owner-1',
+      },
+    });
+    await expect(store.reservePriorityInterrupt({
+      promptId: 'control-1',
+      generation: 'running:10:20',
+      owner: 'owner-2',
+    })).resolves.toMatchObject({ reserved: false });
+
+    const receipt = {
+      generation: 'running:10:20',
+      attempted: true,
+      success: true,
+      method: 'interrupt',
+      error: null,
+      nativeEntered: true,
+      recordedAt: 30,
+    };
+    await expect(store.recordPriorityInterruptReceipt({
+      promptId: 'control-1',
+      generation: receipt.generation,
+      receipt,
+    })).resolves.toMatchObject({ interruptReceipt: receipt });
+    await expect(store.listPending('session-1')).resolves.toMatchObject([
+      { id: 'control-1', deliveryReady: true },
+    ]);
+    await expect(store.get('control-1')).resolves.toMatchObject({
+      interruptReceipt: receipt,
+    });
+  });
+});

--- a/packages/electron/src/main/services/__tests__/PriorityPromptDeliveryService.test.ts
+++ b/packages/electron/src/main/services/__tests__/PriorityPromptDeliveryService.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createPriorityPromptDeliveryService,
+  type PriorityControlPrompt,
+  type PriorityInterruptReceipt,
+  type PriorityTargetState,
+} from '../PriorityPromptDeliveryService';
+
+const SESSION_ID = 'target-session';
+const WORKSPACE = 'D:\\repo';
+
+function controlRow(overrides: Partial<PriorityControlPrompt> = {}): PriorityControlPrompt {
+  return {
+    id: 'control-row-1',
+    sessionId: SESSION_ID,
+    status: 'pending',
+    deliveryClass: 'control',
+    priorityRank: 100,
+    deliveryReady: false,
+    interruptTargetGeneration: null,
+    interruptReservationOwner: null,
+    interruptReceipt: null,
+    ...overrides,
+  };
+}
+
+function state(
+  status: PriorityTargetState['status'],
+  generation = `${status}:10:20`,
+): PriorityTargetState {
+  return {
+    status,
+    generation,
+    lastActivity: 10,
+    updatedAt: 20,
+  };
+}
+
+describe('PriorityPromptDeliveryService', () => {
+  const createControlPrompt = vi.fn();
+  const getTargetState = vi.fn();
+  const hasStructuredPendingPrompt = vi.fn();
+  const reserveInterrupt = vi.fn();
+  const recordInterruptReceipt = vi.fn();
+  const interruptCurrentTurn = vi.fn();
+  const triggerProcessing = vi.fn();
+  const getControlPrompt = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createControlPrompt.mockResolvedValue({
+      row: controlRow(),
+      replayed: false,
+    });
+    getTargetState.mockResolvedValue(state('idle'));
+    hasStructuredPendingPrompt.mockResolvedValue(false);
+    reserveInterrupt.mockImplementation(async ({ generation, owner }) => ({
+      row: controlRow({
+        interruptTargetGeneration: generation,
+        interruptReservationOwner: owner,
+      }),
+      reserved: true,
+    }));
+    recordInterruptReceipt.mockImplementation(async ({ receipt }) =>
+      controlRow({
+        status: 'executing',
+        interruptTargetGeneration: receipt.generation,
+        interruptReservationOwner: 'owner-1',
+        interruptReceipt: receipt,
+      }),
+    );
+    interruptCurrentTurn.mockResolvedValue({
+      success: true,
+      method: 'interrupt',
+      nativeEntered: true,
+    });
+    triggerProcessing.mockResolvedValue(true);
+    getControlPrompt.mockResolvedValue(controlRow({ status: 'executing' }));
+  });
+
+  function createService() {
+    return createPriorityPromptDeliveryService({
+      createControlPrompt,
+      getTargetState,
+      hasStructuredPendingPrompt,
+      reserveInterrupt,
+      recordInterruptReceipt,
+      interruptCurrentTurn,
+      triggerProcessing,
+      getControlPrompt,
+      createReservationOwner: () => 'owner-1',
+    });
+  }
+
+  it('interrupts an ordinary-text waiting session only with explicit authority', async () => {
+    getTargetState
+      .mockResolvedValueOnce(state('waiting_for_input'))
+      .mockResolvedValueOnce(state('waiting_for_input'))
+      .mockResolvedValueOnce(state('running', 'running:30:40'));
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Approved; continue',
+      idempotencyKey: 'reply-1',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'waiting_reply',
+      interruptWaitingForInput: true,
+    });
+
+    expect(hasStructuredPendingPrompt).toHaveBeenCalledWith(SESSION_ID);
+    expect(reserveInterrupt).toHaveBeenCalledWith(expect.objectContaining({
+      generation: 'waiting_for_input:10:20',
+    }));
+    expect(interruptCurrentTurn).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ generation: 'waiting_for_input:10:20' }),
+    );
+    expect(triggerProcessing).toHaveBeenCalledWith(SESSION_ID, WORKSPACE);
+    expect(result).toMatchObject({
+      action: 'interrupt_attempted',
+      processingTriggerCalled: true,
+      processingTriggerAccepted: true,
+      interrupt: {
+        attempted: true,
+        success: true,
+      },
+    });
+  });
+
+  it('durably releases an idle control row before triggering queue processing', async () => {
+    getTargetState
+      .mockResolvedValueOnce(state('idle'))
+      .mockResolvedValueOnce(state('idle'))
+      .mockResolvedValueOnce(state('running', 'running:30:40'));
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Start now',
+      idempotencyKey: 'idle-1',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'operator_directive',
+      interruptWaitingForInput: false,
+    });
+
+    expect(interruptCurrentTurn).not.toHaveBeenCalled();
+    expect(recordInterruptReceipt).toHaveBeenCalledWith(expect.objectContaining({
+      receipt: expect.objectContaining({
+        attempted: false,
+        success: true,
+        method: 'not-required',
+        nativeEntered: false,
+      }),
+    }));
+    expect(recordInterruptReceipt.mock.invocationCallOrder[0])
+      .toBeLessThan(triggerProcessing.mock.invocationCallOrder[0]);
+    expect(result).toMatchObject({
+      action: 'processing_triggered',
+      processingTriggerCalled: true,
+      processingTriggerAccepted: true,
+    });
+  });
+
+  it('leaves a waiting answer queued when interruption authority is absent', async () => {
+    getTargetState.mockResolvedValue(state('waiting_for_input'));
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Continue',
+      idempotencyKey: 'reply-2',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'waiting_reply',
+      interruptWaitingForInput: false,
+    });
+
+    expect(reserveInterrupt).not.toHaveBeenCalled();
+    expect(interruptCurrentTurn).not.toHaveBeenCalled();
+    expect(triggerProcessing).not.toHaveBeenCalled();
+    expect(result.action).toBe('queued_waiting_for_authority');
+  });
+
+  it('requires respond_to_prompt for a structured pending prompt', async () => {
+    getTargetState.mockResolvedValue(state('waiting_for_input'));
+    hasStructuredPendingPrompt.mockResolvedValue(true);
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Approve',
+      idempotencyKey: 'reply-3',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'waiting_reply',
+      interruptWaitingForInput: true,
+    });
+
+    expect(reserveInterrupt).not.toHaveBeenCalled();
+    expect(interruptCurrentTurn).not.toHaveBeenCalled();
+    expect(result.action).toBe('structured_prompt_requires_response');
+  });
+
+  it('fails closed when the lifecycle changes after reservation', async () => {
+    getTargetState
+      .mockResolvedValueOnce(state('running', 'running:10:20'))
+      .mockResolvedValueOnce(state('idle', 'idle:30:40'))
+      .mockResolvedValueOnce(state('idle', 'idle:30:40'));
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Act now',
+      idempotencyKey: 'directive-1',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'operator_directive',
+      interruptWaitingForInput: false,
+    });
+
+    expect(interruptCurrentTurn).not.toHaveBeenCalled();
+    expect(recordInterruptReceipt).toHaveBeenCalledWith(expect.objectContaining({
+      receipt: expect.objectContaining({
+        success: false,
+        nativeEntered: false,
+        error: 'stale lifecycle generation',
+      }),
+    }));
+    expect(result.action).toBe('stale_generation_rejected');
+  });
+
+  it('replays a durable interrupt receipt without interrupting twice', async () => {
+    const receipt: PriorityInterruptReceipt = {
+      generation: 'running:10:20',
+      attempted: true,
+      success: true,
+      method: 'interrupt',
+      error: null,
+      nativeEntered: true,
+      recordedAt: 30,
+    };
+    createControlPrompt.mockResolvedValue({
+      row: controlRow({
+        status: 'executing',
+        interruptTargetGeneration: receipt.generation,
+        interruptReceipt: receipt,
+      }),
+      replayed: true,
+    });
+    getControlPrompt.mockResolvedValue(controlRow({
+      status: 'executing',
+      interruptTargetGeneration: receipt.generation,
+      interruptReceipt: receipt,
+    }));
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Act now',
+      idempotencyKey: 'directive-2',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'operator_directive',
+      interruptWaitingForInput: false,
+    });
+
+    expect(reserveInterrupt).not.toHaveBeenCalled();
+    expect(interruptCurrentTurn).not.toHaveBeenCalled();
+    expect(result.action).toBe('interrupt_receipt_replayed');
+    expect(result.interrupt).toMatchObject({ attempted: true, success: true });
+  });
+});

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -181,10 +181,10 @@ export class AIService {
   // so file edits are linked to tool calls promptly (not just at session end).
   private matchDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-  // Track sessions currently processing a queued prompt to prevent concurrent execution.
-  // Without this, the completion handler and triggerQueueProcessing IPC can race,
-  // each claiming a different prompt and sending both to the AI concurrently.
-  private sessionsProcessingQueue = new Set<string>();
+  // Track the owning lease for each queued-prompt dispatch. Interrupts revoke
+  // the prior lease before priority delivery; a stale dispatch may settle
+  // afterward, but cannot release a newer dispatch's lease or drain FIFO.
+  private queueProcessingLeases = new Map<string, symbol>();
 
   // Track mobile session creation requests to prevent duplicate processing
   // (can happen if the same request is delivered multiple times)
@@ -405,7 +405,7 @@ export class AIService {
     }
 
     const sweepInterruptedQueue = async () => {
-      this.sessionsProcessingQueue.delete(sessionId);
+      this.queueProcessingLeases.delete(sessionId);
       try {
         const { getQueuedPromptsStore } = await import('../RepositoryManager');
         const queueStore = getQueuedPromptsStore();
@@ -915,7 +915,7 @@ export class AIService {
       },
       onChainSettled: async ({ sessionId: settledSessionId, source: settledSource }) => {
         // The completion handler in MessageStreamingHandler deferred endSession
-        // because processingSet still contained this session while the inner
+        // because processingLeases still contained this session while the inner
         // sendMessage was running. Now that the chain has fully drained, mark
         // the session idle and stop its file watcher.
         const stateManager = getSessionStateManager();
@@ -934,7 +934,7 @@ export class AIService {
           promptId,
         });
       },
-      processingSet: this.sessionsProcessingQueue,
+      processingLeases: this.queueProcessingLeases,
       queueStore,
       sendMessageHandler: this.sendMessageHandler,
       sessionId,
@@ -3003,7 +3003,7 @@ export class AIService {
         // marked completed instead of rolled back, so the queue trigger
         // that follows the abort doesn't immediately re-claim and re-send
         // the same input (NIM-615).
-        this.sessionsProcessingQueue.delete(sessionId);
+        this.queueProcessingLeases.delete(sessionId);
         try {
           const { getQueuedPromptsStore } = await import('../RepositoryManager');
           const queueStore = getQueuedPromptsStore();
@@ -3033,7 +3033,7 @@ export class AIService {
     // distinguish the two paths.
     //
     // Defensive cleanup runs before the interrupt: clear the in-memory
-    // sessionsProcessingQueue guard and unwedge any PGLite rows stuck in
+    // queueProcessingLeases guard and unwedge any PGLite rows stuck in
     // 'executing' via sweepExecutingForSession (delivery-aware -- already
     // delivered prompts are marked completed, not rolled back, so the
     // follow-up ai:triggerQueueProcessing doesn't re-send the same input

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -186,6 +186,16 @@ export class AIService {
   // afterward, but cannot release a newer dispatch's lease or drain FIFO.
   private queueProcessingLeases = new Map<string, symbol>();
 
+  /**
+   * Exposes the dispatch-owned lease guard to the streaming lifecycle without
+   * reviving the old broad processing set. A newer priority dispatch owns a
+   * distinct lease, so stale completion/error handlers can only observe the
+   * current owner through this map.
+   */
+  hasActiveQueueLease(sessionId: string): boolean {
+    return this.queueProcessingLeases.has(sessionId);
+  }
+
   // Track mobile session creation requests to prevent duplicate processing
   // (can happen if the same request is delivered multiple times)
   private processingMobileSessionRequests = new Set<string>();

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -30,6 +30,7 @@ import { getSessionStateManager } from '@nimbalyst/runtime/ai/server/SessionStat
 import { parseContextUsageMessage } from '@nimbalyst/runtime/ai/server/utils/contextUsage';
 import { isBedrockToolSearchError } from '@nimbalyst/runtime/ai/server/utils/errorDetection';
 import { parseThinkingMode, resolveEffortLevel } from '@nimbalyst/runtime/ai/server/effortLevels';
+import { applyDeepSeekClaudeAgentProfile, isDeepSeekClaudeAgentModel } from '@nimbalyst/runtime/ai/server/deepSeekClaudeAgent';
 import type { SessionStore } from '@nimbalyst/runtime';
 import {
   ModelIdentifier,
@@ -759,7 +760,11 @@ export class AIService {
     workspacePath?: string
   ): Promise<ProviderConfig> {
     const effectiveWorkspacePath = session.workspacePath || workspacePath;
-    const apiKey = this.getApiKeyForProvider('claude-code', effectiveWorkspacePath);
+    const selectedModel = session.model || session.providerConfig?.model;
+    const apiKey = this.getApiKeyForProvider(
+      isDeepSeekClaudeAgentModel(selectedModel) ? 'deepseek' : 'claude-code',
+      effectiveWorkspacePath,
+    );
 
     const effortLevel = resolveEffortLevel((session.metadata as any)?.effortLevel, getDefaultEffortLevel());
     const config: ProviderConfig = {
@@ -781,7 +786,7 @@ export class AIService {
       config.model = CLAUDE_CODE_SAFE_FALLBACK_MODEL;
     }
 
-    return config;
+    return applyDeepSeekClaudeAgentProfile(config);
   }
 
   /**

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -852,6 +852,14 @@ export class AIService {
     targetWindow: Electron.BrowserWindow | null,
     source: string,
   ): Promise<boolean> {
+    // A long-lived stream can settle after its renderer has reloaded or its
+    // original window has closed. Re-resolve by workspace before deciding the
+    // queue cannot advance; otherwise an eligible ordinary head waits until a
+    // later UI action happens to trigger another drain.
+    const liveTargetWindow = targetWindow && !targetWindow.isDestroyed()
+      ? targetWindow
+      : findWindowByWorkspace(workspacePath);
+
     // NIM-834: claude-code-cli sessions have no in-process turn driver — the SDK
     // dispatch below would call the provider's Phase 1 sendMessage stub and mark
     // the prompt failed (broke meta-agent spawns, restart continuations, and
@@ -954,7 +962,7 @@ export class AIService {
           sessionId: activeSessionId,
           workspacePath: activeWorkspacePath,
         }),
-      targetWindow,
+      targetWindow: liveTargetWindow,
       workspacePath,
     });
   }

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -128,6 +128,12 @@ import { tryClaimAndDispatchNextQueuedPrompt } from './queuedPromptDispatcher';
 import { dispatchQueuedPromptToClaudeCli } from './claudeCliQueueDispatch';
 import { ensureClaudeCliSession, claudeCliSessionSupportsPlugins } from './claudeCliLauncherSingleton';
 import { supportsWorkspaceSlashWorkflowProvider } from '../../../shared/agentWorkflowProviders';
+import { toMillis } from '../../utils/timestampUtils';
+import {
+  createPriorityTargetGeneration,
+  type PriorityTargetState,
+} from '../PriorityPromptDeliveryService';
+import { drainPendingOrdinaryPromptsOnStartup } from './startupQueuedPromptDrain';
 
 const execFileAsync = promisify(execFile);
 
@@ -289,6 +295,163 @@ export class AIService {
       return false;
     }
     return this.processQueuedPrompt(sessionId, workspacePath, targetWindow);
+  }
+
+  public async drainPendingOrdinaryPromptsOnStartup(): Promise<{
+    discovered: number;
+    triggered: number;
+    skipped: number;
+  }> {
+    const { getQueuedPromptsStore } = await import('../RepositoryManager');
+    const { AISessionsRepository } = await import('@nimbalyst/runtime/storage/repositories/AISessionsRepository');
+    const queueStore = getQueuedPromptsStore();
+    return drainPendingOrdinaryPromptsOnStartup({
+      listPendingOrdinarySessionIds: () =>
+        queueStore.listPendingSessionIds({ deliveryClass: 'ordinary' }),
+      resolveWorkspacePath: async (sessionId) => {
+        const session = await AISessionsRepository.get(sessionId);
+        return session?.worktreePath || session?.workspacePath || null;
+      },
+      triggerProcessing: (sessionId, workspacePath) =>
+        this.triggerQueuedPromptProcessingForSession(sessionId, workspacePath),
+      logError: (sessionId, error) => {
+        logger.main.error(
+          `[AIService] startup queue drain failed for session ${sessionId}:`,
+          error,
+        );
+      },
+    });
+  }
+
+  public async interruptCurrentTurnForSession(
+    sessionId: string,
+    expectedState?: PriorityTargetState,
+  ): Promise<{
+    success: boolean;
+    method?: string;
+    error?: string;
+    nativeEntered: boolean;
+  }> {
+    if (!sessionId) {
+      throw new Error('Session ID is required to interrupt');
+    }
+
+    const { database } = await import('../../database/PGLiteDatabaseWorker');
+    const readLifecycle = async () => {
+      const { rows } = await database.query<{
+        provider: string;
+        status: string;
+        last_activity: Date | string | number | null;
+        updated_at: Date | string | number | null;
+      }>(
+        `SELECT provider, status, last_activity, updated_at
+         FROM ai_sessions
+         WHERE id = $1
+         LIMIT 1`,
+        [sessionId],
+      );
+      const row = rows[0];
+      if (!row) {
+        return null;
+      }
+      const lastActivity = toMillis(row.last_activity);
+      const updatedAt = toMillis(row.updated_at);
+      return {
+        provider: row.provider,
+        status: row.status,
+        lastActivity,
+        updatedAt,
+        generation: createPriorityTargetGeneration(
+          row.status as PriorityTargetState['status'],
+          lastActivity,
+          updatedAt,
+        ),
+      };
+    };
+
+    const session = await readLifecycle();
+    if (!session) {
+      return { success: false, error: 'Session not found', nativeEntered: false };
+    }
+
+    if (session.provider === 'claude-code-cli') {
+      const terminalManager = getTerminalSessionManager();
+      if (!terminalManager.isTerminalActive(sessionId)) {
+        return { success: false, error: 'No active terminal for session', nativeEntered: false };
+      }
+      const current = await readLifecycle();
+      if (
+        expectedState
+        && (!current || current.generation !== expectedState.generation || current.status !== expectedState.status)
+      ) {
+        return { success: false, error: 'stale lifecycle generation', nativeEntered: false };
+      }
+      try {
+        terminalManager.writeToTerminal(sessionId, '\x03');
+        logger.main.info(`[AIService] Interrupted claude-code-cli terminal for session ${sessionId}`);
+        return { success: true, method: 'terminal-ctrl-c', nativeEntered: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+          nativeEntered: true,
+        };
+      }
+    }
+
+    const provider = ProviderFactory.getProvider(session.provider as AIProviderType, sessionId);
+    if (!provider) {
+      return { success: false, error: 'No active provider for session', nativeEntered: false };
+    }
+
+    const sweepInterruptedQueue = async () => {
+      this.sessionsProcessingQueue.delete(sessionId);
+      try {
+        const { getQueuedPromptsStore } = await import('../RepositoryManager');
+        const queueStore = getQueuedPromptsStore();
+        const { completed, failed, rolledBack } = await queueStore.sweepExecutingForSession(sessionId);
+        if (completed > 0 || failed > 0 || rolledBack > 0) {
+          logger.main.info(
+            `[AIService] interruptCurrentTurn: swept session ${sessionId} -- ${completed} answered marked completed, ${failed} delivered-but-unanswered marked failed, ${rolledBack} undelivered rolled back`
+          );
+        }
+      } catch (sweepErr) {
+        logger.main.error('[AIService] interruptCurrentTurn: sweepExecutingForSession failed:', sweepErr);
+      }
+    };
+
+    // Preserve the manual IPC behavior. Priority callers pass an expected
+    // lifecycle token; for them, avoid mutating queue state until after the
+    // fenced provider interrupt has actually been entered.
+    if (!expectedState) {
+      await sweepInterruptedQueue();
+    }
+
+    const current = await readLifecycle();
+    if (
+      expectedState
+      && (!current || current.generation !== expectedState.generation || current.status !== expectedState.status)
+    ) {
+      return { success: false, error: 'stale lifecycle generation', nativeEntered: false };
+    }
+
+    try {
+      const result = await provider.interruptCurrentTurn();
+      if (expectedState) {
+        await sweepInterruptedQueue();
+      }
+      logger.main.info(`[AIService] Interrupted current turn for session ${sessionId} (method=${result.method})`);
+      return { success: true, method: result.method, nativeEntered: true };
+    } catch (error) {
+      if (expectedState) {
+        await sweepInterruptedQueue();
+      }
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        nativeEntered: true,
+      };
+    }
   }
 
   public async respondToInteractivePrompt(params: {
@@ -2875,51 +3038,9 @@ export class AIService {
     // delivered prompts are marked completed, not rolled back, so the
     // follow-up ai:triggerQueueProcessing doesn't re-send the same input
     // -- NIM-615).
-    safeHandle('ai:interruptCurrentTurn', async (_event, sessionId: string) => {
-      if (!sessionId) {
-        throw new Error('Session ID is required to interrupt');
-      }
-
-      const { AISessionsRepository } = await import('@nimbalyst/runtime/storage/repositories/AISessionsRepository');
-      const session = await AISessionsRepository.get(sessionId);
-      if (!session) {
-        return { success: false, error: 'Session not found' };
-      }
-
-      if (session.provider === 'claude-code-cli') {
-        const terminalManager = getTerminalSessionManager();
-        if (!terminalManager.isTerminalActive(sessionId)) {
-          return { success: false, error: 'No active terminal for session' };
-        }
-
-        terminalManager.writeToTerminal(sessionId, '\x03');
-        logger.main.info(`[AIService] Interrupted claude-code-cli terminal for session ${sessionId}`);
-        return { success: true, method: 'terminal-ctrl-c' };
-      }
-
-      const provider = ProviderFactory.getProvider(session.provider as AIProviderType, sessionId);
-      if (!provider) {
-        return { success: false, error: 'No active provider for session' };
-      }
-
-      this.sessionsProcessingQueue.delete(sessionId);
-      try {
-        const { getQueuedPromptsStore } = await import('../RepositoryManager');
-        const queueStore = getQueuedPromptsStore();
-        const { completed, failed, rolledBack } = await queueStore.sweepExecutingForSession(sessionId);
-        if (completed > 0 || failed > 0 || rolledBack > 0) {
-          logger.main.info(
-            `[AIService] interruptCurrentTurn: swept session ${sessionId} -- ${completed} answered marked completed, ${failed} delivered-but-unanswered marked failed, ${rolledBack} undelivered rolled back`
-          );
-        }
-      } catch (sweepErr) {
-        logger.main.error('[AIService] interruptCurrentTurn: sweepExecutingForSession failed:', sweepErr);
-      }
-
-      const result = await provider.interruptCurrentTurn();
-      logger.main.info(`[AIService] Interrupted current turn for session ${sessionId} (method=${result.method})`);
-      return { success: true, method: result.method };
-    });
+    safeHandle('ai:interruptCurrentTurn', async (_event, sessionId: string) =>
+      this.interruptCurrentTurnForSession(sessionId)
+    );
 
     // Settings handlers
     safeHandle('ai:getSettings', async () => {

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -95,6 +95,7 @@ import { isFileInWorkspaceOrWorktree, resolveProjectPath } from '../../utils/wor
 import { inferWorktreePathFromFilePath, inferWorktreePathFromCommand } from './worktreeInference';
 import { SessionFilesRepository } from '@nimbalyst/runtime';
 import { buildToolPermissionResponseRecord } from './claudeCliToolPermission';
+import { setSessionPendingPrompt } from './pendingPromptPersistence';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
@@ -511,6 +512,22 @@ export class AIService {
       };
     }
 
+    // A response is a one-shot consumption. Reject duplicates before writing a
+    // second durable row or waking the same blocked waiter twice.
+    if (promptType === 'ask_user_question_request') {
+      const { rows: existingResponses } = await database.query<{ id: string }>(
+        `SELECT id FROM ai_agent_messages
+         WHERE session_id = $1
+           AND content LIKE '%"type":"ask_user_question_response"%'
+           AND content LIKE $2
+         LIMIT 1`,
+        [sessionId, `%"questionId":"${promptId}"%`]
+      );
+      if (existingResponses.length > 0) {
+        return { success: true };
+      }
+    }
+
     await database.query(
       `INSERT INTO ai_agent_messages (session_id, source, direction, content, created_at, hidden)
        VALUES ($1, $2, $3, $4, $5, $6)`,
@@ -570,9 +587,12 @@ export class AIService {
         });
       }
 
-      return resolved || hasAskUserQuestionWaiter || hasSessionFallbackWaiter || hasPersistedQuestionRequest
-        ? { success: true }
-        : { success: false, error: 'Question not found' };
+      const accepted = resolved || hasAskUserQuestionWaiter || hasSessionFallbackWaiter || hasPersistedQuestionRequest;
+      if (accepted) {
+        await setSessionPendingPrompt(sessionId, false);
+        return { success: true };
+      }
+      return { success: false, error: 'Question not found' };
     }
 
     const provider = ProviderFactory.getProvider(session.provider as AIProviderType, sessionId);

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -187,6 +187,7 @@ export class AIService {
   // the prior lease before priority delivery; a stale dispatch may settle
   // afterward, but cannot release a newer dispatch's lease or drain FIFO.
   private queueProcessingLeases = new Map<string, symbol>();
+  private interactivePromptSettlements = new Map<string, Promise<{ success: boolean; error?: string }>>();
 
   /**
    * Exposes the dispatch-owned lease guard to the streaming lifecycle without
@@ -473,6 +474,23 @@ export class AIService {
     response: any;
     respondedBy?: 'desktop' | 'mobile';
   }): Promise<{ success: boolean; error?: string }> {
+    const key = `${params.sessionId}:${params.promptType}:${params.promptId}`;
+    const existing = this.interactivePromptSettlements.get(key);
+    if (existing) return existing;
+    const settlement = this.respondToInteractivePromptOnce(params).finally(() => {
+      this.interactivePromptSettlements.delete(key);
+    });
+    this.interactivePromptSettlements.set(key, settlement);
+    return settlement;
+  }
+
+  private async respondToInteractivePromptOnce(params: {
+    sessionId: string;
+    promptId: string;
+    promptType: 'permission_request' | 'ask_user_question_request' | 'exit_plan_mode_request';
+    response: any;
+    respondedBy?: 'desktop' | 'mobile';
+  }): Promise<{ success: boolean; error?: string }> {
     const { sessionId, promptId, promptType, response, respondedBy = 'desktop' } = params;
     const { AISessionsRepository } = await import('@nimbalyst/runtime/storage/repositories/AISessionsRepository');
     const { database } = await import('../../database/PGLiteDatabaseWorker');
@@ -514,9 +532,10 @@ export class AIService {
 
     // A response is a one-shot consumption. Reject duplicates before writing a
     // second durable row or waking the same blocked waiter twice.
+    let replayedResponse = false;
     if (promptType === 'ask_user_question_request') {
-      const { rows: existingResponses } = await database.query<{ id: string }>(
-        `SELECT id FROM ai_agent_messages
+      const { rows: existingResponses } = await database.query<{ content: unknown }>(
+        `SELECT content FROM ai_agent_messages
          WHERE session_id = $1
            AND content LIKE '%"type":"ask_user_question_response"%'
            AND content LIKE $2
@@ -524,15 +543,29 @@ export class AIService {
         [sessionId, `%"questionId":"${promptId}"%`]
       );
       if (existingResponses.length > 0) {
-        return { success: true };
+        // The durable answer is the claim. A replay must finish its lifecycle
+        // work, not merely acknowledge the existing row and strand its waiter.
+        replayedResponse = true;
+        const stored = existingResponses[0]?.content;
+        if (typeof stored === 'string') {
+          try {
+            responseContent = JSON.parse(stored) as Record<string, unknown>;
+          } catch {
+            // Legacy malformed rows still get deterministic cleanup below.
+          }
+        } else if (stored && typeof stored === 'object') {
+          responseContent = stored as Record<string, unknown>;
+        }
       }
     }
 
-    await database.query(
-      `INSERT INTO ai_agent_messages (session_id, source, direction, content, created_at, hidden)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
-      [sessionId, 'nimbalyst', 'output', JSON.stringify(responseContent), new Date(), false]
-    );
+    if (!replayedResponse) {
+      await database.query(
+        `INSERT INTO ai_agent_messages (session_id, source, direction, content, created_at, hidden)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [sessionId, 'nimbalyst', 'output', JSON.stringify(responseContent), new Date(), false]
+      );
+    }
 
     if (promptType === 'permission_request') {
       const provider = ProviderFactory.getProvider(session.provider as AIProviderType, sessionId);
@@ -547,9 +580,13 @@ export class AIService {
     }
 
     if (promptType === 'ask_user_question_request') {
+      const settledResponse = {
+        answers: responseContent.answers || response.answers || response,
+        cancelled: responseContent.cancelled === true || response.cancelled === true,
+      };
       const provider = ProviderFactory.getProvider(session.provider as AIProviderType, sessionId);
       const resolved = provider && isAskUserQuestionProvider(provider)
-        ? provider.resolveAskUserQuestion(promptId, response.answers || response, sessionId, respondedBy)
+        ? provider.resolveAskUserQuestion(promptId, settledResponse.answers, sessionId, respondedBy)
         : false;
 
       const { rows: askRequestRows } = await database.query<{ id: string }>(
@@ -568,8 +605,8 @@ export class AIService {
       if (hasAskUserQuestionWaiter) {
         ipcMain.emit(askUserQuestionChannel, {} as any, {
           questionId: promptId,
-          answers: response.answers || response,
-          cancelled: response.cancelled || false,
+          answers: settledResponse.answers,
+          cancelled: settledResponse.cancelled,
           respondedBy,
           sessionId,
         });
@@ -580,14 +617,14 @@ export class AIService {
       if (hasSessionFallbackWaiter) {
         ipcMain.emit(sessionFallbackChannel, {} as any, {
           questionId: promptId,
-          answers: response.answers || response,
-          cancelled: response.cancelled || false,
+          answers: settledResponse.answers,
+          cancelled: settledResponse.cancelled,
           respondedBy,
           sessionId,
         });
       }
 
-      const accepted = resolved || hasAskUserQuestionWaiter || hasSessionFallbackWaiter || hasPersistedQuestionRequest;
+      const accepted = resolved || hasAskUserQuestionWaiter || hasSessionFallbackWaiter || hasPersistedQuestionRequest || replayedResponse;
       if (accepted) {
         await setSessionPendingPrompt(sessionId, false);
         return { success: true };

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -36,6 +36,7 @@ import {
 import { getSessionStateManager } from '@nimbalyst/runtime/ai/server/SessionStateManager';
 import { isBedrockToolSearchError } from '@nimbalyst/runtime/ai/server/utils/errorDetection';
 import { parseThinkingMode, resolveEffortLevel } from '@nimbalyst/runtime/ai/server/effortLevels';
+import { applyDeepSeekClaudeAgentProfile, isDeepSeekClaudeAgentModel } from '@nimbalyst/runtime/ai/server/deepSeekClaudeAgent';
 import type { RawDocumentContext, DocumentContextService } from '@nimbalyst/runtime';
 import { AISessionsRepository, resolveClaudeCodeParentContextWindow } from '@nimbalyst/runtime';
 import { toolRegistry } from './tools';
@@ -580,7 +581,9 @@ export class MessageStreamingHandler {
 
       const reinitEffortLevel = resolveEffortLevel((session.metadata as any)?.effortLevel, getDefaultEffortLevel());
       const reinitConfig: any = {
-        apiKey,
+        apiKey: isProviderClaudeCode && isDeepSeekClaudeAgentModel(session.model || session.providerConfig?.model)
+          ? this.svc.getApiKeyForProvider('deepseek', workspacePath)
+          : apiKey,
         maxTokens: (session.providerConfig as any)?.maxTokens,
         temperature: (session.providerConfig as any)?.temperature,
         // Effort level: explicit session value, else the app-wide default the
@@ -638,6 +641,8 @@ export class MessageStreamingHandler {
           }
         }
       }
+
+      if (isProviderClaudeCode) Object.assign(reinitConfig, applyDeepSeekClaudeAgentProfile(reinitConfig));
 
       if (isProviderClaudeCode) {
         const safeConfig = { ...reinitConfig, apiKey: reinitConfig.apiKey ? '***' : undefined };

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -7,9 +7,9 @@
  * re-entry on completion, and error recovery.
  *
  * It accesses several internal members of AIService (state Maps, helper methods)
- * via an `AIServiceInternal` cast — this keeps AIService's public API surface
- * unchanged while letting the handler reach into the same shared state it had
- * when it lived inline in `setupIpcHandlers()`.
+ * through an internal view. Queue-dispatch ownership is deliberately kept on
+ * AIService's typed public lease guard so this handler cannot drift back to the
+ * removed broad processing set.
  */
 
 import { BrowserWindow } from 'electron';
@@ -136,10 +136,9 @@ export type SendMessageHandler = (
 ) => Promise<{ content: string }>;
 
 /**
- * Structural view of the AIService members this handler needs. Keeping it
- * declared here (rather than reaching into the AIService class via `private`
- * access) means AIService's class declaration stays untouched — we just cast
- * the injected service reference to this shape internally.
+ * Structural view of the AIService members this handler needs. Queue dispatch
+ * ownership is intentionally excluded: it is accessed through AIService's
+ * typed `hasActiveQueueLease` method rather than this structural view.
  */
 interface AIServiceInternal {
   // Shared state
@@ -148,7 +147,6 @@ interface AIServiceInternal {
   sendMessageHandler: SendMessageHandler | null;
   processingQueuedPromptIds: Set<string>;
   matchDebounceTimers: Map<string, ReturnType<typeof setTimeout>>;
-  sessionsProcessingQueue: Set<string>;
   documentContextService: DocumentContextService;
   hooklessWatcher: HooklessAgentFileWatcher;
 
@@ -240,6 +238,7 @@ async function getWorkspacePathForSession(sessionId: string): Promise<string | n
 }
 
 export class MessageStreamingHandler {
+  private readonly aiService: AIService;
   private readonly svc: AIServiceInternal;
   private readonly unsubscribeBatchListener: () => void;
   // Per-provider map of event -> currently-installed listener. Used by
@@ -252,6 +251,7 @@ export class MessageStreamingHandler {
   >();
 
   constructor(service: AIService) {
+    this.aiService = service;
     this.svc = service as unknown as AIServiceInternal;
 
     // The shared AgentMessageWriteQueue (in BaseAIProvider) coalesces streaming
@@ -291,6 +291,15 @@ export class MessageStreamingHandler {
   /** Used by AIService teardown to unwire the singleton batch listener. */
   destroy(): void {
     this.unsubscribeBatchListener();
+  }
+
+  /**
+   * Queue ownership is a generation lease, not a session-wide boolean. Keep
+   * this indirection typed against AIService so a future field rename fails
+   * typechecking instead of becoming an undefined `.has()` at runtime.
+   */
+  private hasActiveQueueLease(sessionId: string): boolean {
+    return this.aiService.hasActiveQueueLease(sessionId);
   }
 
   /**
@@ -1116,7 +1125,7 @@ export class MessageStreamingHandler {
         return;
       }
       // A queued/continuation turn may already be taking over; let it own the end.
-      if (this.svc.sessionsProcessingQueue.has(data.sessionId)) return;
+      if (this.hasActiveQueueLease(data.sessionId)) return;
 
       logger.main.info(`[AIService] Sub-agent drain settled for session ${data.sessionId}, ending deferred session`);
       await stateManager.endSession(data.sessionId);
@@ -2186,7 +2195,7 @@ export class MessageStreamingHandler {
             if (
               isExtensionAgentSession
               && session?.id
-              && !this.svc.sessionsProcessingQueue.has(session.id)
+              && !this.hasActiveQueueLease(session.id)
             ) {
               try {
                 await stateManager.updateActivity({ sessionId: session.id, status: 'error' });
@@ -2581,7 +2590,7 @@ export class MessageStreamingHandler {
             const willResume = session.provider === 'claude-code'
               && typeof (provider as any).willResumeAfterCompletion === 'function'
               && (provider as any).willResumeAfterCompletion();
-            const queuedChainAlreadyActive = this.svc.sessionsProcessingQueue.has(session.id);
+            const queuedChainAlreadyActive = this.hasActiveQueueLease(session.id);
             let queuedContinuationScheduled = false;
             if (!hasTeammates && !willResume && !queuedChainAlreadyActive) {
               queuedContinuationScheduled = await this.svc.tryDispatchNextQueuedPrompt(
@@ -2762,7 +2771,7 @@ export class MessageStreamingHandler {
       }
 
       // Clear executing and pending prompt flags for mobile sync
-      if (syncProvider && !this.svc.sessionsProcessingQueue.has(session.id)) {
+      if (syncProvider && !this.hasActiveQueueLease(session.id)) {
         syncProvider.pushChange(session.id, {
           type: 'metadata_updated',
           metadata: { isExecuting: false, hasPendingPrompt: false, updatedAt: Date.now() },
@@ -2829,7 +2838,7 @@ export class MessageStreamingHandler {
         const willResumeOnError = session.provider === 'claude-code'
           && typeof (provider as any).willResumeAfterCompletion === 'function'
           && (provider as any).willResumeAfterCompletion();
-        const queuedChainAlreadyActiveOnError = this.svc.sessionsProcessingQueue.has(session.id);
+        const queuedChainAlreadyActiveOnError = this.hasActiveQueueLease(session.id);
         let queuedContinuationScheduledOnError = false;
         if (!hasTeammatesOnError && !willResumeOnError && !queuedChainAlreadyActiveOnError) {
           queuedContinuationScheduledOnError = await this.svc.tryDispatchNextQueuedPrompt(
@@ -2856,7 +2865,7 @@ export class MessageStreamingHandler {
         }
 
         // Clear executing and pending prompt flags for mobile sync on error
-        if (syncProvider && !this.svc.sessionsProcessingQueue.has(session.id)) {
+        if (syncProvider && !this.hasActiveQueueLease(session.id)) {
           syncProvider.pushChange(session.id, {
             type: 'metadata_updated',
             metadata: { isExecuting: false, hasPendingPrompt: false, updatedAt: Date.now() },

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -130,16 +130,17 @@ export function hasPersistedPendingPrompt(metadata: unknown): boolean {
 export async function runTerminalPromptTransition(params: {
   metadata: unknown;
   hasActiveLease: boolean;
+  hasOtherDeferral?: boolean;
   tryDispatch: () => Promise<boolean>;
   endSession: () => Promise<void>;
   sync?: (hasPendingPrompt: boolean) => void;
 }): Promise<{ deferred: boolean; hasPendingPrompt: boolean }> {
   const hasPendingPrompt = hasPersistedPendingPrompt(params.metadata);
   let dispatched = false;
-  if (!hasPendingPrompt && !params.hasActiveLease) {
+  if (!hasPendingPrompt && !params.hasActiveLease && !params.hasOtherDeferral) {
     dispatched = await params.tryDispatch();
   }
-  const deferred = hasPendingPrompt || params.hasActiveLease || dispatched;
+  const deferred = hasPendingPrompt || params.hasActiveLease || Boolean(params.hasOtherDeferral) || dispatched;
   if (!deferred) await params.endSession();
   if (!params.hasActiveLease) params.sync?.(hasPendingPrompt);
   return { deferred, hasPendingPrompt };
@@ -2629,16 +2630,15 @@ export class MessageStreamingHandler {
             const persistedSession = await AISessionsRepository.get(session.id);
             const hasPendingStructuredPrompt = hasPersistedPendingPrompt(persistedSession?.metadata);
             const queuedChainAlreadyActive = this.hasActiveQueueLease(session.id);
-            let queuedContinuationScheduled = false;
-            if (!hasPendingStructuredPrompt && !hasTeammates && !willResume && !queuedChainAlreadyActive) {
-              queuedContinuationScheduled = await this.svc.tryDispatchNextQueuedPrompt(
-                session.id,
-                workspacePath,
-                BrowserWindow.fromWebContents(event.sender),
-                'completion-handler queue',
-              );
-            }
-            if (hasPendingStructuredPrompt || hasTeammates || willResume || queuedChainAlreadyActive || queuedContinuationScheduled) {
+            const terminalTransition = await runTerminalPromptTransition({
+              metadata: persistedSession?.metadata,
+              hasActiveLease: queuedChainAlreadyActive,
+              hasOtherDeferral: hasTeammates || willResume,
+              tryDispatch: () => this.svc.tryDispatchNextQueuedPrompt(session.id, workspacePath, BrowserWindow.fromWebContents(event.sender), 'completion-handler queue'),
+              endSession: () => stateManager.endSession(session.id),
+            });
+            const queuedContinuationScheduled = terminalTransition.deferred && !hasPendingStructuredPrompt && !hasTeammates && !willResume && !queuedChainAlreadyActive;
+            if (terminalTransition.deferred) {
               const reason = hasPendingStructuredPrompt
                 ? 'structured prompt pending'
                 : hasTeammates
@@ -2650,7 +2650,6 @@ export class MessageStreamingHandler {
                 : 'queued continuation scheduled';
               // logger.main.info(`[AIService] Deferring endSession for ${session.id} - ${reason}`);
             } else {
-              await stateManager.endSession(session.id);
               // Stop file watcher after a brief delay to let pending
               // watcher events drain through WorkspaceFileEditAttributionService.
               // The manager cancels the scheduled stop if a new turn starts
@@ -2883,16 +2882,19 @@ export class MessageStreamingHandler {
         const persistedErrorSession = await AISessionsRepository.get(session.id);
         const hasPendingStructuredPromptOnError = hasPersistedPendingPrompt(persistedErrorSession?.metadata);
         const queuedChainAlreadyActiveOnError = this.hasActiveQueueLease(session.id);
-        let queuedContinuationScheduledOnError = false;
-        if (!hasPendingStructuredPromptOnError && !hasTeammatesOnError && !willResumeOnError && !queuedChainAlreadyActiveOnError) {
-          queuedContinuationScheduledOnError = await this.svc.tryDispatchNextQueuedPrompt(
-            session.id,
-            workspacePath,
-            BrowserWindow.fromWebContents(event.sender),
-            'error-handler queue',
-          );
-        }
-        if (hasPendingStructuredPromptOnError || hasTeammatesOnError || willResumeOnError || queuedChainAlreadyActiveOnError || queuedContinuationScheduledOnError) {
+        const errorTransition = await runTerminalPromptTransition({
+          metadata: persistedErrorSession?.metadata,
+          hasActiveLease: queuedChainAlreadyActiveOnError,
+          hasOtherDeferral: hasTeammatesOnError || willResumeOnError,
+          tryDispatch: () => this.svc.tryDispatchNextQueuedPrompt(session.id, workspacePath, BrowserWindow.fromWebContents(event.sender), 'error-handler queue'),
+          endSession: async () => {
+            await stateManager.endSession(session.id);
+            await this.svc.hooklessWatcher.stopForSession(session.id);
+            codexEditWindowRegistry.clearSession(session.id);
+          },
+        });
+        const queuedContinuationScheduledOnError = errorTransition.deferred && !hasPendingStructuredPromptOnError && !hasTeammatesOnError && !willResumeOnError && !queuedChainAlreadyActiveOnError;
+        if (errorTransition.deferred) {
           const reason = hasPendingStructuredPromptOnError
             ? 'structured prompt pending'
             : hasTeammatesOnError
@@ -2903,11 +2905,6 @@ export class MessageStreamingHandler {
             ? 'queued continuation already active'
             : 'queued continuation scheduled';
           logger.main.info(`[AIService] Deferring endSession for ${session.id} on error - ${reason}`);
-        } else {
-          await stateManager.endSession(session.id);
-          // Stop file watcher - session ended on error
-          await this.svc.hooklessWatcher.stopForSession(session.id);
-          codexEditWindowRegistry.clearSession(session.id);
         }
 
         // Clear executing and pending prompt flags for mobile sync on error

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -127,6 +127,24 @@ export function hasPersistedPendingPrompt(metadata: unknown): boolean {
   );
 }
 
+export async function runTerminalPromptTransition(params: {
+  metadata: unknown;
+  hasActiveLease: boolean;
+  tryDispatch: () => Promise<boolean>;
+  endSession: () => Promise<void>;
+  sync?: (hasPendingPrompt: boolean) => void;
+}): Promise<{ deferred: boolean; hasPendingPrompt: boolean }> {
+  const hasPendingPrompt = hasPersistedPendingPrompt(params.metadata);
+  let dispatched = false;
+  if (!hasPendingPrompt && !params.hasActiveLease) {
+    dispatched = await params.tryDispatch();
+  }
+  const deferred = hasPendingPrompt || params.hasActiveLease || dispatched;
+  if (!deferred) await params.endSession();
+  if (!params.hasActiveLease) params.sync?.(hasPendingPrompt);
+  return { deferred, hasPendingPrompt };
+}
+
 function resolveWorkspaceFileAttributionMode(
   providerName: string,
   provider: AIProvider | null | undefined,

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -114,6 +114,19 @@ import type { AIService } from './AIService';
 import type { HooklessAgentFileWatcher } from './HooklessAgentFileWatcher';
 import type { WorkspaceFileAttributionMode } from '../WorkspaceFileAttributionPolicy';
 
+/**
+ * The terminal streaming paths must project the durable prompt bit, rather
+ * than infer it from the turn having stopped. Kept here so normal and error
+ * completion share the exact same production predicate.
+ */
+export function hasPersistedPendingPrompt(metadata: unknown): boolean {
+  return Boolean(
+    metadata
+    && typeof metadata === 'object'
+    && (metadata as Record<string, unknown>).hasPendingPrompt === true,
+  );
+}
+
 function resolveWorkspaceFileAttributionMode(
   providerName: string,
   provider: AIProvider | null | undefined,
@@ -2596,11 +2609,7 @@ export class MessageStreamingHandler {
               && typeof (provider as any).willResumeAfterCompletion === 'function'
               && (provider as any).willResumeAfterCompletion();
             const persistedSession = await AISessionsRepository.get(session.id);
-            const hasPendingStructuredPrompt = Boolean(
-              persistedSession?.metadata
-              && typeof persistedSession.metadata === 'object'
-              && (persistedSession.metadata as Record<string, unknown>).hasPendingPrompt === true,
-            );
+            const hasPendingStructuredPrompt = hasPersistedPendingPrompt(persistedSession?.metadata);
             const queuedChainAlreadyActive = this.hasActiveQueueLease(session.id);
             let queuedContinuationScheduled = false;
             if (!hasPendingStructuredPrompt && !hasTeammates && !willResume && !queuedChainAlreadyActive) {
@@ -2785,9 +2794,11 @@ export class MessageStreamingHandler {
 
       // Clear executing and pending prompt flags for mobile sync
       if (syncProvider && !this.hasActiveQueueLease(session.id)) {
+        const terminalSession = await AISessionsRepository.get(session.id);
+        const retainsPendingPrompt = hasPersistedPendingPrompt(terminalSession?.metadata);
         syncProvider.pushChange(session.id, {
           type: 'metadata_updated',
-          metadata: { isExecuting: false, hasPendingPrompt: false, updatedAt: Date.now() },
+          metadata: { isExecuting: false, hasPendingPrompt: retainsPendingPrompt, updatedAt: Date.now() },
         });
       }
 
@@ -2852,11 +2863,7 @@ export class MessageStreamingHandler {
           && typeof (provider as any).willResumeAfterCompletion === 'function'
           && (provider as any).willResumeAfterCompletion();
         const persistedErrorSession = await AISessionsRepository.get(session.id);
-        const hasPendingStructuredPromptOnError = Boolean(
-          persistedErrorSession?.metadata
-          && typeof persistedErrorSession.metadata === 'object'
-          && (persistedErrorSession.metadata as Record<string, unknown>).hasPendingPrompt === true,
-        );
+        const hasPendingStructuredPromptOnError = hasPersistedPendingPrompt(persistedErrorSession?.metadata);
         const queuedChainAlreadyActiveOnError = this.hasActiveQueueLease(session.id);
         let queuedContinuationScheduledOnError = false;
         if (!hasPendingStructuredPromptOnError && !hasTeammatesOnError && !willResumeOnError && !queuedChainAlreadyActiveOnError) {

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -2595,9 +2595,15 @@ export class MessageStreamingHandler {
             const willResume = session.provider === 'claude-code'
               && typeof (provider as any).willResumeAfterCompletion === 'function'
               && (provider as any).willResumeAfterCompletion();
+            const persistedSession = await AISessionsRepository.get(session.id);
+            const hasPendingStructuredPrompt = Boolean(
+              persistedSession?.metadata
+              && typeof persistedSession.metadata === 'object'
+              && (persistedSession.metadata as Record<string, unknown>).hasPendingPrompt === true,
+            );
             const queuedChainAlreadyActive = this.hasActiveQueueLease(session.id);
             let queuedContinuationScheduled = false;
-            if (!hasTeammates && !willResume && !queuedChainAlreadyActive) {
+            if (!hasPendingStructuredPrompt && !hasTeammates && !willResume && !queuedChainAlreadyActive) {
               queuedContinuationScheduled = await this.svc.tryDispatchNextQueuedPrompt(
                 session.id,
                 workspacePath,
@@ -2605,8 +2611,10 @@ export class MessageStreamingHandler {
                 'completion-handler queue',
               );
             }
-            if (hasTeammates || willResume || queuedChainAlreadyActive || queuedContinuationScheduled) {
-              const reason = hasTeammates
+            if (hasPendingStructuredPrompt || hasTeammates || willResume || queuedChainAlreadyActive || queuedContinuationScheduled) {
+              const reason = hasPendingStructuredPrompt
+                ? 'structured prompt pending'
+                : hasTeammates
                 ? 'teammates still active'
                 : willResume
                 ? 'lead resuming'

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -2851,9 +2851,15 @@ export class MessageStreamingHandler {
         const willResumeOnError = session.provider === 'claude-code'
           && typeof (provider as any).willResumeAfterCompletion === 'function'
           && (provider as any).willResumeAfterCompletion();
+        const persistedErrorSession = await AISessionsRepository.get(session.id);
+        const hasPendingStructuredPromptOnError = Boolean(
+          persistedErrorSession?.metadata
+          && typeof persistedErrorSession.metadata === 'object'
+          && (persistedErrorSession.metadata as Record<string, unknown>).hasPendingPrompt === true,
+        );
         const queuedChainAlreadyActiveOnError = this.hasActiveQueueLease(session.id);
         let queuedContinuationScheduledOnError = false;
-        if (!hasTeammatesOnError && !willResumeOnError && !queuedChainAlreadyActiveOnError) {
+        if (!hasPendingStructuredPromptOnError && !hasTeammatesOnError && !willResumeOnError && !queuedChainAlreadyActiveOnError) {
           queuedContinuationScheduledOnError = await this.svc.tryDispatchNextQueuedPrompt(
             session.id,
             workspacePath,
@@ -2861,8 +2867,10 @@ export class MessageStreamingHandler {
             'error-handler queue',
           );
         }
-        if (hasTeammatesOnError || willResumeOnError || queuedChainAlreadyActiveOnError || queuedContinuationScheduledOnError) {
-          const reason = hasTeammatesOnError
+        if (hasPendingStructuredPromptOnError || hasTeammatesOnError || willResumeOnError || queuedChainAlreadyActiveOnError || queuedContinuationScheduledOnError) {
+          const reason = hasPendingStructuredPromptOnError
+            ? 'structured prompt pending'
+            : hasTeammatesOnError
             ? 'teammates still active'
             : willResumeOnError
             ? 'lead resuming'
@@ -2881,7 +2889,7 @@ export class MessageStreamingHandler {
         if (syncProvider && !this.hasActiveQueueLease(session.id)) {
           syncProvider.pushChange(session.id, {
             type: 'metadata_updated',
-            metadata: { isExecuting: false, hasPendingPrompt: false, updatedAt: Date.now() },
+            metadata: { isExecuting: false, hasPendingPrompt: hasPendingStructuredPromptOnError, updatedAt: Date.now() },
           });
 
           // Request mobile push notification for agent error (only when truly away)

--- a/packages/electron/src/main/services/ai/__tests__/AIService.interactivePromptSettlement.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/AIService.interactivePromptSettlement.test.ts
@@ -1,46 +1,80 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ipcMain } from 'electron';
+
+const { query, getSession, clearPending } = vi.hoisted(() => ({
+  query: vi.fn(),
+  getSession: vi.fn(),
+  clearPending: vi.fn(),
+}));
+
+vi.mock('../../../database/PGLiteDatabaseWorker', () => ({ database: { query } }));
+vi.mock('@nimbalyst/runtime/storage/repositories/AISessionsRepository', () => ({
+  AISessionsRepository: { get: getSession },
+}));
+vi.mock('../pendingPromptPersistence', () => ({ setSessionPendingPrompt: clearPending }));
+
+import { ProviderFactory } from '@nimbalyst/runtime/ai/server';
 import { AIService } from '../AIService';
 
-type Settlement = { success: boolean; error?: string };
+const params = {
+  sessionId: 'session-a',
+  promptId: 'question-a',
+  promptType: 'ask_user_question_request' as const,
+  response: { answers: { answer: 'Continue' } },
+};
 
-function serviceWithSettlement(settle: () => Promise<Settlement>): AIService {
-  const service = Object.create(AIService.prototype) as any;
-  service.interactivePromptSettlements = new Map();
-  service.respondToInteractivePromptOnce = settle;
-  return service;
+function service(): AIService {
+  const instance = Object.create(AIService.prototype) as any;
+  instance.interactivePromptSettlements = new Map();
+  return instance;
 }
 
-describe('AIService.respondToInteractivePrompt settlement ownership', () => {
-  const params = {
-    sessionId: 'session-a',
-    promptId: 'question-a',
-    promptType: 'ask_user_question_request' as const,
-    response: { answers: { answer: 'Continue' } },
-  };
+beforeEach(() => {
+  query.mockReset();
+  getSession.mockReset().mockResolvedValue({ provider: 'claude-code' });
+  clearPending.mockReset().mockResolvedValue(undefined);
+  (ipcMain as any).listenerCount = vi.fn((channel: string) => channel.startsWith('ask-user-question-response:') ? 1 : 0);
+  (ipcMain as any).emit = vi.fn();
+  vi.spyOn(ProviderFactory, 'getProvider').mockReturnValue({
+    resolveAskUserQuestion: vi.fn(() => false),
+  } as any);
+});
 
-  it('claims concurrent answers once and shares the resulting settlement', async () => {
-    let release!: (value: Settlement) => void;
-    const settle = vi.fn(() => new Promise<Settlement>((resolve) => { release = resolve; }));
-    const service = serviceWithSettlement(settle);
+describe('AIService.respondToInteractivePrompt production settlement', () => {
+  it('writes one durable answer and resumes one IPC waiter for concurrent duplicates', async () => {
+    const inserted: unknown[] = [];
+    query.mockImplementation(async (sql: string, values?: unknown[]) => {
+      if (sql.includes('ask_user_question_response')) return { rows: [] };
+      if (sql.includes('INSERT INTO ai_agent_messages')) { inserted.push(values?.[3]); return { rows: [] }; }
+      return { rows: [{ id: 'request' }] };
+    });
 
-    const first = service.respondToInteractivePrompt(params);
-    const second = service.respondToInteractivePrompt(params);
-    expect(settle).toHaveBeenCalledTimes(1);
-
-    release({ success: true });
-    await expect(Promise.all([first, second])).resolves.toEqual([{ success: true }, { success: true }]);
-    expect((service as any).interactivePromptSettlements).toHaveLength(0);
+    const instance = service();
+    await expect(Promise.all([instance.respondToInteractivePrompt(params), instance.respondToInteractivePrompt(params)])).resolves.toEqual([{ success: true }, { success: true }]);
+    expect(inserted).toHaveLength(1);
+    expect((ipcMain as any).emit).toHaveBeenCalledTimes(1);
+    expect(clearPending).toHaveBeenCalledTimes(1);
   });
 
-  it('releases a cancelled or failed settlement so exactly one later replay can resume', async () => {
-    const settle = vi
-      .fn<() => Promise<Settlement>>()
-      .mockResolvedValueOnce({ success: false, error: 'cancelled' })
-      .mockResolvedValueOnce({ success: true });
-    const service = serviceWithSettlement(settle);
+  it('replays a partial durable row through its waiter and clears pending state', async () => {
+    query.mockImplementation(async (sql: string) => {
+      if (sql.includes('ask_user_question_response')) {
+        return { rows: [{ content: JSON.stringify({ type: 'ask_user_question_response', questionId: params.promptId, answers: { answer: 'Continue' } }) }] };
+      }
+      if (sql.includes('INSERT INTO ai_agent_messages')) throw new Error('must not insert a replay');
+      return { rows: [{ id: 'request' }] };
+    });
 
-    await expect(service.respondToInteractivePrompt(params)).resolves.toEqual({ success: false, error: 'cancelled' });
-    await expect(service.respondToInteractivePrompt(params)).resolves.toEqual({ success: true });
-    expect(settle).toHaveBeenCalledTimes(2);
+    await expect(service().respondToInteractivePrompt(params)).resolves.toEqual({ success: true });
+    expect((ipcMain as any).emit).toHaveBeenCalledTimes(1);
+    expect(clearPending).toHaveBeenCalledWith(params.sessionId, false);
+  });
+
+  it('persists and settles a cancelled answer once', async () => {
+    query.mockImplementation(async (sql: string) => ({ rows: sql.includes('ask_user_question_response') ? [] : [{ id: 'request' }] }));
+
+    await expect(service().respondToInteractivePrompt({ ...params, response: { cancelled: true } })).resolves.toEqual({ success: true });
+    expect((ipcMain as any).emit.mock.calls[0]?.[2]).toMatchObject({ cancelled: true });
+    expect(clearPending).toHaveBeenCalledWith(params.sessionId, false);
   });
 });

--- a/packages/electron/src/main/services/ai/__tests__/AIService.interactivePromptSettlement.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/AIService.interactivePromptSettlement.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AIService } from '../AIService';
+
+type Settlement = { success: boolean; error?: string };
+
+function serviceWithSettlement(settle: () => Promise<Settlement>): AIService {
+  const service = Object.create(AIService.prototype) as any;
+  service.interactivePromptSettlements = new Map();
+  service.respondToInteractivePromptOnce = settle;
+  return service;
+}
+
+describe('AIService.respondToInteractivePrompt settlement ownership', () => {
+  const params = {
+    sessionId: 'session-a',
+    promptId: 'question-a',
+    promptType: 'ask_user_question_request' as const,
+    response: { answers: { answer: 'Continue' } },
+  };
+
+  it('claims concurrent answers once and shares the resulting settlement', async () => {
+    let release!: (value: Settlement) => void;
+    const settle = vi.fn(() => new Promise<Settlement>((resolve) => { release = resolve; }));
+    const service = serviceWithSettlement(settle);
+
+    const first = service.respondToInteractivePrompt(params);
+    const second = service.respondToInteractivePrompt(params);
+    expect(settle).toHaveBeenCalledTimes(1);
+
+    release({ success: true });
+    await expect(Promise.all([first, second])).resolves.toEqual([{ success: true }, { success: true }]);
+    expect((service as any).interactivePromptSettlements).toHaveLength(0);
+  });
+
+  it('releases a cancelled or failed settlement so exactly one later replay can resume', async () => {
+    const settle = vi
+      .fn<() => Promise<Settlement>>()
+      .mockResolvedValueOnce({ success: false, error: 'cancelled' })
+      .mockResolvedValueOnce({ success: true });
+    const service = serviceWithSettlement(settle);
+
+    await expect(service.respondToInteractivePrompt(params)).resolves.toEqual({ success: false, error: 'cancelled' });
+    await expect(service.respondToInteractivePrompt(params)).resolves.toEqual({ success: true });
+    expect(settle).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/electron/src/main/services/ai/__tests__/MessageStreamingHandler.pendingPromptSync.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/MessageStreamingHandler.pendingPromptSync.test.ts
@@ -1,17 +1,24 @@
-import { describe, expect, it } from 'vitest';
-import { hasPersistedPendingPrompt } from '../MessageStreamingHandler';
+import { describe, expect, it, vi } from 'vitest';
+import { runTerminalPromptTransition } from '../MessageStreamingHandler';
 
-describe('MessageStreamingHandler terminal structured-prompt projection', () => {
-  it.each(['normal completion', 'error completion'])(
-    '%s retains the durable pending prompt bit for its queue and sync fences',
-    () => {
-      expect(hasPersistedPendingPrompt({ hasPendingPrompt: true })).toBe(true);
-      expect(hasPersistedPendingPrompt({ hasPendingPrompt: false })).toBe(false);
-    },
-  );
+describe.each(['normal completion', 'error completion'])('MessageStreamingHandler %s terminal transition', (kind) => {
+  it('fences queue dispatch and endSession while a structured prompt is pending', async () => {
+    const tryDispatch = vi.fn(async () => false);
+    const endSession = vi.fn(async () => undefined);
+    const sync = vi.fn();
+    await expect(runTerminalPromptTransition({ metadata: { hasPendingPrompt: true }, hasActiveLease: false, tryDispatch, endSession, sync })).resolves.toEqual({ deferred: true, hasPendingPrompt: true });
+    expect(tryDispatch).not.toHaveBeenCalled();
+    expect(endSession).not.toHaveBeenCalled();
+    expect(sync).toHaveBeenCalledWith(true);
+  });
 
-  it('does not fence a cancelled or absent prompt', () => {
-    expect(hasPersistedPendingPrompt({ cancelled: true })).toBe(false);
-    expect(hasPersistedPendingPrompt(null)).toBe(false);
+  it('dispatches and ends only when no prompt is pending', async () => {
+    const tryDispatch = vi.fn(async () => false);
+    const endSession = vi.fn(async () => undefined);
+    const sync = vi.fn();
+    await expect(runTerminalPromptTransition({ metadata: { hasPendingPrompt: false }, hasActiveLease: false, tryDispatch, endSession, sync })).resolves.toEqual({ deferred: false, hasPendingPrompt: false });
+    expect(tryDispatch).toHaveBeenCalledTimes(1);
+    expect(endSession).toHaveBeenCalledTimes(1);
+    expect(sync).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/electron/src/main/services/ai/__tests__/MessageStreamingHandler.pendingPromptSync.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/MessageStreamingHandler.pendingPromptSync.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { hasPersistedPendingPrompt } from '../MessageStreamingHandler';
+
+describe('MessageStreamingHandler terminal structured-prompt projection', () => {
+  it.each(['normal completion', 'error completion'])(
+    '%s retains the durable pending prompt bit for its queue and sync fences',
+    () => {
+      expect(hasPersistedPendingPrompt({ hasPendingPrompt: true })).toBe(true);
+      expect(hasPersistedPendingPrompt({ hasPendingPrompt: false })).toBe(false);
+    },
+  );
+
+  it('does not fence a cancelled or absent prompt', () => {
+    expect(hasPersistedPendingPrompt({ cancelled: true })).toBe(false);
+    expect(hasPersistedPendingPrompt(null)).toBe(false);
+  });
+});

--- a/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
@@ -279,7 +279,10 @@ describe('queuedPromptDispatcher', () => {
     const queueStore: QueuedPromptStoreLike = {
       listPending: vi.fn(async () =>
         [...rows.values()]
-          .filter((row) => row.status === 'pending')
+          // Production listPending() only returns delivery-ready rows. Keep
+          // stale control rows in this boundary regression to prove they never
+          // become a head-of-line blocker for the ordinary FIFO.
+          .filter((row) => row.status === 'pending' && row.prompt.deliveryReady !== false)
           .map((row) => row.prompt)),
       claim: vi.fn(async (promptId) => {
         const row = rows.get(promptId);
@@ -383,5 +386,66 @@ describe('queuedPromptDispatcher', () => {
     expect(completions).toEqual([priorityPrompt.id, ordinaryPrompt.id]);
     expect(effects).toEqual(['PRIORITY_ACK', 'ORDINARY_MARKER', 'STRUCTURED_REPLY_CONTINUED']);
     expect(sendMessageHandler).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps stale non-ready controls out of ordinary FIFO head selection', async () => {
+    const sessionId = 'long-lived-session';
+    const staleControl: ClaimedQueuedPrompt = {
+      id: 'stale-control',
+      prompt: 'must never dispatch',
+      deliveryReady: false,
+    };
+    const ordinary: ClaimedQueuedPrompt = {
+      id: 'eligible-ordinary',
+      prompt: 'ordinary after long stream',
+      deliveryReady: true,
+    };
+    const rows = new Map([
+      [staleControl.id, { prompt: staleControl, status: 'pending' }],
+      [ordinary.id, { prompt: ordinary, status: 'pending' }],
+    ]);
+    const claims: string[] = [];
+    const queueStore: QueuedPromptStoreLike = {
+      listPending: vi.fn(async () =>
+        [...rows.values()]
+          .filter((row) => row.status === 'pending' && row.prompt.deliveryReady !== false)
+          .map((row) => row.prompt)),
+      claim: vi.fn(async (promptId) => {
+        const row = rows.get(promptId);
+        if (!row || row.status !== 'pending') return null;
+        row.status = 'executing';
+        claims.push(promptId);
+        return row.prompt;
+      }),
+      complete: vi.fn(async (promptId) => {
+        const row = rows.get(promptId);
+        if (row) row.status = 'completed';
+      }),
+      fail: vi.fn(async () => {}),
+    };
+    const leases = new Map<string, symbol>();
+    const targetWindow = {
+      isDestroyed: () => false,
+      webContents: { send: vi.fn(), mainFrame: {} },
+    } as unknown as Electron.BrowserWindow;
+
+    expect(await tryClaimAndDispatchNextQueuedPrompt({
+      continueQueuedPromptChain: vi.fn(async () => {}),
+      logError: vi.fn(),
+      logInfo: vi.fn(),
+      onPromptClaimed: vi.fn(),
+      processingLeases: leases,
+      queueStore,
+      sendMessageHandler: vi.fn(async () => ({ content: 'done' })),
+      sessionId,
+      source: 'long-lived settlement',
+      startSession: vi.fn(async () => {}),
+      targetWindow,
+      workspacePath: '/workspace/project',
+    })).toBe(true);
+
+    await vi.waitFor(() => expect(claims).toEqual([ordinary.id]));
+    expect(rows.get(staleControl.id)?.status).toBe('pending');
+    await vi.waitFor(() => expect(rows.get(ordinary.id)?.status).toBe('completed'));
   });
 });

--- a/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
@@ -272,6 +272,8 @@ describe('queuedPromptDispatcher', () => {
     const priorityStarted = deferred();
     const oldTurn = deferred();
     const priorityTurn = deferred();
+    const structuredPromptPersisted = deferred();
+    const structuredReply = deferred();
     const ordinaryCompleted = deferred();
 
     const queueStore: QueuedPromptStoreLike = {
@@ -316,6 +318,9 @@ describe('queuedPromptDispatcher', () => {
         effects.push('PRIORITY_ACK');
       } else {
         effects.push('ORDINARY_MARKER');
+        structuredPromptPersisted.resolve();
+        await structuredReply.promise;
+        effects.push('STRUCTURED_REPLY_CONTINUED');
       }
       return { content: message };
     });
@@ -362,11 +367,21 @@ describe('queuedPromptDispatcher', () => {
     expect(continueQueuedPromptChain).not.toHaveBeenCalled();
 
     priorityTurn.resolve();
+    await structuredPromptPersisted.promise;
+
+    // AskUserQuestion is now durable and waiting for its response. The FIFO
+    // dispatch must keep its own lease until that structured reply settles;
+    // completion must not clear the lease early or start a duplicate drain.
+    expect(processingSet.has(sessionId)).toBe(true);
+    expect(rows.get(ordinaryPrompt.id)?.status).toBe('executing');
+    expect(completions).toEqual([priorityPrompt.id]);
+
+    structuredReply.resolve();
     await ordinaryCompleted.promise;
 
     expect(claims).toEqual([oldPrompt.id, priorityPrompt.id, ordinaryPrompt.id]);
     expect(completions).toEqual([priorityPrompt.id, ordinaryPrompt.id]);
-    expect(effects).toEqual(['PRIORITY_ACK', 'ORDINARY_MARKER']);
+    expect(effects).toEqual(['PRIORITY_ACK', 'ORDINARY_MARKER', 'STRUCTURED_REPLY_CONTINUED']);
     expect(sendMessageHandler).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
@@ -32,7 +32,7 @@ describe('queuedPromptDispatcher', () => {
       }),
     };
 
-    const processingSet = new Set<string>();
+    const processingSet = new Map<string, symbol>();
     const targetWindow = {
       isDestroyed: () => false,
       webContents: {
@@ -52,7 +52,7 @@ describe('queuedPromptDispatcher', () => {
       onPromptClaimed: ({ sessionId, promptId }) => {
         targetWindow.webContents.send('ai:promptClaimed', { sessionId, promptId });
       },
-      processingSet,
+      processingLeases: processingSet,
       queueStore,
       sendMessageHandler: vi.fn(async () => {
         order.push('sendMessage');
@@ -94,7 +94,7 @@ describe('queuedPromptDispatcher', () => {
       fail: vi.fn(async () => {}),
     };
 
-    const processingSet = new Set<string>();
+    const processingSet = new Map<string, symbol>();
     const targetWindow = {
       isDestroyed: () => false,
       webContents: { send: vi.fn(), mainFrame: {} },
@@ -110,7 +110,7 @@ describe('queuedPromptDispatcher', () => {
       logInfo: vi.fn(),
       onChainSettled,
       onPromptClaimed: () => {},
-      processingSet,
+      processingLeases: processingSet,
       queueStore,
       sendMessageHandler: vi.fn(async () => ({ content: 'ok' })),
       sessionId: 'session-1',
@@ -148,16 +148,16 @@ describe('queuedPromptDispatcher', () => {
       fail: vi.fn(async () => {}),
     };
 
-    const processingSet = new Set<string>();
+    const processingSet = new Map<string, symbol>();
     const targetWindow = {
       isDestroyed: () => false,
       webContents: { send: vi.fn(), mainFrame: {} },
     } as unknown as Electron.BrowserWindow;
 
     const onChainSettled = vi.fn(async () => {});
-    // continueQueuedPromptChain dispatches a follow-on by re-adding to processingSet.
+    // continueQueuedPromptChain dispatches a follow-on by acquiring a new lease.
     const continueQueuedPromptChain = vi.fn(async (sessionId: string) => {
-      processingSet.add(sessionId);
+      processingSet.set(sessionId, Symbol('follow-on'));
     });
 
     await tryClaimAndDispatchNextQueuedPrompt({
@@ -166,7 +166,7 @@ describe('queuedPromptDispatcher', () => {
       logInfo: vi.fn(),
       onChainSettled,
       onPromptClaimed: () => {},
-      processingSet,
+      processingLeases: processingSet,
       queueStore,
       sendMessageHandler: vi.fn(async () => ({ content: 'ok' })),
       sessionId: 'session-1',
@@ -202,7 +202,7 @@ describe('queuedPromptDispatcher', () => {
       fail: vi.fn(async () => {}),
     };
     const sendMessageHandler = vi.fn(async () => ({ content: 'ok' }));
-    const processingSet = new Set<string>();
+    const processingSet = new Map<string, symbol>();
     const targetWindow = {
       isDestroyed: () => false,
       webContents: { send: vi.fn(), mainFrame: {} },
@@ -212,7 +212,7 @@ describe('queuedPromptDispatcher', () => {
       logError: vi.fn(),
       logInfo: vi.fn(),
       onPromptClaimed: vi.fn(),
-      processingSet,
+      processingLeases: processingSet,
       queueStore,
       sendMessageHandler,
       sessionId: 'session-1',
@@ -233,5 +233,140 @@ describe('queuedPromptDispatcher', () => {
     expect(queueStore.claim).toHaveBeenCalledTimes(2);
     expect(sendMessageHandler).toHaveBeenCalledTimes(1);
     expect(queueStore.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps an ordinary FIFO prompt fenced while an interrupting priority dispatch owns the lease', async () => {
+    const deferred = () => {
+      let resolve!: () => void;
+      let reject!: (reason?: unknown) => void;
+      const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+      });
+      return { promise, resolve, reject };
+    };
+
+    const sessionId = 'interrupted-session';
+    const oldPrompt: ClaimedQueuedPrompt = {
+      id: 'initial-executing',
+      prompt: 'initial turn',
+    };
+    const priorityPrompt: ClaimedQueuedPrompt = {
+      id: 'priority-control',
+      prompt: 'priority turn',
+    };
+    const ordinaryPrompt: ClaimedQueuedPrompt = {
+      id: 'ordinary-fifo',
+      prompt: 'ordinary turn',
+    };
+    const rows = new Map([
+      [oldPrompt.id, { prompt: oldPrompt, status: 'pending' }],
+      [priorityPrompt.id, { prompt: priorityPrompt, status: 'held' }],
+      [ordinaryPrompt.id, { prompt: ordinaryPrompt, status: 'held' }],
+    ]);
+    const claims: string[] = [];
+    const completions: string[] = [];
+    const failures: string[] = [];
+    const effects: string[] = [];
+    const oldStarted = deferred();
+    const priorityStarted = deferred();
+    const oldTurn = deferred();
+    const priorityTurn = deferred();
+    const ordinaryCompleted = deferred();
+
+    const queueStore: QueuedPromptStoreLike = {
+      listPending: vi.fn(async () =>
+        [...rows.values()]
+          .filter((row) => row.status === 'pending')
+          .map((row) => row.prompt)),
+      claim: vi.fn(async (promptId) => {
+        const row = rows.get(promptId);
+        if (!row || row.status !== 'pending') return null;
+        row.status = 'executing';
+        claims.push(promptId);
+        return row.prompt;
+      }),
+      complete: vi.fn(async (promptId) => {
+        const row = rows.get(promptId);
+        if (row) row.status = 'completed';
+        completions.push(promptId);
+        if (promptId === ordinaryPrompt.id) ordinaryCompleted.resolve();
+      }),
+      fail: vi.fn(async (promptId) => {
+        const row = rows.get(promptId);
+        if (row) row.status = 'failed';
+        failures.push(promptId);
+      }),
+    };
+    const processingSet = new Map<string, symbol>();
+    const targetWindow = {
+      isDestroyed: () => false,
+      webContents: { send: vi.fn(), mainFrame: {} },
+    } as unknown as Electron.BrowserWindow;
+    const sendMessageHandler = vi.fn(async (
+      _event: Electron.IpcMainInvokeEvent,
+      message: string,
+    ) => {
+      if (message === oldPrompt.prompt) {
+        oldStarted.resolve();
+        await oldTurn.promise;
+      } else if (message === priorityPrompt.prompt) {
+        priorityStarted.resolve();
+        await priorityTurn.promise;
+        effects.push('PRIORITY_ACK');
+      } else {
+        effects.push('ORDINARY_MARKER');
+      }
+      return { content: message };
+    });
+    let dispatch!: (source: string) => Promise<boolean>;
+    const continueQueuedPromptChain = vi.fn(async () => {
+      await dispatch('test continuation');
+    });
+    dispatch = (source) => tryClaimAndDispatchNextQueuedPrompt({
+      continueQueuedPromptChain,
+      logError: vi.fn(),
+      logInfo: vi.fn(),
+      onPromptClaimed: vi.fn(),
+      processingLeases: processingSet,
+      queueStore,
+      sendMessageHandler,
+      sessionId,
+      source,
+      startSession: vi.fn(async () => {}),
+      targetWindow,
+      workspacePath: '/workspace/project',
+    });
+
+    expect(await dispatch('initial queue')).toBe(true);
+    await oldStarted.promise;
+
+    // Priority interruption revokes the initial dispatch lease before claiming
+    // the control prompt. The replacement priority dispatch must remain fenced
+    // when the interrupted dispatch's stale finally block later runs.
+    processingSet.delete(sessionId);
+    rows.get(priorityPrompt.id)!.status = 'pending';
+    expect(await dispatch('priority queue')).toBe(true);
+    await priorityStarted.promise;
+    rows.get(ordinaryPrompt.id)!.status = 'pending';
+
+    oldTurn.reject(new Error('native abort'));
+    await vi.waitFor(() => {
+      expect(failures).toEqual([oldPrompt.id]);
+    });
+
+    expect(processingSet.has(sessionId)).toBe(true);
+    expect(claims).toEqual([oldPrompt.id, priorityPrompt.id]);
+    expect(completions).toEqual([]);
+    expect(effects).toEqual([]);
+    expect(continueQueuedPromptChain).not.toHaveBeenCalled();
+
+    priorityTurn.resolve();
+    await ordinaryCompleted.promise;
+
+    expect(claims).toEqual([oldPrompt.id, priorityPrompt.id, ordinaryPrompt.id]);
+    expect(completions).toEqual([priorityPrompt.id, ordinaryPrompt.id]);
+    expect(effects).toEqual(['PRIORITY_ACK', 'ORDINARY_MARKER']);
+    expect(sendMessageHandler).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
@@ -180,4 +180,58 @@ describe('queuedPromptDispatcher', () => {
 
     expect(onChainSettled).not.toHaveBeenCalled();
   });
+
+  it('dispatches an ordinary prompt exactly once when post-turn drains race', async () => {
+    vi.useFakeTimers();
+
+    const queued: ClaimedQueuedPrompt = {
+      id: 'ordinary-after-active-turn',
+      prompt: 'continue after the current turn',
+      attachments: null,
+      documentContext: null,
+    };
+    let claimed = false;
+    const queueStore: QueuedPromptStoreLike = {
+      listPending: vi.fn(async () => claimed ? [] : [queued]),
+      claim: vi.fn(async () => {
+        if (claimed) return null;
+        claimed = true;
+        return queued;
+      }),
+      complete: vi.fn(async () => {}),
+      fail: vi.fn(async () => {}),
+    };
+    const sendMessageHandler = vi.fn(async () => ({ content: 'ok' }));
+    const processingSet = new Set<string>();
+    const targetWindow = {
+      isDestroyed: () => false,
+      webContents: { send: vi.fn(), mainFrame: {} },
+    } as unknown as Electron.BrowserWindow;
+    const options = {
+      continueQueuedPromptChain: vi.fn(async () => {}),
+      logError: vi.fn(),
+      logInfo: vi.fn(),
+      onPromptClaimed: vi.fn(),
+      processingSet,
+      queueStore,
+      sendMessageHandler,
+      sessionId: 'session-1',
+      source: 'completion-handler queue',
+      startSession: vi.fn(async () => {}),
+      targetWindow,
+      workspacePath: '/workspace/project',
+    };
+
+    const results = await Promise.all([
+      tryClaimAndDispatchNextQueuedPrompt(options),
+      tryClaimAndDispatchNextQueuedPrompt(options),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+
+    await vi.runAllTimersAsync();
+
+    expect(queueStore.claim).toHaveBeenCalledTimes(2);
+    expect(sendMessageHandler).toHaveBeenCalledTimes(1);
+    expect(queueStore.complete).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/electron/src/main/services/ai/__tests__/startupQueuedPromptDrain.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/startupQueuedPromptDrain.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { drainPendingOrdinaryPromptsOnStartup } from '../startupQueuedPromptDrain';
+
+describe('startupQueuedPromptDrain', () => {
+  it('discovers durable ordinary rows and triggers each session once without UI input', async () => {
+    const listPendingOrdinarySessionIds = vi.fn(async () => ['session-a', 'session-b']);
+    const resolveWorkspacePath = vi.fn(async (sessionId: string) =>
+      sessionId === 'session-a' ? 'D:\\repo-a' : 'D:\\repo-b'
+    );
+    const triggerProcessing = vi.fn(async () => true);
+
+    await expect(drainPendingOrdinaryPromptsOnStartup({
+      listPendingOrdinarySessionIds,
+      resolveWorkspacePath,
+      triggerProcessing,
+      logError: vi.fn(),
+    })).resolves.toEqual({ discovered: 2, triggered: 2, skipped: 0 });
+
+    expect(listPendingOrdinarySessionIds).toHaveBeenCalledTimes(1);
+    expect(triggerProcessing).toHaveBeenCalledTimes(2);
+    expect(triggerProcessing).toHaveBeenNthCalledWith(1, 'session-a', 'D:\\repo-a');
+    expect(triggerProcessing).toHaveBeenNthCalledWith(2, 'session-b', 'D:\\repo-b');
+  });
+
+  it('keeps missing-window or failed triggers pending for a later retry', async () => {
+    const error = new Error('window unavailable');
+    const logError = vi.fn();
+    const triggerProcessing = vi.fn()
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(error);
+
+    await expect(drainPendingOrdinaryPromptsOnStartup({
+      listPendingOrdinarySessionIds: async () => ['session-a', 'session-b', 'session-c'],
+      resolveWorkspacePath: async (sessionId) =>
+        sessionId === 'session-c' ? null : `D:\\${sessionId}`,
+      triggerProcessing,
+      logError,
+    })).resolves.toEqual({ discovered: 3, triggered: 0, skipped: 3 });
+
+    expect(logError).toHaveBeenCalledWith('session-b', error);
+  });
+});

--- a/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
+++ b/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
@@ -26,7 +26,7 @@ interface DispatchClaimedQueuedPromptOptions {
   onAfterSettled?: () => Promise<void>;
   onChainSettled?: (payload: { sessionId: string; workspacePath: string; source: string }) => Promise<void>;
   onPromptClaimed: (payload: { sessionId: string; promptId: string }) => void;
-  processingSet: Set<string>;
+  processingLeases: Map<string, symbol>;
   queueStore: QueuedPromptStoreLike;
   sendMessageHandler: (
     event: Electron.IpcMainInvokeEvent,
@@ -52,7 +52,7 @@ export async function dispatchClaimedQueuedPrompt(
     onAfterSettled,
     onChainSettled,
     onPromptClaimed,
-    processingSet,
+    processingLeases,
     queueStore,
     sendMessageHandler,
     sessionId,
@@ -62,12 +62,15 @@ export async function dispatchClaimedQueuedPrompt(
     workspacePath,
   } = options;
 
-  processingSet.add(sessionId);
+  const dispatchLease = Symbol(`queued-prompt:${sessionId}:${claimed.id}`);
+  processingLeases.set(sessionId, dispatchLease);
 
   try {
     await startSession({ sessionId, workspacePath });
   } catch (error) {
-    processingSet.delete(sessionId);
+    if (processingLeases.get(sessionId) === dispatchLease) {
+      processingLeases.delete(sessionId);
+    }
     throw error;
   }
 
@@ -95,7 +98,14 @@ export async function dispatchClaimedQueuedPrompt(
         queueError instanceof Error ? queueError.message : 'Unknown error',
       );
     } finally {
-      processingSet.delete(sessionId);
+      // An interrupt revokes this dispatch's lease before a priority prompt
+      // acquires a replacement. The interrupted dispatch can settle later, but
+      // its stale finally block must not release the replacement lease or
+      // continue the ordinary FIFO chain concurrently with priority delivery.
+      if (processingLeases.get(sessionId) !== dispatchLease) {
+        return;
+      }
+      processingLeases.delete(sessionId);
       try {
         await continueQueuedPromptChain(
           sessionId,
@@ -108,9 +118,9 @@ export async function dispatchClaimedQueuedPrompt(
       }
       // If no follow-on prompt was dispatched, the chain has fully settled.
       // The inner sendMessage's completion handler deferred endSession because
-      // processingSet still contained this session (we hadn't reached this
+      // processingLeases still contained this session (we hadn't reached this
       // delete yet), so nobody has marked the session idle. Do it now.
-      if (!processingSet.has(sessionId) && onChainSettled) {
+      if (!processingLeases.has(sessionId) && onChainSettled) {
         try {
           await onChainSettled({ sessionId, workspacePath, source });
         } catch (settledErr) {
@@ -135,7 +145,7 @@ interface TryClaimAndDispatchNextQueuedPromptOptions {
   onAfterSettled?: DispatchClaimedQueuedPromptOptions['onAfterSettled'];
   onChainSettled?: DispatchClaimedQueuedPromptOptions['onChainSettled'];
   onPromptClaimed: DispatchClaimedQueuedPromptOptions['onPromptClaimed'];
-  processingSet: Set<string>;
+  processingLeases: Map<string, symbol>;
   queueStore: QueuedPromptStoreLike;
   sendMessageHandler: DispatchClaimedQueuedPromptOptions['sendMessageHandler'] | null;
   sessionId: string;
@@ -155,7 +165,7 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
     onAfterSettled,
     onChainSettled,
     onPromptClaimed,
-    processingSet,
+    processingLeases,
     queueStore,
     sendMessageHandler,
     sessionId,
@@ -170,7 +180,7 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
     return false;
   }
 
-  if (processingSet.has(sessionId)) {
+  if (processingLeases.has(sessionId)) {
     logInfo(`[AIService] ${source}: session ${sessionId} already processing a queued prompt, skipping`);
     return false;
   }
@@ -203,7 +213,7 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
     onAfterSettled,
     onChainSettled,
     onPromptClaimed,
-    processingSet,
+    processingLeases,
     queueStore,
     sendMessageHandler,
     sessionId,

--- a/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
+++ b/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
@@ -4,6 +4,7 @@ export interface ClaimedQueuedPrompt {
   id: string;
   prompt: string;
   attachments?: unknown[] | null;
+  deliveryReady?: boolean;
   documentContext?: DocumentContext | null;
 }
 

--- a/packages/electron/src/main/services/ai/startupQueuedPromptDrain.ts
+++ b/packages/electron/src/main/services/ai/startupQueuedPromptDrain.ts
@@ -1,0 +1,34 @@
+export interface StartupQueuedPromptDrainDependencies {
+  listPendingOrdinarySessionIds(): Promise<string[]>;
+  resolveWorkspacePath(sessionId: string): Promise<string | null>;
+  triggerProcessing(sessionId: string, workspacePath: string): Promise<boolean>;
+  logError(sessionId: string, error: unknown): void;
+}
+
+export async function drainPendingOrdinaryPromptsOnStartup(
+  deps: StartupQueuedPromptDrainDependencies,
+): Promise<{ discovered: number; triggered: number; skipped: number }> {
+  const sessionIds = await deps.listPendingOrdinarySessionIds();
+  let triggered = 0;
+  let skipped = 0;
+
+  for (const sessionId of sessionIds) {
+    try {
+      const workspacePath = await deps.resolveWorkspacePath(sessionId);
+      if (!workspacePath) {
+        skipped++;
+        continue;
+      }
+      if (await deps.triggerProcessing(sessionId, workspacePath)) {
+        triggered++;
+      } else {
+        skipped++;
+      }
+    } catch (error) {
+      skipped++;
+      deps.logError(sessionId, error);
+    }
+  }
+
+  return { discovered: sessionIds.length, triggered, skipped };
+}

--- a/packages/electron/src/main/window/__tests__/windowState.test.ts
+++ b/packages/electron/src/main/window/__tests__/windowState.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   windowStates,
+  windows,
   resolveActiveWorkspacePath,
   resolveActiveWorkspacePathForWindowId,
   resolveDocumentServicePath,
   windowReferencesWorkspace,
   anyWindowReferencesWorkspace,
+  hasLiveWindowForWorkspace,
 } from '../windowState';
 import type { WindowState } from '../../types';
 
@@ -22,6 +24,7 @@ function makeState(partial: Partial<WindowState> = {}): WindowState {
 describe('windowState helpers', () => {
   beforeEach(() => {
     windowStates.clear();
+    windows.clear();
   });
 
   describe('resolveActiveWorkspacePath', () => {
@@ -177,6 +180,23 @@ describe('windowState helpers', () => {
     it('returns false when the only references are excluded', () => {
       windowStates.set(1, makeState({ workspacePath: '/ws/lone' }));
       expect(anyWindowReferencesWorkspace('/ws/lone', 1)).toBe(false);
+    });
+  });
+
+  describe('hasLiveWindowForWorkspace', () => {
+    it('returns true only when a non-destroyed window references the path', () => {
+      windows.set(1, { isDestroyed: () => false } as any);
+      windowStates.set(1, makeState({ workspacePath: '/ws/a' }));
+
+      expect(hasLiveWindowForWorkspace('/ws/a')).toBe(true);
+      expect(hasLiveWindowForWorkspace('/ws/b')).toBe(false);
+    });
+
+    it('ignores stale state owned by a destroyed window', () => {
+      windows.set(1, { isDestroyed: () => true } as any);
+      windowStates.set(1, makeState({ workspacePath: '/ws/a' }));
+
+      expect(hasLiveWindowForWorkspace('/ws/a')).toBe(false);
     });
   });
 });

--- a/packages/electron/src/main/window/windowState.ts
+++ b/packages/electron/src/main/window/windowState.ts
@@ -88,3 +88,17 @@ export function anyWindowReferencesWorkspace(path: string, excludeWindowId?: num
     }
     return false;
 }
+
+/**
+ * Whether a live window currently references a workspace path.
+ *
+ * This is the lightweight loaded-project gate for services that must not pull
+ * in WindowManager's startup graph merely to verify routing custody.
+ */
+export function hasLiveWindowForWorkspace(path: string): boolean {
+    for (const [id, window] of windows) {
+        if (window.isDestroyed()) continue;
+        if (windowReferencesWorkspace(windowStates.get(id), path)) return true;
+    }
+    return false;
+}

--- a/packages/electron/src/renderer/components/UnifiedAI/AIInput.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/AIInput.tsx
@@ -11,6 +11,7 @@ import { ModeTag, AIMode } from './ModeTag';
 import { ModelSelector } from './ModelSelector';
 import { EffortLevelSelector } from './EffortLevelSelector';
 import { ThinkingModeSelector } from './ThinkingModeSelector';
+import { isDeepSeekClaudeAgentModel } from '@nimbalyst/runtime/ai/server/deepSeekClaudeAgent';
 import { registerPendingVoiceCommandSetter } from './VoiceModeButton.tsx';
 import { PendingVoiceCommand } from './PendingVoiceCommand';
 import { pendingVoiceCommandAtom, voiceActiveSessionIdAtom, type PendingVoiceCommand as PendingVoiceCommandType } from '../../store/atoms/voiceModeState';
@@ -1407,6 +1408,7 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
               <EffortLevelSelector
                 level={effortLevel}
                 onLevelChange={onEffortLevelChange}
+                allowedLevels={isDeepSeekClaudeAgentModel(currentModel) ? ['high', 'max'] : undefined}
                 disabled={reasoningControlsDisabled}
                 disabledTitle={reasoningControlsDisabledTitle}
               />

--- a/packages/electron/src/renderer/components/UnifiedAI/EffortLevelSelector.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/EffortLevelSelector.tsx
@@ -6,11 +6,12 @@ import { EFFORT_LEVELS, DEFAULT_EFFORT_LEVEL } from '../../utils/modelUtils';
 interface EffortLevelSelectorProps {
   level: EffortLevel;
   onLevelChange: (level: EffortLevel) => void;
+  allowedLevels?: readonly EffortLevel[];
   disabled?: boolean;
   disabledTitle?: string;
 }
 
-export function EffortLevelSelector({ level, onLevelChange, disabled = false, disabledTitle }: EffortLevelSelectorProps) {
+export function EffortLevelSelector({ level, onLevelChange, allowedLevels, disabled = false, disabledTitle }: EffortLevelSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -40,7 +41,8 @@ export function EffortLevelSelector({ level, onLevelChange, disabled = false, di
     }
   }, [disabled]);
 
-  const currentLevel = EFFORT_LEVELS.find(l => l.key === level) ?? EFFORT_LEVELS.find(l => l.key === DEFAULT_EFFORT_LEVEL)!;
+  const visibleLevels = allowedLevels ? EFFORT_LEVELS.filter(({ key }) => allowedLevels.includes(key)) : EFFORT_LEVELS;
+  const currentLevel = visibleLevels.find(l => l.key === level) ?? visibleLevels[0] ?? EFFORT_LEVELS.find(l => l.key === DEFAULT_EFFORT_LEVEL)!;
 
   return (
     <div className="relative inline-block" ref={dropdownRef}>
@@ -61,7 +63,7 @@ export function EffortLevelSelector({ level, onLevelChange, disabled = false, di
 
       {isOpen && (
         <div className="absolute bottom-full left-0 mb-1 min-w-[120px] rounded-lg p-1 z-[1000] bg-[var(--nim-bg)] border border-[var(--nim-border)] shadow-[0_4px_12px_rgba(0,0,0,0.15)]">
-          {EFFORT_LEVELS.map(l => (
+          {visibleLevels.map(l => (
             <button
               key={l.key}
               className={`flex items-center justify-between gap-2 px-2 py-1.5 w-full border-none rounded text-xs cursor-pointer transition-[background] duration-150 text-left text-[var(--nim-text)] hover:bg-[var(--nim-bg-hover)] ${l.key === level ? 'bg-[var(--nim-bg-secondary)] text-[var(--nim-primary)]' : ''}`}

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -109,6 +109,7 @@ import { scrollToTeammateAtom, scrollToMessageAtom, requestOpenSessionAtom } fro
 import { usePostHog } from 'posthog-js/react';
 import { setAgentModeSettingsAtom, showPromptAdditionsAtom, hasExternalEditorAtom, externalEditorNameAtom, openInExternalEditorAtom, defaultAgentModelAtom, defaultEffortLevelAtom, chatShowToolCallsAtom, developerModeAtom } from '../../store/atoms/appSettings';
 import { supportsEffortLevel, supportsThinkingToggle, parseEffortLevel, parseThinkingMode, type EffortLevel, type ThinkingMode } from '../../utils/modelUtils';
+import { isDeepSeekClaudeAgentModel, normalizeDeepSeekEffort, normalizeDeepSeekThinkingMode } from '@nimbalyst/runtime/ai/server/deepSeekClaudeAgent';
 import { buildPlanImplementationPrompt, resolvePlanFilePath } from '../../utils/pathUtils';
 import { resolveTranscriptClickPath } from '../../utils/resolveTranscriptClickPath';
 import { autoCommitEnabledAtom, setAutoCommitEnabledAtom } from '../../store/atoms/autoCommitAtoms';
@@ -518,15 +519,18 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
 
   // Effort level: read from session metadata, fall back to global default
   const showEffortLevel = useMemo(() => supportsEffortLevel(currentModel), [currentModel]);
-  const effortLevel = useMemo(() => {
-    return rawEffortLevel != null ? parseEffortLevel(rawEffortLevel) : defaultEffortLevel;
-  }, [rawEffortLevel, defaultEffortLevel]);
+  const effortLevel = useMemo(() => isDeepSeekClaudeAgentModel(currentModel)
+    ? normalizeDeepSeekEffort(rawEffortLevel)
+    : rawEffortLevel != null ? parseEffortLevel(rawEffortLevel) : defaultEffortLevel,
+  [rawEffortLevel, defaultEffortLevel, currentModel]);
   // Extended-thinking is a power-user control: only surface the selector in
   // developer mode. When hidden, thinkingMode is never set, so the default
   // (adaptive/enabled) applies.
   const developerMode = useAtomValue(developerModeAtom);
-  const showThinkingToggle = useMemo(() => developerMode && supportsThinkingToggle(currentModel), [developerMode, currentModel]);
-  const thinkingMode = useMemo(() => parseThinkingMode(rawThinkingMode), [rawThinkingMode]);
+  const showThinkingToggle = useMemo(() => (developerMode || isDeepSeekClaudeAgentModel(currentModel)) && supportsThinkingToggle(currentModel), [developerMode, currentModel]);
+  const thinkingMode = useMemo(() => isDeepSeekClaudeAgentModel(currentModel)
+    ? normalizeDeepSeekThinkingMode(rawThinkingMode)
+    : parseThinkingMode(rawThinkingMode), [rawThinkingMode, currentModel]);
 
   // Memoize the teammate list passed to AgentTranscriptPanel so its memo
   // comparison doesn't see a new array reference on every keystroke. Without
@@ -1535,12 +1539,16 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
         await window.electronAPI.terminal.setClaudeCliModel(sessionId, modelId);
       }
       await window.electronAPI.invoke('sessions:update-metadata', sessionId, { model: modelId });
+      if (isDeepSeekClaudeAgentModel(modelId)) {
+        await updateSessionMetadataField(sessionId, 'effortLevel', normalizeDeepSeekEffort(rawEffortLevel), null, updateSessionStore);
+        await updateSessionMetadataField(sessionId, 'thinkingMode', normalizeDeepSeekThinkingMode(rawThinkingMode), null, updateSessionStore);
+      }
     } catch (error) {
       console.error('[SessionTranscript] Failed to update model:', error);
       setCurrentModel(previousModel);
       setAgentModeSettings({ defaultModel: previousModel });
     }
-  }, [currentModel, sessionId, setCurrentModel, setAgentModeSettings, provider, cliSessionCommitted]);
+  }, [currentModel, sessionId, setCurrentModel, setAgentModeSettings, provider, cliSessionCommitted, rawEffortLevel, rawThinkingMode, updateSessionStore]);
 
   const handleEffortLevelChange = useCallback(async (level: EffortLevel) => {
     const previousLevel = effortLevel;

--- a/packages/electron/src/renderer/help/HelpContent.ts
+++ b/packages/electron/src/renderer/help/HelpContent.ts
@@ -248,6 +248,14 @@ export const HelpContent: Record<string, HelpEntry> = {
     title: 'Claude Agent (Claude Code Based)',
     body: 'The in-app agent built on Claude Code with full Nimbalyst integration: it sees your active document and selection, renders the rich inline transcript, and tracks every file it edits. Uses your configured Anthropic API key.',
   },
+  'deepseek-effort-selector': {
+    title: 'DeepSeek Effort',
+    body: 'High and Max control how much reasoning work DeepSeek applies.',
+  },
+  'deepseek-reasoning-selector': {
+    title: 'DeepSeek Reasoning',
+    body: 'Turn DeepSeek reasoning on or off for the next request.',
+  },
   'model-picker-provider-claude-code-cli': {
     title: 'Claude Code CLI (Terminal Mode)',
     body: 'Runs the genuine claude terminal binary in an embedded terminal, billed to your Claude subscription. You get native CLI behavior — its slash commands and TUI — in the Raw terminal drawer, while Nimbalyst mirrors the conversation into the rich transcript.',

--- a/packages/electron/src/renderer/help/__tests__/HelpContent.deepSeek.test.ts
+++ b/packages/electron/src/renderer/help/__tests__/HelpContent.deepSeek.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { getHelpContent } from '../HelpContent';
+
+describe('DeepSeek controls help', () => {
+  it('documents reasoning control', () => {
+    expect(getHelpContent('deepseek-reasoning-selector')?.title).toBe('DeepSeek Reasoning');
+  });
+
+  it('documents the restricted effort selector', () => {
+    expect(getHelpContent('deepseek-effort-selector')?.title).toBe('DeepSeek Effort');
+  });
+});

--- a/packages/electron/src/renderer/utils/modelUtils.ts
+++ b/packages/electron/src/renderer/utils/modelUtils.ts
@@ -22,6 +22,7 @@ import {
   type ClaudeCodeVariant,
 } from '@nimbalyst/runtime/ai/modelConstants';
 import { CLAUDE_CODE_VARIANTS, ModelIdentifier, isClaudeCodeFamily } from '@nimbalyst/runtime/ai/server/types';
+import { isDeepSeekClaudeAgentModel } from '@nimbalyst/runtime/ai/server/deepSeekClaudeAgent';
 
 export {
   type EffortLevel,
@@ -84,6 +85,7 @@ function getClaudeCodeFamilyPrefix(modelId?: string): string {
 }
 
 export function getClaudeCodeModelLabel(modelId?: string): string {
+  if (isDeepSeekClaudeAgentModel(modelId)) return 'Claude agent - DeepSeek';
   const variant = extractClaudeCodeVariant(modelId) ?? 'sonnet';
   const parsed = modelId ? ModelIdentifier.tryParse(modelId) : null;
   const version = CLAUDE_CODE_VARIANT_VERSIONS[variant];
@@ -92,6 +94,7 @@ export function getClaudeCodeModelLabel(modelId?: string): string {
 }
 
 export function getClaudeCodeModelShortLabel(modelId?: string): string {
+  if (isDeepSeekClaudeAgentModel(modelId)) return 'DeepSeek';
   const variant = extractClaudeCodeVariant(modelId) ?? 'sonnet';
   const parsed = modelId ? ModelIdentifier.tryParse(modelId) : null;
   const version = CLAUDE_CODE_VARIANT_VERSIONS[variant];
@@ -254,6 +257,7 @@ export function getModelShortName(provider: string, modelId: string): string {
  */
 export function supportsEffortLevel(modelId?: string): boolean {
   if (!modelId) return false;
+  if (isDeepSeekClaudeAgentModel(modelId)) return true;
   const variant = extractClaudeCodeVariant(modelId);
   if (
     variant === 'fable' ||
@@ -281,6 +285,7 @@ export function supportsEffortLevel(modelId?: string): boolean {
  */
 export function supportsThinkingToggle(modelId?: string): boolean {
   if (!modelId) return false;
+  if (isDeepSeekClaudeAgentModel(modelId)) return true;
   const variant = extractClaudeCodeVariant(modelId);
   if (!variant) return false;
   return variant.startsWith('opus') || variant.startsWith('sonnet');

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -42,6 +42,10 @@
       "import": "./dist/ai/server/effortLevels.js",
       "types": "./dist/ai/server/effortLevels.d.ts"
     },
+    "./ai/server/sessionLaunchConfiguration": {
+      "import": "./dist/ai/server/sessionLaunchConfiguration.js",
+      "types": "./dist/ai/server/sessionLaunchConfiguration.d.ts"
+    },
     "./ai/types": {
       "import": "./dist/ai/types.js",
       "types": "./dist/ai/types.d.ts"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -42,6 +42,10 @@
       "import": "./dist/ai/server/effortLevels.js",
       "types": "./dist/ai/server/effortLevels.d.ts"
     },
+    "./ai/server/deepSeekClaudeAgent": {
+      "import": "./dist/ai/server/deepSeekClaudeAgent.js",
+      "types": "./dist/ai/server/deepSeekClaudeAgent.d.ts"
+    },
     "./ai/server/sessionLaunchConfiguration": {
       "import": "./dist/ai/server/sessionLaunchConfiguration.js",
       "types": "./dist/ai/server/sessionLaunchConfiguration.d.ts"

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -239,7 +239,7 @@ export const OPENAI_MODELS: ModelDefinition[] = [
  *   `opus` to the next version.
  */
 export type ClaudeCodeVariant = 'fable' | 'opus' | 'sonnet' | 'haiku' | 'opus-4-7' | 'opus-4-6' | 'sonnet-4-6';
-export type ClaudeCodeVariantInput = ClaudeCodeVariant | 'opus-4-8' | 'fable-5';
+export type ClaudeCodeVariantInput = ClaudeCodeVariant | 'opus-4-8' | 'sonnet-5' | 'fable-5';
 
 /**
  * Accepted input aliases for Claude Agent model identifiers.
@@ -270,6 +270,7 @@ const CLAUDE_CODE_VARIANT_INPUT_MAP: Readonly<Record<ClaudeCodeVariantInput, Cla
   'opus-4-7': 'opus-4-7',
   'opus-4-6': 'opus-4-6',
   sonnet: 'sonnet',
+  'sonnet-5': 'sonnet',
   'sonnet-4-6': 'sonnet-4-6',
   haiku: 'haiku',
 };

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -258,6 +258,7 @@ export const CLAUDE_CODE_ACCEPTED_VARIANT_INPUTS: readonly ClaudeCodeVariantInpu
   'opus-4-7',
   'opus-4-6',
   'sonnet',
+  'sonnet-5',
   'sonnet-4-6',
   'haiku',
 ] as const;

--- a/packages/runtime/src/ai/server/ModelIdentifier.ts
+++ b/packages/runtime/src/ai/server/ModelIdentifier.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_MODELS,
   normalizeClaudeCodeVariant,
 } from '../modelConstants';
+import { DEEPSEEK_CLAUDE_AGENT_MODEL_VARIANT } from './deepSeekClaudeAgent';
 
 /**
  * Valid Claude Code model suffixes (e.g., -1m for 1M context window)
@@ -172,6 +173,10 @@ export class ModelIdentifier {
           suffix = validSuffix;
           break;
         }
+      }
+
+      if (baseVariant === DEEPSEEK_CLAUDE_AGENT_MODEL_VARIANT) {
+        return new ModelIdentifier(provider, baseVariant);
       }
 
       const normalizedVariant = normalizeClaudeCodeVariant(baseVariant);

--- a/packages/runtime/src/ai/server/__tests__/deepSeekClaudeAgent.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/deepSeekClaudeAgent.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { applyDeepSeekClaudeAgentProfile, DEEPSEEK_CLAUDE_AGENT_MODEL_ID, DEEPSEEK_CLAUDE_BACKEND_ID, isDeepSeekClaudeBackend, normalizeDeepSeekEffort } from '../deepSeekClaudeAgent';
+
+describe('DeepSeek Claude Agent launch profile', () => {
+  it('atomically maps the picker model to a supported backend and real DOFs', () => {
+    expect(applyDeepSeekClaudeAgentProfile({ model: DEEPSEEK_CLAUDE_AGENT_MODEL_ID, effortLevel: 'low', thinkingMode: 'disabled' })).toEqual({ model: DEEPSEEK_CLAUDE_AGENT_MODEL_ID, customBackend: DEEPSEEK_CLAUDE_BACKEND_ID, effortLevel: 'high', thinkingMode: 'disabled' });
+  });
+  it('normalizes legacy effort values to High or Max', () => {
+    expect(normalizeDeepSeekEffort('low')).toBe('high');
+    expect(normalizeDeepSeekEffort('medium')).toBe('high');
+    expect(normalizeDeepSeekEffort('xhigh')).toBe('max');
+    expect(normalizeDeepSeekEffort('max')).toBe('max');
+  });
+  it('keeps retired backend ids readable as the canonical V4 profile', () => {
+    expect(isDeepSeekClaudeBackend('deepseek-chat')).toBe(true);
+    expect(isDeepSeekClaudeBackend('deepseek-reasoner')).toBe(true);
+    expect(applyDeepSeekClaudeAgentProfile({ model: 'claude-code:sonnet', customBackend: 'deepseek-reasoner', effortLevel: 'xhigh' }).customBackend).toBe(DEEPSEEK_CLAUDE_BACKEND_ID);
+  });
+
+  it('keeps high effort as high', () => expect(normalizeDeepSeekEffort('high')).toBe('high'));
+  it('enables reasoning by default', () => expect(applyDeepSeekClaudeAgentProfile({ model: DEEPSEEK_CLAUDE_AGENT_MODEL_ID }).thinkingMode).toBe('enabled'));
+  it('keeps explicit enabled reasoning', () => expect(applyDeepSeekClaudeAgentProfile({ model: DEEPSEEK_CLAUDE_AGENT_MODEL_ID, thinkingMode: 'enabled' }).thinkingMode).toBe('enabled'));
+  it('recognizes the synthetic model variant', () => expect(applyDeepSeekClaudeAgentProfile({ model: 'deepseek' }).customBackend).toBe(DEEPSEEK_CLAUDE_BACKEND_ID));
+  it('does not change an ordinary Claude Agent model', () => expect(applyDeepSeekClaudeAgentProfile({ model: 'claude-code:sonnet' }).customBackend).toBeUndefined());
+});

--- a/packages/runtime/src/ai/server/__tests__/sessionLaunchConfiguration.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/sessionLaunchConfiguration.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSessionLaunchToolScope,
+  resolveSessionReasoningConfiguration,
+} from '../sessionLaunchConfiguration';
+
+describe('session launch reasoning configuration', () => {
+  it('accepts explicit Codex effort without claiming provider effectiveness', () => {
+    expect(resolveSessionReasoningConfiguration({
+      provider: 'openai-codex',
+      model: 'openai-codex:gpt-5.6-sol',
+      effortLevel: 'max',
+      appDefaultEffortLevel: 'high',
+    })).toEqual({
+      requestedEffortLevel: 'max',
+      requestedThinkingMode: null,
+      effortLevel: 'max',
+      thinkingMode: null,
+      effortLevelSource: 'requested',
+      thinkingModeSource: null,
+    });
+  });
+
+  it('accepts supported Claude effort and adaptive-thinking requests', () => {
+    expect(resolveSessionReasoningConfiguration({
+      provider: 'claude-code',
+      model: 'claude-code:opus',
+      effortLevel: 'xhigh',
+      thinkingMode: 'disabled',
+      appDefaultEffortLevel: 'medium',
+    })).toMatchObject({
+      effortLevel: 'xhigh',
+      thinkingMode: 'disabled',
+      effortLevelSource: 'requested',
+      thinkingModeSource: 'requested',
+    });
+  });
+
+  it('normalizes an app default but rejects the same unsupported explicit value', () => {
+    expect(resolveSessionReasoningConfiguration({
+      provider: 'claude-code',
+      model: 'claude-code:sonnet-4-6',
+      appDefaultEffortLevel: 'xhigh',
+    }).effortLevel).toBe('high');
+
+    expect(() => resolveSessionReasoningConfiguration({
+      provider: 'claude-code',
+      model: 'claude-code:sonnet-4-6',
+      effortLevel: 'xhigh',
+      appDefaultEffortLevel: 'high',
+    })).toThrow('Supported values: low, medium, high, max');
+  });
+
+  it.each([
+    ['openai-codex-acp', 'openai-codex-acp:gpt-5.6-sol'],
+    ['claude-code-cli', 'claude-code-cli:opus'],
+    ['claude-code', 'claude-code:haiku'],
+    ['opencode', 'opencode:default'],
+  ])('rejects effort for unsupported %s models', (provider, model) => {
+    expect(() => resolveSessionReasoningConfiguration({
+      provider,
+      model,
+      effortLevel: 'high',
+      appDefaultEffortLevel: 'high',
+    })).toThrow('Supported values: none');
+  });
+
+  it('rejects thinking toggles for fixed-adaptive Fable', () => {
+    expect(() => resolveSessionReasoningConfiguration({
+      provider: 'claude-code',
+      model: 'claude-code:fable',
+      thinkingMode: 'disabled',
+      appDefaultEffortLevel: 'high',
+    })).toThrow('thinkingMode is not supported');
+  });
+
+  it('validates tool scopes instead of silently treating unknown values as full', () => {
+    expect(parseSessionLaunchToolScope(undefined)).toBe('full');
+    expect(parseSessionLaunchToolScope('write')).toBe('write');
+    expect(() => parseSessionLaunchToolScope('admin')).toThrow(
+      'Invalid toolScope "admin"',
+    );
+  });
+});

--- a/packages/runtime/src/ai/server/deepSeekClaudeAgent.ts
+++ b/packages/runtime/src/ai/server/deepSeekClaudeAgent.ts
@@ -1,0 +1,44 @@
+import type { EffortLevel, ThinkingMode } from './effortLevels';
+
+export const DEEPSEEK_CLAUDE_AGENT_MODEL_ID = 'claude-code:deepseek';
+export const DEEPSEEK_CLAUDE_AGENT_MODEL_VARIANT = 'deepseek';
+export const DEEPSEEK_CLAUDE_BACKEND_ID = 'deepseek-v4';
+
+export const DEEPSEEK_EFFORT_LEVELS = [
+  { key: 'high', label: 'High' },
+  { key: 'max', label: 'Max' },
+] as const satisfies readonly { key: EffortLevel; label: string }[];
+
+const DEEPSEEK_LEGACY_BACKEND_IDS = new Set(['deepseek-chat', 'deepseek-reasoner']);
+
+export function isDeepSeekClaudeAgentModel(model: string | undefined | null): boolean {
+  const normalized = model?.toLowerCase();
+  return normalized === DEEPSEEK_CLAUDE_AGENT_MODEL_ID || normalized === DEEPSEEK_CLAUDE_AGENT_MODEL_VARIANT;
+}
+
+export function isDeepSeekClaudeBackend(backendId: string | undefined | null): boolean {
+  return backendId === DEEPSEEK_CLAUDE_BACKEND_ID || (backendId != null && DEEPSEEK_LEGACY_BACKEND_IDS.has(backendId));
+}
+
+export function normalizeDeepSeekEffort(value: unknown): 'high' | 'max' {
+  return value === 'max' || value === 'xhigh' ? 'max' : 'high';
+}
+
+export function normalizeDeepSeekThinkingMode(value: unknown): ThinkingMode {
+  return value === 'disabled' ? 'disabled' : 'enabled';
+}
+
+export function applyDeepSeekClaudeAgentProfile<T extends {
+  model?: string;
+  customBackend?: string;
+  effortLevel?: EffortLevel | string;
+  thinkingMode?: ThinkingMode;
+}>(config: T): T & { customBackend?: string; effortLevel?: EffortLevel | string; thinkingMode?: ThinkingMode } {
+  if (!isDeepSeekClaudeAgentModel(config.model) && !isDeepSeekClaudeBackend(config.customBackend)) return config;
+  return {
+    ...config,
+    customBackend: DEEPSEEK_CLAUDE_BACKEND_ID,
+    effortLevel: normalizeDeepSeekEffort(config.effortLevel),
+    thinkingMode: normalizeDeepSeekThinkingMode(config.thinkingMode),
+  };
+}

--- a/packages/runtime/src/ai/server/effortLevels.ts
+++ b/packages/runtime/src/ai/server/effortLevels.ts
@@ -17,13 +17,79 @@ export const EFFORT_LEVELS: { key: EffortLevel; label: string }[] = [
 ];
 
 export const DEFAULT_EFFORT_LEVEL: EffortLevel = 'high';
-// Default to 'enabled' so the app omits the SDK thinking option and preserves
-// the SDK's default adaptive thinking (Claude decides depth) on supported
-// Opus/Sonnet models. Users can opt into 'disabled' (Extended: Off) per session.
+// "enabled" is the persisted compatibility value for adaptive thinking. The
+// provider translates it to `thinking: { type: 'adaptive' }`; it must not be
+// presented as manual "extended thinking", which is a different API mode.
 export const DEFAULT_THINKING_MODE: ThinkingMode = 'enabled';
 
 const VALID_EFFORT_LEVELS = new Set<string>(['low', 'medium', 'high', 'xhigh', 'max']);
 const VALID_THINKING_MODES = new Set<string>(['enabled', 'disabled']);
+
+const CLAUDE_EFFORT_LEVELS = {
+  current: EFFORT_LEVELS,
+  legacyAdaptive: EFFORT_LEVELS.filter(level => level.key !== 'xhigh'),
+} as const;
+
+function normalizedModelId(modelId: string | undefined | null): string {
+  return (modelId ?? '').toLowerCase().replace(/-1m$/, '').replace(/\[1m\]$/, '');
+}
+
+/**
+ * Return only the effort values the selected model accepts.
+ *
+ * Claude Sonnet 5, Fable 5, Opus 4.8, and Opus 4.7 support the complete
+ * low/medium/high/xhigh/max ladder. Opus 4.6 and Sonnet 4.6 support the same
+ * ladder except xhigh. Haiku has no adaptive-effort control in this surface.
+ * Other providers keep their existing transport-owned ladder.
+ */
+export function supportedEffortLevelsForModel(
+  modelId: string | undefined | null
+): { key: EffortLevel; label: string }[] {
+  const id = normalizedModelId(modelId);
+  if (id.startsWith('claude-code-cli:') || id.startsWith('openai-codex-acp:')) return [];
+  if (id.startsWith('claude-code:')) {
+    if (id.includes('haiku')) return [];
+    if (id.includes('opus-4-6') || id.includes('sonnet-4-6')) {
+      return [...CLAUDE_EFFORT_LEVELS.legacyAdaptive];
+    }
+  }
+  return [...CLAUDE_EFFORT_LEVELS.current];
+}
+
+/**
+ * Whether the selected model supports an explicit adaptive-thinking toggle.
+ *
+ * Fable is intentionally excluded: it is always adaptive and cannot be
+ * disabled. Claude CLI and non-Claude transports do not forward this setting.
+ */
+export function supportsThinkingModeForModel(
+  modelId: string | undefined | null
+): boolean {
+  const id = normalizedModelId(modelId);
+  if (!id.startsWith('claude-code:')) return false;
+  const variant = id.slice('claude-code:'.length);
+  return variant.startsWith('opus') || variant.startsWith('sonnet');
+}
+
+/**
+ * Normalize a stored/global effort to a value the selected model accepts.
+ * Unsupported intermediate levels step down rather than silently upgrading
+ * capability or cost (for example xhigh -> high on Sonnet 4.6).
+ */
+export function normalizeEffortForModel(
+  modelId: string | undefined | null,
+  effort: EffortLevel
+): EffortLevel {
+  const supported = supportedEffortLevelsForModel(modelId);
+  if (supported.length === 0 || supported.some(level => level.key === effort)) return effort;
+
+  const requestedIndex = EFFORT_LEVELS.findIndex(level => level.key === effort);
+  for (let index = requestedIndex - 1; index >= 0; index -= 1) {
+    const candidate = EFFORT_LEVELS[index].key;
+    if (supported.some(level => level.key === candidate)) return candidate;
+  }
+  return supported[0].key;
+}
 
 /**
  * Validate and return a valid EffortLevel, or the default if invalid.
@@ -49,12 +115,19 @@ export function parseEffortLevel(value: unknown): EffortLevel {
  */
 export function resolveEffortLevel(
   sessionEffortLevel: unknown,
-  appDefaultEffortLevel: EffortLevel | undefined
+  appDefaultEffortLevel: EffortLevel | undefined,
+  modelId?: string | null,
 ): EffortLevel | undefined {
+  let resolved: EffortLevel | undefined;
   if (sessionEffortLevel != null && sessionEffortLevel !== '') {
-    return parseEffortLevel(sessionEffortLevel);
+    resolved = parseEffortLevel(sessionEffortLevel);
+  } else {
+    resolved = appDefaultEffortLevel;
   }
-  return appDefaultEffortLevel;
+  if (resolved === undefined) return undefined;
+  const supported = supportedEffortLevelsForModel(modelId);
+  if (supported.length === 0) return undefined;
+  return normalizeEffortForModel(modelId, resolved);
 }
 
 /**

--- a/packages/runtime/src/ai/server/providers/BaseAgentProvider.ts
+++ b/packages/runtime/src/ai/server/providers/BaseAgentProvider.ts
@@ -41,6 +41,7 @@ export abstract class BaseAgentProvider extends BaseAIProvider {
     'mcp__nimbalyst-host__get_session_result',
     'mcp__nimbalyst-host__list_queued_prompts',
     'mcp__nimbalyst-host__send_prompt',
+    'mcp__nimbalyst-host__send_prompt_now',
     'mcp__nimbalyst-host__notify_user',
     'mcp__nimbalyst-host__respond_to_prompt',
     'mcp__nimbalyst-host__get_session_summary',

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -100,6 +100,7 @@ import {
 } from './claudeCode/toolAuthorization';
 import { ClaudeCodeDeps } from './claudeCode/dependencyInjection';
 import { buildSdkOptions, type PromptStreamController } from './claudeCode/sdkOptionsBuilder';
+import { applyDeepSeekClaudeAgentProfile, DEEPSEEK_CLAUDE_AGENT_MODEL_ID } from '../deepSeekClaudeAgent';
 import { resolveEffectiveSessionMode } from './claudeCode/resolveEffectiveSessionMode';
 import {
   hasRunningTasks as computeHasRunningTasks,
@@ -506,7 +507,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     //   config: safeConfig
     // }, null, 2));
 
-    this.config = config;
+    this.config = applyDeepSeekClaudeAgentProfile(config);
 
     // Claude Code manages its own authentication - do not require or use API key
   }
@@ -3687,6 +3688,14 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
       }
 
     }
+
+    models.push({
+      id: DEEPSEEK_CLAUDE_AGENT_MODEL_ID,
+      name: 'Claude agent - DeepSeek',
+      provider: 'claude-code' as const,
+      maxTokens: 8192,
+      contextWindow: 128000,
+    });
 
     return models;
   }

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts
@@ -9,6 +9,10 @@ describe('resolveClaudeCodeModelVariant', () => {
       expect(resolveClaudeCodeModelVariant('claude-code:sonnet', DEFAULT_MODEL)).toBe('sonnet');
     });
 
+    it('normalizes the persisted Sonnet 5 default', () => {
+      expect(resolveClaudeCodeModelVariant('claude-code:sonnet-5', DEFAULT_MODEL)).toBe('sonnet');
+    });
+
     it('resolves opus variant', () => {
       expect(resolveClaudeCodeModelVariant('claude-code:opus', DEFAULT_MODEL)).toBe('opus');
     });
@@ -45,6 +49,10 @@ describe('resolveClaudeCodeModelVariant', () => {
     it('sonnet-1m resolves to sonnet[1m] (Sonnet 4.6)', () => {
       const result = resolveClaudeCodeModelVariant('claude-code:sonnet-1m', DEFAULT_MODEL);
       expect(result).toBe('sonnet[1m]');
+    });
+
+    it('normalizes the persisted Sonnet 5 1M default', () => {
+      expect(resolveClaudeCodeModelVariant('claude-code:sonnet-5-1m', DEFAULT_MODEL)).toBe('sonnet[1m]');
     });
 
     it('opus-1m resolves to opus[1m]', () => {

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts
@@ -35,6 +35,10 @@ describe('resolveClaudeCodeModelVariant', () => {
     it('uses default model when config model is empty string', () => {
       expect(resolveClaudeCodeModelVariant('', DEFAULT_MODEL)).toBe('opus[1m]');
     });
+
+    it('routes the DeepSeek picker model through the Sonnet harness', () => {
+      expect(resolveClaudeCodeModelVariant('claude-code:deepseek', DEFAULT_MODEL)).toBe('sonnet');
+    });
   });
 
   describe('extended context (1M) variants', () => {

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts
@@ -10,7 +10,7 @@ describe('resolveClaudeCodeModelVariant', () => {
     });
 
     it('normalizes the persisted Sonnet 5 default', () => {
-      expect(resolveClaudeCodeModelVariant('claude-code:sonnet-5', DEFAULT_MODEL)).toBe('sonnet');
+      expect(resolveClaudeCodeModelVariant('claude-code:sonnet-5', DEFAULT_MODEL)).toBe('sonnet[1m]');
     });
 
     it('resolves opus variant', () => {

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.sonnet5Boundary.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.sonnet5Boundary.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { ProviderFactory } from '../../ProviderFactory';
+
+type ProviderBoundary = {
+  initialize(config: { model?: string }): Promise<void>;
+  resolveModelVariant(): string;
+};
+
+describe('ClaudeCodeProvider persisted Sonnet 5 launch boundary', () => {
+  for (const model of ['claude-code:sonnet-5', 'claude-code:sonnet-5-1m']) {
+    it(`launches persisted ${model} through the single one-mega route`, async () => {
+      const sessionId = `sonnet5-boundary-${model}`;
+      const provider = ProviderFactory.createProvider('claude-code', sessionId) as unknown as ProviderBoundary;
+      try {
+        await provider.initialize({ model });
+        expect(provider.resolveModelVariant()).toBe('sonnet[1m]');
+      } finally {
+        ProviderFactory.destroyProvider(sessionId, 'claude-code');
+      }
+    });
+  }
+});

--- a/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
@@ -12,6 +12,7 @@ import { app } from 'electron';
 import { ClaudeCodeDeps } from './dependencyInjection';
 import { resolveClaudeAgentCliPath } from './cliPathResolver';
 import { type ThinkingMode } from '../../effortLevels';
+import { DEEPSEEK_CLAUDE_BACKEND_ID, normalizeDeepSeekEffort, normalizeDeepSeekThinkingMode } from '../../deepSeekClaudeAgent';
 
 type SessionMode = 'planning' | 'agent' | 'auto' | undefined;
 
@@ -42,7 +43,7 @@ export interface BuildSdkOptionsDeps {
     resolveTeamContext: (sessionId?: string) => Promise<string | undefined>;
   };
   sessions: { getSessionId: (sessionId: string) => string | null | undefined };
-  config: { model?: string; apiKey?: string; effortLevel?: string; thinkingMode?: ThinkingMode };
+  config: { model?: string; apiKey?: string; effortLevel?: string; thinkingMode?: ThinkingMode; customBackend?: string };
   abortController: AbortController;
 }
 
@@ -426,6 +427,18 @@ export async function buildSdkOptions(
       }),
   };
 
+  if (config.customBackend === DEEPSEEK_CLAUDE_BACKEND_ID) {
+    delete env.ANTHROPIC_API_KEY;
+    env.ANTHROPIC_BASE_URL = 'https://api.deepseek.com/anthropic';
+    if (config.apiKey) env.ANTHROPIC_AUTH_TOKEN = config.apiKey;
+    env.ANTHROPIC_DEFAULT_OPUS_MODEL = 'deepseek-v4-pro[1m]';
+    env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'deepseek-v4-pro[1m]';
+    env.ANTHROPIC_DEFAULT_HAIKU_MODEL = 'deepseek-v4-flash';
+    env.CLAUDE_CODE_SUBAGENT_MODEL = 'deepseek-v4-flash';
+    env.CLAUDE_CODE_EFFORT_LEVEL = normalizeDeepSeekEffort(config.effortLevel);
+    options.thinking = { type: normalizeDeepSeekThinkingMode(config.thinkingMode) };
+  }
+
   // NIM-376: Overlay enhanced PATH so the Claude Code SDK can find stdio MCP
   // subprocess binaries (`npx`, `uvx`, `docker`, ...) when Nimbalyst is launched
   // from Dock/Finder. GUI-launched Electron on macOS has a minimal PATH
@@ -486,7 +499,7 @@ export async function buildSdkOptions(
   }
 
   // Per-session API key
-  if (config.apiKey) {
+  if (config.apiKey && config.customBackend !== DEEPSEEK_CLAUDE_BACKEND_ID) {
     env.ANTHROPIC_API_KEY = config.apiKey;
     if (teammateManager.packagedBuildOptions?.env) {
       teammateManager.packagedBuildOptions.env.ANTHROPIC_API_KEY = config.apiKey;

--- a/packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts
+++ b/packages/runtime/src/ai/server/services/__tests__/mcpTopologyConfig.test.ts
@@ -68,6 +68,7 @@ describe('Topology descriptor', () => {
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('settings_get_overview')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('spawn_session')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('list_queued_prompts')).toBe(MCP_HOST);
+    expect(FIRST_PARTY_TOOL_TO_SERVER.get('send_prompt_now')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('notify_user')).toBe(MCP_HOST);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('tracker_create')).toBe(MCP_TRACKERS);
     expect(FIRST_PARTY_TOOL_TO_SERVER.get('voice_agent_speak')).toBe(MCP_SITUATIONAL);

--- a/packages/runtime/src/ai/server/services/mcpTopology.ts
+++ b/packages/runtime/src/ai/server/services/mcpTopology.ts
@@ -153,6 +153,7 @@ export const HOST_TOOLS: readonly string[] = [
   'create_session',
   'spawn_session',
   'send_prompt',
+  'send_prompt_now',
   'list_queued_prompts',
   'notify_user',
   'respond_to_prompt',

--- a/packages/runtime/src/ai/server/sessionLaunchConfiguration.ts
+++ b/packages/runtime/src/ai/server/sessionLaunchConfiguration.ts
@@ -1,0 +1,205 @@
+import {
+  DEFAULT_THINKING_MODE,
+  EFFORT_LEVELS,
+  normalizeEffortForModel,
+  supportedEffortLevelsForModel,
+  supportsThinkingModeForModel,
+  type EffortLevel,
+  type ThinkingMode,
+} from './effortLevels';
+
+export const SESSION_LAUNCH_TOOL_SCOPES = ['read', 'write', 'full'] as const;
+export const SESSION_LAUNCH_EFFORT_LEVELS = EFFORT_LEVELS.map(({ key }) => key);
+export const SESSION_LAUNCH_THINKING_MODES = ['enabled', 'disabled'] as const;
+
+export type SessionLaunchToolScope = (typeof SESSION_LAUNCH_TOOL_SCOPES)[number];
+export type SessionLaunchValueSource =
+  | 'requested'
+  | 'inherited'
+  | 'app-default'
+  | 'provider-default'
+  | 'default';
+export type SessionLaunchWorktreeMode = 'existing' | 'new' | 'inherited' | 'none';
+
+export interface RequestedSessionLaunchConfiguration {
+  provider: string | null;
+  model: string | null;
+  effortLevel: EffortLevel | null;
+  thinkingMode: ThinkingMode | null;
+  toolScope: SessionLaunchToolScope | null;
+  inheritModel: boolean;
+  isolated: boolean;
+  useWorktree: boolean;
+  notifyOnComplete: boolean | null;
+}
+
+export interface ResolvedSessionLaunchConfiguration {
+  provider: string;
+  model: string;
+  effortLevel: EffortLevel | null;
+  thinkingMode: ThinkingMode | null;
+  toolScope: SessionLaunchToolScope;
+  isolated: boolean;
+  worktreeMode: SessionLaunchWorktreeMode;
+  notifyOnComplete: boolean;
+  sources: {
+    provider: SessionLaunchValueSource;
+    model: SessionLaunchValueSource;
+    effortLevel: SessionLaunchValueSource | null;
+    thinkingMode: SessionLaunchValueSource | null;
+    toolScope: SessionLaunchValueSource;
+  };
+}
+
+export interface SessionLaunchConfiguration {
+  requested: RequestedSessionLaunchConfiguration;
+  resolved: ResolvedSessionLaunchConfiguration;
+  effectiveness: 'not-provider-confirmed';
+}
+
+export interface ResolveSessionReasoningInput {
+  provider: string;
+  model: string;
+  effortLevel?: unknown;
+  thinkingMode?: unknown;
+  appDefaultEffortLevel?: EffortLevel;
+}
+
+export interface ResolvedSessionReasoning {
+  requestedEffortLevel: EffortLevel | null;
+  requestedThinkingMode: ThinkingMode | null;
+  effortLevel: EffortLevel | null;
+  thinkingMode: ThinkingMode | null;
+  effortLevelSource: SessionLaunchValueSource | null;
+  thinkingModeSource: SessionLaunchValueSource | null;
+}
+
+function parseOptionalEffortLevel(value: unknown): EffortLevel | null {
+  if (value === undefined || value === null) return null;
+  if (
+    typeof value !== 'string'
+    || !SESSION_LAUNCH_EFFORT_LEVELS.includes(value as EffortLevel)
+  ) {
+    throw new Error(
+      `Invalid effortLevel ${JSON.stringify(value)}. Expected one of: ${SESSION_LAUNCH_EFFORT_LEVELS.join(', ')}`
+    );
+  }
+  return value as EffortLevel;
+}
+
+function parseOptionalThinkingMode(value: unknown): ThinkingMode | null {
+  if (value === undefined || value === null) return null;
+  if (
+    typeof value !== 'string'
+    || !SESSION_LAUNCH_THINKING_MODES.includes(value as ThinkingMode)
+  ) {
+    throw new Error(
+      `Invalid thinkingMode ${JSON.stringify(value)}. Expected one of: ${SESSION_LAUNCH_THINKING_MODES.join(', ')}`
+    );
+  }
+  return value as ThinkingMode;
+}
+
+export function parseSessionLaunchToolScope(value: unknown): SessionLaunchToolScope {
+  if (value === undefined || value === null) return 'full';
+  if (
+    typeof value !== 'string'
+    || !SESSION_LAUNCH_TOOL_SCOPES.includes(value as SessionLaunchToolScope)
+  ) {
+    throw new Error(
+      `Invalid toolScope ${JSON.stringify(value)}. Expected one of: ${SESSION_LAUNCH_TOOL_SCOPES.join(', ')}`
+    );
+  }
+  return value as SessionLaunchToolScope;
+}
+
+/**
+ * Validate requested reasoning controls against the resolved provider/model,
+ * then resolve application defaults without claiming provider effectiveness.
+ */
+export function resolveSessionReasoningConfiguration(
+  input: ResolveSessionReasoningInput
+): ResolvedSessionReasoning {
+  const requestedEffortLevel = parseOptionalEffortLevel(input.effortLevel);
+  const requestedThinkingMode = parseOptionalThinkingMode(input.thinkingMode);
+  const supportsEffort =
+    input.provider === 'openai-codex' || input.provider === 'claude-code';
+  const supportedEffortLevels = supportsEffort
+    ? supportedEffortLevelsForModel(input.model)
+    : [];
+
+  if (
+    requestedEffortLevel
+    && !supportedEffortLevels.some(({ key }) => key === requestedEffortLevel)
+  ) {
+    const supportedDescription = supportedEffortLevels.length > 0
+      ? supportedEffortLevels.map(({ key }) => key).join(', ')
+      : 'none';
+    throw new Error(
+      `effortLevel ${JSON.stringify(requestedEffortLevel)} is not supported for ${input.provider} model ${input.model}. Supported values: ${supportedDescription}`
+    );
+  }
+
+  const supportsThinkingMode =
+    input.provider === 'claude-code' && supportsThinkingModeForModel(input.model);
+  if (requestedThinkingMode && !supportsThinkingMode) {
+    throw new Error(
+      `thinkingMode is not supported for ${input.provider} model ${input.model}`
+    );
+  }
+
+  let effortLevel: EffortLevel | null = null;
+  let effortLevelSource: SessionLaunchValueSource | null = null;
+  if (requestedEffortLevel) {
+    effortLevel = requestedEffortLevel;
+    effortLevelSource = 'requested';
+  } else if (supportedEffortLevels.length > 0 && input.appDefaultEffortLevel) {
+    effortLevel = normalizeEffortForModel(input.model, input.appDefaultEffortLevel);
+    effortLevelSource = 'app-default';
+  }
+
+  const thinkingMode = supportsThinkingMode
+    ? requestedThinkingMode ?? DEFAULT_THINKING_MODE
+    : null;
+  const thinkingModeSource = supportsThinkingMode
+    ? requestedThinkingMode
+      ? 'requested' as const
+      : 'provider-default' as const
+    : null;
+
+  return {
+    requestedEffortLevel,
+    requestedThinkingMode,
+    effortLevel,
+    thinkingMode,
+    effortLevelSource,
+    thinkingModeSource,
+  };
+}
+
+export function isSessionLaunchConfiguration(
+  value: unknown
+): value is SessionLaunchConfiguration {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const candidate = value as Partial<SessionLaunchConfiguration>;
+  if (
+    !candidate.requested
+    || typeof candidate.requested !== 'object'
+    || !candidate.resolved
+    || typeof candidate.resolved !== 'object'
+    || candidate.effectiveness !== 'not-provider-confirmed'
+  ) {
+    return false;
+  }
+  const resolved = candidate.resolved as Partial<ResolvedSessionLaunchConfiguration>;
+  return Boolean(
+    typeof resolved.provider === 'string'
+    && typeof resolved.model === 'string'
+    && typeof resolved.toolScope === 'string'
+    && typeof resolved.isolated === 'boolean'
+    && typeof resolved.worktreeMode === 'string'
+    && typeof resolved.notifyOnComplete === 'boolean'
+    && resolved.sources
+    && typeof resolved.sources === 'object'
+  );
+}

--- a/packages/runtime/src/ai/server/types.ts
+++ b/packages/runtime/src/ai/server/types.ts
@@ -250,6 +250,10 @@ export function resolveClaudeCodeModelVariant(configuredModel: string | undefine
   type ClaudeCodeVariant = typeof CLAUDE_CODE_VARIANTS[number];
   const configured = configuredModel || defaultModel;
 
+  if (/^(claude-code:)?sonnet-5(?:-1m)?$/i.test(configured)) {
+    return 'sonnet[1m]';
+  }
+
   if (isDeepSeekClaudeAgentModel(configured)) return 'sonnet';
 
   const toSdkBase = (variant: string): string => CLAUDE_CODE_PINNED_SDK_MODELS[variant as ClaudeCodeVariant] ?? variant;

--- a/packages/runtime/src/ai/server/types.ts
+++ b/packages/runtime/src/ai/server/types.ts
@@ -12,6 +12,7 @@ import {
   CLAUDE_CODE_PINNED_SDK_MODELS,
   normalizeClaudeCodeVariant,
 } from '../modelConstants';
+import { isDeepSeekClaudeAgentModel } from './deepSeekClaudeAgent';
 import type { TranscriptViewMessage } from './transcript/TranscriptProjector';
 export type { ToolDefinition } from '../tools';
 export { ModelIdentifier } from './ModelIdentifier';
@@ -249,6 +250,8 @@ export function resolveClaudeCodeModelVariant(configuredModel: string | undefine
   type ClaudeCodeVariant = typeof CLAUDE_CODE_VARIANTS[number];
   const configured = configuredModel || defaultModel;
 
+  if (isDeepSeekClaudeAgentModel(configured)) return 'sonnet';
+
   const toSdkBase = (variant: string): string => CLAUDE_CODE_PINNED_SDK_MODELS[variant as ClaudeCodeVariant] ?? variant;
 
   // Try parsing with ModelIdentifier
@@ -411,6 +414,7 @@ export interface ProviderConfig {
   allowedTools?: string[];  // List of allowed tool names, ['*'] for all tools
   effortLevel?: EffortLevel;  // Effort level for Opus 4.6 adaptive reasoning (low/medium/high/max)
   thinkingMode?: ThinkingMode;  // Extended thinking mode for Claude Agent (enabled/disabled)
+  customBackend?: string;  // Per-session Claude Agent backend selected by a synthetic model profile
   responseFormat?: ProviderResponseFormat;  // Response format constraint (extension chat completions)
   skipLogging?: boolean;  // Skip message logging to DB (extension stateless completions)
 }

--- a/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/CrossSessionToolWidget.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/CrossSessionToolWidget.tsx
@@ -14,6 +14,9 @@
 import React from 'react';
 import type { CustomToolWidgetProps } from './index';
 import { SessionReferenceChip } from '../../session/SessionReferenceChip';
+import {
+  isSessionLaunchConfiguration,
+} from '../../../../ai/server/sessionLaunchConfiguration';
 
 interface ActionMeta {
   label: string;
@@ -24,9 +27,10 @@ interface ActionMeta {
 
 const ACTIONS: Record<string, ActionMeta> = {
   send_prompt: { label: 'Send prompt', icon: 'send', detailArg: 'prompt' },
+  send_prompt_now: { label: 'Send priority prompt', icon: 'priority_high', detailArg: 'prompt' },
   respond_to_prompt: { label: 'Respond to prompt', icon: 'reply', detailArg: 'response' },
   spawn_session: { label: 'Spawn session', icon: 'rocket_launch', detailArg: 'prompt' },
-  create_session: { label: 'Create session', icon: 'add_circle', detailArg: 'initialPrompt' },
+  create_session: { label: 'Create session', icon: 'add_circle', detailArg: 'prompt' },
   get_session_status: { label: 'Get session status', icon: 'query_stats' },
   get_session_result: { label: 'Get session result', icon: 'task_alt' },
   list_queued_prompts: { label: 'List queued prompts', icon: 'list' },
@@ -66,16 +70,20 @@ function getResultText(result: unknown): string | null {
   return null;
 }
 
+function parseResultJson(result: unknown): unknown {
+  const text = getResultText(result);
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
 /** Collect distinct session ids referenced by the result JSON. */
 function collectResultSessionIds(result: unknown): string[] {
-  const text = getResultText(result);
-  if (!text) return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch {
-    return [];
-  }
+  const parsed = parseResultJson(result);
+  if (!parsed) return [];
   const ids: string[] = [];
   const add = (v: unknown) => {
     if (isUuid(v) && !ids.includes(v)) ids.push(v);
@@ -93,6 +101,90 @@ function collectResultSessionIds(result: unknown): string[] {
   };
   visit(parsed);
   return ids;
+}
+
+interface LaunchSummaryItem {
+  label: string;
+  value: string;
+  source?: string | null;
+}
+
+function launchSummaryItems(
+  toolName: string,
+  args: Record<string, unknown>,
+  result: unknown,
+): LaunchSummaryItem[] {
+  const parsedResult = parseResultJson(result);
+  const launchConfiguration =
+    parsedResult && typeof parsedResult === 'object' && !Array.isArray(parsedResult)
+      ? (parsedResult as Record<string, unknown>).launchConfiguration
+      : null;
+  const config = isSessionLaunchConfiguration(launchConfiguration)
+    ? launchConfiguration
+    : null;
+
+  if (config) {
+    const { resolved } = config;
+    const items: LaunchSummaryItem[] = [
+      {
+        label: 'Model',
+        value: resolved.model,
+        source: resolved.sources.model,
+      },
+    ];
+    if (resolved.effortLevel) {
+      items.push({
+        label: 'Effort',
+        value: resolved.effortLevel,
+        source: resolved.sources.effortLevel,
+      });
+    }
+    if (resolved.thinkingMode) {
+      items.push({
+        label: 'Thinking',
+        value: resolved.thinkingMode === 'enabled' ? 'Adaptive' : 'Off',
+        source: resolved.sources.thinkingMode,
+      });
+    }
+    items.push({
+      label: 'Scope',
+      value: resolved.toolScope,
+      source: resolved.sources.toolScope,
+    });
+    items.push({
+      label: 'Workspace',
+      value: resolved.isolated
+        ? 'isolated'
+        : resolved.worktreeMode === 'none'
+          ? 'shared'
+          : `${resolved.worktreeMode} worktree`,
+    });
+    items.push({
+      label: 'Notify',
+      value: resolved.notifyOnComplete ? 'on' : 'off',
+    });
+    return items;
+  }
+
+  if (toolName !== 'create_session' && toolName !== 'spawn_session') return [];
+  const items: LaunchSummaryItem[] = [];
+  if (typeof args.model === 'string') {
+    items.push({ label: 'Model', value: args.model, source: 'requested' });
+  }
+  if (typeof args.effortLevel === 'string') {
+    items.push({ label: 'Effort', value: args.effortLevel, source: 'requested' });
+  }
+  if (typeof args.thinkingMode === 'string') {
+    items.push({
+      label: 'Thinking',
+      value: args.thinkingMode === 'enabled' ? 'Adaptive' : 'Off',
+      source: 'requested',
+    });
+  }
+  if (typeof args.toolScope === 'string') {
+    items.push({ label: 'Scope', value: args.toolScope, source: 'requested' });
+  }
+  return items;
 }
 
 function truncate(text: string, max = 120): string {
@@ -124,6 +216,7 @@ export const CrossSessionToolWidget: React.FC<CustomToolWidgetProps> = ({
     action.detailArg && typeof args[action.detailArg] === 'string'
       ? (args[action.detailArg] as string)
       : null;
+  const launchSummary = launchSummaryItems(bare, args, tool.result);
 
   const canExpand = Boolean(detail || tool.result);
   const isError = tool.isError || tool.status === 'error';
@@ -193,6 +286,37 @@ export const CrossSessionToolWidget: React.FC<CustomToolWidgetProps> = ({
           </button>
         ) : null}
       </div>
+
+      {launchSummary.length > 0 ? (
+        <div
+          className="cross-session-tool-widget-launch-summary"
+          aria-label="Launch configuration"
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '4px',
+            marginTop: '6px',
+          }}
+        >
+          {launchSummary.map((item) => (
+            <span
+              key={`${item.label}:${item.value}`}
+              className="cross-session-tool-widget-launch-item"
+              title={item.source ? `${item.label} source: ${item.source}` : undefined}
+              style={{
+                padding: '2px 6px',
+                borderRadius: '999px',
+                background: 'var(--nim-bg-tertiary)',
+                color: 'var(--nim-text-muted)',
+                fontSize: '11px',
+              }}
+            >
+              {item.label}: {truncate(item.value, 42)}
+              {item.source ? ` · ${item.source}` : ''}
+            </span>
+          ))}
+        </div>
+      ) : null}
 
       {detail && !isExpanded ? (
         <div

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/CrossSessionToolWidget.test.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/CrossSessionToolWidget.test.tsx
@@ -3,7 +3,15 @@
  */
 
 import React from 'react';
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+  describe,
+  expect,
+  it,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
 import * as rtl from '@testing-library/react';
 import { createStore, Provider as JotaiProvider } from 'jotai';
 import type { TranscriptViewMessage } from '../../../../ai/server/transcript/TranscriptProjector';
@@ -54,6 +62,7 @@ function renderWidget(
   message: TranscriptViewMessage,
   meta?: SessionRefMeta,
   onToggle = () => {},
+  isExpanded = false,
 ) {
   const store = createStore();
   if (meta) store.set(sessionRefMapAtom, new Map([[meta.id, meta]]));
@@ -61,7 +70,7 @@ function renderWidget(
     <JotaiProvider store={store}>
       <CrossSessionToolWidget
         message={message}
-        isExpanded={false}
+        isExpanded={isExpanded}
         onToggle={onToggle}
         sessionId="host"
       />
@@ -70,7 +79,7 @@ function renderWidget(
 }
 
 describe('CrossSessionToolWidget', () => {
-  let dispatchSpy: ReturnType<typeof vi.spyOn>;
+  let dispatchSpy: MockInstance<(event: Event) => boolean>;
   beforeEach(() => {
     dispatchSpy = vi.spyOn(window, 'dispatchEvent');
   });
@@ -102,6 +111,117 @@ describe('CrossSessionToolWidget', () => {
     );
     expect(screen.getByText('Spawn session')).toBeDefined();
     expect(screen.getByText('Child A')).toBeDefined();
+  });
+
+  it('keeps list_spawned_sessions array results clickable', () => {
+    renderWidget(
+      toolMessage('list_spawned_sessions', {}, [{ sessionId: CHILD }]),
+      { id: CHILD, title: 'Listed child' },
+    );
+    expect(screen.getByText('List spawned sessions')).toBeDefined();
+    expect(screen.getByText('Listed child')).toBeDefined();
+  });
+
+  it('labels priority delivery separately from ordinary FIFO delivery', () => {
+    renderWidget(
+      toolMessage('send_prompt_now', {
+        sessionId: CHILD,
+        prompt: 'Interrupt and inspect the gate',
+      }),
+      { id: CHILD, title: 'Priority target' },
+    );
+    expect(screen.getByText('Send priority prompt')).toBeDefined();
+    expect(screen.getByText('Priority target')).toBeDefined();
+  });
+
+  it('shows resolved launch settings and provenance at a glance', () => {
+    renderWidget(
+      toolMessage(
+        'spawn_session',
+        {
+          prompt: 'Do the thing',
+          effortLevel: 'max',
+        },
+        {
+          sessionId: CHILD,
+          launchConfiguration: {
+            requested: {
+              provider: null,
+              model: null,
+              effortLevel: 'max',
+              thinkingMode: null,
+              toolScope: null,
+              inheritModel: false,
+              isolated: true,
+              useWorktree: false,
+              notifyOnComplete: false,
+            },
+            resolved: {
+              provider: 'openai-codex',
+              model: 'openai-codex:gpt-5.6-sol',
+              effortLevel: 'max',
+              thinkingMode: null,
+              toolScope: 'full',
+              isolated: true,
+              worktreeMode: 'none',
+              notifyOnComplete: false,
+              sources: {
+                provider: 'inherited',
+                model: 'inherited',
+                effortLevel: 'requested',
+                thinkingMode: null,
+                toolScope: 'default',
+              },
+            },
+            effectiveness: 'not-provider-confirmed',
+          },
+        },
+      ),
+    );
+
+    expect(screen.getByText('Model: openai-codex:gpt-5.6-sol · inherited')).toBeDefined();
+    expect(screen.getByText('Effort: max · requested')).toBeDefined();
+    expect(screen.getByText('Scope: full · default')).toBeDefined();
+    expect(screen.getByText('Workspace: isolated')).toBeDefined();
+    expect(screen.getByText('Notify: off')).toBeDefined();
+  });
+
+  it('keeps the full launch receipt in expanded details', () => {
+    renderWidget(
+      toolMessage(
+        'create_session',
+        { prompt: 'Create a child', thinkingMode: 'disabled' },
+        {
+          sessionId: CHILD,
+          launchConfiguration: {
+            requested: {},
+            resolved: {
+              provider: 'claude-code',
+              model: 'claude-code:opus',
+              effortLevel: 'high',
+              thinkingMode: 'disabled',
+              toolScope: 'full',
+              isolated: false,
+              worktreeMode: 'none',
+              notifyOnComplete: true,
+              sources: {
+                provider: 'requested',
+                model: 'requested',
+                effortLevel: 'app-default',
+                thinkingMode: 'requested',
+                toolScope: 'default',
+              },
+            },
+            effectiveness: 'not-provider-confirmed',
+          },
+        },
+      ),
+      undefined,
+      () => {},
+      true,
+    );
+
+    expect(screen.getByText(/not-provider-confirmed/)).toBeDefined();
   });
 
   it('opens the session via open-ai-session when the chip is clicked', () => {

--- a/scripts/__tests__/check-push-authors.test.mjs
+++ b/scripts/__tests__/check-push-authors.test.mjs
@@ -9,8 +9,15 @@ import { findForbiddenAuthors, parseGitLog } from '../check-push-authors.mjs';
 
 const CHECK_SCRIPT = fileURLToPath(new URL('../check-push-authors.mjs', import.meta.url));
 
+// Git exports repository-local GIT_* variables to hooks. If this test runs
+// inside pre-push and inherits those variables, `cwd` alone is not an isolation
+// boundary: scratch commits can mutate the repository that invoked the hook.
+const SCRATCH_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.toUpperCase().startsWith('GIT_')),
+);
+
 function git(cwd, ...args) {
-  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+  return execFileSync('git', args, { cwd, encoding: 'utf8', env: SCRATCH_ENV });
 }
 
 function commitAs(cwd, name, email, message) {
@@ -55,7 +62,11 @@ test('CLI rejects a range containing a fixture-authored commit', (t) => {
   commitAs(repo, 'Greg Hinkle', 'greghinkle@gmail.com', 'real work');
   commitAs(repo, 'Test User', 'test@example.com', 'seed');
   assert.throws(
-    () => execFileSync('node', [CHECK_SCRIPT, 'HEAD~1..HEAD'], { cwd: repo, encoding: 'utf8' }),
+    () => execFileSync(
+      'node',
+      [CHECK_SCRIPT, 'HEAD~1..HEAD'],
+      { cwd: repo, encoding: 'utf8', env: SCRATCH_ENV },
+    ),
     (error) => {
       assert.equal(error.status, 1);
       assert.match(error.stderr, /test-fixture authors/);
@@ -69,6 +80,10 @@ test('CLI passes a range of real commits', (t) => {
   const repo = makeScratchRepo(t);
   commitAs(repo, 'Greg Hinkle', 'greghinkle@gmail.com', 'first');
   commitAs(repo, 'Greg Hinkle', 'greghinkle@gmail.com', 'second');
-  const stdout = execFileSync('node', [CHECK_SCRIPT, 'HEAD~1..HEAD'], { cwd: repo, encoding: 'utf8' });
+  const stdout = execFileSync(
+    'node',
+    [CHECK_SCRIPT, 'HEAD~1..HEAD'],
+    { cwd: repo, encoding: 'utf8', env: SCRATCH_ENV },
+  );
   assert.match(stdout, /OK: no test-fixture authors/);
 });

--- a/scripts/check-push-authors.mjs
+++ b/scripts/check-push-authors.mjs
@@ -5,6 +5,8 @@
 // ("seed", "hook must reject", author "Test User") to public main. Any outgoing
 // commit with one of these identities is an escaped fixture, never real work.
 import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const FORBIDDEN_NAMES = new Set(['Test', 'Test User', 'Your Name']);
 const FORBIDDEN_EMAIL_PATTERN = /(^test@|@example\.(com|net|org)$|@test\.?$)/i;
@@ -57,6 +59,9 @@ function main() {
   console.log(`[check-push-authors] OK: no test-fixture authors in ${range}.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+const isMain = process.argv[1]
+  && path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1]);
+
+if (isMain) {
   main();
 }


### PR DESCRIPTION
## Summary

- persist requested and resolved launch configuration, effort, and provenance for delegated sessions
- add durable, idempotent priority/force-interrupt delivery with lifecycle fencing and agent-visible receipts
- preserve ordinary send_prompt FIFO while draining it exactly once after turns and after restart
- preserve creator custody when an authorized project-A session creates an isolated fresh-worktree child in an already-loaded project B, without requiring a duplicate parent row in B

## Lineage

Refs NIM-207
Refs NIM-408
Refs NIM-411
Refs #964
Refs #966

This is the combined current-main replacement for the overlapping delivery seams explored in #967 and #810. It integrates the validated NIM-411 behavior, reuses the merged NIM-407 capability helpers, and carries the NIM-408 cross-project targeting surface forward without introducing a second writer.

## Installed-candidate finding and repair

The no-UI V13 custody smoke on candidate 274636d1 reproduced a fail-closed defect before child creation: the project-A caller resolved globally, but spawn_session was evaluated in the project-B host context and incorrectly required the caller row to belong to B. Commit 34c177b7 resolves creator authority from the caller's source-project row while retaining explicit loaded-target, isolated, fresh-worktree, unrelated-caller, and invalid-target gates. The durable local evidence is recorded in _pending/v13_nim207_installed_runtime_smoke_receipt_20260724.md.

## Validation

- NIM-408 regression: reproduced red, then 11/11 passed
- focused NIM-207/NIM-408/NIM-411 affected suite: 16 files, 88 tests passed
- full monorepo typecheck passed
- pre-push policy gate: 8/8 passed
- push hook prerequisite builds and full monorepo typecheck passed
- git diff --check passed
- local Windows full Vitest remains non-authoritative because the repository tracks platform-nonportable failures; 6,475 tests passed and 106 unrelated tests failed, while the affected suites above are green and CI remains required

The rebuilt installed-V13 project-A to project-B custody smoke remains mandatory before terminal acceptance. It must prove create/query, priority claim and interrupt exactly once, ordinary FIFO post-turn and restart drain exactly once, structured reply, and native-worktree commit custody.

## Source recovery note

The unpublished stale-author reconciliation commit remains preserved at refs/recovery/nim408-stale-author-20260724-0744. Repository-local identity was repaired to the canonical YoGitmeister identity without changing global config or enabling worktreeConfig. Commit 4460277c recreates the exact accepted 11-path release-core tree on parent 87f0bfd3 with correct author, committer, and DCO; commit 34c177b7 is the separate three-path NIM-408 repair.

## Why this is worth merging

Cross-project delegation needs an auditable chain of custody. Recording who created a session, which project owns it, how it was launched, and how it can be interrupted lets operators verify model routing and recover work without guessing from labels or process state. The queue and structured-prompt guards make that auditability operational, not merely descriptive.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
