### PR TITLE
fix: draw the File/Edit/View menu bar in the window on Windows/Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Windows and Linux get the File/Edit/View menus back, now drawn in the project window's title bar.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/ipc/WindowChromeHandlers.ts
+++ b/packages/electron/src/main/ipc/WindowChromeHandlers.ts
@@ -1,5 +1,8 @@
-import { safeOn } from '../utils/ipcRegistry';
+import { BrowserWindow } from 'electron';
+import { safeHandle, safeOn } from '../utils/ipcRegistry';
 import { setResolvedTitleBarOverlayColors } from '../window/windowChrome';
+import { getWindowMenuBar, invokeWindowMenuItem } from '../menu/menuBarBridge';
+import { WINDOW_MENU_CHANNELS } from '../../shared/menuBar';
 
 let handlersRegistered = false;
 
@@ -8,6 +11,15 @@ export function registerWindowChromeHandlers(): void {
 
   safeOn('window-chrome:set-overlay-colors', (_event, payload: unknown) => {
     setResolvedTitleBarOverlayColors(payload);
+  });
+
+  safeHandle(WINDOW_MENU_CHANNELS.get, () => getWindowMenuBar());
+
+  safeHandle(WINDOW_MENU_CHANNELS.invoke, (event, id: unknown, revision: unknown) => {
+    if (typeof id !== 'string' || typeof revision !== 'number') {
+      return { invoked: false };
+    }
+    return invokeWindowMenuItem(id, revision, BrowserWindow.fromWebContents(event.sender));
   });
 
   handlersRegistered = true;

--- a/packages/electron/src/main/menu/ApplicationMenu.ts
+++ b/packages/electron/src/main/menu/ApplicationMenu.ts
@@ -44,6 +44,7 @@ import { getFocusedWindow } from '../utils/windowFocus';
 import { showSplashScreen } from '../window/SplashScreen';
 import { autoUpdaterService } from '../services/autoUpdater';
 import { KeyboardShortcuts } from './KeyboardShortcuts';
+import { notifyWindowMenuChanged } from './menuBarBridge';
 import { AnalyticsService } from '../services/analytics/AnalyticsService';
 import { FeatureTrackingService } from '../services/analytics/FeatureTrackingService';
 import { getDialogDefaultPath, rememberDialogSelection } from '../utils/dialogPaths';
@@ -1914,6 +1915,9 @@ export async function createApplicationMenu() {
     }
 
     Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+    // Windows/Linux hide the native strip behind the custom title bar, so the
+    // renderer mirrors this menu — tell it the model changed.
+    notifyWindowMenuChanged();
 }
 
 // Update application menu

--- a/packages/electron/src/main/menu/__tests__/menuBarBridge.test.ts
+++ b/packages/electron/src/main/menu/__tests__/menuBarBridge.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getApplicationMenu, getAllWindows, getFocusedWindow, quit, error } = vi.hoisted(() => ({
+  getApplicationMenu: vi.fn(),
+  getAllWindows: vi.fn(() => [] as unknown[]),
+  getFocusedWindow: vi.fn(() => null as unknown),
+  quit: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: { quit },
+  Menu: { getApplicationMenu },
+  BrowserWindow: { getAllWindows, getFocusedWindow },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { menu: { error, warn: vi.fn(), info: vi.fn() } },
+}));
+
+import {
+  getWindowMenuBar,
+  invokeWindowMenuItem,
+  notifyWindowMenuChanged,
+  resetWindowMenuRevisionForTests,
+} from '../menuBarBridge';
+
+const realPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+function makeWindow() {
+  return {
+    isDestroyed: () => false,
+    webContents: {
+      send: vi.fn(),
+      copy: vi.fn(),
+      undo: vi.fn(),
+    },
+    minimize: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetWindowMenuRevisionForTests();
+  setPlatform('win32');
+  getAllWindows.mockReturnValue([]);
+  getFocusedWindow.mockReturnValue(null);
+});
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+});
+
+describe('getWindowMenuBar', () => {
+  it('serializes the live application menu on Windows', () => {
+    getApplicationMenu.mockReturnValue({
+      items: [{ label: 'File', submenu: { items: [{ label: 'Save', accelerator: 'CmdOrCtrl+S' }] } }],
+    });
+
+    const menuBar = getWindowMenuBar();
+
+    expect(menuBar.items[0].label).toBe('File');
+    expect(menuBar.items[0].submenu?.[0].acceleratorLabel).toBe('Ctrl+S');
+  });
+
+  it('flags macOS as not drawing the bar in-window, where the system menu bar shows it', () => {
+    setPlatform('darwin');
+    getApplicationMenu.mockReturnValue({ items: [{ label: 'File' }] });
+
+    const menuBar = getWindowMenuBar();
+
+    expect(menuBar.inWindow).toBe(false);
+    expect(menuBar.items).toHaveLength(1);
+  });
+});
+
+describe('notifyWindowMenuChanged', () => {
+  it('bumps the revision and pushes the model to every window', () => {
+    getApplicationMenu.mockReturnValue({ items: [{ label: 'File' }] });
+    const window = makeWindow();
+    getAllWindows.mockReturnValue([window]);
+
+    expect(getWindowMenuBar().revision).toBe(0);
+    notifyWindowMenuChanged();
+
+    expect(getWindowMenuBar().revision).toBe(1);
+    expect(window.webContents.send).toHaveBeenCalledWith(
+      'window-menu:changed',
+      expect.objectContaining({ revision: 1 }),
+    );
+  });
+
+  it('skips destroyed windows', () => {
+    getApplicationMenu.mockReturnValue({ items: [] });
+    const destroyed = { ...makeWindow(), isDestroyed: () => true };
+    getAllWindows.mockReturnValue([destroyed]);
+
+    notifyWindowMenuChanged();
+
+    expect(destroyed.webContents.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('invokeWindowMenuItem', () => {
+  it('runs the click handler with the sender window', () => {
+    const click = vi.fn();
+    getApplicationMenu.mockReturnValue({
+      items: [{ label: 'File', submenu: { items: [{ label: 'Save', click }] } }],
+    });
+    const window = makeWindow();
+
+    const result = invokeWindowMenuItem('0.0', 0, window as never);
+
+    expect(result).toEqual({ invoked: true });
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click.mock.calls[0][1]).toBe(window);
+  });
+
+  it('rejects a stale revision instead of firing whatever now sits at that index', () => {
+    const click = vi.fn();
+    getApplicationMenu.mockReturnValue({ items: [{ label: 'File', submenu: { items: [{ click }] } }] });
+
+    notifyWindowMenuChanged();
+    const result = invokeWindowMenuItem('0.0', 0, makeWindow() as never);
+
+    expect(result).toEqual({ invoked: false, staleRevision: true });
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it('performs role items, which carry no click handler', () => {
+    getApplicationMenu.mockReturnValue({
+      items: [{ label: 'Edit', submenu: { items: [{ label: 'Copy', role: 'copy' }] } }],
+    });
+    const window = makeWindow();
+
+    expect(invokeWindowMenuItem('0.0', 0, window as never)).toEqual({ invoked: true });
+    expect(window.webContents.copy).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes role casing (selectAll) and falls back to the focused window', () => {
+    getApplicationMenu.mockReturnValue({
+      items: [{ label: 'Window', submenu: { items: [{ label: 'Minimize', role: 'minimize' }] } }],
+    });
+    const focused = makeWindow();
+    getFocusedWindow.mockReturnValue(focused);
+
+    expect(invokeWindowMenuItem('0.0', 0, null)).toEqual({ invoked: true });
+    expect(focused.minimize).toHaveBeenCalledTimes(1);
+  });
+
+  it('flips checkbox state before the handler runs, like a native click', () => {
+    const item = { label: 'Show Panel', type: 'checkbox', checked: false, click: vi.fn() };
+    getApplicationMenu.mockReturnValue({ items: [{ label: 'View', submenu: { items: [item] } }] });
+
+    invokeWindowMenuItem('0.0', 0, makeWindow() as never);
+
+    expect(item.checked).toBe(true);
+    expect(item.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('selects radio items rather than toggling them', () => {
+    const item = { label: 'Dark', type: 'radio', checked: true, click: vi.fn() };
+    getApplicationMenu.mockReturnValue({ items: [{ label: 'View', submenu: { items: [item] } }] });
+
+    invokeWindowMenuItem('0.0', 0, makeWindow() as never);
+
+    expect(item.checked).toBe(true);
+  });
+
+  it('ignores disabled items, separators, and unknown ids', () => {
+    const click = vi.fn();
+    getApplicationMenu.mockReturnValue({
+      items: [
+        {
+          label: 'File',
+          submenu: { items: [{ label: 'Save', enabled: false, click }, { type: 'separator' }] },
+        },
+      ],
+    });
+
+    expect(invokeWindowMenuItem('0.0', 0, null)).toEqual({ invoked: false });
+    expect(invokeWindowMenuItem('0.1', 0, null)).toEqual({ invoked: false });
+    expect(invokeWindowMenuItem('9.9', 0, null)).toEqual({ invoked: false });
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it('does not let a throwing handler escape into the IPC layer', () => {
+    getApplicationMenu.mockReturnValue({
+      items: [{
+        label: 'File',
+        submenu: { items: [{ label: 'Boom', click: () => { throw new Error('boom'); } }] },
+      }],
+    });
+
+    expect(invokeWindowMenuItem('0.0', 0, null)).toEqual({ invoked: false });
+    expect(error).toHaveBeenCalled();
+  });
+});

--- a/packages/electron/src/main/menu/__tests__/menuBarSerialization.test.ts
+++ b/packages/electron/src/main/menu/__tests__/menuBarSerialization.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findMenuItemByPath,
+  formatAcceleratorLabel,
+  serializeMenuBar,
+  serializeMenuItems,
+  type MenuLike,
+} from '../menuBarSerialization';
+
+function menu(items: MenuLike['items']): MenuLike {
+  return { items };
+}
+
+describe('formatAcceleratorLabel', () => {
+  it('renders CmdOrCtrl as Ctrl off macOS and Cmd on it', () => {
+    expect(formatAcceleratorLabel('CmdOrCtrl+Shift+P', 'win32')).toBe('Ctrl+Shift+P');
+    expect(formatAcceleratorLabel('CmdOrCtrl+Shift+P', 'darwin')).toBe('Cmd+Shift+P');
+  });
+
+  it('maps Alt to Option only on macOS', () => {
+    expect(formatAcceleratorLabel('Alt+Left', 'win32')).toBe('Alt+Left');
+    expect(formatAcceleratorLabel('Alt+Left', 'darwin')).toBe('Option+Left');
+  });
+
+  it('keeps function keys and passes through the Plus escape hatch', () => {
+    expect(formatAcceleratorLabel('F12', 'win32')).toBe('F12');
+    expect(formatAcceleratorLabel('CmdOrCtrl+Plus', 'win32')).toBe('Ctrl++');
+  });
+
+  it('returns undefined for a missing or blank accelerator', () => {
+    expect(formatAcceleratorLabel(undefined, 'win32')).toBeUndefined();
+    expect(formatAcceleratorLabel('   ', 'win32')).toBeUndefined();
+  });
+});
+
+describe('serializeMenuItems', () => {
+  it('ids items by their index path so they resolve back to the live menu', () => {
+    const source = menu([
+      {
+        label: 'File',
+        submenu: menu([
+          { label: 'Save', accelerator: 'CmdOrCtrl+S' },
+          {
+            label: 'New',
+            submenu: menu([{ label: 'Document' }]),
+          },
+        ]),
+      },
+      { label: 'Edit', submenu: menu([{ label: 'Undo', role: 'undo' }]) },
+    ]);
+
+    const items = serializeMenuItems(source, 'win32');
+
+    expect(items.map((item) => item.id)).toEqual(['0', '1']);
+    expect(items[0].type).toBe('submenu');
+    expect(items[0].submenu?.[0]).toMatchObject({
+      id: '0.0',
+      label: 'Save',
+      type: 'normal',
+      acceleratorLabel: 'Ctrl+S',
+    });
+    expect(items[0].submenu?.[1].submenu?.[0].id).toBe('0.1.0');
+
+    expect(findMenuItemByPath(source, '0.1.0')?.label).toBe('Document');
+    expect(findMenuItemByPath(source, '1.0')?.role).toBe('undo');
+  });
+
+  it('skips hidden items but keeps ids aligned with the live indices', () => {
+    const source = menu([
+      {
+        label: 'View',
+        submenu: menu([
+          { label: 'Zoom In' },
+          { label: 'Debug Only', visible: false },
+          { label: 'Zoom Out' },
+        ]),
+      },
+    ]);
+
+    const submenu = serializeMenuItems(source, 'win32')[0].submenu ?? [];
+
+    expect(submenu.map((item) => item.label)).toEqual(['Zoom In', 'Zoom Out']);
+    expect(submenu.map((item) => item.id)).toEqual(['0.0', '0.2']);
+    expect(findMenuItemByPath(source, '0.2')?.label).toBe('Zoom Out');
+  });
+
+  it('drops separators left stranded by hidden items', () => {
+    const source = menu([
+      {
+        label: 'Help',
+        submenu: menu([
+          { type: 'separator' },
+          { label: 'Docs' },
+          { type: 'separator' },
+          { label: 'Dev Only', visible: false },
+          { type: 'separator' },
+          { label: 'About' },
+          { type: 'separator' },
+        ]),
+      },
+    ]);
+
+    const submenu = serializeMenuItems(source, 'win32')[0].submenu ?? [];
+
+    expect(submenu.map((item) => item.type)).toEqual([
+      'normal',
+      'separator',
+      'normal',
+    ]);
+    expect(submenu.map((item) => item.label)).toEqual(['Docs', '', 'About']);
+  });
+
+  it('reports enabled and checked state', () => {
+    const items = serializeMenuItems(
+      menu([
+        {
+          label: 'View',
+          submenu: menu([
+            { label: 'Dark', type: 'radio', checked: true },
+            { label: 'Light', type: 'radio', checked: false },
+            { label: 'Unavailable', enabled: false },
+          ]),
+        },
+      ]),
+      'win32',
+    );
+
+    expect(items[0].submenu).toMatchObject([
+      { label: 'Dark', type: 'radio', checked: true, enabled: true },
+      { label: 'Light', type: 'radio', checked: false },
+      { label: 'Unavailable', type: 'normal', enabled: false },
+    ]);
+  });
+
+  it('treats an empty submenu as a normal item', () => {
+    const items = serializeMenuItems(menu([{ label: 'Empty', submenu: menu([]) }]), 'win32');
+    expect(items[0].type).toBe('normal');
+  });
+});
+
+describe('serializeMenuBar', () => {
+  it('carries the revision and tolerates a missing menu', () => {
+    expect(serializeMenuBar(null, 'win32', 7)).toEqual({ revision: 7, inWindow: true, items: [] });
+    expect(serializeMenuBar(menu([{ label: 'File' }]), 'win32', 3).revision).toBe(3);
+  });
+
+  it('marks the bar as not drawn in-window on macOS, but still serializes it', () => {
+    const menuBar = serializeMenuBar(menu([{ label: 'File' }]), 'darwin', 1);
+
+    expect(menuBar.inWindow).toBe(false);
+    expect(menuBar.items).toHaveLength(1);
+  });
+});
+
+describe('findMenuItemByPath', () => {
+  it('rejects malformed or out-of-range paths', () => {
+    const source = menu([{ label: 'File', submenu: menu([{ label: 'Save' }]) }]);
+
+    expect(findMenuItemByPath(source, '0.9')).toBeNull();
+    expect(findMenuItemByPath(source, '')).toBeNull();
+    expect(findMenuItemByPath(source, 'constructor')).toBeNull();
+    expect(findMenuItemByPath(source, '0..1')).toBeNull();
+    expect(findMenuItemByPath(null, '0')).toBeNull();
+  });
+});

--- a/packages/electron/src/main/menu/menuBarBridge.ts
+++ b/packages/electron/src/main/menu/menuBarBridge.ts
@@ -1,0 +1,138 @@
+/**
+ * Bridge between the live application menu and the renderer-drawn menu bar.
+ *
+ * Windows/Linux workspace windows are frameless (`windowChrome.ts`), which
+ * hides the native menu strip. The application menu is still installed — it is
+ * what makes the accelerators work — so the renderer mirrors it instead of
+ * owning a second copy of the template.
+ *
+ * On macOS this serves an empty model: the system menu bar already shows it.
+ */
+
+import { app, BrowserWindow, Menu, type MenuItem } from 'electron';
+import { WINDOW_MENU_CHANNELS, type SerializedMenuBar } from '../../shared/menuBar';
+import { findMenuItemByPath, serializeMenuBar, type MenuLike } from './menuBarSerialization';
+import { logger } from '../utils/logger';
+
+let revision = 0;
+
+/**
+ * Role items carry no `click` handler, so invoking one has to perform the role
+ * ourselves. Only roles reachable from a non-mac window need an entry; the
+ * mac-only roles (hide/unhide/front) never render in this strip.
+ */
+const ROLE_ACTIONS: Record<string, (window: BrowserWindow | null) => void> = {
+  undo: (window) => window?.webContents.undo(),
+  redo: (window) => window?.webContents.redo(),
+  cut: (window) => window?.webContents.cut(),
+  copy: (window) => window?.webContents.copy(),
+  paste: (window) => window?.webContents.paste(),
+  pasteandmatchstyle: (window) => window?.webContents.pasteAndMatchStyle(),
+  delete: (window) => window?.webContents.delete(),
+  selectall: (window) => window?.webContents.selectAll(),
+  reload: (window) => window?.webContents.reload(),
+  forcereload: (window) => window?.webContents.reloadIgnoringCache(),
+  toggledevtools: (window) => window?.webContents.toggleDevTools(),
+  resetzoom: (window) => {
+    if (window) window.webContents.setZoomLevel(0);
+  },
+  zoomin: (window) => {
+    if (window) window.webContents.setZoomLevel(window.webContents.getZoomLevel() + 0.5);
+  },
+  zoomout: (window) => {
+    if (window) window.webContents.setZoomLevel(window.webContents.getZoomLevel() - 0.5);
+  },
+  togglefullscreen: (window) => window?.setFullScreen(!window.isFullScreen()),
+  minimize: (window) => window?.minimize(),
+  close: (window) => window?.close(),
+  quit: () => app.quit(),
+};
+
+function currentMenu(): MenuLike | null {
+  return (Menu.getApplicationMenu() as unknown as MenuLike | null) ?? null;
+}
+
+export function getWindowMenuBar(): SerializedMenuBar {
+  return serializeMenuBar(currentMenu(), process.platform, revision);
+}
+
+/**
+ * Called after every `Menu.setApplicationMenu`. Bumps the revision (which
+ * invalidates in-flight item ids) and pushes the fresh model to every window.
+ */
+export function notifyWindowMenuChanged(): void {
+  revision += 1;
+
+  const payload = getWindowMenuBar();
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (window.isDestroyed()) continue;
+    try {
+      window.webContents.send(WINDOW_MENU_CHANNELS.changed, payload);
+    } catch (error) {
+      logger.menu.error('Failed to push menu bar model to window:', error);
+    }
+  }
+}
+
+export interface InvokeWindowMenuItemResult {
+  invoked: boolean;
+  /** Set when the caller's model was stale and should be refreshed. */
+  staleRevision?: boolean;
+}
+
+/**
+ * Run the application-menu item at `id` as if the native menu had been used.
+ */
+export function invokeWindowMenuItem(
+  id: string,
+  itemRevision: number,
+  senderWindow: BrowserWindow | null,
+): InvokeWindowMenuItemResult {
+  if (itemRevision !== revision) {
+    return { invoked: false, staleRevision: true };
+  }
+
+  const item = findMenuItemByPath(currentMenu(), id);
+  if (!item || item.enabled === false || item.type === 'separator') {
+    return { invoked: false };
+  }
+
+  const window = senderWindow && !senderWindow.isDestroyed()
+    ? senderWindow
+    : BrowserWindow.getFocusedWindow();
+
+  try {
+    // Native clicks flip the checked state before dispatching; mirror that so
+    // handlers reading `menuItem.checked` see what they would natively.
+    if (item.type === 'checkbox') {
+      item.checked = item.checked !== true;
+    } else if (item.type === 'radio') {
+      item.checked = true;
+    }
+
+    if (typeof item.click === 'function') {
+      (item.click as (
+        menuItem: MenuItem,
+        browserWindow: BrowserWindow | undefined,
+        event: Record<string, unknown>,
+      ) => void)(item as unknown as MenuItem, window ?? undefined, {});
+      return { invoked: true };
+    }
+
+    const role = item.role?.toLowerCase();
+    const roleAction = role ? ROLE_ACTIONS[role] : undefined;
+    if (roleAction) {
+      roleAction(window);
+      return { invoked: true };
+    }
+  } catch (error) {
+    logger.menu.error(`Failed to invoke menu item ${id}:`, error);
+    return { invoked: false };
+  }
+
+  return { invoked: false };
+}
+
+export function resetWindowMenuRevisionForTests(): void {
+  revision = 0;
+}

--- a/packages/electron/src/main/menu/menuBarSerialization.ts
+++ b/packages/electron/src/main/menu/menuBarSerialization.ts
@@ -1,0 +1,203 @@
+/**
+ * Pure helpers that turn a live Electron `Menu` into the renderer-facing
+ * `SerializedMenuBar` model (see `shared/menuBar.ts`) and back again.
+ *
+ * Deliberately free of `electron` imports so it can be unit tested against
+ * plain objects — the electron-coupled side lives in `menuBarBridge.ts`.
+ */
+
+import type {
+  SerializedMenuBar,
+  SerializedMenuItem,
+  SerializedMenuItemType,
+} from '../../shared/menuBar';
+
+/** Structural stand-in for Electron's `MenuItem`. */
+export interface MenuItemLike {
+  label?: string;
+  type?: string;
+  enabled?: boolean;
+  visible?: boolean;
+  checked?: boolean;
+  accelerator?: string;
+  role?: string;
+  submenu?: MenuLike;
+  click?: unknown;
+}
+
+/** Structural stand-in for Electron's `Menu`. */
+export interface MenuLike {
+  items: MenuItemLike[];
+}
+
+const MODIFIER_LABELS: Record<string, { darwin: string; other: string }> = {
+  commandorcontrol: { darwin: 'Cmd', other: 'Ctrl' },
+  cmdorctrl: { darwin: 'Cmd', other: 'Ctrl' },
+  command: { darwin: 'Cmd', other: 'Cmd' },
+  cmd: { darwin: 'Cmd', other: 'Cmd' },
+  control: { darwin: 'Control', other: 'Ctrl' },
+  ctrl: { darwin: 'Control', other: 'Ctrl' },
+  alt: { darwin: 'Option', other: 'Alt' },
+  option: { darwin: 'Option', other: 'Alt' },
+  altgr: { darwin: 'AltGr', other: 'AltGr' },
+  shift: { darwin: 'Shift', other: 'Shift' },
+  super: { darwin: 'Super', other: 'Win' },
+  meta: { darwin: 'Cmd', other: 'Win' },
+};
+
+const KEY_LABELS: Record<string, string> = {
+  plus: '+',
+  space: 'Space',
+  tab: 'Tab',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  insert: 'Insert',
+  return: 'Enter',
+  enter: 'Enter',
+  up: 'Up',
+  down: 'Down',
+  left: 'Left',
+  right: 'Right',
+  home: 'Home',
+  end: 'End',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+  escape: 'Esc',
+  esc: 'Esc',
+  numadd: 'Num+',
+  numsub: 'Num-',
+  nummult: 'Num*',
+  numdiv: 'Num/',
+  numdec: 'Num.',
+};
+
+/**
+ * Render an Electron accelerator for display. Electron parses accelerators
+ * itself — this is cosmetic only, so an unrecognized token is passed through
+ * rather than dropped.
+ */
+export function formatAcceleratorLabel(
+  accelerator: string | undefined,
+  platform: NodeJS.Platform,
+): string | undefined {
+  if (!accelerator) return undefined;
+  const trimmed = accelerator.trim();
+  if (!trimmed) return undefined;
+
+  // "Plus" is the escape hatch for a literal +, so it can't be a separator.
+  const tokens = trimmed.split('+').filter((token) => token.length > 0);
+  const labels = tokens.map((token) => {
+    const key = token.toLowerCase();
+    const modifier = MODIFIER_LABELS[key];
+    if (modifier) return platform === 'darwin' ? modifier.darwin : modifier.other;
+    const named = KEY_LABELS[key];
+    if (named) return named;
+    if (key.length === 1) return token.toUpperCase();
+    // Function keys and the like already arrive in display form.
+    return token;
+  });
+
+  return labels.join('+');
+}
+
+function normalizeType(item: MenuItemLike): SerializedMenuItemType {
+  if (item.type === 'separator') return 'separator';
+  if (item.type === 'checkbox') return 'checkbox';
+  if (item.type === 'radio') return 'radio';
+  if (item.submenu && item.submenu.items.length > 0) return 'submenu';
+  return 'normal';
+}
+
+/**
+ * Hidden items leave separators stranded — a template whose whole dev-only
+ * group is invisible would otherwise render a divider against nothing.
+ */
+function dropStrandedSeparators(items: SerializedMenuItem[]): SerializedMenuItem[] {
+  const result: SerializedMenuItem[] = [];
+  for (const item of items) {
+    if (item.type !== 'separator') {
+      result.push(item);
+      continue;
+    }
+    if (result.length === 0) continue;
+    if (result[result.length - 1].type === 'separator') continue;
+    result.push(item);
+  }
+  while (result.length > 0 && result[result.length - 1].type === 'separator') {
+    result.pop();
+  }
+  return result;
+}
+
+/**
+ * Serialize a menu's items. `parentId` is the index path of the owning
+ * submenu; ids use the item's index in the *original* array so
+ * `findMenuItemByPath` can walk straight back to the live `MenuItem`.
+ */
+export function serializeMenuItems(
+  menu: MenuLike | undefined,
+  platform: NodeJS.Platform,
+  parentId = '',
+): SerializedMenuItem[] {
+  if (!menu?.items) return [];
+
+  const serialized: SerializedMenuItem[] = [];
+  menu.items.forEach((item, index) => {
+    if (item.visible === false) return;
+
+    const id = parentId ? `${parentId}.${index}` : `${index}`;
+    const type = normalizeType(item);
+    const entry: SerializedMenuItem = {
+      id,
+      label: item.label ?? '',
+      type,
+      enabled: item.enabled !== false,
+    };
+
+    const acceleratorLabel = formatAcceleratorLabel(item.accelerator, platform);
+    if (acceleratorLabel) entry.acceleratorLabel = acceleratorLabel;
+    if (type === 'checkbox' || type === 'radio') entry.checked = item.checked === true;
+    if (type === 'submenu') {
+      entry.submenu = serializeMenuItems(item.submenu, platform, id);
+    }
+
+    serialized.push(entry);
+  });
+
+  return dropStrandedSeparators(serialized);
+}
+
+export function serializeMenuBar(
+  menu: MenuLike | null | undefined,
+  platform: NodeJS.Platform,
+  revision: number,
+): SerializedMenuBar {
+  return {
+    revision,
+    inWindow: platform !== 'darwin',
+    items: serializeMenuItems(menu ?? undefined, platform),
+  };
+}
+
+const PATH_PATTERN = /^\d+(\.\d+)*$/;
+
+/** Resolve an index-path id back to the live menu item, or null. */
+export function findMenuItemByPath(
+  menu: MenuLike | null | undefined,
+  id: string,
+): MenuItemLike | null {
+  if (!menu || !PATH_PATTERN.test(id)) return null;
+
+  let items: MenuItemLike[] | undefined = menu.items;
+  let found: MenuItemLike | null = null;
+
+  for (const segment of id.split('.')) {
+    if (!items) return null;
+    const item: MenuItemLike | undefined = items[Number(segment)];
+    if (!item) return null;
+    found = item;
+    items = item.submenu?.items;
+  }
+
+  return found;
+}

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -265,6 +265,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setTitleBarOverlayColors: (colors: { color: string; symbolColor: string }) =>
     ipcRenderer.send('window-chrome:set-overlay-colors', colors),
 
+  // In-window menu bar (Windows/Linux; macOS keeps its system menu bar)
+  getWindowMenuBar: () => ipcRenderer.invoke('window-menu:get'),
+  invokeWindowMenuItem: (id: string, revision: number) =>
+    ipcRenderer.invoke('window-menu:invoke', id, revision),
+
   // File operations
   openFile: () => ipcRenderer.invoke('open-file'),
   openFileDialog: (options?: {

--- a/packages/electron/src/renderer/App.tsx
+++ b/packages/electron/src/renderer/App.tsx
@@ -128,6 +128,7 @@ import { initSyncListeners } from './store/listeners/syncListeners';
 import { initDbMigrationListeners } from './store/listeners/dbMigrationListeners';
 import { initOpenAICodexAuthListeners } from './store/listeners/openAICodexAuthListeners';
 import { initThemeListener } from './store/listeners/themeListeners';
+import { initWindowMenuListener } from './store/listeners/windowMenuListeners';
 import { initThemeFallbackListener } from './store/listeners/themeFallbackListeners';
 import { initTrackerSyncListeners } from './store/listeners/trackerSyncListeners';
 import { initPullRequestListeners } from './store/listeners/pullRequestListeners';
@@ -370,7 +371,9 @@ export default function App() {
     const cleanupNetworkAvailability = initNetworkAvailabilityListeners();
     const cleanupCollabReplicas = initCollabReplicaListeners();
     const cleanupCollabConversion = initCollabConversionListeners();
+    const cleanupWindowMenu = initWindowMenuListener();
     return () => {
+      cleanupWindowMenu?.();
       cleanupActionPrompts?.();
       cleanupAiCommands?.();
       cleanupAppCommands?.();

--- a/packages/electron/src/renderer/components/WindowTopBar/WindowMenuBar.css
+++ b/packages/electron/src/renderer/components/WindowTopBar/WindowMenuBar.css
@@ -1,0 +1,108 @@
+.window-menu-bar {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.window-menu-bar__top-item {
+  flex: 0 0 auto;
+  height: 24px;
+  margin: 0;
+  padding: 0 7px;
+  color: var(--nim-text-muted);
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  font: inherit;
+  font-size: 12px;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.window-menu-bar__top-item:hover,
+.window-menu-bar__top-item[data-open='true'] {
+  color: var(--nim-text);
+  background: var(--nim-bg-hover);
+}
+
+.window-menu-bar__top-item:focus-visible {
+  outline: 2px solid var(--nim-border-focus);
+  outline-offset: -2px;
+}
+
+.window-menu-bar__menu {
+  z-index: 10000;
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  max-width: min(420px, calc(100vw - 24px));
+  overflow-y: auto;
+  padding: 4px;
+  color: var(--nim-text);
+  background: var(--nim-bg-secondary);
+  border: 1px solid var(--nim-border);
+  border-radius: 7px;
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--nim-text) 16%, transparent);
+}
+
+.window-menu-bar__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 26px;
+  padding: 3px 8px 3px 4px;
+  color: var(--nim-text);
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: default;
+}
+
+.window-menu-bar__item:hover:not([data-disabled='true']),
+.window-menu-bar__item:focus-visible,
+.window-menu-bar__item[data-submenu-open='true'] {
+  background: var(--nim-bg-hover);
+  outline: none;
+}
+
+.window-menu-bar__item[data-disabled='true'] {
+  color: var(--nim-text-disabled);
+  cursor: default;
+}
+
+.window-menu-bar__item-check {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  color: var(--nim-primary);
+}
+
+.window-menu-bar__item-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.window-menu-bar__item-accelerator {
+  flex: 0 0 auto;
+  padding-left: 16px;
+  color: var(--nim-text-faint);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.window-menu-bar__separator {
+  height: 1px;
+  margin: 4px 2px;
+  background: var(--nim-border);
+}

--- a/packages/electron/src/renderer/components/WindowTopBar/WindowMenuBar.tsx
+++ b/packages/electron/src/renderer/components/WindowTopBar/WindowMenuBar.tsx
@@ -1,0 +1,340 @@
+/**
+ * In-window menu bar for Windows/Linux.
+ *
+ * Workspace windows are frameless there (see `main/window/windowChrome.ts`), so
+ * the native File/Edit/View strip is hidden. This renders the same menu inside
+ * the custom title bar, driven by the serialized model in `windowMenuBarAtom`
+ * — `main/menu/ApplicationMenu.ts` remains the only place the menu is defined.
+ *
+ * macOS serves an empty model (the system menu bar already shows it), so this
+ * renders nothing there.
+ *
+ * Nesting uses @floating-ui/react's FloatingTree so a click inside a submenu
+ * portal doesn't read as an outside-press on its parent.
+ */
+
+import React, { createContext, useCallback, useContext, useRef, useState } from 'react';
+import { useAtomValue } from 'jotai';
+import {
+  FloatingFocusManager,
+  FloatingList,
+  FloatingNode,
+  FloatingPortal,
+  FloatingTree,
+  autoUpdate,
+  flip,
+  offset,
+  safePolygon,
+  shift,
+  size,
+  useClick,
+  useDismiss,
+  useFloating,
+  useFloatingNodeId,
+  useHover,
+  useInteractions,
+  useListItem,
+  useListNavigation,
+  useMergeRefs,
+  useRole,
+} from '@floating-ui/react';
+import { MaterialSymbol } from '@nimbalyst/runtime';
+import type { SerializedMenuItem } from '../../../shared/menuBar';
+import { windowMenuBarAtom } from '../../store/atoms/windowMenu';
+import './WindowMenuBar.css';
+
+interface MenuBarContextValue {
+  revision: number;
+  closeAll: () => void;
+}
+
+const MenuBarContext = createContext<MenuBarContextValue>({
+  revision: 0,
+  closeAll: () => {},
+});
+
+interface MenuListContextValue {
+  getItemProps: (props?: React.HTMLProps<HTMLElement>) => Record<string, unknown>;
+  activeIndex: number | null;
+}
+
+/** Per-list interaction props, so items don't have to be prop-drilled. */
+const MenuListContext = createContext<MenuListContextValue>({
+  getItemProps: () => ({}),
+  activeIndex: null,
+});
+
+function menuMiddleware(placement: 'bottom-start' | 'right-start') {
+  return [
+    offset(placement === 'bottom-start' ? 2 : { mainAxis: 0, alignmentAxis: -4 }),
+    flip({ padding: 8 }),
+    shift({ padding: 8 }),
+    size({
+      padding: 8,
+      apply({ availableHeight, elements }) {
+        elements.floating.style.maxHeight = `${Math.max(160, availableHeight)}px`;
+      },
+    }),
+  ];
+}
+
+function MenuSeparator() {
+  return <div className="window-menu-bar__separator" role="separator" />;
+}
+
+function ItemAffordances({ item }: { item: SerializedMenuItem }) {
+  return (
+    <>
+      <span className="window-menu-bar__item-check" aria-hidden="true">
+        {item.checked === true && <MaterialSymbol icon="check" size={15} />}
+      </span>
+      <span className="window-menu-bar__item-label">{item.label}</span>
+      {item.acceleratorLabel && (
+        <span className="window-menu-bar__item-accelerator">{item.acceleratorLabel}</span>
+      )}
+    </>
+  );
+}
+
+function CommandItem({ item }: { item: SerializedMenuItem }) {
+  const { revision, closeAll } = useContext(MenuBarContext);
+  const { ref, index } = useListItem();
+  const { getItemProps, activeIndex } = useContext(MenuListContext);
+
+  const disabled = !item.enabled;
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      role={item.type === 'checkbox' || item.type === 'radio' ? 'menuitemcheckbox' : 'menuitem'}
+      aria-checked={item.type === 'normal' ? undefined : item.checked === true}
+      aria-disabled={disabled || undefined}
+      tabIndex={activeIndex === index ? 0 : -1}
+      className="window-menu-bar__item"
+      data-testid={`window-menu-item-${item.id}`}
+      data-disabled={disabled}
+      {...getItemProps({
+        onClick: () => {
+          if (disabled) return;
+          void window.electronAPI?.invokeWindowMenuItem?.(item.id, revision);
+          closeAll();
+        },
+      })}
+    >
+      <ItemAffordances item={item} />
+    </button>
+  );
+}
+
+function MenuItems({ items }: { items: SerializedMenuItem[] }) {
+  return (
+    <>
+      {items.map((item) => {
+        if (item.type === 'separator') return <MenuSeparator key={item.id} />;
+        if (item.type === 'submenu') return <SubMenu key={item.id} item={item} />;
+        return <CommandItem key={item.id} item={item} />;
+      })}
+    </>
+  );
+}
+
+function SubMenu({ item }: { item: SerializedMenuItem }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const nodeId = useFloatingNodeId();
+  const elementsRef = useRef<Array<HTMLButtonElement | null>>([]);
+  const parentList = useContext(MenuListContext);
+  const { ref: itemRef, index: itemIndex } = useListItem();
+
+  const { refs, floatingStyles, context } = useFloating({
+    nodeId,
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement: 'right-start',
+    strategy: 'fixed',
+    middleware: menuMiddleware('right-start'),
+    whileElementsMounted: autoUpdate,
+  });
+
+  const hover = useHover(context, { handleClose: safePolygon({ blockPointerEvents: true }) });
+  const click = useClick(context, { toggle: true, ignoreMouse: true });
+  const dismiss = useDismiss(context, { bubbles: true });
+  const role = useRole(context, { role: 'menu' });
+  const listNavigation = useListNavigation(context, {
+    listRef: elementsRef,
+    activeIndex,
+    nested: true,
+    onNavigate: setActiveIndex,
+    loop: true,
+  });
+
+  const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions([
+    hover,
+    click,
+    dismiss,
+    role,
+    listNavigation,
+  ]);
+
+  const mergedTriggerRef = useMergeRefs([refs.setReference, itemRef]);
+  const disabled = !item.enabled;
+
+  return (
+    <FloatingNode id={nodeId}>
+      <button
+        ref={mergedTriggerRef}
+        type="button"
+        role="menuitem"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-disabled={disabled || undefined}
+        tabIndex={parentList.activeIndex === itemIndex ? 0 : -1}
+        className="window-menu-bar__item"
+        data-testid={`window-menu-item-${item.id}`}
+        data-disabled={disabled}
+        data-submenu-open={isOpen}
+        {...parentList.getItemProps(getReferenceProps())}
+      >
+        <ItemAffordances item={item} />
+        <MaterialSymbol icon="chevron_right" size={16} />
+      </button>
+      {isOpen && !disabled && (
+        <FloatingPortal>
+          <FloatingFocusManager context={context} modal={false} initialFocus={-1} returnFocus>
+            <div
+              ref={refs.setFloating}
+              style={floatingStyles}
+              className="window-menu-bar__menu"
+              data-testid={`window-menu-submenu-${item.id}`}
+              {...getFloatingProps()}
+            >
+              <MenuListContext.Provider value={{ getItemProps, activeIndex }}>
+                <FloatingList elementsRef={elementsRef}>
+                  <MenuItems items={item.submenu ?? []} />
+                </FloatingList>
+              </MenuListContext.Provider>
+            </div>
+          </FloatingFocusManager>
+        </FloatingPortal>
+      )}
+    </FloatingNode>
+  );
+}
+
+function TopLevelMenu({
+  item,
+  isOpen,
+  onOpenChange,
+  onHoverWhileBarActive,
+}: {
+  item: SerializedMenuItem;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onHoverWhileBarActive: () => void;
+}) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const nodeId = useFloatingNodeId();
+  const elementsRef = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const { refs, floatingStyles, context } = useFloating({
+    nodeId,
+    open: isOpen,
+    onOpenChange,
+    placement: 'bottom-start',
+    strategy: 'fixed',
+    middleware: menuMiddleware('bottom-start'),
+    whileElementsMounted: autoUpdate,
+  });
+
+  const click = useClick(context, { toggle: true });
+  const dismiss = useDismiss(context, { bubbles: false });
+  const role = useRole(context, { role: 'menu' });
+  const listNavigation = useListNavigation(context, {
+    listRef: elementsRef,
+    activeIndex,
+    onNavigate: setActiveIndex,
+    loop: true,
+  });
+
+  const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions([
+    click,
+    dismiss,
+    role,
+    listNavigation,
+  ]);
+
+  return (
+    <FloatingNode id={nodeId}>
+      <button
+        ref={refs.setReference}
+        type="button"
+        className="window-menu-bar__top-item window-top-bar__no-drag"
+        data-testid={`window-menu-top-${item.id}`}
+        data-open={isOpen}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        {...getReferenceProps({
+          // Classic menu-bar behavior: once a menu is open, sliding across the
+          // bar switches menus without another click.
+          onMouseEnter: onHoverWhileBarActive,
+        })}
+      >
+        {item.label}
+      </button>
+      {isOpen && (
+        <FloatingPortal>
+          <FloatingFocusManager context={context} modal={false} initialFocus={-1} returnFocus>
+            <div
+              ref={refs.setFloating}
+              style={floatingStyles}
+              className="window-menu-bar__menu"
+              data-testid={`window-menu-dropdown-${item.id}`}
+              {...getFloatingProps()}
+            >
+              <MenuListContext.Provider value={{ getItemProps, activeIndex }}>
+                <FloatingList elementsRef={elementsRef}>
+                  <MenuItems items={item.submenu ?? []} />
+                </FloatingList>
+              </MenuListContext.Provider>
+            </div>
+          </FloatingFocusManager>
+        </FloatingPortal>
+      )}
+    </FloatingNode>
+  );
+}
+
+export function WindowMenuBar() {
+  const menuBar = useAtomValue(windowMenuBarAtom);
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const closeAll = useCallback(() => setOpenId(null), []);
+
+  if (!menuBar.inWindow || menuBar.items.length === 0) return null;
+
+  return (
+    <MenuBarContext.Provider value={{ revision: menuBar.revision, closeAll }}>
+      <nav
+        className="window-menu-bar"
+        data-component="WindowMenuBar"
+        data-testid="window-menu-bar"
+        aria-label="Application menu"
+      >
+        <FloatingTree>
+          {menuBar.items.map((item) => (
+            <TopLevelMenu
+              key={item.id}
+              item={item}
+              isOpen={openId === item.id}
+              onOpenChange={(open) => setOpenId(open ? item.id : null)}
+              onHoverWhileBarActive={() => {
+                setOpenId((current) => (current === null ? current : item.id));
+              }}
+            />
+          ))}
+        </FloatingTree>
+      </nav>
+    </MenuBarContext.Provider>
+  );
+}

--- a/packages/electron/src/renderer/components/WindowTopBar/WindowTopBar.css
+++ b/packages/electron/src/renderer/components/WindowTopBar/WindowTopBar.css
@@ -28,6 +28,11 @@
   min-width: 0;
 }
 
+.window-top-bar__left {
+  display: flex;
+  overflow: hidden;
+}
+
 .window-top-bar__right {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/packages/electron/src/renderer/components/WindowTopBar/WindowTopBar.tsx
+++ b/packages/electron/src/renderer/components/WindowTopBar/WindowTopBar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MaterialSymbol } from '@nimbalyst/runtime';
 import { MAIN_WINDOW_TITLE_BAR_HEIGHT } from '../../../shared/windowChrome';
 import { FloatingPortal, useFloatingMenu } from '../../hooks/useFloatingMenu';
+import { WindowMenuBar } from './WindowMenuBar';
 import './WindowTopBar.css';
 
 export interface WindowTopBarGitStatus {
@@ -331,7 +332,11 @@ export function WindowTopBar({
       }}
     >
       <div className="window-top-bar__available-area">
-        <div className="window-top-bar__left" />
+        {/* Windows/Linux only: macOS keeps the menu in the system menu bar and
+            WindowMenuBar renders nothing there. */}
+        <div className="window-top-bar__left">
+          <WindowMenuBar />
+        </div>
 
         <div className="window-top-bar__identity">
           <span

--- a/packages/electron/src/renderer/components/WindowTopBar/__tests__/WindowMenuBar.test.tsx
+++ b/packages/electron/src/renderer/components/WindowTopBar/__tests__/WindowMenuBar.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { Provider, createStore } from 'jotai';
+import { WindowMenuBar } from '../WindowMenuBar';
+import { windowMenuBarAtom } from '../../../store/atoms/windowMenu';
+import { EMPTY_MENU_BAR, type SerializedMenuBar } from '../../../../shared/menuBar';
+
+vi.mock('@nimbalyst/runtime', () => ({
+  MaterialSymbol: ({ icon }: { icon: string }) => (
+    <span data-icon={icon} aria-hidden="true">{icon}</span>
+  ),
+}));
+
+const invokeWindowMenuItem = vi.fn().mockResolvedValue({ invoked: true });
+
+const MENU_BAR: SerializedMenuBar = {
+  revision: 4,
+  inWindow: true,
+  items: [
+    {
+      id: '0',
+      label: 'File',
+      type: 'submenu',
+      enabled: true,
+      submenu: [
+        { id: '0.0', label: 'Save', type: 'normal', enabled: true, acceleratorLabel: 'Ctrl+S' },
+        { id: '0.1', label: 'Save As', type: 'normal', enabled: false },
+        { id: '0.2', label: '', type: 'separator', enabled: true },
+        {
+          id: '0.3',
+          label: 'New',
+          type: 'submenu',
+          enabled: true,
+          submenu: [{ id: '0.3.0', label: 'Document', type: 'normal', enabled: true }],
+        },
+      ],
+    },
+    {
+      id: '1',
+      label: 'View',
+      type: 'submenu',
+      enabled: true,
+      submenu: [
+        { id: '1.0', label: 'Dark', type: 'radio', enabled: true, checked: true },
+      ],
+    },
+  ],
+};
+
+function renderMenuBar(menuBar: SerializedMenuBar = MENU_BAR) {
+  const store = createStore();
+  store.set(windowMenuBarAtom, menuBar);
+  return render(
+    <Provider store={store}>
+      <WindowMenuBar />
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  invokeWindowMenuItem.mockClear();
+  (window as unknown as { electronAPI: unknown }).electronAPI = { invokeWindowMenuItem };
+});
+
+afterEach(() => cleanup());
+
+describe('WindowMenuBar', () => {
+  it('renders nothing when the model is empty', () => {
+    renderMenuBar(EMPTY_MENU_BAR);
+    expect(screen.queryByTestId('window-menu-bar')).toBeNull();
+  });
+
+  it('renders nothing on macOS, where the system menu bar owns the menu', () => {
+    renderMenuBar({ ...MENU_BAR, inWindow: false });
+    expect(screen.queryByTestId('window-menu-bar')).toBeNull();
+  });
+
+  it('renders the top-level menus with stable markers', () => {
+    renderMenuBar();
+
+    const bar = screen.getByTestId('window-menu-bar');
+    expect(bar.getAttribute('data-component')).toBe('WindowMenuBar');
+    expect(screen.getByTestId('window-menu-top-0').textContent).toBe('File');
+    expect(screen.getByTestId('window-menu-top-1').textContent).toBe('View');
+    expect(screen.queryByTestId('window-menu-dropdown-0')).toBeNull();
+  });
+
+  it('opens a menu on click and shows labels, accelerators, and separators', () => {
+    renderMenuBar();
+
+    fireEvent.click(screen.getByTestId('window-menu-top-0'));
+
+    const dropdown = screen.getByTestId('window-menu-dropdown-0');
+    expect(dropdown.textContent).toContain('Save');
+    expect(dropdown.textContent).toContain('Ctrl+S');
+    expect(dropdown.querySelectorAll('[role="separator"]').length).toBe(1);
+    expect(screen.getByTestId('window-menu-item-0.1').getAttribute('data-disabled')).toBe('true');
+  });
+
+  it('invokes the clicked item against the revision it was rendered from', () => {
+    renderMenuBar();
+
+    fireEvent.click(screen.getByTestId('window-menu-top-0'));
+    fireEvent.click(screen.getByTestId('window-menu-item-0.0'));
+
+    expect(invokeWindowMenuItem).toHaveBeenCalledWith('0.0', 4);
+    expect(screen.queryByTestId('window-menu-dropdown-0')).toBeNull();
+  });
+
+  it('does not invoke a disabled item', () => {
+    renderMenuBar();
+
+    fireEvent.click(screen.getByTestId('window-menu-top-0'));
+    fireEvent.click(screen.getByTestId('window-menu-item-0.1'));
+
+    expect(invokeWindowMenuItem).not.toHaveBeenCalled();
+  });
+
+  it('shows checked state for radio and checkbox items', () => {
+    renderMenuBar();
+
+    fireEvent.click(screen.getByTestId('window-menu-top-1'));
+
+    const item = screen.getByTestId('window-menu-item-1.0');
+    expect(item.getAttribute('role')).toBe('menuitemcheckbox');
+    expect(item.getAttribute('aria-checked')).toBe('true');
+    expect(item.querySelector('[data-icon="check"]')).not.toBeNull();
+  });
+
+  it('opens a submenu from its parent item', () => {
+    renderMenuBar();
+
+    fireEvent.click(screen.getByTestId('window-menu-top-0'));
+    const submenuTrigger = screen.getByTestId('window-menu-item-0.3');
+    expect(submenuTrigger.getAttribute('aria-haspopup')).toBe('menu');
+
+    fireEvent.click(submenuTrigger);
+
+    expect(screen.getByTestId('window-menu-submenu-0.3').textContent).toContain('Document');
+  });
+
+  it('switches menus on hover once one is open, but not before', () => {
+    renderMenuBar();
+
+    fireEvent.mouseEnter(screen.getByTestId('window-menu-top-1'));
+    expect(screen.queryByTestId('window-menu-dropdown-1')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('window-menu-top-0'));
+    fireEvent.mouseEnter(screen.getByTestId('window-menu-top-1'));
+
+    expect(screen.queryByTestId('window-menu-dropdown-0')).toBeNull();
+    expect(screen.getByTestId('window-menu-dropdown-1')).not.toBeNull();
+  });
+});

--- a/packages/electron/src/renderer/electron.d.ts
+++ b/packages/electron/src/renderer/electron.d.ts
@@ -219,6 +219,11 @@ interface ElectronAPI {
   onOpenFeedback: (callback: () => void) => () => void;
   onThemeChange: (callback: (theme: string) => void) => () => void;
   setTitleBarOverlayColors: (colors: { color: string; symbolColor: string }) => void;
+  getWindowMenuBar: () => Promise<import('../shared/menuBar').SerializedMenuBar>;
+  invokeWindowMenuItem: (
+    id: string,
+    revision: number,
+  ) => Promise<{ invoked: boolean; staleRevision?: boolean }>;
   onMcpConfigChanged: (callback: (data: { scope: 'user' | 'workspace'; workspacePath?: string }) => void) => () => void;
 
   // Offscreen editor IPC

--- a/packages/electron/src/renderer/store/atoms/windowMenu.ts
+++ b/packages/electron/src/renderer/store/atoms/windowMenu.ts
@@ -1,0 +1,15 @@
+/**
+ * Window Menu Bar Atom
+ *
+ * Holds the serialized application menu that the in-window menu bar renders on
+ * Windows/Linux (macOS keeps its system menu bar and this stays empty).
+ *
+ * Written by store/listeners/windowMenuListeners.ts, which fetches the initial
+ * model and then applies every `window-menu:changed` push from main. Components
+ * read it; they never subscribe to the IPC event themselves.
+ */
+
+import { atom } from 'jotai';
+import { EMPTY_MENU_BAR, type SerializedMenuBar } from '../../../shared/menuBar';
+
+export const windowMenuBarAtom = atom<SerializedMenuBar>(EMPTY_MENU_BAR);

--- a/packages/electron/src/renderer/store/listeners/windowMenuListeners.ts
+++ b/packages/electron/src/renderer/store/listeners/windowMenuListeners.ts
@@ -1,0 +1,52 @@
+/**
+ * Central Window Menu Bar Listener
+ *
+ * Subscribes to `window-menu:changed` ONCE and mirrors the serialized
+ * application menu into `windowMenuBarAtom`. Also fetches the initial model,
+ * since main only pushes on rebuilds.
+ *
+ * The in-window menu bar (Windows/Linux) renders from that atom. On macOS main
+ * serves an empty model and this listener is effectively inert.
+ *
+ * Call initWindowMenuListener() once at app startup.
+ */
+
+import { store } from '@nimbalyst/runtime/store';
+import { WINDOW_MENU_CHANNELS, type SerializedMenuBar } from '../../../shared/menuBar';
+import { windowMenuBarAtom } from '../atoms/windowMenu';
+
+let initialized = false;
+
+export function initWindowMenuListener(): () => void {
+  if (initialized) {
+    return () => {};
+  }
+  initialized = true;
+
+  const unsubscribe = window.electronAPI?.on?.(
+    WINDOW_MENU_CHANNELS.changed,
+    (menuBar: SerializedMenuBar) => {
+      if (menuBar && Array.isArray(menuBar.items)) {
+        store.set(windowMenuBarAtom, menuBar);
+      }
+    },
+  );
+
+  void window.electronAPI?.getWindowMenuBar?.()
+    .then((menuBar) => {
+      if (menuBar && Array.isArray(menuBar.items)) {
+        store.set(windowMenuBarAtom, menuBar);
+      }
+    })
+    .catch(() => {
+      // A window without the menu bridge (e.g. the About window) just renders
+      // no strip; nothing to recover from.
+    });
+
+  return () => {
+    initialized = false;
+    if (typeof unsubscribe === 'function') {
+      unsubscribe();
+    }
+  };
+}

--- a/packages/electron/src/shared/menuBar.ts
+++ b/packages/electron/src/shared/menuBar.ts
@@ -1,0 +1,56 @@
+/**
+ * Wire model for the in-window menu bar.
+ *
+ * macOS draws the application menu in the system menu bar, but Windows and
+ * Linux workspace windows use a frameless title bar (see `windowChrome.ts`), so
+ * the native menu strip is hidden there. The renderer draws its own strip from
+ * this model instead of the menu template being duplicated in the renderer —
+ * `ApplicationMenu.ts` stays the single source of truth.
+ *
+ * Item ids are index paths into the live `Menu` ("2.4.1"), so they are only
+ * valid for the revision they were serialized with. Every rebuild bumps
+ * `revision`; an invoke carrying a stale revision is rejected rather than
+ * firing whichever item happens to sit at that index now.
+ */
+
+export const WINDOW_MENU_CHANNELS = {
+  get: 'window-menu:get',
+  invoke: 'window-menu:invoke',
+  changed: 'window-menu:changed',
+} as const;
+
+export type SerializedMenuItemType =
+  | 'normal'
+  | 'separator'
+  | 'submenu'
+  | 'checkbox'
+  | 'radio';
+
+export interface SerializedMenuItem {
+  /** Index path into the application menu, e.g. "2.4.1". */
+  id: string;
+  label: string;
+  type: SerializedMenuItemType;
+  enabled: boolean;
+  checked?: boolean;
+  /** Platform-formatted accelerator for display only, e.g. "Ctrl+Shift+P". */
+  acceleratorLabel?: string;
+  submenu?: SerializedMenuItem[];
+}
+
+export interface SerializedMenuBar {
+  revision: number;
+  /**
+   * Whether this platform draws the menu bar inside the window. False on
+   * macOS, where the system menu bar already shows it — the model is still
+   * served there so the bridge stays exercisable from any platform.
+   */
+  inWindow: boolean;
+  items: SerializedMenuItem[];
+}
+
+export const EMPTY_MENU_BAR: SerializedMenuBar = {
+  revision: 0,
+  inWindow: false,
+  items: [],
+};


### PR DESCRIPTION
## What

The custom project title bar (8a7ecb9ef, shipped in v0.71.0) switched non-mac workspace windows from `titleBarStyle: 'default'` to `'hidden'` plus `autoHideMenuBar: true`. That hid the native File/Edit/View/Window/Help strip on Windows and Linux — it only appears while Alt is held, and `WindowTopBar` had no replacement, so every menu-only command (anything without an accelerator) became unreachable.

This renders the menu inline in the custom title bar, the way VS Code does on Windows/Linux with `window.menuBarVisibility: "classic"`.

## How

`ApplicationMenu.ts` stays the only place the menu is defined. The live `Menu` is serialized to the renderer and mirrored by a new `WindowMenuBar`:

- `shared/menuBar.ts` — wire model. Item ids are index paths into the live menu, valid only for the revision they were serialized with.
- `main/menu/menuBarSerialization.ts` — pure serialize/lookup/accelerator-format helpers, no electron import.
- `main/menu/menuBarBridge.ts` — serves the model, pushes it on every rebuild, and invokes items. Role items (undo/copy/minimize/...) carry no click handler, so the bridge performs the role; checkbox/radio state flips before dispatch the way a native click does.
- `WindowMenuBar.tsx` — the strip, with submenus, accelerators, checked state, and keyboard navigation via `@floating-ui/react`'s `FloatingTree`.

Every rebuild bumps a revision; an invoke carrying a stale one is rejected rather than firing whichever item now sits at that index.

macOS is unaffected — the model is flagged `inWindow: false` there and the component renders nothing, so the system menu bar keeps its job. The native menu stays installed on all platforms, which is what keeps the accelerators working.

## Testing

- `menuBarSerialization.test.ts` — ids/index paths, hidden items, stranded separators, accelerator formatting per platform, path lookup rejection.
- `menuBarBridge.test.ts` — click dispatch, role items, checkbox vs radio, stale-revision rejection, disabled items, throwing handlers.
- `WindowMenuBar.test.tsx` — open/close, submenu, checked state, hover-switch between menus, invoke with the right id and revision.

Full suite green (7098 passed) and full typecheck clean.

**Not yet verified on Windows.** The unit tests cover serialization, dispatch, and rendering, but no one has seen the strip render on an actual Windows build — that needs a Windows run before merge.

Fixes NIM-2228