### PR TITLE
fix(electron): keep Git status off the main event loop

### DIFF
--- a/packages/electron/src/main/services/GitStatusService.ts
+++ b/packages/electron/src/main/services/GitStatusService.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFile, execSync } from 'child_process';
 import { existsSync, statSync } from 'fs';
 import { dirname, isAbsolute, join, relative, resolve } from 'path';
 import { getUntrackedFilesInDirectory, isGitAvailable, logEbadfDiagnostic } from '../utils/gitUtils';
@@ -98,6 +98,14 @@ export function findGitRootForFile(filePath: string, boundary: string): string |
 export class GitStatusService {
   private cache: Map<string, { status: GitStatusResult; timestamp: number }> = new Map();
   private readonly CACHE_TTL_MS = 5000; // 5 seconds cache
+  // `clearCache` can run while an async status command is pending. Incrementing
+  // this generation prevents an older command from repopulating an invalidated
+  // cache entry after it completes.
+  private cacheGeneration = 0;
+  // Coalesce same-repository cache misses from independent status APIs. This
+  // holds only the child-process result; each caller still parses and caches
+  // its own result shape.
+  private readonly inFlightGitStatus = new Map<string, Promise<string>>();
 
   /**
    * Get git status for a list of files in a workspace.
@@ -160,11 +168,12 @@ export class GitStatusService {
     }
 
     const result: GitStatusResult = {};
+    const cacheGeneration = this.cacheGeneration;
 
     for (const [rootPath, rootFiles] of filesByRoot) {
       let statusMap: Map<string, FileGitStatus>;
       try {
-        const statusOutput = this.executeGitStatus(rootPath);
+        const statusOutput = await this.executeGitStatus(rootPath);
         statusMap = this.parseGitStatus(statusOutput);
       } catch (error) {
         logEbadfDiagnostic('GitStatusService', error);
@@ -223,7 +232,9 @@ export class GitStatusService {
     }
 
     // Cache the result
-    this.cache.set(cacheKey, { status: result, timestamp: Date.now() });
+    if (this.cacheGeneration === cacheGeneration) {
+      this.cache.set(cacheKey, { status: result, timestamp: Date.now() });
+    }
 
     return result;
   }
@@ -232,14 +243,33 @@ export class GitStatusService {
    * Execute git status --porcelain command and return raw output
    * @private
    */
-  private executeGitStatus(workspacePath: string): string {
-    // IMPORTANT: Don't trim() here as it removes the leading space from status codes
-    return execSync('git status --porcelain', {
-      cwd: workspacePath,
-      encoding: 'utf8',
-      timeout: 5000, // 5 second timeout
-      stdio: ['pipe', 'pipe', 'pipe']
+  private async executeGitStatus(workspacePath: string): Promise<string> {
+    const inFlight = this.inFlightGitStatus.get(workspacePath);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    let statusPromise: Promise<string>;
+    statusPromise = new Promise<string>((resolve, reject) => {
+      execFile('git', ['status', '--porcelain'], {
+        cwd: workspacePath,
+        encoding: 'utf8',
+        timeout: 5000, // Preserve the existing 5 second timeout.
+      }, (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(stdout);
+      });
+    }).finally(() => {
+      if (this.inFlightGitStatus.get(workspacePath) === statusPromise) {
+        this.inFlightGitStatus.delete(workspacePath);
+      }
     });
+    this.inFlightGitStatus.set(workspacePath, statusPromise);
+    // IMPORTANT: Don't trim() here as it removes the leading space from status codes.
+    return statusPromise;
   }
 
   /**
@@ -393,9 +423,10 @@ export class GitStatusService {
       return Object.keys(cached.status);
     }
 
+    const cacheGeneration = this.cacheGeneration;
     try {
       // Get git status for the entire repository using porcelain format
-      const statusOutput = this.executeGitStatus(workspacePath);
+      const statusOutput = await this.executeGitStatus(workspacePath);
 
       // Parse status output
       const statusMap = this.parseGitStatus(statusOutput);
@@ -450,7 +481,9 @@ export class GitStatusService {
           };
         }
       }
-      this.cache.set(cacheKey, { status: cacheResult, timestamp: Date.now() });
+      if (this.cacheGeneration === cacheGeneration) {
+        this.cache.set(cacheKey, { status: cacheResult, timestamp: Date.now() });
+      }
 
       return uncommittedFiles;
     } catch (error) {
@@ -627,6 +660,7 @@ export class GitStatusService {
       return Object.keys(cached.status);
     }
 
+    const cacheGeneration = this.cacheGeneration;
     try {
       // Get the current branch of this worktree
       const worktreeBranch = this.getCurrentBranch(workspacePath);
@@ -693,7 +727,9 @@ export class GitStatusService {
       }
 
       // Cache the result
-      this.cache.set(cacheKey, { status: cacheResult, timestamp: Date.now() });
+      if (this.cacheGeneration === cacheGeneration) {
+        this.cache.set(cacheKey, { status: cacheResult, timestamp: Date.now() });
+      }
 
       // Convert Set to Array
       return Array.from(filePathSet);
@@ -734,9 +770,10 @@ export class GitStatusService {
       return cached.status;
     }
 
+    const cacheGeneration = this.cacheGeneration;
     try {
       // Get git status for the entire repository using porcelain format
-      const statusOutput = this.executeGitStatus(workspacePath);
+      const statusOutput = await this.executeGitStatus(workspacePath);
 
       // Parse status output
       const statusMap = this.parseGitStatus(statusOutput);
@@ -780,7 +817,9 @@ export class GitStatusService {
       }
 
       // Cache the result
-      this.cache.set(cacheKey, { status: result, timestamp: Date.now() });
+      if (this.cacheGeneration === cacheGeneration) {
+        this.cache.set(cacheKey, { status: result, timestamp: Date.now() });
+      }
 
       return result;
     } catch (error) {
@@ -870,6 +909,7 @@ export class GitStatusService {
    * Clear the cache for a specific workspace or all workspaces
    */
   clearCache(workspacePath?: string): void {
+    this.cacheGeneration += 1;
     if (workspacePath) {
       // Clear cache entries for this workspace.
       //

--- a/packages/electron/src/main/services/__tests__/GitStatusService.executeGitStatus.test.ts
+++ b/packages/electron/src/main/services/__tests__/GitStatusService.executeGitStatus.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+}));
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return { ...actual, execFile: execFileMock };
+});
+
+vi.mock('../../utils/gitUtils', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/gitUtils')>('../../utils/gitUtils');
+  return { ...actual, isGitAvailable: () => true };
+});
+
+import { GitStatusService } from '../GitStatusService';
+
+type GitStatusServiceInternals = {
+  executeGitStatus(workspacePath: string): Promise<string>;
+};
+
+function executeGitStatus(service: GitStatusService, workspacePath: string): Promise<string> {
+  return (service as unknown as GitStatusServiceInternals).executeGitStatus(workspacePath);
+}
+
+let workspacePath: string;
+
+beforeEach(async () => {
+  execFileMock.mockReset();
+  workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), 'nim-git-status-cache-'));
+  await fs.mkdir(path.join(workspacePath, '.git'));
+});
+
+afterEach(async () => {
+  await fs.rm(workspacePath, { recursive: true, force: true });
+});
+
+describe('GitStatusService executeGitStatus', () => {
+  it('coalesces concurrent status requests for one repository into one asynchronous child process', async () => {
+    execFileMock.mockImplementation((_file, _args, _options, callback) => {
+      queueMicrotask(() => callback(null, ' M changed.ts\n', ''));
+    });
+    const service = new GitStatusService();
+
+    await expect(Promise.all([
+      executeGitStatus(service, '/workspace'),
+      executeGitStatus(service, '/workspace'),
+    ])).resolves.toEqual([' M changed.ts\n', ' M changed.ts\n']);
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledWith(
+      'git',
+      ['status', '--porcelain'],
+      expect.objectContaining({ cwd: '/workspace', encoding: 'utf8', timeout: 5000 }),
+      expect.any(Function),
+    );
+  });
+
+  it('clears a failed in-flight request so a later request preserves retry behavior', async () => {
+    execFileMock
+      .mockImplementationOnce((_file, _args, _options, callback) => {
+        queueMicrotask(() => callback(new Error('git status failed'), '', 'fatal'));
+      })
+      .mockImplementationOnce((_file, _args, _options, callback) => {
+        queueMicrotask(() => callback(null, '', ''));
+      });
+    const service = new GitStatusService();
+
+    await expect(executeGitStatus(service, '/workspace')).rejects.toThrow('git status failed');
+    await expect(executeGitStatus(service, '/workspace')).resolves.toBe('');
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not repopulate a cleared status cache when a pending command completes', async () => {
+    let completeStatus: ((error: Error | null, stdout: string, stderr: string) => void) | undefined;
+    execFileMock.mockImplementationOnce((_file, _args, _options, callback) => {
+      completeStatus = callback;
+    });
+    const service = new GitStatusService();
+
+    const staleRequest = service.getAllFileStatuses(workspacePath);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+
+    service.clearCache(workspacePath);
+    completeStatus!(null, ' M stale.ts\n', '');
+    await expect(staleRequest).resolves.toEqual({
+      [path.join(workspacePath, 'stale.ts')]: expect.objectContaining({ status: 'modified' }),
+    });
+
+    execFileMock.mockImplementationOnce((_file, _args, _options, callback) => {
+      callback(null, ' M fresh.ts\n', '');
+    });
+    await expect(service.getAllFileStatuses(workspacePath)).resolves.toEqual({
+      [path.join(workspacePath, 'fresh.ts')]: expect.objectContaining({ status: 'modified' }),
+    });
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the synchronous `git status --porcelain` wait on Electron's main process with asynchronous `execFile` work.
- Coalesce concurrent status requests for the same repository root.
- Prevent a completion that began before cache invalidation from repopulating the cache afterward.

## Coverage
- Adds focused coverage for concurrent coalescing, retry after a Git failure, and cache invalidation while a status request is in flight.

## Validation
- `git diff --check` passed.
- The focused Vitest suite could not run locally: this clean containment clone has no installed dependency toolchain, and the existing executable from another checkout could not resolve its dependencies against this clone. No dependency install was performed.

Fixes #1063

Related to #868; #895 previously addressed Git-root caching but did not remove the synchronous Git status wait.