### PR TITLE
fix(tracker): honor the schema contract in tracker_create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New Claude Agent sessions now accept Sonnet 5 saved as an explicit default instead of failing before the first prompt runs.
 - Tracker saved views can be saved from any view state and exited with a Close control.
 - The grouping dropdown in tracker Display Options now groups rows.
+- Creating a plan or decision from an AI session now works instead of being rejected by schema validation, and new items start on their type's own default status instead of "to-do".
 - Tracker filters can match items by the status they changed to or from.
 - Clicking a tracker grid column header toggles sorting.
 - The nim CLI now reports an error and exits non-zero when the app rejects a tracker create or update, instead of printing success.

--- a/packages/electron/src/main/mcp/tools/__tests__/trackerCreateSchemaContract.test.ts
+++ b/packages/electron/src/main/mcp/tools/__tests__/trackerCreateSchemaContract.test.ts
@@ -1,0 +1,162 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Contract tests for tracker_create against the REAL builtin tracker schemas
+ * (packages/runtime .../models/builtins/*.yaml) and the real registry
+ * validator — no mocked globalRegistry. This pins the promise that the MCP
+ * create path can create every creatable builtin type with only the arguments
+ * the tool's own docs (docs/TRACKER_WORKFLOWS.md) tell agents to pass:
+ * - the initial status comes from the schema's own `default`, not a
+ *   hardcoded "to-do" (plan defaults to 'draft', idea to 'new');
+ * - required non-inline self-id fields (plan.planId, decision.decisionId)
+ *   are populated instead of failing validation.
+ */
+
+const { mockQuery, mockDocumentServices } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockDocumentServices: new Map<string, any>(),
+}));
+
+vi.mock('../../../database/initialize', () => ({
+  getDatabase: () => ({
+    query: mockQuery,
+    getEngine: vi.fn(() => 'pglite'),
+  }),
+}));
+
+vi.mock('../../../services/TrackerIdentityService', () => ({
+  getCurrentIdentity: vi.fn(() => ({ displayName: 'Test User' })),
+}));
+
+vi.mock('../../../services/TrackerPolicyService', () => ({
+  getEffectiveTrackerSyncPolicy: vi.fn(() => ({ mode: 'local', scope: 'project' })),
+  getInitialTrackerSyncStatus: vi.fn(() => 'local'),
+  shouldSyncTrackerItem: vi.fn(() => false),
+}));
+
+vi.mock('../../../services/TrackerSyncManager', () => ({
+  isTrackerSyncActive: vi.fn(() => false),
+  syncTrackerItem: vi.fn(),
+}));
+
+vi.mock('../../../services/TrackerSchemaService', () => ({
+  getTrackerRoleField: vi.fn(() => null),
+  ensureWorkspaceTrackerSchemasLoaded: vi.fn(),
+}));
+
+vi.mock('../../../utils/store', () => ({
+  getWorkspaceState: vi.fn(() => ({ issueKeyPrefix: 'NIM' })),
+  isAnalyticsEnabled: vi.fn(() => true),
+}));
+
+vi.mock('../../../window/WindowManager', () => ({
+  findWindowByWorkspace: vi.fn(() => null),
+  documentServices: mockDocumentServices,
+}));
+
+vi.mock('../../../services/MainBodyDocService', () => ({
+  applyHeadlessBodyMarkdown: vi.fn(async () => undefined),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp'),
+    isPackaged: false,
+    getName: vi.fn(() => 'Nimbalyst'),
+  },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+import { handleTrackerCreate } from '../trackerToolHandlers';
+import { loadBuiltinTrackers } from '@nimbalyst/runtime/plugins/TrackerPlugin/models/ModelLoader';
+import { globalRegistry } from '@nimbalyst/runtime/plugins/TrackerPlugin/models/TrackerDataModel';
+
+function makeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'item_test',
+    issue_key: null,
+    issue_number: null,
+    type: 'task',
+    type_tags: ['task'],
+    data: JSON.stringify({ title: 'x', status: 'to-do', priority: 'medium' }),
+    updated: '2026-07-26T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function setupCreateQueue(type: string) {
+  const createdRow = makeRow({ id: `${type}_test`, type, type_tags: [type], workspace: '/tmp/ws' });
+  const keyedRow = { ...createdRow, issue_key: 'NIM-1', issue_number: 1 };
+  mockQuery
+    .mockResolvedValueOnce({ rows: [] }) // INSERT
+    .mockResolvedValueOnce({ rows: [createdRow] }) // resolve created
+    .mockResolvedValueOnce({ rows: [{ max_num: 0 }] }) // MAX(issue_number)
+    .mockResolvedValueOnce({ rows: [] }) // UPDATE issue_key
+    .mockResolvedValueOnce({ rows: [keyedRow] }) // re-resolve
+    .mockResolvedValueOnce({ rows: [{ body_version: 1 }] }) // UPDATE content (description path)
+    .mockResolvedValueOnce({ rows: [] }) // INSERT tracker_body_cache
+    .mockResolvedValueOnce({ rows: [keyedRow] }); // notifyTrackerItemAdded
+}
+
+/** The data JSONB handed to the INSERT. */
+function insertedData(): Record<string, any> {
+  const insert = mockQuery.mock.calls.find((c) => String(c[0]).includes('INSERT INTO tracker_items'));
+  expect(insert, 'expected an INSERT INTO tracker_items call').toBeTruthy();
+  return JSON.parse(String((insert as any[])[1][3]));
+}
+
+beforeAll(() => {
+  loadBuiltinTrackers();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDocumentServices.clear();
+});
+
+describe('tracker_create honors the builtin schema contract (real schemas)', () => {
+  it('creates a decision with exactly the docs/TRACKER_WORKFLOWS.md arguments', async () => {
+    setupCreateQueue('decision');
+    // Verbatim shape from docs/TRACKER_WORKFLOWS.md "Decision Tracking".
+    const result = await handleTrackerCreate(
+      {
+        type: 'decision',
+        title: 'Use library X over Y',
+        priority: 'medium',
+        labels: ['extensions'],
+        description: '## Context\nwhy\n\n## Reasoning\nbecause',
+      },
+      '/tmp/ws',
+    );
+    expect(result.isError).toBe(false);
+    const data = insertedData();
+    expect(typeof data.decisionId).toBe('string');
+    expect(data.decisionId.length).toBeGreaterThan(0);
+  });
+
+  it('creates a plan with title only, defaulting status to the schema default', async () => {
+    setupCreateQueue('plan');
+    const result = await handleTrackerCreate({ type: 'plan', title: 'A plan' }, '/tmp/ws');
+    expect(result.isError).toBe(false);
+    const data = insertedData();
+    expect(data.status).toBe('draft');
+    expect(typeof data.planId).toBe('string');
+  });
+
+  it('creates an idea with the schema default status, not an out-of-schema "to-do"', async () => {
+    setupCreateQueue('idea');
+    const result = await handleTrackerCreate({ type: 'idea', title: 'An idea' }, '/tmp/ws');
+    expect(result.isError).toBe(false);
+    const model = globalRegistry.get('idea');
+    const statusOptions = model?.fields.find((f) => f.name === 'status')?.options?.map((o) => o.value) ?? [];
+    expect(insertedData().status).toBe('new');
+    expect(statusOptions).toContain(insertedData().status);
+  });
+
+  it('still creates a task with status to-do', async () => {
+    setupCreateQueue('task');
+    const result = await handleTrackerCreate({ type: 'task', title: 'A task' }, '/tmp/ws');
+    expect(result.isError).toBe(false);
+    expect(insertedData().status).toBe('to-do');
+  });
+});

--- a/packages/electron/src/main/mcp/tools/__tests__/trackerToolHandlers.test.ts
+++ b/packages/electron/src/main/mcp/tools/__tests__/trackerToolHandlers.test.ts
@@ -1423,3 +1423,92 @@ describe('handleTrackerUpdate session linking (NIM-879)', () => {
     expect(sqls.some((s) => s.includes('UPDATE ai_sessions'))).toBe(true);
   });
 });
+
+describe('handleTrackerCreate schema defaults', () => {
+  // A plan-shaped model: its status has no 'to-do' option, and planId is a
+  // required, non-inline field no MCP caller ever supplies.
+  const PLAN_MODEL = {
+    type: 'plan',
+    fields: [
+      { name: 'planId', type: 'string', required: true, displayInline: false },
+      { name: 'title', type: 'string', required: true, displayInline: true },
+      {
+        name: 'status',
+        type: 'select',
+        required: true,
+        default: 'draft',
+        options: [{ value: 'draft' }, { value: 'in-development' }, { value: 'completed' }],
+      },
+    ],
+  };
+
+  function setupCreateQueue() {
+    const createdRow = makeRow({ id: 'plan_test', type: 'plan', workspace: '/tmp/ws', issue_key: null, issue_number: null });
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // INSERT
+      .mockResolvedValueOnce({ rows: [createdRow] }) // resolve created
+      .mockResolvedValueOnce({ rows: [{ max_num: 0 }] }) // MAX(issue_number)
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE issue_key
+      .mockResolvedValueOnce({ rows: [{ ...createdRow, issue_key: 'NIM-1', issue_number: 1 }] }) // re-resolve
+      .mockResolvedValueOnce({ rows: [{ ...createdRow, issue_key: 'NIM-1', issue_number: 1 }] }); // notifyTrackerItemAdded
+  }
+
+  /** The data JSONB handed to the INSERT. */
+  function insertedData(): Record<string, any> {
+    const insert = mockQuery.mock.calls.find((c) => String(c[0]).includes('INSERT INTO tracker_items'));
+    return JSON.parse(String((insert as any[])[1][3]));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDocumentServices.clear();
+    mockGlobalRegistry.get.mockReturnValue(PLAN_MODEL as any);
+    mockGlobalRegistry.validate.mockReturnValue({ valid: true, errors: [] });
+  });
+
+  it('defaults status from the schema rather than a hardcoded "to-do"', async () => {
+    setupCreateQueue();
+    const result = await handleTrackerCreate({ type: 'plan', title: 'A plan' }, '/tmp/ws');
+    expect(result.isError).toBe(false);
+    expect(insertedData().status).toBe('draft');
+  });
+
+  it('honours an explicit status over the schema default', async () => {
+    setupCreateQueue();
+    await handleTrackerCreate({ type: 'plan', title: 'A plan', status: 'in-development' }, '/tmp/ws');
+    expect(insertedData().status).toBe('in-development');
+  });
+
+  it('populates a required self-id field no caller supplies', async () => {
+    setupCreateQueue();
+    await handleTrackerCreate({ type: 'plan', title: 'A plan' }, '/tmp/ws');
+    const data = insertedData();
+    expect(typeof data.planId).toBe('string');
+    expect(data.planId.length).toBeGreaterThan(0);
+  });
+
+  it('does not clobber a caller-supplied self-id field', async () => {
+    setupCreateQueue();
+    await handleTrackerCreate(
+      { type: 'plan', title: 'A plan', fields: { planId: 'explicit-id' } },
+      '/tmp/ws',
+    );
+    expect(insertedData().planId).toBe('explicit-id');
+  });
+
+  it('leaves inline required fields (title) alone', async () => {
+    setupCreateQueue();
+    await handleTrackerCreate({ type: 'plan', title: 'A plan' }, '/tmp/ws');
+    expect(insertedData().title).toBe('A plan');
+  });
+
+  it('falls back to "to-do" when the schema declares no default', async () => {
+    mockGlobalRegistry.get.mockReturnValue({
+      type: 'task',
+      fields: [{ name: 'title', type: 'string', required: true }, { name: 'status', type: 'select' }],
+    } as any);
+    setupCreateQueue();
+    await handleTrackerCreate({ type: 'task', title: 'A task' }, '/tmp/ws');
+    expect(insertedData().status).toBe('to-do');
+  });
+});

--- a/packages/electron/src/main/mcp/tools/trackerToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/trackerToolHandlers.ts
@@ -1866,9 +1866,17 @@ export async function handleTrackerCreate(
     const statusField = rf('workflowStatus', 'status');
     const priorityField = rf('priority', 'priority');
 
+    // Default the initial status from the schema, not a hardcoded "to-do".
+    // Types whose status options don't include "to-do" (plan -> 'draft',
+    // idea -> 'new', milestone -> 'planned') would otherwise start on an
+    // out-of-schema status.
+    const statusFieldDef = model?.fields?.find((f) => f.name === statusField);
+    const defaultStatus =
+      (typeof statusFieldDef?.default === 'string' && statusFieldDef.default) || 'to-do';
+
     const data: Record<string, any> = {
       [titleField]: args.title,
-      [statusField]: args.status || "to-do",
+      [statusField]: args.status || defaultStatus,
       [priorityField]: args.priority || "medium",
       created: new Date().toISOString().split("T")[0],
       authorIdentity,
@@ -1897,6 +1905,17 @@ export async function handleTrackerCreate(
         if (value !== undefined) {
           data[key] = value;
         }
+      }
+    }
+
+    // Auto-populate required self-identifier fields (e.g. plan.planId,
+    // decision.decisionId) that the schema marks required but no MCP caller
+    // ever supplies. These are non-inline string fields; seed them with the
+    // item id so they're stable and unique. Without this, full-document types
+    // fail schema validation and cannot be created via tracker_create at all.
+    for (const f of model?.fields ?? []) {
+      if (f.required && f.type === 'string' && f.displayInline === false && data[f.name] === undefined) {
+        data[f.name] = id;
       }
     }
 


### PR DESCRIPTION
## Summary

`tracker_create` builds every new item with a hardcoded initial status of `"to-do"` and never populates fields the type's schema marks `required`, so the create call documented in `docs/TRACKER_WORKFLOWS.md` is rejected for `decision` (`decisionId` is required), `plan` fails on `planId`, and `idea`/`milestone` are created on an out-of-schema status instead of their schema default.

This change makes `handleTrackerCreate` honor the schema contract:
- the initial status comes from the status field's own `default`, falling back to `"to-do"` only when the schema declares none;
- required non-inline string self-id fields (`plan.planId`, `decision.decisionId`) are seeded with the item id when the caller didn't supply them, before validation runs.

MCP path only — the in-app "+ New" flow already reads the schema default and is unchanged. Explicit `status`/`fields` arguments still win over both defaults.

## Related issue

Closes #1036

## Testing

- New `trackerCreateSchemaContract.test.ts` exercises `handleTrackerCreate` against the real builtin YAML schemas and the real registry validator: the verbatim `TRACKER_WORKFLOWS.md` decision call, plan/idea creation on their schema defaults, and a task control. All four failed (or asserted the wrong status) before the fix and pass after.
- Extended `trackerToolHandlers.test.ts` with schema-default unit tests: schema default used, explicit status wins, self-id populated, caller-supplied self-id preserved, `"to-do"` fallback without a schema default.
- `npm run typecheck` and the tracker suites pass locally.

## Notes for reviewers

Seeding the self-id fields with the item id keeps them stable and unique without inventing a new id scheme; the guard is deliberately narrow (`required` + `type: 'string'` + `displayInline: false`) so visible required fields like `title` still fail validation when missing.
