### PR TITLE
fix: keep worktree test commits inside their sandbox

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,6 +12,15 @@ base=$(git merge-base HEAD origin/main 2>/dev/null || echo HEAD~1)
 echo "[pre-push] Checking outgoing commits for test-fixture authors..."
 node scripts/check-push-authors.mjs "$base..HEAD"
 
+# Hooks export repository-local GIT_* variables. In a linked worktree GIT_DIR
+# is absolute, so a real-Git test running in a temp directory can otherwise
+# mutate this branch and the shared repository config. Git documents this list
+# specifically for commands that leave the hook's repository.
+git_local_env=$(git rev-parse --local-env-vars)
+# Intentional word splitting: rev-parse returns one variable name per line.
+unset $git_local_env
+unset GIT_NAMESPACE
+
 if ! git diff --quiet "$base" HEAD -- package-lock.json 'package.json' '*/package.json' 2>/dev/null; then
   echo "[pre-push] Manifest/lockfile changed; validating lockfile sync (npm ci --dry-run)..."
   if ! npm ci --dry-run >/dev/null 2>&1; then

--- a/packages/electron/src/main/services/GitCommitService.ts
+++ b/packages/electron/src/main/services/GitCommitService.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import simpleGit, { SimpleGit } from 'simple-git';
 import { gitOperationLock } from './GitOperationLock';
 import { GIT_INHERITED_ENV_UNSAFE } from './gitInheritedEnvUnsafe';
+import { sanitizeGitRepositoryEnv } from './gitRepositoryEnv';
 
 export interface GitCommitExecutionResult {
   success: boolean;
@@ -168,7 +169,8 @@ export async function executeGitCommit(
      * Environment for the git subprocess (and any hooks it runs). Production callers
      * pass an enhanced env (see getGitSubprocessEnv) so husky hooks invoking nvm/Homebrew
      * binaries like `yarn` resolve, since GUI-launched apps don't inherit the shell PATH.
-     * When omitted, git inherits process.env as usual.
+     * Repository-selection variables are always removed so workspacePath remains
+     * authoritative. When omitted, all other values come from process.env.
      */
     env?: Record<string, string>;
     /** Stream git and hook output while the commit workflow is running. */
@@ -213,9 +215,11 @@ export async function executeGitCommit(
         return restored;
       };
       try {
-        const git: SimpleGit = options?.env
-          ? simpleGit(workspacePath, { unsafe: GIT_INHERITED_ENV_UNSAFE }).env(options.env)
-          : simpleGit(workspacePath);
+        const gitEnv = sanitizeGitRepositoryEnv(options?.env ?? process.env);
+        const git: SimpleGit = simpleGit(
+          workspacePath,
+          { unsafe: GIT_INHERITED_ENV_UNSAFE }
+        ).env(gitEnv);
         if (options?.onOutput) {
           git.outputHandler((_command, stdout, stderr) => {
             stdout.on('data', (chunk: Buffer | string) => options.onOutput?.('stdout', chunk.toString()));

--- a/packages/electron/src/main/services/__tests__/GitCommitService.test.ts
+++ b/packages/electron/src/main/services/__tests__/GitCommitService.test.ts
@@ -82,6 +82,44 @@ describe('GitCommitService', () => {
     expect(result.commitHash).toBeTruthy();
   });
 
+  it('ignores inherited repository-selection env and commits only in the requested workspace', async () => {
+    await initScratchRepo(tmpRoot);
+    const selectedPath = path.join(tmpRoot, 'a.txt');
+    await fs.writeFile(selectedPath, 'scratch\n', 'utf8');
+
+    const decoyRoot = await fs.mkdtemp(path.join(testTempRoot, 'nim-git-commit-decoy-'));
+    await initScratchRepo(decoyRoot);
+    await fs.writeFile(path.join(decoyRoot, 'seed.txt'), 'seed\n', 'utf8');
+    await git(['add', 'seed.txt'], decoyRoot);
+    await git(['commit', '-q', '-m', 'decoy baseline'], decoyRoot);
+    const decoyHeadBefore = (await gitOutput(['rev-parse', 'HEAD'], decoyRoot)).trim();
+    await fs.writeFile(path.join(decoyRoot, 'a.txt'), 'must stay uncommitted\n', 'utf8');
+
+    const inheritedKeys = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE'] as const;
+    const previousValues = new Map(
+      inheritedKeys.map((key) => [key, process.env[key]])
+    );
+    process.env.GIT_DIR = path.join(decoyRoot, '.git');
+    process.env.GIT_WORK_TREE = decoyRoot;
+    process.env.GIT_INDEX_FILE = path.join(decoyRoot, '.git', 'index');
+
+    try {
+      const result = await executeGitCommit(tmpRoot, 'commit requested workspace', [selectedPath]);
+
+      expect(result.success).toBe(true);
+      expect((await gitOutput(['rev-parse', 'HEAD'], decoyRoot)).trim()).toBe(decoyHeadBefore);
+      expect(await gitOutput(['status', '--porcelain', '--', 'a.txt'], decoyRoot)).toBe('?? a.txt\n');
+      expect(await gitOutput(['log', '-1', '--format=%s'], tmpRoot)).toBe('commit requested workspace\n');
+    } finally {
+      for (const key of inheritedKeys) {
+        const previousValue = previousValues.get(key);
+        if (previousValue === undefined) delete process.env[key];
+        else process.env[key] = previousValue;
+      }
+      await fs.rm(decoyRoot, { recursive: true, force: true });
+    }
+  });
+
   it('commits only the selected file while preserving unrelated staged and unstaged hunks', async () => {
     await initScratchRepo(tmpRoot);
 

--- a/packages/electron/src/main/services/__tests__/GitWorktreeService.test.ts
+++ b/packages/electron/src/main/services/__tests__/GitWorktreeService.test.ts
@@ -30,7 +30,9 @@ describe('GitWorktreeService.validateWorkspaceHasCommits', () => {
   });
 
   it('throws WorkspaceHasNoCommitsError for a `git init`-ed repo with no commits', async () => {
-    const git = simpleGit(tmpDir);
+    // Never let a pre-push hook's GIT_DIR redirect this mutating init into the
+    // developer's shared repository.
+    const git = simpleGit(tmpDir).env(gitSandboxEnv(undefined, { pinConfigPaths: false }));
     await git.init();
 
     await expect(service.validateWorkspaceHasCommits(tmpDir))

--- a/packages/electron/src/main/services/__tests__/gitRepositoryEnv.test.ts
+++ b/packages/electron/src/main/services/__tests__/gitRepositoryEnv.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeGitRepositoryEnv } from '../gitRepositoryEnv';
+
+describe('sanitizeGitRepositoryEnv', () => {
+  it('removes repository redirects while preserving user-facing Git behavior', () => {
+    expect(sanitizeGitRepositoryEnv({
+      PATH: '/test/bin',
+      GIT_ASKPASS: '/test/askpass',
+      GIT_EDITOR: 'vim',
+      GIT_SSH_COMMAND: 'ssh -i test-key',
+      GIT_DIR: '/real/repo/.git',
+      GIT_WORK_TREE: '/real/repo',
+      GIT_INDEX_FILE: '/real/repo/.git/index',
+      GIT_COMMON_DIR: '/real/repo/.git',
+      GIT_OBJECT_DIRECTORY: '/real/repo/.git/objects',
+      GIT_NAMESPACE: 'escaped-fixture',
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'core.bare',
+      GIT_CONFIG_VALUE_0: 'true',
+    })).toEqual({
+      PATH: '/test/bin',
+      GIT_ASKPASS: '/test/askpass',
+      GIT_EDITOR: 'vim',
+      GIT_SSH_COMMAND: 'ssh -i test-key',
+    });
+  });
+});

--- a/packages/electron/src/main/services/gitEnv.ts
+++ b/packages/electron/src/main/services/gitEnv.ts
@@ -1,6 +1,7 @@
 import simpleGit, { SimpleGit, SimpleGitOptions } from 'simple-git';
 import { getEnhancedPath, getShellEnvironment } from './CLIManager';
 import { GIT_INHERITED_ENV_UNSAFE } from './gitInheritedEnvUnsafe';
+import { sanitizeGitRepositoryEnv } from './gitRepositoryEnv';
 
 /**
  * Build the environment for git subprocesses that may run hooks (commit, merge,
@@ -22,11 +23,11 @@ export function getGitSubprocessEnv(): Record<string, string> {
       base[key] = value;
     }
   }
-  return {
+  return sanitizeGitRepositoryEnv({
     ...base,
     ...(getShellEnvironment() ?? {}),
     PATH: getEnhancedPath(),
-  };
+  });
 }
 
 /**

--- a/packages/electron/src/main/services/gitRepositoryEnv.ts
+++ b/packages/electron/src/main/services/gitRepositoryEnv.ts
@@ -1,0 +1,45 @@
+/**
+ * Git exports repository-local variables to hooks. Those variables override a
+ * subprocess cwd, so forwarding them to a Git command for another workspace can
+ * mutate the hook's repository instead of the requested one.
+ *
+ * Keep user-facing behavior variables such as PATH, GIT_SSH_COMMAND,
+ * GIT_ASKPASS, and GIT_EDITOR. Remove only variables that can redirect repository
+ * discovery, refs, objects, config, the work tree, or the index.
+ */
+const GIT_REPOSITORY_ENV_KEYS = new Set([
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_COMMON_DIR',
+  'GIT_CONFIG',
+  'GIT_CONFIG_COUNT',
+  'GIT_CONFIG_PARAMETERS',
+  'GIT_DIR',
+  'GIT_GRAFT_FILE',
+  'GIT_IMPLICIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_NAMESPACE',
+  'GIT_NO_REPLACE_OBJECTS',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_PREFIX',
+  'GIT_QUARANTINE_PATH',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_SHALLOW_FILE',
+  'GIT_WORK_TREE',
+]);
+
+export function sanitizeGitRepositoryEnv(
+  source: Record<string, string | undefined>
+): Record<string, string> {
+  const sanitized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    const isIndexedConfigEntry = /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(key);
+    if (
+      value !== undefined &&
+      !GIT_REPOSITORY_ENV_KEYS.has(key) &&
+      !isIndexedConfigEntry
+    ) {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}

--- a/packages/electron/src/main/services/testSupport/gitTestSandbox.ts
+++ b/packages/electron/src/main/services/testSupport/gitTestSandbox.ts
@@ -59,8 +59,10 @@ export function gitSandboxEnv(
     if (key.startsWith('GIT_')) delete env[key];
   }
   // A test must never launch an interactive editor (it would hang the suite),
-  // and simple-git refuses to run at all when EDITOR is forwarded.
+  // pager, or visual tool. simple-git also rejects these inherited variables
+  // unless callers enable unsafe flags, which sandboxed fixtures should not.
   delete env.EDITOR;
+  delete env.PAGER;
   delete env.VISUAL;
   if (pinConfigPaths) {
     // A path that does not exist reads as an empty config, so the developer's


### PR DESCRIPTION
## Summary

- clear repository-local Git environment variables before pre-push npm/test commands
- make `GitCommitService` keep the requested workspace authoritative
- harden real-Git fixtures and add a decoy-repository regression

## Verification

- red-first decoy test reproduced the escaped commit before the fix
- focused Git suites: 20 tests passed
- exact linked-worktree pre-push hook under Node 24: 906 files passed, 7 skipped; 7,067 tests passed, 26 skipped
- repository remained non-bare with no escaped fixture commits or files

Fixes NIM-2234