### PR TITLE
feat: show the session launcher shortcut in keyboard tips

### DIFF
--- a/packages/electron/src/renderer/tips/__tests__/tipDefinitions.test.tsx
+++ b/packages/electron/src/renderer/tips/__tests__/tipDefinitions.test.tsx
@@ -7,6 +7,7 @@ import { dialogRef } from '../../contexts/DialogContext';
 import { windowModeAtom } from '../../store/atoms/windowMode';
 import { openSettingsCommandAtom } from '../../store/atoms/settingsNavigation';
 import { FEATURE_USAGE_KEYS, type FeatureUsageKey, type FeatureUsageRecord } from '../../../shared/featureUsage';
+import { KeyboardShortcuts } from '../../../shared/KeyboardShortcuts';
 import { tipCreateWorktreeSessionRequestAtom } from '../atoms';
 import { keyboardShortcutsTip } from '../definitions/keyboard-shortcuts';
 import { sessionCleanupTip } from '../definitions/session-cleanup';
@@ -115,6 +116,13 @@ describe('contextual tip definitions', () => {
     keyboardShortcutsTip.content.action?.onClick?.();
 
     expect(dialogRef.current?.open).toHaveBeenCalledWith(DIALOG_IDS.KEYBOARD_SHORTCUTS, {});
+  });
+
+  it('advertises the session launcher shortcut in the shortcuts tip', () => {
+    expect(keyboardShortcutsTip.version).toBe(2);
+    expect(keyboardShortcutsTip.content.body).toContain(
+      `**${KeyboardShortcuts.file.sessionLaunchPopup}**`,
+    );
   });
 
   it('shows the session launch shortcut tip to established session users without shortcut usage', () => {

--- a/packages/electron/src/renderer/tips/definitions/keyboard-shortcuts.tsx
+++ b/packages/electron/src/renderer/tips/definitions/keyboard-shortcuts.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MaterialSymbol } from '@nimbalyst/runtime';
 import { FEATURE_USAGE_KEYS } from '../../../shared/featureUsage';
+import { KeyboardShortcuts } from '../../../shared/KeyboardShortcuts';
 import { dialogRef } from '../../contexts/DialogContext';
 import { DIALOG_IDS } from '../../dialogs/registry';
 import type { TipDefinition } from '../types';
@@ -10,7 +11,7 @@ const KeyboardIcon = <MaterialSymbol icon="keyboard_command_key" size={16} />;
 export const keyboardShortcutsTip: TipDefinition = {
   id: 'tip-keyboard-shortcuts',
   name: 'Keyboard Shortcuts Suggestion',
-  version: 1,
+  version: 2,
   trigger: {
     screen: '*',
     condition: (context) =>
@@ -22,7 +23,7 @@ export const keyboardShortcutsTip: TipDefinition = {
   content: {
     icon: KeyboardIcon,
     title: 'Learn the shortcuts that matter',
-    body: 'You have used the app for a while, but have not triggered any tracked keyboard shortcuts yet. The shortcuts dialog is a fast way to find the ones you will actually use.',
+    body: `Press **${KeyboardShortcuts.file.sessionLaunchPopup}** anywhere in Nimbalyst to open the session launcher. The shortcuts dialog is a fast way to find the other shortcuts you will actually use.`,
     action: {
       label: 'Open Shortcuts',
       onClick: () => {


### PR DESCRIPTION
## Summary

- Show the centralized `Cmd+Shift+N` session-launcher shortcut in the “Learn the shortcuts that matter” tip.
- Bump the tip version so users who dismissed the previous copy can see the update.
- Add focused regression coverage for the shortcut copy and version.

## Validation

- `npx vitest run packages/electron/src/renderer/tips/__tests__/tipDefinitions.test.tsx` — 14 tests passed.
- `npm run typecheck` — passed across all workspaces.

## Push note

The pre-push hook was skipped with explicit approval because its Git-service tests previously mutated the containing repository. The focused test and full typecheck were run separately before pushing.