### PR TITLE
Make AskUserQuestion header model/agent-aware (remove hardcoded “Claude”)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- AskUserQuestion headers now identify the model or agent asking instead of always saying Claude.
 - AI sessions that preview a web page no longer strand a blank, unclosable window on a second monitor.
 - Sorting a tracker view by Updated, or any other date column, now orders rows by date instead of alphabetically by month name.
 

--- a/packages/runtime/src/ai/server/transcript/TranscriptProjector.ts
+++ b/packages/runtime/src/ai/server/transcript/TranscriptProjector.ts
@@ -18,6 +18,19 @@ import type {
   AssistantMessagePayload,
 } from './types';
 
+const PROVIDER_SOURCE_LABELS: Record<string, string> = {
+  claude: 'Claude',
+  'claude-code': 'Claude Agent',
+  'claude-code-cli': 'Claude Code CLI',
+  openai: 'OpenAI',
+  'openai-codex': 'OpenAI Codex',
+  'openai-codex-acp': 'OpenAI Codex',
+  opencode: 'OpenCode',
+  'copilot-cli': 'GitHub Copilot',
+  lmstudio: 'LM Studio',
+  voice: 'Voice Agent',
+};
+
 // ---------------------------------------------------------------------------
 // View model types
 // ---------------------------------------------------------------------------
@@ -47,6 +60,7 @@ export interface TranscriptViewMessage {
   toolCall?: {
     toolName: string;
     toolDisplayName: string;
+    sourceLabel?: string;
     status: 'running' | 'completed' | 'error';
     description: string | null;
     arguments: Record<string, unknown>;
@@ -153,7 +167,16 @@ export class TranscriptProjector {
     // Attach child events to subagent parents
     for (const [subagentId, parent] of subagentParents) {
       if (parent.subagent) {
-        parent.subagent.childEvents = subagentEvents.get(subagentId) ?? [];
+        const childEvents = subagentEvents.get(subagentId) ?? [];
+        const sourceLabel = resolveSubagentSourceLabel(parent.subagent);
+        if (sourceLabel) {
+          for (const child of childEvents) {
+            if (child.toolCall) {
+              child.toolCall.sourceLabel = sourceLabel;
+            }
+          }
+        }
+        parent.subagent.childEvents = childEvents;
       }
     }
 
@@ -250,6 +273,7 @@ function projectEvent(
       base.toolCall = {
         toolName: p.toolName,
         toolDisplayName: p.toolDisplayName,
+        sourceLabel: resolveToolSourceLabel(p.sourceLabel, event.provider),
         status: p.status,
         description: p.description,
         arguments: p.arguments,
@@ -278,7 +302,11 @@ function projectEvent(
       // Populate a synthetic toolCall so that existing custom widgets
       // (ToolPermissionWidget, AskUserQuestionWidget, etc.) can render
       // without changes -- they access data via message.toolCall.
-      base.toolCall = interactivePromptToToolCall(prompt, event.providerToolCallId);
+      base.toolCall = interactivePromptToToolCall(
+        prompt,
+        event.providerToolCallId,
+        event.provider,
+      );
       break;
     }
     case 'subagent': {
@@ -290,6 +318,8 @@ function projectEvent(
       base.toolCall = {
         toolName: 'Task',
         toolDisplayName: 'Task',
+        sourceLabel: resolveSubagentSourceLabel(p)
+          ?? resolveToolSourceLabel(undefined, event.provider),
         status: p.status === 'completed' ? 'completed' : 'running',
         description: null,
         arguments: {
@@ -334,6 +364,7 @@ const PROMPT_TYPE_TO_TOOL_NAME: Record<string, string> = {
 function interactivePromptToToolCall(
   prompt: InteractivePromptPayload,
   providerToolCallId: string | null,
+  provider: string,
 ): TranscriptViewMessage['toolCall'] {
   const toolName = PROMPT_TYPE_TO_TOOL_NAME[prompt.promptType] ?? prompt.promptType;
   const status: 'running' | 'completed' | 'error' =
@@ -349,6 +380,10 @@ function interactivePromptToToolCall(
   return {
     toolName,
     toolDisplayName: toolName,
+    sourceLabel: resolveToolSourceLabel(
+      prompt.promptType === 'ask_user_question' ? prompt.sourceLabel : undefined,
+      provider,
+    ),
     status,
     description: null,
     arguments: prompt as unknown as Record<string, unknown>,
@@ -359,4 +394,26 @@ function interactivePromptToToolCall(
     providerToolCallId: providerToolCallId ?? (prompt as any).requestId ?? null,
     progress: [],
   };
+}
+
+function resolveSubagentSourceLabel(
+  subagent: SubagentPayload,
+): string | undefined {
+  return (
+    subagent.teammateName?.trim()
+    || subagent.teamName?.trim()
+    || subagent.model?.trim()
+    || subagent.agentType?.trim()
+    || undefined
+  );
+}
+
+function resolveToolSourceLabel(
+  sourceLabel: string | null | undefined,
+  provider: string,
+): string {
+  const explicitLabel = sourceLabel?.trim();
+  if (explicitLabel) return explicitLabel;
+
+  return PROVIDER_SOURCE_LABELS[provider] ?? (provider.trim() || 'assistant');
 }

--- a/packages/runtime/src/ai/server/transcript/TranscriptWriter.ts
+++ b/packages/runtime/src/ai/server/transcript/TranscriptWriter.ts
@@ -175,6 +175,7 @@ export class TranscriptWriter {
     params: {
       toolName: string;
       toolDisplayName: string;
+      sourceLabel?: string;
       description?: string | null;
       arguments: Record<string, unknown>;
       targetFilePath?: string | null;
@@ -188,6 +189,7 @@ export class TranscriptWriter {
     const payload: ToolCallPayload = {
       toolName: params.toolName,
       toolDisplayName: params.toolDisplayName,
+      ...(params.sourceLabel ? { sourceLabel: params.sourceLabel } : {}),
       status: 'running',
       description: params.description ?? null,
       arguments: params.arguments,

--- a/packages/runtime/src/ai/server/transcript/__tests__/ClaudeCodeRawParser.test.ts
+++ b/packages/runtime/src/ai/server/transcript/__tests__/ClaudeCodeRawParser.test.ts
@@ -248,6 +248,7 @@ describe('ClaudeCodeRawParser', () => {
         content: JSON.stringify({
           type: 'assistant',
           message: {
+            model: 'claude-sonnet-4-5-20250929',
             content: [{
               type: 'tool_use',
               id: 'tool-1',
@@ -266,6 +267,7 @@ describe('ClaudeCodeRawParser', () => {
         toolName: 'Read',
         providerToolCallId: 'tool-1',
         arguments: { file_path: '/test.ts' },
+        sourceLabel: 'Claude Sonnet 4.5',
       });
     });
 

--- a/packages/runtime/src/ai/server/transcript/__tests__/TranscriptProjector.test.ts
+++ b/packages/runtime/src/ai/server/transcript/__tests__/TranscriptProjector.test.ts
@@ -114,6 +114,49 @@ describe('TranscriptProjector', () => {
     expect(vm.messages[0].toolCall!.progress[1].elapsedSeconds).toBe(10);
   });
 
+  it('projects an explicit tool source label', () => {
+    const vm = TranscriptProjector.project([
+      makeEvent({
+        eventType: 'tool_call',
+        provider: 'claude-code',
+        payload: {
+          toolName: 'AskUserQuestion',
+          toolDisplayName: 'AskUserQuestion',
+          status: 'running',
+          description: null,
+          arguments: { questions: [] },
+          targetFilePath: null,
+          mcpServer: null,
+          mcpTool: null,
+          sourceLabel: 'Claude Sonnet 4.5',
+        },
+      }),
+    ]);
+
+    expect(vm.messages[0].toolCall?.sourceLabel).toBe('Claude Sonnet 4.5');
+  });
+
+  it('falls back to the provider label for tool calls without a source label', () => {
+    const vm = TranscriptProjector.project([
+      makeEvent({
+        eventType: 'tool_call',
+        provider: 'openai-codex',
+        payload: {
+          toolName: 'AskUserQuestion',
+          toolDisplayName: 'AskUserQuestion',
+          status: 'running',
+          description: null,
+          arguments: { questions: [] },
+          targetFilePath: null,
+          mcpServer: null,
+          mcpTool: null,
+        },
+      }),
+    ]);
+
+    expect(vm.messages[0].toolCall?.sourceLabel).toBe('OpenAI Codex');
+  });
+
   it('nests subagent events under subagent parent', () => {
     const events: TranscriptEvent[] = [
       makeEvent({
@@ -127,7 +170,7 @@ describe('TranscriptProjector', () => {
         payload: {
           agentType: 'Explore',
           status: 'completed',
-          teammateName: null,
+          teammateName: 'Researcher',
           teamName: null,
           teammateMode: null,
           model: null,
@@ -142,8 +185,9 @@ describe('TranscriptProjector', () => {
         eventType: 'tool_call',
         subagentId: 'sub-1',
         payload: {
-          toolName: 'Glob',
-          toolDisplayName: 'Glob',
+          toolName: 'AskUserQuestion',
+          toolDisplayName: 'AskUserQuestion',
+          sourceLabel: 'Claude Sonnet 4.5',
           status: 'completed',
           description: null,
           arguments: { pattern: '*.ts' },
@@ -176,6 +220,7 @@ describe('TranscriptProjector', () => {
     });
     expect(vm.messages[1].subagent!.childEvents).toHaveLength(2);
     expect(vm.messages[1].subagent!.childEvents[0].type).toBe('tool_call');
+    expect(vm.messages[1].subagent!.childEvents[0].toolCall?.sourceLabel).toBe('Researcher');
     expect(vm.messages[1].subagent!.childEvents[1].type).toBe('assistant_message');
   });
 

--- a/packages/runtime/src/ai/server/transcript/__tests__/TranscriptTransformer.test.ts
+++ b/packages/runtime/src/ai/server/transcript/__tests__/TranscriptTransformer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TranscriptTransformer } from '../TranscriptTransformer';
+import { TranscriptProjector } from '../TranscriptProjector';
 import type { IRawMessageStore, RawMessage, ISessionMetadataStore } from '../TranscriptTransformer';
 import type { ITranscriptEventStore, TranscriptEvent } from '../types';
 
@@ -290,6 +291,35 @@ describe('TranscriptTransformer', () => {
       const status = metadataStore.getStatus(SESSION_ID);
       expect(status.transformStatus).toBe('complete');
       expect(status.transformVersion).toBe(TranscriptTransformer.CURRENT_VERSION);
+    });
+
+    it('preserves the model label from a raw tool call through projection', async () => {
+      const rawStore = createMockRawStore([
+        makeRawMessage({
+          id: 1,
+          sessionId: SESSION_ID,
+          direction: 'output',
+          content: JSON.stringify({
+            type: 'assistant',
+            message: {
+              model: 'claude-sonnet-4-5-20250929',
+              content: [{
+                type: 'tool_use',
+                id: 'question-1',
+                name: 'AskUserQuestion',
+                input: { questions: [] },
+              }],
+            },
+          }),
+        }),
+      ]);
+      const transformer = new TranscriptTransformer(rawStore, transcriptStore, metadataStore);
+
+      await transformer.ensureTransformed(SESSION_ID, PROVIDER);
+
+      const events = await transcriptStore.getSessionEvents(SESSION_ID);
+      const message = TranscriptProjector.project(events).messages[0];
+      expect(message.toolCall?.sourceLabel).toBe('Claude Sonnet 4.5');
     });
 
     it('resumes from lastRawMessageId when pending', async () => {

--- a/packages/runtime/src/ai/server/transcript/parsers/ClaudeCodeRawParser.ts
+++ b/packages/runtime/src/ai/server/transcript/parsers/ClaudeCodeRawParser.ts
@@ -13,6 +13,7 @@
 
 import type { RawMessage } from '../TranscriptTransformer';
 import { parseMcpToolName } from '../utils';
+import { CLAUDE_MODELS } from '../../../modelConstants';
 import type {
   IRawMessageParser,
   ParseContext,
@@ -248,6 +249,7 @@ export class ClaudeCodeRawParser implements IRawMessageParser {
                 block,
                 context,
                 parentToolUseId,
+                this.resolveModelSourceLabel(turnModel),
               );
               descriptors.push(...toolDescriptors);
             } else if (block.type === 'tool_result') {
@@ -411,6 +413,7 @@ export class ClaudeCodeRawParser implements IRawMessageParser {
     block: any,
     context: ParseContext,
     parentToolUseId?: string,
+    sourceLabel?: string,
   ): Promise<CanonicalEventDescriptor[]> {
     const descriptors: CanonicalEventDescriptor[] = [];
     const toolName = block.name ?? 'unknown';
@@ -482,6 +485,7 @@ export class ClaudeCodeRawParser implements IRawMessageParser {
       type: 'tool_call_started',
       toolName,
       toolDisplayName: toolName,
+      ...(sourceLabel ? { sourceLabel } : {}),
       arguments: args,
       mcpServer,
       mcpTool,
@@ -491,6 +495,11 @@ export class ClaudeCodeRawParser implements IRawMessageParser {
     });
 
     return descriptors;
+  }
+
+  private resolveModelSourceLabel(model: string | undefined): string | undefined {
+    if (!model) return undefined;
+    return CLAUDE_MODELS.find((candidate) => candidate.id === model)?.displayName ?? model;
   }
 
   private parseToolResult(

--- a/packages/runtime/src/ai/server/transcript/parsers/IRawMessageParser.ts
+++ b/packages/runtime/src/ai/server/transcript/parsers/IRawMessageParser.ts
@@ -100,6 +100,7 @@ export interface ToolCallStartedDescriptor {
   type: 'tool_call_started';
   toolName: string;
   toolDisplayName: string;
+  sourceLabel?: string;
   arguments: Record<string, unknown>;
   targetFilePath?: string | null;
   mcpServer?: string | null;

--- a/packages/runtime/src/ai/server/transcript/processDescriptor.ts
+++ b/packages/runtime/src/ai/server/transcript/processDescriptor.ts
@@ -116,6 +116,7 @@ export async function processDescriptor(
       const event = await writer.createToolCall(sessionId, {
         toolName: desc.toolName,
         toolDisplayName: desc.toolDisplayName,
+        sourceLabel: desc.sourceLabel,
         arguments: desc.arguments,
         targetFilePath: desc.targetFilePath,
         mcpServer: desc.mcpServer,

--- a/packages/runtime/src/ai/server/transcript/types.ts
+++ b/packages/runtime/src/ai/server/transcript/types.ts
@@ -101,6 +101,8 @@ export interface SystemMessagePayload {
 export interface ToolCallPayload {
   toolName: string;
   toolDisplayName: string;
+  /** Model/agent label captured when the tool call was created. */
+  sourceLabel?: string;
   status: 'running' | 'completed' | 'error';
   description: string | null;
   arguments: Record<string, unknown>;
@@ -140,6 +142,8 @@ export interface PermissionRequestPayload {
 export interface AskUserQuestionPayload {
   promptType: 'ask_user_question';
   requestId: string;
+  /** Model/agent label captured when the prompt was created. */
+  sourceLabel?: string;
   status: 'pending' | 'resolved' | 'cancelled';
   questions: Array<{
     question: string;

--- a/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/AskUserQuestionWidget.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/AskUserQuestionWidget.tsx
@@ -34,19 +34,6 @@ interface Question {
   multiSelect: boolean;
 }
 
-function resolveQuestionSourceLabel(input: {
-  displayName?: string | null;
-  agentName?: string | null;
-  modelName?: string | null;
-}): string {
-  return (
-    input.displayName?.trim() ||
-    input.agentName?.trim() ||
-    input.modelName?.trim() ||
-    'assistant'
-  );
-}
-
 // ============================================================
 // Helper Functions
 // ============================================================
@@ -243,14 +230,7 @@ export const AskUserQuestionWidget: React.FC<CustomToolWidgetProps> = ({
   const host = useAtomValue(interactiveWidgetHostAtom(sessionId));
 
   const questions = parseQuestions(toolCall.arguments);
-  const displayName = (message.metadata?.teammateName as string | undefined) ?? null;
-  const agentName = message.subagent?.teamName ?? null;
-  const modelName = message.model ?? message.subagent?.model ?? null;
-  const questionSourceLabel = resolveQuestionSourceLabel({
-    displayName,
-    agentName,
-    modelName,
-  });
+  const questionSourceLabel = toolCall.sourceLabel?.trim() || 'assistant';
 
   // Parse result to determine completion state
   const rawResult = toolCall.result;

--- a/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/AskUserQuestionWidget.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/AskUserQuestionWidget.tsx
@@ -2,7 +2,7 @@
  * AskUserQuestionWidget
  *
  * Interactive widget for the AskUserQuestion tool.
- * Renders questions from Claude and allows user to select answers.
+ * Renders questions from the assistant/model and allows user to select answers.
  *
  * Uses InteractiveWidgetHost for operations that require access to atoms, callbacks, and analytics.
  * The host is read from interactiveWidgetHostAtom(sessionId) - no prop drilling needed.
@@ -32,6 +32,19 @@ interface Question {
   header: string;
   options: QuestionOption[];
   multiSelect: boolean;
+}
+
+function resolveQuestionSourceLabel(input: {
+  displayName?: string | null;
+  agentName?: string | null;
+  modelName?: string | null;
+}): string {
+  return (
+    input.displayName?.trim() ||
+    input.agentName?.trim() ||
+    input.modelName?.trim() ||
+    'assistant'
+  );
 }
 
 // ============================================================
@@ -230,6 +243,14 @@ export const AskUserQuestionWidget: React.FC<CustomToolWidgetProps> = ({
   const host = useAtomValue(interactiveWidgetHostAtom(sessionId));
 
   const questions = parseQuestions(toolCall.arguments);
+  const displayName = (message.metadata?.teammateName as string | undefined) ?? null;
+  const agentName = message.subagent?.teamName ?? null;
+  const modelName = message.model ?? message.subagent?.model ?? null;
+  const questionSourceLabel = resolveQuestionSourceLabel({
+    displayName,
+    agentName,
+    modelName,
+  });
 
   // Parse result to determine completion state
   const rawResult = toolCall.result;
@@ -555,7 +576,7 @@ export const AskUserQuestionWidget: React.FC<CustomToolWidgetProps> = ({
           </svg>
         </div>
         <span className="text-sm font-semibold text-nim flex-1">
-          Questions from Claude
+          {`Questions from ${questionSourceLabel}`}
         </span>
         {!host && (
           <span data-testid="ask-user-question-pending" className="text-xs text-nim-muted">Waiting...</span>

--- a/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/index.ts
+++ b/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/index.ts
@@ -141,7 +141,7 @@ const BUILT_IN_TOOL_WIDGETS: CustomToolWidgetRegistry = {
   // Editor screenshot capture tool (works for mockups and all other editor types)
   'capture_editor_screenshot': EditorScreenshotWidget,
 
-  // AskUserQuestion tool - displays questions from Claude for user input
+  // AskUserQuestion tool - displays assistant/model questions for user input
   'AskUserQuestion': AskUserQuestionWidget,
 
   // PromptForUserInput tool - generic structured-input prompt with typed fields

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/TranscriptWidgets.test.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/TranscriptWidgets.test.tsx
@@ -20,7 +20,11 @@ import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import * as rtl from '@testing-library/react';
 import { createStore, Provider as JotaiProvider } from 'jotai';
-import type { TranscriptViewMessage } from '../../../../ai/server/transcript/TranscriptProjector';
+import {
+  TranscriptProjector,
+  type TranscriptViewMessage,
+} from '../../../../ai/server/transcript/TranscriptProjector';
+import type { TranscriptEvent } from '../../../../ai/server/transcript/types';
 import type { CustomToolWidgetProps } from '../CustomToolWidgets/index';
 
 const { render, screen, fireEvent } = rtl;
@@ -761,24 +765,44 @@ describe('AskUserQuestionWidget', () => {
   });
 
   it('uses the model label in the question header when available', () => {
-    const message = makeToolMessage(
-      'AskUserQuestion',
-      {
-        questions: [
-          {
-            question: 'Which framework?',
-            header: 'Framework',
-            options: [
-              { label: 'React', description: 'Component library' },
-              { label: 'Vue', description: 'Progressive framework' },
-            ],
-            multiSelect: false,
-          },
-        ],
+    const event: TranscriptEvent = {
+      id: 1,
+      sessionId: 'model-label',
+      sequence: 0,
+      createdAt: new Date(),
+      eventType: 'tool_call',
+      searchableText: null,
+      payload: {
+        toolName: 'AskUserQuestion',
+        toolDisplayName: 'AskUserQuestion',
+        status: 'running',
+        description: null,
+        arguments: {
+          questions: [
+            {
+              question: 'Which framework?',
+              header: 'Framework',
+              options: [
+                { label: 'React', description: 'Component library' },
+                { label: 'Vue', description: 'Progressive framework' },
+              ],
+              multiSelect: false,
+            },
+          ],
+        },
+        targetFilePath: null,
+        mcpServer: null,
+        mcpTool: null,
+        sourceLabel: 'Claude Sonnet 4.5',
       },
-      undefined,
-      { model: 'Claude Sonnet 4.5' }
-    );
+      parentEventId: null,
+      searchable: false,
+      subagentId: null,
+      provider: 'claude-code',
+      providerToolCallId: 'question-1',
+    };
+    const message = TranscriptProjector.project([event]).messages[0];
+
     render(
       <Wrapper>
         <AskUserQuestionWidget

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/TranscriptWidgets.test.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/TranscriptWidgets.test.tsx
@@ -760,6 +760,38 @@ describe('AskUserQuestionWidget', () => {
     expect((screen.getByTestId('ask-user-question-cancel') as HTMLButtonElement).disabled).toBe(true);
   });
 
+  it('uses the model label in the question header when available', () => {
+    const message = makeToolMessage(
+      'AskUserQuestion',
+      {
+        questions: [
+          {
+            question: 'Which framework?',
+            header: 'Framework',
+            options: [
+              { label: 'React', description: 'Component library' },
+              { label: 'Vue', description: 'Progressive framework' },
+            ],
+            multiSelect: false,
+          },
+        ],
+      },
+      undefined,
+      { model: 'Claude Sonnet 4.5' }
+    );
+    render(
+      <Wrapper>
+        <AskUserQuestionWidget
+          message={message}
+          isExpanded={false}
+          onToggle={() => {}}
+          sessionId="model-label"
+        />
+      </Wrapper>
+    );
+    expect(screen.getByText('Questions from Claude Sonnet 4.5')).toBeDefined();
+  });
+
   it('renders completed state with answers', () => {
     const message = makeToolMessage(
       'AskUserQuestion',


### PR DESCRIPTION
Fixes #1082

## Summary
This PR removes the hardcoded `Questions from Claude` label in the AskUserQuestion custom widget and makes the title dynamic based on available runtime metadata.

## Changes
- In `packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/AskUserQuestionWidget.tsx`:
  - Resolve question source label using:
    1. `displayName`
    2. `agentName`
    3. `modelName`
    4. `"assistant"` fallback
  - Render header as:
    - `Questions from ${resolvedLabel}`
- In `packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/index.ts`:
  - Update stale comment that mentioned Claude specifically.
- Updated relevant tests/snapshots if needed.

## Why
The previous label was misleading whenever the active model was not Claude. This ensures accurate, provider-agnostic UI text while preserving existing AskUserQuestion behavior.

## Validation
- [ ] AskUserQuestion with `displayName` set shows that label
- [ ] Without `displayName`, uses `agentName`
- [ ] Without `agentName`, uses `modelName`
- [ ] Without any metadata, shows `Questions from assistant`
- [ ] No regression in selection/submit/cancel behavior