### PR TITLE
fix(workstreams): refresh child pins immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Bug fixes go here -->
 - Agent-mode document embeds now recover when their target file is created after the document opens.
 - Automations no longer rerun the same scheduled occurrence after restarting while a run is waiting or fails.
+- Pinning or unpinning a session inside an expanded workstream now updates its icon, menu, and position immediately.
 - Voice Mode now explains blocked or missing microphones on Windows and links directly to microphone privacy settings.
 
 ### Removed

--- a/packages/electron/src/renderer/components/AgenticCoding/SessionHistory.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/SessionHistory.tsx
@@ -74,6 +74,10 @@ import { usePostHog } from 'posthog-js/react';
 import { WorkspaceSummaryHeader, generateWorkspaceAccentColor } from '../WorkspaceSummaryHeader';
 import { errorNotificationService } from '../../services/ErrorNotificationService';
 import { FloatingPortal, useFloatingMenu } from '../../hooks/useFloatingMenu';
+import {
+  reconcileSessionPinToggle,
+  workstreamChildrenNeedRefresh,
+} from './workstreamChildPinReconciliation';
 import './SessionHistory.css';
 
 // SessionItem is the shared SessionMeta type from the store atoms.
@@ -1777,11 +1781,14 @@ const SessionHistoryComponent: React.FC = () => {
   // Toggle pin status for a session
   const handleSessionPinToggle = useCallback(async (sessionId: string, isPinned: boolean) => {
     try {
-      await window.electronAPI.invoke('sessions:update-pinned', sessionId, isPinned);
-      // Update atom state (optimistic update)
-      updateSessionStore({ sessionId, updates: { isPinned } });
-      // Also update filtered list for immediate feedback
-      setSessions(prev => prev.map(s => s.id === sessionId ? { ...s, isPinned } : s));
+      await reconcileSessionPinToggle({
+        sessionId,
+        isPinned,
+        invoke: (channel, ...args) => window.electronAPI.invoke(channel, ...args),
+        updateSessionStore,
+        setSessions,
+        setWorkstreamChildrenCache,
+      });
     } catch (error) {
       console.error('[SessionHistory] Failed to toggle session pin:', error);
     }
@@ -2572,40 +2579,17 @@ const SessionHistoryComponent: React.FC = () => {
     const cache = workstreamChildrenCacheRef.current;
     const registrySnapshot = store.get(sessionRegistryAtom);
 
-    const workstreamChildrenNeedRefresh = (session: SessionItem) => {
-      const cachedChildren = cache.get(session.id);
-      if (!cachedChildren) {
-        return true;
-      }
-
-      // Only refetch on STRUCTURAL changes (add/remove child, or a child we
-      // cached is no longer in the registry). updatedAt/title/isArchived/etc
-      // churn on every streamed message via sessions:refresh-list, which used
-      // to make this comparison flap forever during an active session and
-      // burn the renderer at 100% CPU. Field updates for existing children
-      // already propagate via sessions:session-updated -> sessionRegistryAtom
-      // patch -- the UI reads those directly via per-id atoms, it doesn't
-      // need our cached SessionItem copy to also be up to date.
-      if (cachedChildren.length !== (session.childCount ?? 0)) {
-        return true;
-      }
-
-      for (const child of cachedChildren) {
-        if (!registrySnapshot.has(child.id)) {
-          return true;
-        }
-      }
-
-      return false;
-    };
-
     // Find workstream sessions that are expanded
     const workstreamSessionsNeedingFetch = sessions.filter(s =>
       !s.worktreeId &&
       (s.childCount ?? 0) > 0 &&
       !collapsedGroups.includes(`workstream:${s.id}`) &&
       !pendingWorkstreamChildrenFetchesRef.current.has(s.id) &&
-      workstreamChildrenNeedRefresh(s)
+      workstreamChildrenNeedRefresh(
+        cache.get(s.id),
+        s.childCount ?? 0,
+        registrySnapshot,
+      )
     );
 
     if (workstreamSessionsNeedingFetch.length === 0) {

--- a/packages/electron/src/renderer/components/AgenticCoding/__tests__/WorkstreamGroup.childPinReconciliation.test.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/__tests__/WorkstreamGroup.childPinReconciliation.test.tsx
@@ -1,0 +1,306 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+vi.mock('jotai', async () => {
+  const actual = await vi.importActual<typeof import('jotai')>('jotai');
+  return {
+    ...actual,
+    useAtomValue: (target: { __testValue?: unknown }) => target?.__testValue,
+    useSetAtom: (target: { __testSetter?: (...args: unknown[]) => unknown }) =>
+      target?.__testSetter ?? vi.fn(),
+  };
+});
+
+vi.mock('@nimbalyst/runtime', () => ({
+  MaterialSymbol: ({ icon, className }: { icon: string; className?: string }) => (
+    <span data-icon={icon} className={className} />
+  ),
+  ProviderIcon: ({ provider }: { provider: string }) => <span data-provider={provider} />,
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock('../../../store', () => {
+  const value = (testValue: unknown) => ({ __testValue: testValue });
+  const setter = (testSetter: (...args: unknown[]) => unknown = vi.fn()) => ({
+    __testSetter: testSetter,
+  });
+  return {
+    sessionProcessingAtom: () => value(false),
+    sessionUnreadAtom: () => value(false),
+    sessionPendingPromptAtom: () => value(false),
+    sessionHasPendingInteractivePromptAtom: () => value(false),
+    groupSessionStatusAtom: () => value({
+      hasPendingInteractivePrompt: false,
+      hasProcessing: false,
+      hasPendingPrompt: false,
+      hasUnread: false,
+    }),
+    reparentSessionAtom: setter(async () => true),
+    refreshSessionListAtom: setter(async () => undefined),
+    sessionShareAtom: () => value(null),
+    removeSessionShareAtom: setter(),
+    shareKeysAtom: value(new Map()),
+    buildShareUrl: vi.fn(),
+  };
+});
+
+vi.mock('../../../services/ErrorNotificationService', () => ({
+  errorNotificationService: { showError: vi.fn() },
+}));
+
+vi.mock('../../../dialogs', () => ({
+  dialogRef: { current: null },
+  DIALOG_IDS: { SHARE: 'share' },
+}));
+
+vi.mock('../SessionRelativeTime', () => ({
+  SessionRelativeTime: () => <span data-testid="relative-time" />,
+}));
+
+vi.mock('../SessionContextMenu', () => ({
+  SessionContextMenu: ({
+    isPinned,
+    onPinToggle,
+  }: {
+    isPinned: boolean;
+    onPinToggle?: (isPinned: boolean) => void;
+  }) => (
+    <button onClick={() => onPinToggle?.(!isPinned)}>
+      {isPinned ? 'Unpin' : 'Pin'}
+    </button>
+  ),
+}));
+
+import type { SessionMeta } from '../../../store';
+import { WorkstreamGroup } from '../WorkstreamGroup';
+import {
+  reconcileSessionPinToggle,
+  workstreamChildrenNeedRefresh,
+} from '../workstreamChildPinReconciliation';
+
+const workspacePath = 'D:/workspace';
+const parentId = 'parent-session';
+const targetId = 'target-child';
+const siblingId = 'sibling-child';
+
+function session(overrides: Partial<SessionMeta> & Pick<SessionMeta, 'id' | 'title'>): SessionMeta {
+  const { id, title, ...rest } = overrides;
+  return {
+    id,
+    title,
+    createdAt: 100,
+    updatedAt: 100,
+    provider: 'claude',
+    sessionType: 'session',
+    messageCount: 0,
+    workspaceId: workspacePath,
+    isArchived: false,
+    isPinned: false,
+    worktreeId: null,
+    parentSessionId: parentId,
+    childCount: 0,
+    uncommittedCount: 0,
+    ...rest,
+  };
+}
+
+function childRows() {
+  return screen.getAllByTestId('workstream-child-item');
+}
+
+function childTitles() {
+  return childRows().map(row => within(row).getByText(/Target|Sibling/).textContent);
+}
+
+function renderExpandedWorkstream(
+  children: SessionMeta[],
+  onSessionPinToggle: (sessionId: string, isPinned: boolean) => void,
+  onWorkstreamPinToggle = vi.fn(),
+) {
+  return render(
+    <WorkstreamGroup
+      type="workstream"
+      id={parentId}
+      title="Parent"
+      isExpanded
+      isActive={false}
+      onToggle={vi.fn()}
+      onSelect={vi.fn()}
+      sessions={children}
+      activeSessionId={null}
+      onSessionSelect={vi.fn()}
+      onSessionPinToggle={onSessionPinToggle}
+      onWorkstreamPinToggle={onWorkstreamPinToggle}
+      isPinned={false}
+      childCount={children.length}
+      projectPath={workspacePath}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('expanded workstream child pin reconciliation', () => {
+  it('reconciles true -> false without refresh or removal', async () => {
+    const target = session({
+      id: targetId,
+      title: 'Target',
+      isPinned: true,
+      updatedAt: 100,
+    });
+    const sibling = session({
+      id: siblingId,
+      title: 'Sibling',
+      updatedAt: 200,
+    });
+    const parent = session({
+      id: parentId,
+      title: 'Parent',
+      sessionType: 'workstream',
+      parentSessionId: null,
+      childCount: 2,
+      isPinned: false,
+    });
+    let sessions = [parent];
+    let cache = new Map([[parentId, [target, sibling]]]);
+    const invoke = vi.fn().mockResolvedValue({ success: true });
+    const updateSessionStore = vi.fn();
+    const parentPinToggle = vi.fn();
+
+    const onSessionPinToggle = (sessionId: string, isPinned: boolean) => {
+      void reconcileSessionPinToggle({
+        sessionId,
+        isPinned,
+        invoke,
+        updateSessionStore,
+        setSessions: updater => { sessions = updater(sessions); },
+        setWorkstreamChildrenCache: updater => { cache = updater(cache); },
+      });
+    };
+
+    const view = renderExpandedWorkstream(
+      cache.get(parentId) ?? [],
+      onSessionPinToggle,
+      parentPinToggle,
+    );
+
+    expect(childTitles()).toEqual(['Target', 'Sibling']);
+    expect(within(childRows()[0]).getByTestId('relative-time').parentElement?.parentElement
+      ?.querySelector('[data-icon="push_pin"]')).not.toBeNull();
+
+    fireEvent.contextMenu(childRows()[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Unpin' }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('sessions:update-pinned', targetId, false);
+    });
+    view.rerender(
+      <WorkstreamGroup
+        type="workstream"
+        id={parentId}
+        title="Parent"
+        isExpanded
+        isActive={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+        sessions={cache.get(parentId) ?? []}
+        activeSessionId={null}
+        onSessionSelect={vi.fn()}
+        onSessionPinToggle={onSessionPinToggle}
+        onWorkstreamPinToggle={parentPinToggle}
+        isPinned={sessions[0].isPinned}
+        childCount={2}
+        projectPath={workspacePath}
+      />,
+    );
+
+    expect(childTitles()).toEqual(['Sibling', 'Target']);
+    expect(childRows()[1].querySelector('[data-icon="push_pin"]')).toBeNull();
+    fireEvent.contextMenu(childRows()[1]);
+    expect(screen.getByRole('button', { name: 'Pin' })).toBeTruthy();
+    expect(updateSessionStore).toHaveBeenCalledWith({
+      sessionId: targetId,
+      updates: { isPinned: false },
+    });
+    expect(sessions[0].isPinned).toBe(false);
+    expect(parentPinToggle).not.toHaveBeenCalled();
+  });
+
+  it('reconciles false -> true without refresh or removal', async () => {
+    const target = session({
+      id: targetId,
+      title: 'Target',
+      updatedAt: 100,
+    });
+    const sibling = session({
+      id: siblingId,
+      title: 'Sibling',
+      updatedAt: 200,
+    });
+    let cache = new Map([[parentId, [target, sibling]]]);
+    const invoke = vi.fn().mockResolvedValue({ success: true });
+    const updateSessionStore = vi.fn();
+
+    const onSessionPinToggle = (sessionId: string, isPinned: boolean) => {
+      void reconcileSessionPinToggle({
+        sessionId,
+        isPinned,
+        invoke,
+        updateSessionStore,
+        setSessions: vi.fn(),
+        setWorkstreamChildrenCache: updater => { cache = updater(cache); },
+      });
+    };
+
+    const view = renderExpandedWorkstream(cache.get(parentId) ?? [], onSessionPinToggle);
+
+    expect(childTitles()).toEqual(['Sibling', 'Target']);
+    fireEvent.contextMenu(childRows()[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Pin' }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('sessions:update-pinned', targetId, true);
+    });
+    view.rerender(
+      <WorkstreamGroup
+        type="workstream"
+        id={parentId}
+        title="Parent"
+        isExpanded
+        isActive={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+        sessions={cache.get(parentId) ?? []}
+        activeSessionId={null}
+        onSessionSelect={vi.fn()}
+        onSessionPinToggle={onSessionPinToggle}
+        isPinned={false}
+        childCount={2}
+        projectPath={workspacePath}
+      />,
+    );
+
+    expect(childTitles()).toEqual(['Target', 'Sibling']);
+    expect(childRows()[0].querySelector('[data-icon="push_pin"]')).not.toBeNull();
+    fireEvent.contextMenu(childRows()[0]);
+    expect(screen.getByRole('button', { name: 'Unpin' })).toBeTruthy();
+  });
+
+  it('does not require a children refetch for registry-only field updates', () => {
+    const cachedChildren = [
+      session({ id: targetId, title: 'Target', isPinned: false }),
+      session({ id: siblingId, title: 'Sibling', isPinned: false }),
+    ];
+    const registryAfterPin = new Map<string, SessionMeta>([
+      [targetId, { ...cachedChildren[0], isPinned: true }],
+      [siblingId, cachedChildren[1]],
+    ]);
+
+    expect(workstreamChildrenNeedRefresh(cachedChildren, 2, registryAfterPin)).toBe(false);
+  });
+});

--- a/packages/electron/src/renderer/components/AgenticCoding/workstreamChildPinReconciliation.ts
+++ b/packages/electron/src/renderer/components/AgenticCoding/workstreamChildPinReconciliation.ts
@@ -1,0 +1,69 @@
+import type { SessionMeta } from '../../store';
+
+type StateUpdater<T> = (updater: (previous: T) => T) => void;
+
+interface ReconcileSessionPinToggleOptions {
+  sessionId: string;
+  isPinned: boolean;
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+  updateSessionStore: (payload: {
+    sessionId: string;
+    updates: Pick<SessionMeta, 'isPinned'>;
+  }) => void;
+  setSessions: StateUpdater<SessionMeta[]>;
+  setWorkstreamChildrenCache: StateUpdater<Map<string, SessionMeta[]>>;
+}
+
+export function patchWorkstreamChildPin(
+  cache: Map<string, SessionMeta[]>,
+  sessionId: string,
+  isPinned: boolean,
+): Map<string, SessionMeta[]> {
+  // The cache remains the membership snapshot. Only reconcile the mutable
+  // field the expanded row renders directly from its cached SessionMeta.
+  for (const [parentId, children] of cache) {
+    const childIndex = children.findIndex(child => child.id === sessionId);
+    if (childIndex === -1) continue;
+    if (children[childIndex].isPinned === isPinned) return cache;
+
+    const updatedChildren = [...children];
+    updatedChildren[childIndex] = { ...updatedChildren[childIndex], isPinned };
+    const updatedCache = new Map(cache);
+    updatedCache.set(parentId, updatedChildren);
+    return updatedCache;
+  }
+
+  return cache;
+}
+
+export async function reconcileSessionPinToggle({
+  sessionId,
+  isPinned,
+  invoke,
+  updateSessionStore,
+  setSessions,
+  setWorkstreamChildrenCache,
+}: ReconcileSessionPinToggleOptions): Promise<void> {
+  await invoke('sessions:update-pinned', sessionId, isPinned);
+  updateSessionStore({ sessionId, updates: { isPinned } });
+  setSessions(previous =>
+    previous.map(session => session.id === sessionId ? { ...session, isPinned } : session),
+  );
+  setWorkstreamChildrenCache(previous =>
+    patchWorkstreamChildPin(previous, sessionId, isPinned),
+  );
+}
+
+export function workstreamChildrenNeedRefresh(
+  cachedChildren: SessionMeta[] | undefined,
+  childCount: number,
+  registrySnapshot: Map<string, SessionMeta>,
+): boolean {
+  // Field-only registry changes must not restart sessions:list-children.
+  // Refresh only when membership changed or a cached child disappeared.
+  if (!cachedChildren || cachedChildren.length !== childCount) {
+    return true;
+  }
+
+  return cachedChildren.some(child => !registrySnapshot.has(child.id));
+}


### PR DESCRIPTION
## Summary
- reconcile child pin state into expanded workstream caches after persistence
- preserve structural-only child refetch behavior
- cover pin and unpin icon, menu, ordering, target, and parent isolation

## Tests
- focused Vitest: 3 passed
- changed-file ESLint: passed
- patch-scoped TypeScript: passed
- full gates attempted; blocked by the existing shared dependency tree (missing posthog-js, incompatible workspace links/types, and a better-sqlite3 Node ABI mismatch)

Refs NIM-422