### PR TITLE
feat: add Claude Opus 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Trackers now offer an editable grid, field-filter pills, shareable saved views, triage inboxes, release and review workflows, and expanded CLI commands.
 - Sharing a markdown document to your team now offers to share the documents it embeds, and teammates see those embeds live inline.
 - Voice agents can inspect the current Nimbalyst view, selected file, and active session, and capture the app window with explicit permission.
+- Claude Opus 5 is selectable across chat, Claude Agent, and the Claude Code CLI, and Opus 4.8 stays selectable as a pinned choice.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/docs/FEATURE_INVENTORY.md
+++ b/docs/FEATURE_INVENTORY.md
@@ -390,6 +390,7 @@ Companion app; pairs with a desktop over encrypted sync. Voice mode is not inclu
 - Claude Code CLI sessions: mid-session model switching from the model picker (drives the CLI's `/model` command; idle turns only)
 - Claude Fable 5 selectable across all Claude providers (chat, Claude Agent, Claude Code CLI)
 - Claude Sonnet 5 selectable across all Claude providers, with the previous Sonnet 4.6 still selectable as a pinned choice
+- Claude Opus 5 selectable across all Claude providers, with the previous Opus 4.8 still selectable as a pinned choice
 
 ## Settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,22 +142,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.217",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.217.tgz",
-      "integrity": "sha512-juszT3itL8R6OQ6nb/8IZE34UjKps8Jf7N8vjCXLx+vbJc+k3EojZOs93tJwT5iTRvfV1a0N53zJbKn/iJpKrQ==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.217",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.217",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.217",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.217",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.217",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.217",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.217",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.217"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.217",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.217.tgz",
-      "integrity": "sha512-dl119zmL1Ssyd8Fx0xfVMpss2scrGCZwf+rhZwl2lHa2dYuXVluLgqi4DUIWDj3rRYdrAvaMpjCAv6a5w07ddw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
       "cpu": [
         "arm64"
       ],
@@ -179,9 +179,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.217",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.217.tgz",
-      "integrity": "sha512-IeKL1HN8fEcRQ4uw5d02by1ThpjhRtOgfHcCTBQ2KS4JfEIHvc1VGWt6Exb2a7VHhT8uRcfjPk9urbmYayZmaw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
       "cpu": [
         "x64"
       ],
@@ -192,9 +192,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.217",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.217.tgz",
-      "integrity": "sha512-KtrnfEwUSCdq2cc4Pgysl+U66vqw3h7u04N5/OLHmYZ4AZYy8JcqdOaSJZ27iL2bgbAxyKwu5/9YmEk9A4IswA==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
       "cpu": [
         "arm64"
       ],
@@ -208,9 +208,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.217",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.217.tgz",
-      "integrity": "sha512-Bb4AJxqrVPouM4sYIdvX3/AO5womhe70u3Euv+6B5J2OoqcRaWarVvYevX3KRruC5TvlV2Josw14dsL5qVNL+A==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
       "cpu": [
         "arm64"
       ],
@@ -224,9 +224,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.217",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.217.tgz",
-      "integrity": "sha512-JsAQyfl4n0PR4LX0h1SxMo0raERGb8B8dvbaoNQRRSpb9A2vvcwPEjyKu0eRKHRhTvspvuD6TfNxzxrmnouX9A==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
       "cpu": [
         "x64"
       ],
@@ -240,9 +240,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.217",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.217.tgz",
-      "integrity": "sha512-qhugNZd77vAoPMIGM8vFHlbwTltFyI1POmfyl0ZJSpc6v7RE9+5+nqL2aGbGSDsDQkEHrJasXURxIeTMn9ut2w==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
       "cpu": [
         "x64"
       ],
@@ -256,9 +256,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.217",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.217.tgz",
-      "integrity": "sha512-LuaQ+PXZvIToAR81JoiGa6Me9HDma2WH2oiYlAWh43IWaXHyOqgaI1aqSM0BjDhy2UiYWTvGzAopnqPnk+jSBw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
       "cpu": [
         "arm64"
       ],
@@ -269,9 +269,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.217",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.217.tgz",
-      "integrity": "sha512-4r/T+ze/S/CLZ58tP4Mw52XPmsc/LOrCOd8jZOqM13FCPWdCMU2osWmszEIKGVMRG2cGsaLVDYcks5cWFqjCjw==",
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
       "cpu": [
         "x64"
       ],
@@ -4821,10 +4821,6 @@
     },
     "node_modules/@nimbalyst/extension-playwright": {
       "resolved": "packages/extensions/playwright",
-      "link": true
-    },
-    "node_modules/@nimbalyst/extension-project-graph": {
-      "resolved": "packages/extensions/project-graph",
       "link": true
     },
     "node_modules/@nimbalyst/extension-rtl-support": {
@@ -13398,45 +13394,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
-    "node_modules/graphology": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.26.0.tgz",
-      "integrity": "sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==",
-      "license": "MIT",
-      "dependencies": {
-        "events": "^3.3.0"
-      },
-      "peerDependencies": {
-        "graphology-types": ">=0.24.0"
-      }
-    },
-    "node_modules/graphology-layout-forceatlas2": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/graphology-layout-forceatlas2/-/graphology-layout-forceatlas2-0.10.1.tgz",
-      "integrity": "sha512-ogzBeF1FvWzjkikrIFwxhlZXvD2+wlY54lqhsrWprcdPjopM2J9HoMweUmIgwaTvY4bUYVimpSsOdvDv1gPRFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graphology-utils": "^2.1.0"
-      },
-      "peerDependencies": {
-        "graphology-types": ">=0.19.0"
-      }
-    },
-    "node_modules/graphology-types": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
-      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
-      "license": "MIT"
-    },
-    "node_modules/graphology-utils": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
-      "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "graphology-types": ">=0.23.0"
-      }
-    },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
@@ -20906,16 +20863,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/sigma": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sigma/-/sigma-3.0.3.tgz",
-      "integrity": "sha512-5H0zFlx6/NTQpqBg4Rm569ZOpnBOXMaS25UQThIWMU3XyzI5AhmorK/gnl87BvJBLhQd0tW4C0LIp3enWzMoNw==",
-      "license": "MIT",
-      "dependencies": {
-        "events": "^3.3.0",
-        "graphology-utils": "^2.5.2"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -24390,7 +24337,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.217",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@anthropic-ai/sdk": "^0.109.0",
         "@electric-sql/pglite": "0.3.14",
         "@electron-toolkit/utils": "^4.0.0",
@@ -25183,7 +25130,7 @@
     },
     "packages/extension-sdk": {
       "name": "@nimbalyst/extension-sdk",
-      "version": "0.3.0",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -26291,6 +26238,7 @@
     "packages/extensions/project-graph": {
       "name": "@nimbalyst/extension-project-graph",
       "version": "0.1.0",
+      "extraneous": true,
       "dependencies": {
         "graphology": "^0.26.0",
         "graphology-layout-forceatlas2": "^0.10.1",
@@ -26308,44 +26256,6 @@
       "peerDependencies": {
         "react": "^18.2.0 || ^19.0.0",
         "react-dom": "^18.2.0 || ^19.0.0"
-      }
-    },
-    "packages/extensions/project-graph/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/extensions/project-graph/node_modules/@vitejs/plugin-react": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
-      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.29.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-rc.3",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.18.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "packages/extensions/project-graph/node_modules/react-refresh": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "packages/extensions/rtl-support": {
@@ -26534,7 +26444,7 @@
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.20.0",
-        "@anthropic-ai/claude-agent-sdk": "^0.3.217",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@anthropic-ai/sdk": "^0.109.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "zod-to-json-schema": "^3.25.0"
   },
   "overrides": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.217",
+    "@anthropic-ai/claude-agent-sdk": "0.3.220",
     "prismjs": "^1.30.0",
     "vite": "^7.0.0",
     "zod": "^4.0.0",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -51,7 +51,7 @@
     "marketing:screenshots:grep": "playwright test --config=marketing/playwright.marketing.config.ts --grep"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.217",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@anthropic-ai/sdk": "^0.109.0",
     "@electric-sql/pglite": "0.3.14",
     "@electron-toolkit/utils": "^4.0.0",

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.providerInheritance.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.providerInheritance.test.ts
@@ -34,8 +34,8 @@ vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
       const provider = id.slice(0, i);
       const model = id.slice(i + 1);
       if (provider === 'claude-code') {
-        if (model === 'opus-4-8') return { provider, model: 'opus', combined: 'claude-code:opus' };
-        if (model === 'opus-4-8-1m') return { provider, model: 'opus-1m', combined: 'claude-code:opus-1m' };
+        if (model === 'opus-5') return { provider, model: 'opus', combined: 'claude-code:opus' };
+        if (model === 'opus-5-1m') return { provider, model: 'opus-1m', combined: 'claude-code:opus-1m' };
         if (model === 'unknown') throw new Error(`Unsupported Claude Agent model "${id}"`);
       }
       return { provider, model, combined: `${provider}:${model}` };
@@ -223,13 +223,13 @@ describe('MetaAgentService child-spawn provider inheritance', () => {
     expect(created.model).toBe('openai-codex:gpt-5.5');
   });
 
-  it('normalizes explicit claude-code opus-4-8 aliases before persisting the child session', async () => {
+  it('normalizes explicit claude-code opus-5 aliases before persisting the child session', async () => {
     const service = MetaAgentService.getInstance();
     (service as any).aiService = { queuePromptForSession: vi.fn() };
     vi.mocked(AISessionsRepository.get).mockResolvedValue(GEMINI_PARENT as any);
 
     await (service as any).createChildSessionInternal('parent-gemini-session', '/workspace/path', {
-      model: 'claude-code:opus-4-8-1m',
+      model: 'claude-code:opus-5-1m',
     });
 
     const created = vi.mocked(AISessionsRepository.create).mock.calls[0][0] as any;

--- a/packages/electron/src/renderer/utils/__tests__/modelUtils.effort.test.ts
+++ b/packages/electron/src/renderer/utils/__tests__/modelUtils.effort.test.ts
@@ -8,6 +8,8 @@ describe('supportsEffortLevel', () => {
     'claude-code:sonnet',
     'claude-code:fable',
     'claude-code-cli:fable-1m',
+    'claude-code:opus-4-8',
+    'claude-code-cli:opus-4-8-1m',
     'claude-code:opus-4-7',
     'claude-code-cli:opus-4-7-1m',
     'claude-code:sonnet-4-6',

--- a/packages/electron/src/renderer/utils/modelUtils.ts
+++ b/packages/electron/src/renderer/utils/modelUtils.ts
@@ -258,6 +258,7 @@ export function supportsEffortLevel(modelId?: string): boolean {
   if (
     variant === 'fable' ||
     variant === 'opus' ||
+    variant === 'opus-4-8' ||
     variant === 'opus-4-7' ||
     variant === 'opus-4-6' ||
     variant === 'sonnet' ||

--- a/packages/ios/NimbalystNative/Sources/Utils/ModelLabel.swift
+++ b/packages/ios/NimbalystNative/Sources/Utils/ModelLabel.swift
@@ -37,9 +37,10 @@ public enum ModelLabel {
     /// Mirrors `CLAUDE_CODE_VARIANT_VERSIONS` in `modelConstants.ts`.
     private static let claudeCodeVariantVersions: [String: String] = [
         "fable": "5",
-        "opus": "4.8",
+        "opus": "5",
         "sonnet": "5",
         "haiku": "4.5",
+        "opus-4-8": "4.8",
         "opus-4-7": "4.7",
         "opus-4-6": "4.6",
         "sonnet-4-6": "4.6",
@@ -113,6 +114,7 @@ public enum ModelLabel {
     private static let claudeApiShortNames: [String: String] = [
         "claude-fable-5": "Fable 5",
         "claude-sonnet-5": "Sonnet 5",
+        "claude-opus-5": "Opus 5",
         "claude-opus-4-8": "Opus 4.8",
         "claude-opus-4-7": "Opus 4.7",
         "claude-opus-4-6": "Opus 4.6",

--- a/packages/ios/NimbalystNative/Tests/ModelLabelTests.swift
+++ b/packages/ios/NimbalystNative/Tests/ModelLabelTests.swift
@@ -10,14 +10,14 @@ final class ModelLabelTests: XCTestCase {
 
     func testClaudeCodeCanonicalVariants() {
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:fable"), "Fable 5")
-        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:opus"), "Opus 4.8")
+        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:opus"), "Opus 5")
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:sonnet"), "Sonnet 5")
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:haiku"), "Haiku 4.5")
     }
 
     func testClaudeCodeExtendedContextVariants() {
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:fable-1m"), "Fable 5")
-        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:opus-1m"), "Opus 4.8")
+        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:opus-1m"), "Opus 5")
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:sonnet-1m"), "Sonnet 5")
     }
 
@@ -26,9 +26,16 @@ final class ModelLabelTests: XCTestCase {
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:fable-5"), "Fable 5")
     }
 
-    func testClaudeCodeOpus48AliasVariants() {
+    func testClaudeCodeOpus48PinnedVariants() {
+        // Pinned after the canonical `opus` rolled forward to 5, so an
+        // Opus 4.8 session keeps its own badge instead of reading "Opus 5".
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:opus-4-8"), "Opus 4.8")
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:opus-4-8-1m"), "Opus 4.8")
+    }
+
+    func testClaudeCodeOpus5AliasVariants() {
+        // `opus-5` is accepted as an input alias for canonical `opus`.
+        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-code:opus-5"), "Opus 5")
     }
 
     func testClaudeCodePinnedVariant() {
@@ -39,6 +46,8 @@ final class ModelLabelTests: XCTestCase {
 
     func testClaudeCodeRawSDKModelIds() {
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-fable-5"), "Fable 5")
+        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-opus-5"), "Opus 5")
+        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-opus-4-8"), "Opus 4.8")
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-opus-4-7"), "Opus 4.7")
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-opus-4-6"), "Opus 4.6")
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code", model: "claude-sonnet-4-5-20250929"), "Sonnet 4.5")
@@ -58,8 +67,8 @@ final class ModelLabelTests: XCTestCase {
         // The subscription CLI shares the variant set with the SDK provider, so
         // the model badge resolves the same way (must NOT collapse to Sonnet).
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code-cli", model: "claude-code-cli:fable"), "Fable 5")
-        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code-cli", model: "claude-code-cli:opus"), "Opus 4.8")
-        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code-cli", model: "claude-code-cli:opus-1m"), "Opus 4.8")
+        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code-cli", model: "claude-code-cli:opus"), "Opus 5")
+        XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code-cli", model: "claude-code-cli:opus-1m"), "Opus 5")
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code-cli", model: "claude-code-cli:sonnet-1m"), "Sonnet 5")
         XCTAssertEqual(ModelLabel.shortLabel(provider: "claude-code-cli", model: "claude-code-cli:opus-4-6"), "Opus 4.6")
     }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -178,7 +178,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.20.0",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.217",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@anthropic-ai/sdk": "^0.109.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -20,6 +20,16 @@ export const CLAUDE_MODELS: ModelDefinition[] = [
     contextWindow: 1000000,
   },
   {
+    id: 'claude-opus-5',
+    displayName: 'Claude Opus 5 (1M)',
+    shortName: 'Opus 5',
+    maxTokens: 8192,
+    // Opus 5 ships with a 1M context window natively (dateless alias, pinned
+    // snapshot). Adaptive thinking is on by default; rejects `temperature`
+    // like Opus 4.7+ (see ClaudeProvider.supportsTemperature).
+    contextWindow: 1000000,
+  },
+  {
     id: 'claude-opus-4-8',
     displayName: 'Claude Opus 4.8 (1M)',
     shortName: 'Opus 4.8',
@@ -238,22 +248,36 @@ export const OPENAI_MODELS: ModelDefinition[] = [
  *   the previous-generation Opus selectable after bumping the canonical
  *   `opus` to the next version.
  */
-export type ClaudeCodeVariant = 'fable' | 'opus' | 'sonnet' | 'haiku' | 'opus-4-7' | 'opus-4-6' | 'sonnet-4-6';
-export type ClaudeCodeVariantInput = ClaudeCodeVariant | 'opus-4-8' | 'fable-5';
+export type ClaudeCodeVariant =
+  | 'fable'
+  | 'opus'
+  | 'sonnet'
+  | 'haiku'
+  | 'opus-4-8'
+  | 'opus-4-7'
+  | 'opus-4-6'
+  | 'sonnet-4-6';
+export type ClaudeCodeVariantInput = ClaudeCodeVariant | 'opus-5' | 'fable-5';
 
 /**
  * Accepted input aliases for Claude Agent model identifiers.
  *
- * `opus-4-8` is intentionally accepted as an alias for the canonical `opus`
+ * `opus-5` is intentionally accepted as an alias for the canonical `opus`
  * variant so legacy code paths (meta-agent, Agent tool, imported session IDs)
  * can request the current Opus generation explicitly without requiring a
  * duplicate visible picker entry. `fable-5` is accepted as an alias for
  * `fable` for the same reason.
+ *
+ * `opus-4-8` was that alias until the canonical `opus` rolled forward to
+ * Opus 5; it is now a pinned variant in its own right, so sessions that
+ * persisted it keep resolving to Opus 4.8 rather than silently following
+ * `opus` up a generation.
  */
 export const CLAUDE_CODE_ACCEPTED_VARIANT_INPUTS: readonly ClaudeCodeVariantInput[] = [
   'fable',
   'fable-5',
   'opus',
+  'opus-5',
   'opus-4-8',
   'opus-4-7',
   'opus-4-6',
@@ -266,7 +290,8 @@ const CLAUDE_CODE_VARIANT_INPUT_MAP: Readonly<Record<ClaudeCodeVariantInput, Cla
   fable: 'fable',
   'fable-5': 'fable',
   opus: 'opus',
-  'opus-4-8': 'opus',
+  'opus-5': 'opus',
+  'opus-4-8': 'opus-4-8',
   'opus-4-7': 'opus-4-7',
   'opus-4-6': 'opus-4-6',
   sonnet: 'sonnet',
@@ -280,9 +305,10 @@ export function normalizeClaudeCodeVariant(variant: string): ClaudeCodeVariant |
 
 export const CLAUDE_CODE_VARIANT_VERSIONS: Record<ClaudeCodeVariant, string> = {
   fable: '5',
-  opus: '4.8',
+  opus: '5',
   sonnet: '5',
   haiku: '4.5',
+  'opus-4-8': '4.8',
   'opus-4-7': '4.7',
   'opus-4-6': '4.6',
   'sonnet-4-6': '4.6',
@@ -293,6 +319,7 @@ export const CLAUDE_CODE_MODEL_LABELS: Record<ClaudeCodeVariant, string> = {
   opus: 'Opus',
   sonnet: 'Sonnet',
   haiku: 'Haiku',
+  'opus-4-8': 'Opus',
   'opus-4-7': 'Opus',
   'opus-4-6': 'Opus',
   'sonnet-4-6': 'Sonnet',
@@ -310,6 +337,9 @@ export const CLAUDE_CODE_PINNED_SDK_MODELS: Partial<Record<ClaudeCodeVariant, st
   // the interactive-CLI path (`resolveClaudeCliModelArg`) does not read this
   // map and keeps sending the working `fable` alias to the PTY.
   fable: 'claude-fable-5',
+  // Pinned so the previous-generation Opus stays selectable after the
+  // canonical `opus` alias rolled forward to Opus 5.
+  'opus-4-8': 'claude-opus-4-8',
   'opus-4-7': 'claude-opus-4-7',
   'opus-4-6': 'claude-opus-4-6',
   // Pinned so the previous-generation Sonnet stays selectable after the
@@ -329,8 +359,8 @@ export const CLAUDE_CODE_PINNED_SDK_MODELS: Partial<Record<ClaudeCodeVariant, st
  * is 1M. The earlier "plain models window at 200k client-side" behavior was real
  * on CLI 2.1.175 but is now stale.
  *
- * The pinned legacy variants (`opus-4-7`/`opus-4-6`/`sonnet-4-6`) are included
- * too: the model catalog lists all three at a 1M window, and we don't want a
+ * The pinned legacy variants (`opus-4-8`/`opus-4-7`/`opus-4-6`/`sonnet-4-6`) are
+ * included too: the model catalog lists them all at a 1M window, and we don't want a
  * redundant second `-1m` picker row for them either. The SDK-path meter reads
  * the REAL reported window per turn (see `resolveClaudeCodeParentContextWindow`),
  * so even if a legacy variant's live window differed it would self-correct — the
@@ -340,6 +370,7 @@ export const CLAUDE_CODE_NATIVE_1M_VARIANTS: readonly ClaudeCodeVariant[] = [
   'fable',
   'opus',
   'sonnet',
+  'opus-4-8',
   'opus-4-7',
   'opus-4-6',
   'sonnet-4-6',
@@ -443,7 +474,7 @@ export function resolveClaudeCodeParentContextWindow(
 export const CLAUDE_CODE_SAFE_FALLBACK_MODEL = 'claude-code:opus' as const;
 
 export const DEFAULT_MODELS = {
-  claude: 'claude:claude-opus-4-8',
+  claude: 'claude:claude-opus-5',
   openai: 'openai:gpt-5.6-sol',
   // Plain `opus` (not `opus-1m`): the current CLI runs plain Opus at 1M natively
   // at a flat price, so the `[1m]` suffix is a redundant no-op (GitHub #825).

--- a/packages/runtime/src/ai/server/__tests__/ModelIdentifier.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/ModelIdentifier.test.ts
@@ -26,12 +26,22 @@ describe('ModelIdentifier', () => {
       expect(id.isExtendedContext).toBe(true);
     });
 
-    it('normalizes claude-code opus-4-8 alias to canonical opus', () => {
-      const id = ModelIdentifier.parse('claude-code:opus-4-8-1m');
+    it('normalizes claude-code opus-5 alias to canonical opus', () => {
+      const id = ModelIdentifier.parse('claude-code:opus-5-1m');
       expect(id.provider).toBe('claude-code');
       expect(id.model).toBe('opus-1m');
       expect(id.combined).toBe('claude-code:opus-1m');
       expect(id.baseVariant).toBe('opus');
+      expect(id.isExtendedContext).toBe(true);
+    });
+
+    it('keeps claude-code opus-4-8 as its own pinned variant', () => {
+      // Was an alias for canonical `opus` until `opus` rolled forward to 5.
+      const id = ModelIdentifier.parse('claude-code:opus-4-8-1m');
+      expect(id.provider).toBe('claude-code');
+      expect(id.model).toBe('opus-4-8-1m');
+      expect(id.combined).toBe('claude-code:opus-4-8-1m');
+      expect(id.baseVariant).toBe('opus-4-8');
       expect(id.isExtendedContext).toBe(true);
     });
 
@@ -108,11 +118,18 @@ describe('ModelIdentifier', () => {
       expect(id.isExtendedContext).toBe(true);
     });
 
-    it('accepts explicit opus-4-8 alias and normalizes to canonical opus', () => {
-      const id = ModelIdentifier.create('claude-code', 'Opus-4-8');
+    it('accepts explicit opus-5 alias and normalizes to canonical opus', () => {
+      const id = ModelIdentifier.create('claude-code', 'Opus-5');
       expect(id.provider).toBe('claude-code');
       expect(id.model).toBe('opus');
       expect(id.combined).toBe('claude-code:opus');
+    });
+
+    it('accepts explicit opus-4-8 as the pinned previous generation', () => {
+      const id = ModelIdentifier.create('claude-code', 'Opus-4-8');
+      expect(id.provider).toBe('claude-code');
+      expect(id.model).toBe('opus-4-8');
+      expect(id.combined).toBe('claude-code:opus-4-8');
     });
 
     it('throws on invalid claude-code variant', () => {
@@ -248,7 +265,7 @@ describe('ModelIdentifier', () => {
     it('returns default ModelIdentifier for claude', () => {
       const id = ModelIdentifier.getDefaultForProvider('claude');
       expect(id.provider).toBe('claude');
-      expect(id.combined).toBe('claude:claude-opus-4-8');
+      expect(id.combined).toBe('claude:claude-opus-5');
     });
 
     it('returns default ModelIdentifier for claude-code', () => {
@@ -286,7 +303,7 @@ describe('ModelIdentifier', () => {
 
   describe('getDefaultModelId', () => {
     it('returns default model ID string for all providers', () => {
-      expect(ModelIdentifier.getDefaultModelId('claude')).toBe('claude:claude-opus-4-8');
+      expect(ModelIdentifier.getDefaultModelId('claude')).toBe('claude:claude-opus-5');
       expect(ModelIdentifier.getDefaultModelId('claude-code')).toBe('claude-code:opus');
       expect(ModelIdentifier.getDefaultModelId('openai')).toBe('openai:gpt-5.6-sol');
       expect(ModelIdentifier.getDefaultModelId('openai-codex')).toBe('openai-codex:gpt-5.6-sol');

--- a/packages/runtime/src/ai/server/providers/ClaudeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeProvider.ts
@@ -974,7 +974,8 @@ export class ClaudeProvider extends BaseAIProvider {
    * same pattern.
    *
    * Strategy: denylist of known-rejecting prefixes. Today that is
-   * `claude-opus-4-N` for N >= 7 and `claude-sonnet-N` for N >= 5 (Sonnet 5
+   * `claude-opus-4-N` for N >= 7, `claude-opus-N` for N >= 5 (Opus 5 dropped
+   * the minor-version segment), and `claude-sonnet-N` for N >= 5 (Sonnet 5
    * adopted the same deprecation). Everything else -- Sonnet 3.x / 4.x, all
    * Haiku variants, Opus 4 / 4.1 / 4.5 / 4.6, and any `claude-3-*` Opus model
    * -- still accepts `temperature`.
@@ -1003,6 +1004,18 @@ export class ClaudeProvider extends BaseAIProvider {
     if (opusMinor) {
       const minor = parseInt(opusMinor[1], 10);
       return minor < 7;
+    }
+
+    // Opus 5+ dropped the `4-` minor-version segment, so the check above can't
+    // see it. Same deprecation as Opus 4.7+ -- `temperature` returns HTTP 400.
+    // This must stay AFTER the `claude-opus-4-N` branch: `claude-opus-4-7`
+    // would otherwise match here with major 4 and be misclassified as
+    // accepting. The date-suffixed `claude-opus-4-20250514` falls through to
+    // here (major 4, accepts), which is correct.
+    const opusMajor = id.match(/^claude-opus-(\d{1,2})(?:-|$)/);
+    if (opusMajor) {
+      const major = parseInt(opusMajor[1], 10);
+      return major < 5;
     }
 
     // Sonnet 5+ adopted the same deprecation as Opus 4.7+ (adaptive thinking,

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.modelVariant.test.ts
@@ -53,8 +53,8 @@ describe('resolveClaudeCodeModelVariant', () => {
       expect(result).toBe('haiku[1m]');
     });
 
-    it('opus-4-8-1m alias resolves to opus[1m]', () => {
-      const result = resolveClaudeCodeModelVariant('claude-code:opus-4-8-1m', DEFAULT_MODEL);
+    it('opus-5-1m alias resolves to opus[1m]', () => {
+      const result = resolveClaudeCodeModelVariant('claude-code:opus-5-1m', DEFAULT_MODEL);
       expect(result).toBe('opus[1m]');
     });
   });
@@ -88,9 +88,24 @@ describe('resolveClaudeCodeModelVariant', () => {
   });
 
   describe('pinned-version variants', () => {
-    it('opus-4-8 resolves to the canonical opus SDK alias', () => {
-      const result = resolveClaudeCodeModelVariant('claude-code:opus-4-8', DEFAULT_MODEL);
+    it('opus-5 resolves to the canonical opus SDK alias', () => {
+      // `opus-5` is the explicit-current-generation alias, mirroring what
+      // `opus-4-8` was before the canonical `opus` rolled forward to 5.
+      const result = resolveClaudeCodeModelVariant('claude-code:opus-5', DEFAULT_MODEL);
       expect(result).toBe('opus');
+    });
+
+    it('opus-4-8 resolves to the full claude-opus-4-8 SDK model ID', () => {
+      // Pinned after the canonical `opus` alias was bumped to 5. Previously
+      // this was an alias for canonical `opus`; keeping it as an alias would
+      // silently drag Opus 4.8 sessions up a generation.
+      const result = resolveClaudeCodeModelVariant('claude-code:opus-4-8', DEFAULT_MODEL);
+      expect(result).toBe('claude-opus-4-8');
+    });
+
+    it('opus-4-8-1m resolves to claude-opus-4-8[1m]', () => {
+      const result = resolveClaudeCodeModelVariant('claude-code:opus-4-8-1m', DEFAULT_MODEL);
+      expect(result).toBe('claude-opus-4-8[1m]');
     });
 
     it('opus-4-7 resolves to the full claude-opus-4-7 SDK model ID', () => {
@@ -142,8 +157,12 @@ describe('resolveClaudeCodeModelVariant', () => {
       expect(resolveClaudeCodeModelVariant('opus-1m', DEFAULT_MODEL)).toBe('opus[1m]');
     });
 
-    it('accepts raw opus-4-8 alias without provider prefix', () => {
-      expect(resolveClaudeCodeModelVariant('opus-4-8', DEFAULT_MODEL)).toBe('opus');
+    it('accepts raw opus-5 alias without provider prefix', () => {
+      expect(resolveClaudeCodeModelVariant('opus-5', DEFAULT_MODEL)).toBe('opus');
+    });
+
+    it('accepts raw opus-4-8 pinned variant without provider prefix', () => {
+      expect(resolveClaudeCodeModelVariant('opus-4-8', DEFAULT_MODEL)).toBe('claude-opus-4-8');
     });
   });
 });

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeProvider.temperature.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeProvider.temperature.test.ts
@@ -61,6 +61,34 @@ describe('ClaudeProvider.supportsTemperature', () => {
     });
   });
 
+  describe('rejects temperature for Opus 5+', () => {
+    it('returns false for claude-opus-5', () => {
+      // Opus 5 dropped the `4-` minor-version segment, so the
+      // `claude-opus-4-N` branch can't see it. Without a dedicated major
+      // check it would fail open and send `temperature` -> HTTP 400.
+      expect(ClaudeProvider.supportsTemperature('claude-opus-5')).toBe(false);
+    });
+
+    it('returns false for a future dated/minor Opus 5 id', () => {
+      expect(ClaudeProvider.supportsTemperature('claude-opus-5-1')).toBe(false);
+      expect(ClaudeProvider.supportsTemperature('claude-opus-6')).toBe(false);
+    });
+
+    it('matches case-insensitively', () => {
+      expect(ClaudeProvider.supportsTemperature('CLAUDE-OPUS-5')).toBe(false);
+    });
+
+    it('does not misclassify Opus 4.x via the major-version branch', () => {
+      // The major branch must run AFTER the `claude-opus-4-N` branch:
+      // `claude-opus-4-7` matches both, and major 4 would wrongly accept.
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-7')).toBe(false);
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-8')).toBe(false);
+      // ...while genuinely older Opus 4.x still accepts it.
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-6')).toBe(true);
+      expect(ClaudeProvider.supportsTemperature('claude-opus-4-20250514')).toBe(true);
+    });
+  });
+
   describe('rejects temperature for Sonnet 5+', () => {
     it('returns false for claude-sonnet-5', () => {
       // Sonnet 5 adopted the Opus 4.7+ posture: adaptive thinking, effort

--- a/packages/runtime/src/ai/server/types.ts
+++ b/packages/runtime/src/ai/server/types.ts
@@ -218,10 +218,10 @@ export function shouldBlockStartedSessionProviderSwitch(
  * Claude Code uses simplified variant names (opus, sonnet, haiku) instead of full model IDs.
  * These are ONLY valid for the claude-code provider.
  *
- * `opus-4-7`, `opus-4-6`, and `sonnet-4-6` are pinned-version variants retained
- * after bumping the canonical `opus`/`sonnet` aliases (to 4.8 / 5), so users can
- * still choose previous generations. See CLAUDE_CODE_PINNED_SDK_MODELS in
- * modelConstants.ts.
+ * `opus-4-8`, `opus-4-7`, `opus-4-6`, and `sonnet-4-6` are pinned-version
+ * variants retained after bumping the canonical `opus`/`sonnet` aliases (to
+ * Opus 5 / Sonnet 5), so users can still choose previous generations. See
+ * CLAUDE_CODE_PINNED_SDK_MODELS in modelConstants.ts.
  *
  * `fable` is the Fable 5 tier above Opus — the CLI accepts it as a first-class
  * alias (`--model fable`, `/model fable`). On the current CLI plain `fable`
@@ -231,7 +231,7 @@ export function shouldBlockStartedSessionProviderSwitch(
  * real on CLI 2.1.175 but is now stale. Note it requires usage credits on
  * subscription plans (the CLI surfaces that itself when unavailable).
  */
-export const CLAUDE_CODE_VARIANTS = ['fable', 'opus', 'opus-4-7', 'opus-4-6', 'sonnet', 'sonnet-4-6', 'haiku'] as const;
+export const CLAUDE_CODE_VARIANTS = ['fable', 'opus', 'opus-4-8', 'opus-4-7', 'opus-4-6', 'sonnet', 'sonnet-4-6', 'haiku'] as const;
 
 /**
  * Resolves a configured model string to the SDK model value.


### PR DESCRIPTION
Adds Claude Opus 5 across the chat, Claude Agent (SDK), and Claude Code CLI providers, following the same shape as `d777526` (Sonnet 5) and `6196e6e` (#473, Opus 4.8).

## What changed

- **`claude-opus-5` added to `CLAUDE_MODELS`** (1M context), and it becomes `DEFAULT_MODELS.claude` — matching the precedent set when Opus 4.8 landed.
- **Canonical `opus` variant rolls forward to 5**, and **`opus-4-8` is promoted from an input alias to a pinned variant** so existing Opus 4.8 sessions keep resolving to `claude-opus-4-8` instead of silently following `opus` up a generation. `opus-5` takes over as the explicit current-generation alias (same role `opus-4-8` and `fable-5` played before).
- **`temperature` is now omitted for Opus 5.** This is the one real bug rather than a table update: `supportsTemperature` only matched `claude-opus-4-N`, so `claude-opus-5` fell through to the fail-open `return true` and would have sent `temperature` → HTTP 400 on every chat request. Added a major-version branch, ordered *after* the existing `claude-opus-4-N` branch so `claude-opus-4-7` isn't misclassified as accepting.
- **Bumped `@anthropic-ai/claude-agent-sdk` 0.3.217 → 0.3.220** (root `overrides` plus both workspace ranges). This is required, not incidental: 0.3.217's bundled CLI contains no `claude-opus-5` and resolves the `opus` alias to `claude-opus-4-8`, so without it the picker reads "Opus 5" while Claude Agent sessions actually run 4.8. Caught by live-testing this branch — a session asked what model it was and answered `claude-opus-4-8[1m]`. 0.3.220 ships `aliases:{opus:{default:"claude-opus-5"}}`. Same reason `d777526` bumped the SDK when it added Sonnet 5. (The `claude-code-cli` provider path was unaffected — it shells out to the user's own CLI, which already knows Opus 5.)
- Mirrored the version/label tables in the iOS `ModelLabel` badge, added `opus-4-8` to `supportsEffortLevel` (an allowlist — a new pinned variant would otherwise silently lose its effort control), and added `opus-4-8` to `CLAUDE_CODE_VARIANTS` so `reconcileClaudeCodeModels` back-fills it into existing users' pickers.

## Verification

- `npm run test:prepush` — full suite green (875 files / 6818 tests) both before and after the SDK bump.
- `npm run check:override-sync` passes; the root override had to move in lockstep or npm silently keeps resolving 0.3.217.
- Verified end to end in a running dev build: the Claude Agent now reports Opus 5 instead of 4.8.
- `npm run typecheck` — clean apart from one pre-existing `monaco-editor` duplicate-install error in `monacoConfig.ts`, which reproduces on an unmodified `main` in my environment and is unrelated to this change.
- Model support checked against the Claude Code CLI binary (2.1.220), which carries `claude-opus-5` and accepts the `opus-5`, `opus-4-8`, and `opus-4-7` short aliases.
- Tests updated where they asserted the old `opus-4-8`→canonical-`opus` mapping, plus new coverage for the Opus 5 temperature denylist, `opus-4-8` pinned resolution (including `[1m]`), and the `opus-5` alias.

Swift tests are updated but I could not run `ios:test:swift` locally.

The lockfile also drops a stale `@nimbalyst/extension-project-graph` entry — that workspace is neither on disk nor tracked in git on `main`, so `npm install` prunes it. Happy to strip that hunk if you'd rather keep it.

## Two things worth a maintainer's eye

1. **`resolveClaudeCliModelArg` collapses every `opus*` variant to the bare `opus` alias.** That was harmless while `opus-4-8` *was* canonical `opus`; now it means a Claude Code CLI session pinned to Opus 4.8 sends `--model opus` and gets Opus 5. The same collapse already applies to `opus-4-7`/`opus-4-6`, so I left it alone rather than widen this PR — but CLI 2.1.220 does accept the pinned aliases, so passing them through looks viable if you want the pin to hold on that path too. Happy to follow up.
2. **`opus[1m]`.** The 2.1.220 bundle carries a distinct `opus[1m]` entry labelled "Opus (1M context)" / "Opus 5 with 1M context" alongside a `pricingSuffix` concept, which reads differently from the "plain and `[1m]` are identical for current-gen" finding from 2.1.204 (#825 / NIM-1660). I did not change the 1M classification — `opus` was already in `CLAUDE_CODE_NATIVE_1M_VARIANTS` and the meter self-corrects from the real reported window — but it may be worth re-verifying on the current CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
