### PR TITLE
fix(git): batch NIM-479 untracked expansion

### DIFF
--- a/docs/POSTHOG_EVENTS.md
+++ b/docs/POSTHOG_EVENTS.md
@@ -84,6 +84,7 @@ All events include `$session_id` property automatically. Dev users are marked wi
 | `worktree_archive_failed` | `WorktreeHandlers.ts:937, 961` | Worktree archive fails | `error_type`<br/>`stage` (archiving-sessions/removing-worktree) | (pending release as of 6d0b51b5) |  |
 | `worktree_rebase_attempted` | `WorktreeHandlers.ts:804` | User initiates rebase of worktree from base branch | `success`<br/>`had_conflicts`<br/>`had_untracked_files_conflict` | (pending release) |  |
 | `worktree_merge_attempted` | `WorktreeHandlers.ts:756` | User initiates merge of worktree to main branch | `success`<br/>`had_conflicts` | (pending release) |  |
+| `git_status_untracked_expanded` | `GitStatusService.ts` | A repository-wide status refresh expands collapsed untracked directories | `workspace_hash` (truncated SHA-256)<br/>`caller_class` (whole_workspace/worktree_session/mixed)<br/>`generation` (capped)<br/>`in_flight_count` (capped)<br/>`git_duration_ms` (capped)<br/>`expansion_duration_ms` (capped)<br/>`untracked_directory_count` (capped)<br/>`untracked_result_count` (capped)<br/>`event_loop_lag_ms` (capped) | (pending release) | No workspace paths or filenames are collected. |
 
 ### Theme Management
 

--- a/packages/electron/src/main/services/GitStatusService.ts
+++ b/packages/electron/src/main/services/GitStatusService.ts
@@ -1,7 +1,14 @@
 import { execSync } from 'child_process';
+import { createHash } from 'crypto';
 import { existsSync, statSync } from 'fs';
 import { dirname, isAbsolute, join, relative, resolve } from 'path';
-import { getUntrackedFilesInDirectory, isGitAvailable, logEbadfDiagnostic } from '../utils/gitUtils';
+import {
+  getUntrackedFilesInDirectories,
+  isGitAvailable,
+  logEbadfDiagnostic,
+  type UntrackedExpansionOptions,
+} from '../utils/gitUtils';
+import { AnalyticsService } from './analytics/AnalyticsService';
 
 export interface FileGitStatus {
   filePath: string;
@@ -11,6 +18,33 @@ export interface FileGitStatus {
 
 export interface GitStatusResult {
   [filePath: string]: FileGitStatus;
+}
+
+type GitStatusCallerClass = 'whole_workspace' | 'worktree_session';
+
+type UntrackedExpander = (
+  repoRoot: string,
+  directories: string[],
+  options: UntrackedExpansionOptions
+) => Promise<string[]>;
+
+interface RootStatusSnapshot {
+  generation: number;
+  timestamp: number;
+  statuses: GitStatusResult;
+  uncommittedFiles: string[];
+}
+
+interface RootStatusInFlight {
+  generation: number;
+  controller: AbortController;
+  callers: Set<GitStatusCallerClass>;
+  promise: Promise<RootStatusSnapshot>;
+}
+
+export interface GitStatusServiceOptions {
+  expandUntrackedFiles?: UntrackedExpander;
+  analytics?: Pick<AnalyticsService, 'sendEvent'>;
 }
 
 /**
@@ -98,6 +132,16 @@ export function findGitRootForFile(filePath: string, boundary: string): string |
 export class GitStatusService {
   private cache: Map<string, { status: GitStatusResult; timestamp: number }> = new Map();
   private readonly CACHE_TTL_MS = 5000; // 5 seconds cache
+  private static readonly rootSnapshots = new Map<string, RootStatusSnapshot>();
+  private static readonly rootInFlight = new Map<string, RootStatusInFlight>();
+  private static readonly rootGenerations = new Map<string, number>();
+  private readonly expandUntrackedFiles: UntrackedExpander;
+  private readonly analytics: Pick<AnalyticsService, 'sendEvent'>;
+
+  constructor(options: GitStatusServiceOptions = {}) {
+    this.expandUntrackedFiles = options.expandUntrackedFiles ?? getUntrackedFilesInDirectories;
+    this.analytics = options.analytics ?? AnalyticsService.getInstance();
+  }
 
   /**
    * Get git status for a list of files in a workspace.
@@ -357,6 +401,138 @@ export class GitStatusService {
   }
 
   /**
+   * Build one repository-wide changed-file snapshot. Both whole-workspace and
+   * worktree/session callers join this single flight so a large repository
+   * never starts one `git ls-files` process per collapsed untracked directory.
+   */
+  private async getRootStatusSnapshot(
+    workspacePath: string,
+    callerClass: GitStatusCallerClass
+  ): Promise<RootStatusSnapshot> {
+    const repoRoot = resolve(workspacePath);
+    const generation = GitStatusService.rootGenerations.get(repoRoot) ?? 0;
+    const cached = GitStatusService.rootSnapshots.get(repoRoot);
+    if (cached && cached.generation === generation && Date.now() - cached.timestamp < this.CACHE_TTL_MS) {
+      return cached;
+    }
+
+    const existing = GitStatusService.rootInFlight.get(repoRoot);
+    if (existing && existing.generation === generation) {
+      existing.callers.add(callerClass);
+      return existing.promise;
+    }
+
+    const controller = new AbortController();
+    const inFlight: RootStatusInFlight = {
+      generation,
+      controller,
+      callers: new Set([callerClass]),
+      promise: Promise.resolve(undefined as never),
+    };
+    inFlight.promise = this.buildRootStatusSnapshot(repoRoot, inFlight);
+    GitStatusService.rootInFlight.set(repoRoot, inFlight);
+
+    try {
+      const snapshot = await inFlight.promise;
+      // An invalidation may have superseded this work while its Git process
+      // was still exiting. Only the current generation may become reusable.
+      if ((GitStatusService.rootGenerations.get(repoRoot) ?? 0) !== generation || controller.signal.aborted) {
+        throw new Error('Git status snapshot invalidated');
+      }
+      GitStatusService.rootSnapshots.set(repoRoot, snapshot);
+      return snapshot;
+    } finally {
+      if (GitStatusService.rootInFlight.get(repoRoot) === inFlight) {
+        GitStatusService.rootInFlight.delete(repoRoot);
+      }
+    }
+  }
+
+  private async buildRootStatusSnapshot(
+    repoRoot: string,
+    inFlight: RootStatusInFlight
+  ): Promise<RootStatusSnapshot> {
+    const gitStartedAt = Date.now();
+    const statusOutput = this.executeGitStatus(repoRoot);
+    const gitDurationMs = Date.now() - gitStartedAt;
+    this.throwIfAborted(inFlight.controller.signal);
+
+    const result: GitStatusResult = {};
+    const untrackedDirectories: string[] = [];
+    for (const [relativePath, fileStatus] of this.parseGitStatus(statusOutput).entries()) {
+      if (fileStatus.status === 'unchanged') continue;
+
+      const absolutePath = resolve(repoRoot, relativePath);
+      if (fileStatus.status === 'untracked') {
+        try {
+          if (statSync(absolutePath).isDirectory()) {
+            untrackedDirectories.push(absolutePath);
+            continue;
+          }
+        } catch {
+          // A concurrently deleted path remains a normal status entry.
+        }
+      }
+
+      result[absolutePath] = { ...fileStatus, filePath: absolutePath };
+    }
+
+    let expansionDurationMs = 0;
+    let eventLoopLagMs = 0;
+    if (untrackedDirectories.length > 0) {
+      const lagStartedAt = Date.now();
+      const eventLoopLag = new Promise<number>(resolveLag => {
+        setImmediate(() => resolveLag(Math.min(Date.now() - lagStartedAt, 5000)));
+      });
+      const expansionStartedAt = Date.now();
+      const relativeFiles = await this.expandUntrackedFiles(repoRoot, untrackedDirectories, {
+        signal: inFlight.controller.signal,
+        timeoutMs: 5000,
+        maxBufferBytes: 8 * 1024 * 1024,
+      });
+      expansionDurationMs = Date.now() - expansionStartedAt;
+      eventLoopLagMs = await eventLoopLag;
+      this.throwIfAborted(inFlight.controller.signal);
+
+      for (const relativePath of relativeFiles) {
+        const filePath = resolve(repoRoot, relativePath);
+        result[filePath] = { filePath, status: 'untracked', gitStatusCode: '??' };
+      }
+
+      const callers = inFlight.callers.size === 1
+        ? Array.from(inFlight.callers)[0]
+        : 'mixed';
+      this.analytics.sendEvent('git_status_untracked_expanded', {
+        workspace_hash: createHash('sha256').update(repoRoot).digest('hex').slice(0, 16),
+        caller_class: callers,
+        generation: Math.min(inFlight.generation, 1_000_000),
+        in_flight_count: Math.min(GitStatusService.rootInFlight.size, 100),
+        git_duration_ms: Math.min(gitDurationMs, 60_000),
+        expansion_duration_ms: Math.min(expansionDurationMs, 60_000),
+        untracked_directory_count: Math.min(untrackedDirectories.length, 100_000),
+        untracked_result_count: Math.min(relativeFiles.length, 100_000),
+        event_loop_lag_ms: eventLoopLagMs,
+      });
+    }
+
+    const statuses = this.copyStatuses(result);
+    return {
+      generation: inFlight.generation,
+      timestamp: Date.now(),
+      statuses,
+      uncommittedFiles: Object.keys(statuses),
+    };
+  }
+
+  private throwIfAborted(signal: AbortSignal): void {
+    if (signal.aborted) throw new Error('Git status snapshot invalidated');
+  }
+
+  private copyStatuses(statuses: GitStatusResult): GitStatusResult {
+    return Object.fromEntries(Object.entries(statuses).map(([path, status]) => [path, { ...status }]));
+  }
+
+  /**
    * Get all uncommitted files in the workspace.
    * Returns files that are either:
    * - Untracked (not yet in git)
@@ -369,7 +545,10 @@ export class GitStatusService {
    * @param workspacePath The workspace/repository path
    * @returns Array of file paths (relative to workspace) that have uncommitted changes
    */
-  async getUncommittedFiles(workspacePath: string): Promise<string[]> {
+  async getUncommittedFiles(
+    workspacePath: string,
+    callerClass: GitStatusCallerClass = 'whole_workspace'
+  ): Promise<string[]> {
     if (!workspacePath) {
       return [];
     }
@@ -384,75 +563,9 @@ export class GitStatusService {
       return [];
     }
 
-    // Check cache
-    const cacheKey = `${workspacePath}:uncommitted`;
-    const cached = this.cache.get(cacheKey);
-    if (cached && Date.now() - cached.timestamp < this.CACHE_TTL_MS) {
-      // Cache stores GitStatusResult, but we need string[] for uncommitted files
-      // Convert to array of file paths
-      return Object.keys(cached.status);
-    }
-
     try {
-      // Get git status for the entire repository using porcelain format
-      const statusOutput = this.executeGitStatus(workspacePath);
-
-      // Parse status output
-      const statusMap = this.parseGitStatus(statusOutput);
-
-      // Filter for uncommitted files (untracked or modified, not deleted)
-      // Convert relative paths to absolute paths using path.resolve
-      const uncommittedFiles: string[] = [];
-      const cacheResult: GitStatusResult = {};
-
-      for (const [relativePath, fileStatus] of statusMap.entries()) {
-        // Include if untracked, modified, staged, or deleted (but not unchanged)
-        if (fileStatus.status === 'untracked' ||
-            fileStatus.status === 'modified' ||
-            fileStatus.status === 'staged' ||
-            fileStatus.status === 'deleted') {
-          // Convert to absolute path (git returns paths relative to workspace)
-          const absolutePath = resolve(workspacePath, relativePath);
-
-          // For untracked entries, check if it's a directory
-          // git status --porcelain shows untracked directories with trailing slash (e.g., "?? newdir/")
-          // or they may appear without trailing slash but be a directory
-          if (fileStatus.status === 'untracked') {
-            try {
-              const stats = statSync(absolutePath);
-              if (stats.isDirectory()) {
-                // Expand the untracked directory to individual files, honoring
-                // .gitignore so an installed node_modules/dist doesn't explode
-                // into tens of thousands of paths (NIM-1782).
-                const relFiles = getUntrackedFilesInDirectory(workspacePath, absolutePath);
-                for (const relFile of relFiles) {
-                  const filePath = resolve(workspacePath, relFile);
-                  uncommittedFiles.push(filePath);
-                  cacheResult[filePath] = {
-                    filePath,
-                    status: 'untracked',
-                    gitStatusCode: '??'
-                  };
-                }
-                continue; // Skip adding the directory itself
-              }
-            } catch {
-              // If stat fails (file doesn't exist), just add the path as-is
-            }
-          }
-
-          uncommittedFiles.push(absolutePath);
-
-          // Cache with absolute path as key
-          cacheResult[absolutePath] = {
-            ...fileStatus,
-            filePath: absolutePath
-          };
-        }
-      }
-      this.cache.set(cacheKey, { status: cacheResult, timestamp: Date.now() });
-
-      return uncommittedFiles;
+      const snapshot = await this.getRootStatusSnapshot(workspacePath, callerClass);
+      return [...snapshot.uncommittedFiles];
     } catch (error) {
       logEbadfDiagnostic('GitStatusService', error);
       console.error('[GitStatusService] Error getting uncommitted files:', error);
@@ -679,7 +792,7 @@ export class GitStatusService {
       }
 
       // 2. Get uncommitted files (staged, modified, or untracked)
-      const uncommittedFiles = await this.getUncommittedFiles(workspacePath);
+      const uncommittedFiles = await this.getUncommittedFiles(workspacePath, 'worktree_session');
       for (const absolutePath of uncommittedFiles) {
         filePathSet.add(absolutePath);
 
@@ -727,62 +840,9 @@ export class GitStatusService {
       return {};
     }
 
-    // Check cache (use null byte separator to avoid path collisions with colons on Windows)
-    const cacheKey = `${workspacePath}\0all-statuses`;
-    const cached = this.cache.get(cacheKey);
-    if (cached && Date.now() - cached.timestamp < this.CACHE_TTL_MS) {
-      return cached.status;
-    }
-
     try {
-      // Get git status for the entire repository using porcelain format
-      const statusOutput = this.executeGitStatus(workspacePath);
-
-      // Parse status output
-      const statusMap = this.parseGitStatus(statusOutput);
-
-      // Build result with absolute paths
-      const result: GitStatusResult = {};
-      for (const [relativePath, fileStatus] of statusMap.entries()) {
-        // Only include changed files (not unchanged)
-        if (fileStatus.status !== 'unchanged') {
-          const absolutePath = resolve(workspacePath, relativePath);
-
-          // For untracked entries, check if it's a directory and expand it
-          if (fileStatus.status === 'untracked') {
-            try {
-              const stats = statSync(absolutePath);
-              if (stats.isDirectory()) {
-                // Expand the untracked directory to individual files, honoring
-                // .gitignore so an installed node_modules/dist doesn't explode
-                // into tens of thousands of paths (NIM-1782).
-                const relFiles = getUntrackedFilesInDirectory(workspacePath, absolutePath);
-                for (const relFile of relFiles) {
-                  const filePath = resolve(workspacePath, relFile);
-                  result[filePath] = {
-                    filePath,
-                    status: 'untracked',
-                    gitStatusCode: '??'
-                  };
-                }
-                continue; // Skip adding the directory itself
-              }
-            } catch {
-              // If stat fails (file doesn't exist), just add the path as-is
-            }
-          }
-
-          result[absolutePath] = {
-            ...fileStatus,
-            filePath: absolutePath
-          };
-        }
-      }
-
-      // Cache the result
-      this.cache.set(cacheKey, { status: result, timestamp: Date.now() });
-
-      return result;
+      const snapshot = await this.getRootStatusSnapshot(workspacePath, 'whole_workspace');
+      return this.copyStatuses(snapshot.statuses);
     } catch (error) {
       logEbadfDiagnostic('GitStatusService', error);
       console.error('[GitStatusService] Error getting all file statuses:', error);
@@ -871,6 +931,16 @@ export class GitStatusService {
    */
   clearCache(workspacePath?: string): void {
     if (workspacePath) {
+      const repoRoot = resolve(workspacePath);
+      GitStatusService.rootGenerations.set(
+        repoRoot,
+        (GitStatusService.rootGenerations.get(repoRoot) ?? 0) + 1
+      );
+      GitStatusService.rootSnapshots.delete(repoRoot);
+      const active = GitStatusService.rootInFlight.get(repoRoot);
+      active?.controller.abort();
+      GitStatusService.rootInFlight.delete(repoRoot);
+
       // Clear cache entries for this workspace.
       //
       // Two key shapes coexist:
@@ -893,6 +963,12 @@ export class GitStatusService {
     } else {
       // Clear entire cache
       this.cache.clear();
+      for (const active of GitStatusService.rootInFlight.values()) {
+        active.controller.abort();
+      }
+      GitStatusService.rootInFlight.clear();
+      GitStatusService.rootSnapshots.clear();
+      GitStatusService.rootGenerations.clear();
     }
   }
 

--- a/packages/electron/src/main/services/__tests__/GitStatusService.untrackedExpansion.test.ts
+++ b/packages/electron/src/main/services/__tests__/GitStatusService.untrackedExpansion.test.ts
@@ -1,30 +1,39 @@
 /**
- * Regression test for NIM-1782: "Commit with AI" on a worktree enumerated
- * gitignored files (node_modules) and blew the commit prompt up to 90k files.
- *
- * `git status --porcelain` collapses an untracked directory into a single
- * `?? dir/` entry. `GitStatusService` re-expands those directories so the
- * edited-files UI can list individual files -- but the expansion must respect
- * `.gitignore`, or an untracked dir that contains an installed `node_modules`
- * explodes into tens of thousands of ignored paths.
- *
- * Builds a REAL git repo on disk (the code shells out to `git`), drops an
- * untracked directory containing both a tracked-eligible file and a gitignored
- * `node_modules`, and asserts the expansion returns only git-visible files.
+ * Regression coverage for NIM-479's batched untracked expansion. The fixture
+ * intentionally uses real Git: only Git can authoritatively apply ignore and
+ * nested-repository semantics.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execFileSync } from 'child_process';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { GitStatusService } from '../GitStatusService';
+import { getUntrackedFilesInDirectories } from '../../utils/gitUtils';
 import { assertGitSandbox, gitSandboxEnv } from '../testSupport/gitTestSandbox';
+
+vi.mock('../analytics/AnalyticsService', () => ({
+  AnalyticsService: { getInstance: () => ({ sendEvent: vi.fn() }) },
+}));
 
 let repo: string;
 
 function git(args: string[], cwd: string): void {
   execFileSync('git', args, { cwd, stdio: 'pipe', env: gitSandboxEnv() });
+}
+
+function createService(expandUntrackedFiles = getUntrackedFilesInDirectories): GitStatusService {
+  return new GitStatusService({
+    expandUntrackedFiles,
+    analytics: { sendEvent: vi.fn() },
+  });
+}
+
+function relativePaths(statuses: Record<string, unknown>): string[] {
+  return Object.keys(statuses)
+    .map(filePath => path.relative(repo, filePath).split(path.sep).join('/'))
+    .sort();
 }
 
 beforeEach(async () => {
@@ -33,52 +42,112 @@ beforeEach(async () => {
   git(['config', 'user.email', 'test@example.com'], repo);
   git(['config', 'user.name', 'Test'], repo);
   git(['config', 'commit.gpgsign', 'false'], repo);
-  // A hook-inherited GIT_DIR would otherwise redirect the commit below onto the
-  // developer's live branch. See testSupport/gitTestSandbox.ts.
   assertGitSandbox(repo);
 
-  // Ignore node_modules, like every real repo.
   await fs.writeFile(path.join(repo, '.gitignore'), 'node_modules/\ndist/\n');
   git(['add', '.gitignore'], repo);
   git(['commit', '-m', 'init'], repo);
 
-  // A brand-new untracked directory. `git status --porcelain` reports this as a
-  // SINGLE entry: `?? newpkg/`.
-  const pkg = path.join(repo, 'newpkg');
-  await fs.mkdir(path.join(pkg, 'src'), { recursive: true });
-  await fs.writeFile(path.join(pkg, 'src', 'index.ts'), 'export const a = 1;\n');
-  await fs.writeFile(path.join(pkg, 'package.json'), '{"name":"newpkg"}\n');
+  // One hundred collapsed `?? dir/` entries exercise the single batched
+  // pathspec call. Each directory has one visible source file.
+  await Promise.all(Array.from({ length: 100 }, async (_, index) => {
+    const directory = path.join(repo, `newpkg-${String(index).padStart(3, '0')}`);
+    await fs.mkdir(path.join(directory, 'src'), { recursive: true });
+    await fs.writeFile(path.join(directory, 'src', 'index.ts'), `export const value = ${index};\n`);
+  }));
 
-  // An installed node_modules inside that untracked dir -- gitignored, and the
-  // source of the 90k-file blowup when expanded with a gitignore-blind walk.
-  const dep = path.join(pkg, 'node_modules', 'left-pad');
-  await fs.mkdir(dep, { recursive: true });
-  await fs.writeFile(path.join(dep, 'index.js'), 'module.exports = () => {};\n');
-  await fs.writeFile(path.join(dep, 'package.json'), '{"name":"left-pad"}\n');
+  // NUL-separated output keeps whitespace-containing filenames intact.
+  await fs.mkdir(path.join(repo, 'newpkg-000', 'src'), { recursive: true });
+  await fs.writeFile(path.join(repo, 'newpkg-000', 'src', 'with spaces.ts'), 'export {};\n');
+
+  const ignored = path.join(repo, 'newpkg-000', 'node_modules', 'left-pad');
+  await fs.mkdir(ignored, { recursive: true });
+  await fs.writeFile(path.join(ignored, 'index.js'), 'module.exports = () => {};\n');
+  await fs.mkdir(path.join(repo, 'newpkg-001', 'dist'), { recursive: true });
+  await fs.writeFile(path.join(repo, 'newpkg-001', 'dist', 'bundle.js'), 'ignored\n');
+
+  // A nested repository must retain Git's boundary semantics. Its untracked
+  // file belongs to the nested repository, not the outer expansion.
+  const nested = path.join(repo, 'nested-repo');
+  await fs.mkdir(nested);
+  git(['init'], nested);
+  git(['config', 'user.email', 'test@example.com'], nested);
+  git(['config', 'user.name', 'Test'], nested);
+  await fs.writeFile(path.join(nested, 'tracked.ts'), 'export const tracked = true;\n');
+  git(['add', 'tracked.ts'], nested);
+  git(['commit', '-m', 'nested init'], nested);
+  await fs.writeFile(path.join(nested, 'nested-change.ts'), 'export const nested = true;\n');
 });
 
 afterEach(async () => {
   await fs.rm(repo, { recursive: true, force: true });
 });
 
-describe('GitStatusService untracked-directory expansion (NIM-1782)', () => {
-  it('expands untracked dirs to git-visible files only, excluding gitignored node_modules', async () => {
-    const service = new GitStatusService();
-    const statuses = await service.getAllFileStatuses(repo);
+describe('GitStatusService untracked-directory expansion (NIM-479)', () => {
+  it('uses one async batched Git expansion while concurrent callers share it without blocking the event loop', async () => {
+    const expansion = vi.fn(async (...args: Parameters<typeof getUntrackedFilesInDirectories>) => {
+      // Keep the expansion pending long enough for the sentinel to prove that
+      // the main thread is free to service timer callbacks.
+      await new Promise(resolve => setTimeout(resolve, 75));
+      return getUntrackedFilesInDirectories(...args);
+    });
+    const service = createService(expansion);
+    let ticks = 0;
+    const sentinel = setInterval(() => { ticks += 1; }, 5);
 
-    const rel = Object.keys(statuses)
-      .map((p) => path.relative(repo, p).split(path.sep).join('/'))
-      .sort();
+    try {
+      const [statuses, uncommittedFiles] = await Promise.all([
+        service.getAllFileStatuses(repo),
+        service.getUncommittedFiles(repo, 'worktree_session'),
+      ]);
+      const rel = relativePaths(statuses);
 
-    // The git-visible untracked files inside the directory ARE included.
-    expect(rel).toContain('newpkg/src/index.ts');
-    expect(rel).toContain('newpkg/package.json');
+      expect(expansion).toHaveBeenCalledTimes(1);
+      expect(ticks).toBeGreaterThan(3);
+      expect(uncommittedFiles).toHaveLength(Object.keys(statuses).length);
+      expect(rel).toContain('newpkg-000/src/index.ts');
+      expect(rel).toContain('newpkg-000/src/with spaces.ts');
+      expect(rel).toContain('newpkg-099/src/index.ts');
+      expect(rel).not.toContain('newpkg-000/node_modules/left-pad/index.js');
+      expect(rel).not.toContain('newpkg-001/dist/bundle.js');
+      expect(rel).not.toContain('nested-repo/nested-change.ts');
 
-    // Gitignored files inside the untracked directory are NOT included.
-    const ignored = rel.filter((p) => p.includes('node_modules') || p.includes('/dist/'));
-    expect(ignored).toEqual([]);
+      const nested = await service.getFileStatus(repo, [path.join('nested-repo', 'nested-change.ts')]);
+      expect(nested[path.join('nested-repo', 'nested-change.ts')]).toMatchObject({ status: 'untracked' });
+    } finally {
+      clearInterval(sentinel);
+    }
+  });
 
-    // Sanity: the whole set is small (the real bug produced ~90k entries).
-    expect(rel.length).toBeLessThan(20);
+  it('invalidates an active generation without publishing it and permits one shared successor', async () => {
+    let releaseFirstExpansion!: () => void;
+    let firstExpansionStarted!: () => void;
+    const firstRelease = new Promise<void>(resolve => { releaseFirstExpansion = resolve; });
+    const firstStarted = new Promise<void>(resolve => { firstExpansionStarted = resolve; });
+    let calls = 0;
+    const expansion = vi.fn(async (...args: Parameters<typeof getUntrackedFilesInDirectories>) => {
+      calls += 1;
+      if (calls === 1) {
+        firstExpansionStarted();
+        await firstRelease;
+      }
+      return getUntrackedFilesInDirectories(...args);
+    });
+    const service = createService(expansion);
+
+    const staleRequest = service.getAllFileStatuses(repo);
+    await firstStarted;
+    service.clearCache(repo);
+    const successorRequest = service.getUncommittedFiles(repo, 'worktree_session');
+    releaseFirstExpansion();
+
+    const [stale, successor] = await Promise.all([staleRequest, successorRequest]);
+    expect(stale).toEqual({});
+    expect(successor).toContain(path.join(repo, 'newpkg-099', 'src', 'index.ts'));
+    expect(calls).toBe(2);
+
+    const cachedSuccessor = await service.getAllFileStatuses(repo);
+    expect(relativePaths(cachedSuccessor)).toContain('newpkg-000/src/index.ts');
+    expect(calls).toBe(2);
   });
 });

--- a/packages/electron/src/main/utils/gitUtils.ts
+++ b/packages/electron/src/main/utils/gitUtils.ts
@@ -111,6 +111,53 @@ export function getUntrackedFilesInDirectory(repoRoot: string, dirAbsolutePath: 
   }
 }
 
+export interface UntrackedExpansionOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maxBufferBytes?: number;
+}
+
+/**
+ * Asynchronously list untracked, non-ignored files across several untracked
+ * directories with one Git invocation. `-z` is deliberately retained end to
+ * end: filenames may contain newlines, spaces, or other line separators.
+ *
+ * Git, rather than a filesystem walk, remains the authority for both ignore
+ * rules and nested-repository boundaries.
+ */
+export async function getUntrackedFilesInDirectories(
+  repoRoot: string,
+  dirAbsolutePaths: string[],
+  options: UntrackedExpansionOptions = {}
+): Promise<string[]> {
+  if (dirAbsolutePaths.length === 0) return [];
+
+  const pathspecs = [...new Set(dirAbsolutePaths.map(dir => {
+    const relDir = relative(repoRoot, dir);
+    return relDir === '' ? '.' : relDir;
+  }))];
+
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['ls-files', '--others', '--exclude-standard', '-z', '--', ...pathspecs],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        timeout: options.timeoutMs ?? 5000,
+        maxBuffer: options.maxBufferBytes ?? 8 * 1024 * 1024,
+        signal: options.signal,
+      }
+    );
+    return stdout.split('\0').filter(Boolean);
+  } catch (error) {
+    // An invalidation must reach the owner so it can reject this generation
+    // instead of publishing a partial, now-stale expansion.
+    if (options.signal?.aborted) throw error;
+    return [];
+  }
+}
+
 /**
  * Returns the number of open file descriptors in the current process,
  * or null if unavailable (Windows or read error).


### PR DESCRIPTION
## Summary
- replace per-directory synchronous untracked expansion with one bounded async Git call per root/generation
- share cancellation-safe expansion snapshots across workspace and worktree/session callers
- add real-Git coverage for 100 directories, ignores, nested repositories, event-loop responsiveness, and invalidation

## Tests
- npx vitest run packages/electron/src/main/services/__tests__/GitStatusService.untrackedExpansion.test.ts
- npm run typecheck --workspace=@nimbalyst/electron

Full workspace typecheck and pre-push suite were attempted but have unrelated existing failures in other workspaces/tests.