### PR TITLE
fix: run dev:user2 through a cross-platform Node script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "npm run test:unit",
     "test:unit": "vitest",
     "test:prepush": "vitest --run",
-    "test:prepush-gate": "node --test scripts/__tests__/prepush-test-gate.test.mjs scripts/__tests__/check-main-bundle-graph.test.mjs scripts/__tests__/check-push-authors.test.mjs",
+    "test:prepush-gate": "node --test scripts/__tests__/prepush-test-gate.test.mjs scripts/__tests__/check-main-bundle-graph.test.mjs scripts/__tests__/check-push-authors.test.mjs packages/electron/scripts/__tests__/dev-user2.test.mjs",
     "test:unit:ui": "vitest --ui",
     "test:unit:coverage": "vitest --coverage",
     "test:provider:integration": "cross-env RUN_AI_PROVIDER_TESTS=true vitest --run",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "start": "electron-vite preview",
     "dev": "./scripts/dev.sh",
-    "dev:user2": "NIMBALYST_USER_DATA_DIR=\"$HOME/Library/Application Support/@nimbalyst/electron-user2\" VITE_PORT=5274 ./scripts/dev.sh",
-    "dev:user2:loop": "NIMBALYST_USER_DATA_DIR=\"$HOME/Library/Application Support/@nimbalyst/electron-user2\" VITE_PORT=5274 ./scripts/dev-loop.sh",
+    "dev:user2": "node ./scripts/dev-user2.mjs",
+    "dev:user2:loop": "node ./scripts/dev-user2.mjs --loop",
     "dev:loop": "./scripts/dev-loop.sh",
     "licenses:generate": "node build/generate-third-party-licenses.js",
     "licenses:check": "node build/generate-third-party-licenses.js --check",

--- a/packages/electron/scripts/__tests__/dev-user2.test.mjs
+++ b/packages/electron/scripts/__tests__/dev-user2.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  createUser2Environment,
+  resolveUser2DataDir,
+  resolvePackageBinary,
+  restartSignalPath,
+} from '../dev-user2.mjs';
+
+test('resolves the Windows user2 directory from APPDATA', () => {
+  assert.equal(
+    resolveUser2DataDir({
+      platform: 'win32',
+      environment: { APPDATA: 'C:\\Users\\test\\AppData\\Roaming' },
+      homeDirectory: 'C:\\Users\\test',
+    }),
+    path.join('C:\\Users\\test\\AppData\\Roaming', '@nimbalyst', 'electron-user2'),
+  );
+});
+
+test('resolves the macOS user2 directory under Application Support', () => {
+  assert.equal(
+    resolveUser2DataDir({
+      platform: 'darwin',
+      environment: {},
+      homeDirectory: '/Users/test',
+    }),
+    path.join('/Users/test', 'Library', 'Application Support', '@nimbalyst', 'electron-user2'),
+  );
+});
+
+test('resolves the Linux user2 directory from XDG_CONFIG_HOME', () => {
+  assert.equal(
+    resolveUser2DataDir({
+      platform: 'linux',
+      environment: { XDG_CONFIG_HOME: '/tmp/config' },
+      homeDirectory: '/home/test',
+    }),
+    path.join('/tmp/config', '@nimbalyst', 'electron-user2'),
+  );
+});
+
+test('creates an isolated user2 environment', () => {
+  const environment = createUser2Environment({
+    platform: 'win32',
+    environment: {
+      APPDATA: 'C:\\Users\\test\\AppData\\Roaming',
+      PRESERVED: 'yes',
+    },
+    homeDirectory: 'C:\\Users\\test',
+  });
+
+  assert.equal(environment.PRESERVED, 'yes');
+  assert.equal(environment.VITE_PORT, '5274');
+  assert.equal(environment.ELECTRON_ENTRY, 'out2/main/index.js');
+  assert.equal(
+    environment.NIMBALYST_USER_DATA_DIR,
+    path.join('C:\\Users\\test\\AppData\\Roaming', '@nimbalyst', 'electron-user2'),
+  );
+});
+
+test('resolves JavaScript entry points without Windows command shims', () => {
+  assert.equal(path.basename(resolvePackageBinary('electron-vite')), 'electron-vite.js');
+  assert.equal(path.basename(resolvePackageBinary('typescript', 'tsc')), 'tsc');
+});
+
+test('uses a per-instance restart signal', () => {
+  assert.equal(
+    restartSignalPath('/tmp/@nimbalyst/electron-user2', '/repo/packages/electron'),
+    path.join('/repo/packages/electron', '.restart-requested-electron-user2'),
+  );
+});

--- a/packages/electron/scripts/dev-user2.mjs
+++ b/packages/electron/scripts/dev-user2.mjs
@@ -1,0 +1,123 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ELECTRON_DIR = path.dirname(SCRIPT_DIR);
+const EXTENSION_SDK_DIR = path.resolve(ELECTRON_DIR, '..', 'extension-sdk');
+const require = createRequire(import.meta.url);
+
+export function resolveUser2DataDir({
+  platform = process.platform,
+  environment = process.env,
+  homeDirectory = homedir(),
+} = {}) {
+  if (platform === 'win32') {
+    const appData = environment.APPDATA || path.join(homeDirectory, 'AppData', 'Roaming');
+    return path.join(appData, '@nimbalyst', 'electron-user2');
+  }
+
+  if (platform === 'darwin') {
+    return path.join(homeDirectory, 'Library', 'Application Support', '@nimbalyst', 'electron-user2');
+  }
+
+  const configHome = environment.XDG_CONFIG_HOME || path.join(homeDirectory, '.config');
+  return path.join(configHome, '@nimbalyst', 'electron-user2');
+}
+
+export function createUser2Environment(options = {}) {
+  const environment = options.environment ?? process.env;
+  const userDataDir = resolveUser2DataDir({ ...options, environment });
+
+  return {
+    ...environment,
+    NIMBALYST_USER_DATA_DIR: userDataDir,
+    VITE_PORT: '5274',
+    ELECTRON_ENTRY: 'out2/main/index.js',
+  };
+}
+
+export function resolvePackageBinary(packageName, binaryName = packageName) {
+  const packageJsonPath = require.resolve(`${packageName}/package.json`);
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  const binaryPath = typeof packageJson.bin === 'string'
+    ? packageJson.bin
+    : packageJson.bin?.[binaryName];
+
+  if (!binaryPath) {
+    throw new Error(`Package "${packageName}" does not define the "${binaryName}" binary`);
+  }
+
+  return path.resolve(path.dirname(packageJsonPath), binaryPath);
+}
+
+export function restartSignalPath(userDataDir, electronDir = ELECTRON_DIR) {
+  return path.join(electronDir, `.restart-requested-${path.basename(userDataDir)}`);
+}
+
+function run(command, args, environment, cwd = ELECTRON_DIR) {
+  const result = spawnSync(command, args, {
+    cwd,
+    env: environment,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    console.error(`[dev:user2] Failed to start ${command}:`, result.error);
+    return 1;
+  }
+
+  return result.status ?? 1;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export async function runUser2({ loop = false } = {}) {
+  const environment = createUser2Environment();
+  const userDataDir = environment.NIMBALYST_USER_DATA_DIR;
+  const restartSignal = restartSignalPath(userDataDir);
+  const typescript = resolvePackageBinary('typescript', 'tsc');
+  const workerBuild = path.join(ELECTRON_DIR, 'build', 'build-worker.js');
+  const electronVite = resolvePackageBinary('electron-vite');
+
+  console.log(`[dev:user2] Using userData directory: ${userDataDir}`);
+  console.log('[dev:user2] Using Vite port 5274 and isolated build output: out2/');
+  console.log('[dev:user2] Building @nimbalyst/extension-sdk...');
+
+  const sdkStatus = run(
+    process.execPath,
+    [typescript, '--project', path.join(EXTENSION_SDK_DIR, 'tsconfig.json')],
+    environment,
+    EXTENSION_SDK_DIR,
+  );
+  if (sdkStatus !== 0) return sdkStatus;
+
+  if (loop && existsSync(restartSignal)) {
+    unlinkSync(restartSignal);
+  }
+
+  do {
+    const workerStatus = run(process.execPath, [workerBuild], environment);
+    if (workerStatus !== 0) return workerStatus;
+
+    const devStatus = run(process.execPath, [electronVite, 'dev', '--outDir=out2'], environment);
+    if (!loop || !existsSync(restartSignal)) return devStatus;
+
+    unlinkSync(restartSignal);
+    console.log('[dev:user2] Restart requested; relaunching in 2 seconds...');
+    await delay(2000);
+  } while (true);
+}
+
+const isDirectRun = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  const status = await runUser2({ loop: process.argv.includes('--loop') });
+  process.exit(status);
+}


### PR DESCRIPTION
## Problem

`dev:user2` and `dev:user2:loop` were inline shell one-liners:

```
NIMBALYST_USER_DATA_DIR="$HOME/Library/Application Support/@nimbalyst/electron-user2" VITE_PORT=5274 ./scripts/dev.sh
```

Nothing here works on Windows — the `VAR=value cmd` env prefix, the hardcoded macOS `Application Support` path, and the `./scripts/*.sh` invocation all fail.

## Change

Replaces both scripts with `packages/electron/scripts/dev-user2.mjs`:

- userData dir resolves per platform — `%APPDATA%` on Windows, `Application Support` on macOS, `$XDG_CONFIG_HOME` elsewhere
- `tsc` and `electron-vite` resolve to their `.js` entry points via `require.resolve('<pkg>/package.json')` + the `bin` field, so Windows `.cmd` shims are bypassed
- the `--loop` restart-signal watch is reimplemented in Node, matching `dev-loop.sh`'s per-instance `.restart-requested-<basename>` filename (same path `getRestartSignalPath()` in `appPaths.ts` writes)
- `VITE_PORT=5274` and `ELECTRON_ENTRY=out2/main/index.js` isolation is preserved

## Testing

`packages/electron/scripts/__tests__/dev-user2.test.mjs` covers per-platform path resolution, env construction, binary resolution, and the restart-signal filename.

The root vitest config only includes `packages/**/__tests__/**/*.test.{ts,tsx}`, so a `.mjs` test would never have run. It is wired into `test:prepush-gate` alongside the other `node --test` files, which the `.githooks/pre-push` hook executes.

Verified on macOS: gate is 16/16, both build steps (`extension-sdk` tsc, `build-worker.js`) run, and the resolved userData dir / restart-signal path are byte-identical to what the old shell scripts produced.

Windows itself is unverified — no Windows machine in this loop.

## Notes

- No CHANGELOG entry: dev-only tooling, not user-facing.
- The new script builds `@nimbalyst/extension-sdk` before starting, which `dev.sh` does not. Intentional for a fresh checkout that has no `dist/`; `tsc` is incremental so it will not churn `dist/` and full-reload open windows. It does leave `dev` and `dev:user2` asymmetric.