### PR TITLE
fix(queue): recover prompts after window reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Queued chat messages now continue through a replacement project window after the original window reloads or closes.
 - Windows and Linux get the File/Edit/View menus back, now drawn in the project window's title bar.
 
 ### Removed

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -656,7 +656,11 @@ export class AIService {
     targetWindow: Electron.BrowserWindow | null,
     source: string
   ): Promise<void> {
-    if (!targetWindow || targetWindow.isDestroyed()) {
+    const liveWindow =
+      targetWindow && !targetWindow.isDestroyed()
+        ? targetWindow
+        : findWindowByWorkspace(workspacePath);
+    if (!liveWindow || liveWindow.isDestroyed()) {
       logger.main.info(`[AIService] ${source}: no live window available to continue queued prompts for session ${sessionId}`);
       return;
     }
@@ -672,7 +676,7 @@ export class AIService {
     logger.main.info(
       `[AIService] ${source}: ${pendingPrompts.length} pending prompts remain for session ${sessionId}, triggering next`
     );
-    await this.processQueuedPrompt(sessionId, workspacePath, targetWindow);
+    await this.processQueuedPrompt(sessionId, workspacePath, liveWindow);
   }
 
   public async tryDispatchNextQueuedPrompt(
@@ -713,6 +717,7 @@ export class AIService {
         this.continueQueuedPromptChain(nextSessionId, nextWorkspacePath, nextTargetWindow, nextSource),
       logError: (message, error) => logger.main.error(message, error),
       logInfo: (message) => logger.main.info(message),
+      resolveLiveWindow: findWindowByWorkspace,
       onAfterSettled: async () => {
         try {
           const { AISessionsRepository } = await import('@nimbalyst/runtime/storage/repositories/AISessionsRepository');

--- a/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
@@ -131,6 +131,128 @@ describe('queuedPromptDispatcher', () => {
     });
   });
 
+  it('dispatches once to a replacement window when the original window is destroyed', async () => {
+    vi.useFakeTimers();
+
+    // Regression: a long guarded/streaming prompt retains its original
+    // BrowserWindow. If that renderer dies or reloads, FIFO continuation must
+    // not bail just because the passed window is gone — a replacement window
+    // for the same workspace should receive the next queued prompt exactly once.
+    const claimedPrompt: ClaimedQueuedPrompt = {
+      id: 'prompt-1',
+      prompt: 'continue',
+      attachments: null,
+      documentContext: null,
+    };
+
+    const queueStore: QueuedPromptStoreLike = {
+      listPending: vi.fn(async () => [claimedPrompt]),
+      claim: vi.fn(async () => claimedPrompt),
+      complete: vi.fn(async () => {}),
+      fail: vi.fn(async () => {}),
+    };
+
+    const processingSet = new Set<string>();
+
+    // The original window is destroyed (renderer died/reloaded mid-stream).
+    const destroyedWindow = {
+      isDestroyed: () => true,
+      webContents: { send: vi.fn(), mainFrame: {} },
+    } as unknown as Electron.BrowserWindow;
+
+    // The replacement window for the same workspace is live.
+    const replacementWindow = {
+      isDestroyed: () => false,
+      webContents: { send: vi.fn(), mainFrame: {} },
+    } as unknown as Electron.BrowserWindow;
+
+    let dispatchedSender: Electron.WebContents | undefined;
+    const sendMessageHandler = vi.fn(async (event: Electron.IpcMainInvokeEvent) => {
+      dispatchedSender = event.sender;
+      return { content: 'ok' };
+    });
+    const resolveLiveWindow = vi.fn((_workspacePath: string) => replacementWindow);
+
+    const processed = await tryClaimAndDispatchNextQueuedPrompt({
+      continueQueuedPromptChain: vi.fn(async () => {}),
+      logError: vi.fn(),
+      logInfo: vi.fn(),
+      onPromptClaimed: () => {},
+      processingSet,
+      queueStore,
+      sendMessageHandler,
+      resolveLiveWindow,
+      sessionId: 'session-1',
+      source: 'test queue',
+      startSession: vi.fn(async () => {}),
+      targetWindow: destroyedWindow,
+      workspacePath: '/workspace/project',
+    });
+
+    // Without the fix the dispatcher bails on the destroyed window and never
+    // resolves a replacement, so nothing is dispatched.
+    expect(processed).toBe(true);
+    expect(resolveLiveWindow).toHaveBeenCalledWith('/workspace/project');
+
+    await vi.runAllTimersAsync();
+
+    // Exactly-once after the deferred dispatch settles. The replacement
+    // window's webContents, not the destroyed original, is the IPC sender.
+    expect(sendMessageHandler).toHaveBeenCalledTimes(1);
+    expect(dispatchedSender).toBe(replacementWindow.webContents);
+    expect(queueStore.complete).toHaveBeenCalledTimes(1);
+    expect(queueStore.fail).not.toHaveBeenCalled();
+    expect(processingSet.has('session-1')).toBe(false);
+  });
+
+  it('bails (without dispatching) when the window is destroyed and no replacement exists', async () => {
+    vi.useFakeTimers();
+
+    const claimedPrompt: ClaimedQueuedPrompt = {
+      id: 'prompt-1',
+      prompt: 'continue',
+      attachments: null,
+      documentContext: null,
+    };
+
+    const queueStore: QueuedPromptStoreLike = {
+      listPending: vi.fn(async () => [claimedPrompt]),
+      claim: vi.fn(async () => claimedPrompt),
+      complete: vi.fn(async () => {}),
+      fail: vi.fn(async () => {}),
+    };
+
+    const processingSet = new Set<string>();
+
+    const destroyedWindow = {
+      isDestroyed: () => true,
+      webContents: { send: vi.fn(), mainFrame: {} },
+    } as unknown as Electron.BrowserWindow;
+
+    const sendMessageHandler = vi.fn(async () => ({ content: 'ok' }));
+
+    const processed = await tryClaimAndDispatchNextQueuedPrompt({
+      continueQueuedPromptChain: vi.fn(async () => {}),
+      logError: vi.fn(),
+      logInfo: vi.fn(),
+      onPromptClaimed: () => {},
+      processingSet,
+      queueStore,
+      sendMessageHandler,
+      resolveLiveWindow: vi.fn(() => null),
+      sessionId: 'session-1',
+      source: 'test queue',
+      startSession: vi.fn(async () => {}),
+      targetWindow: destroyedWindow,
+      workspacePath: '/workspace/project',
+    });
+
+    expect(processed).toBe(false);
+    expect(sendMessageHandler).not.toHaveBeenCalled();
+    expect(queueStore.claim).not.toHaveBeenCalled();
+    expect(processingSet.has('session-1')).toBe(false);
+  });
+
   it('does NOT fire onChainSettled when a follow-on prompt is dispatched', async () => {
     vi.useFakeTimers();
 

--- a/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
+++ b/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
@@ -141,6 +141,7 @@ interface TryClaimAndDispatchNextQueuedPromptOptions {
   sessionId: string;
   source: string;
   startSession: DispatchClaimedQueuedPromptOptions['startSession'];
+  resolveLiveWindow?: (workspacePath: string) => Electron.BrowserWindow | null;
   targetWindow: Electron.BrowserWindow | null;
   workspacePath: string;
 }
@@ -161,11 +162,17 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
     sessionId,
     source,
     startSession,
+    resolveLiveWindow,
     targetWindow,
     workspacePath,
   } = options;
 
-  if (!targetWindow || targetWindow.isDestroyed()) {
+  const liveWindow =
+    targetWindow && !targetWindow.isDestroyed()
+      ? targetWindow
+      : resolveLiveWindow?.(workspacePath) ?? null;
+
+  if (!liveWindow || liveWindow.isDestroyed()) {
     logInfo(`[AIService] ${source}: no live window available to continue queued prompts for session ${sessionId}`);
     return false;
   }
@@ -209,7 +216,7 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
     sessionId,
     source,
     startSession,
-    targetWindow,
+    targetWindow: liveWindow,
     workspacePath,
   });
 


### PR DESCRIPTION
Fixes #962

Re-resolves a live workspace window before dispatching queued messages after the original renderer reloads or closes. Adds exactly-once regression coverage for a replacement window and a safe bail when no replacement exists.

Internal tracker: NIM-465. NIM-471 and NIM-472 remain separate ordinary-FIFO acceptance and trigger-provenance work.

Verification:
- npx vitest run src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts — 5 passed
- npm run typecheck:prepush — passed in a clean clone