### PR TITLE
fix(tracker): refresh full-document items after an external file edit

### DIFF
--- a/packages/electron/src/main/file/WorkspaceWatcher.ts
+++ b/packages/electron/src/main/file/WorkspaceWatcher.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow } from 'electron';
 import { safeHandle } from '../utils/ipcRegistry';
 import { logger } from '../utils/logger';
-import { getWindowId, windowStates } from '../window/WindowManager';
+import { documentServices, getWindowId, windowStates } from '../window/WindowManager';
 import { clearGitStatusCache } from '../ipc/GitStatusHandlers';
 import { optimizedWorkspaceWatcher } from './OptimizedWorkspaceWatcher';
 import { gitRefWatcher } from './GitRefWatcher';
@@ -111,6 +111,11 @@ export function startWorkspaceWatcher(window: BrowserWindow, workspacePath: stri
     startProjectFileSync(workspacePath).catch((error) => {
         logger.workspaceWatcher.error('Failed to start ProjectFileSync:', error);
     });
+
+    // Keep the document metadata cache warm on external .md edits (non-blocking)
+    startTrackerMetadataWatch(workspacePath).catch((error) => {
+        logger.workspaceWatcher.error('Failed to start tracker metadata watch:', error);
+    });
 }
 
 // Stop watching a workspace
@@ -135,6 +140,7 @@ export function stopWorkspaceWatcher(windowId: number) {
             }
             if (!otherWindowUsesWorkspace) {
                 stopProjectFileSync(path);
+                stopTrackerMetadataWatch(path);
             }
         }
     }
@@ -175,6 +181,10 @@ export async function stopAllWorkspaceWatchers() {
         stopProjectFileSync(workspacePath);
     }
 
+    for (const workspacePath of [...trackerMetadataWatches.keys()]) {
+        stopTrackerMetadataWatch(workspacePath);
+    }
+
     try {
         await Promise.all([
             optimizedWorkspaceWatcher.stopAll(),
@@ -186,6 +196,124 @@ export async function stopAllWorkspaceWatchers() {
         console.error('[WorkspaceWatcher] Error in stopAll:', error);
         throw error;
     }
+}
+
+// ============================================================================
+// Tracker Metadata Refresh
+// ============================================================================
+
+/**
+ * A workspace-wide watcher already existed on the bus, but none of its
+ * subscribers told ElectronDocumentService anything: the file tree consumed
+ * `file-changed-on-disk` for open editors only, and `refreshFileMetadata` was
+ * reachable only from the in-app save path. That left the tracker metadata
+ * cache -- what the Tracker view renders from -- refreshed once per renderer
+ * lifetime, so an external edit stayed invisible until the app restarted.
+ *
+ * `refreshFileMetadata` already fires the metadata + tracker-item watcher
+ * events the Tracker view subscribes to, so feeding it here updates the view
+ * live with no renderer changes.
+ *
+ * Note this covers files the bus reports on. Gitignored tracker files get no
+ * `change` events, so reads stay honest via the document service's own
+ * mtime revalidation rather than this watcher.
+ */
+
+/** Coalesces an editor's write-truncate-write burst without feeling laggy. */
+const TRACKER_METADATA_DEBOUNCE_MS = 300;
+
+/**
+ * Past this many distinct paths in one window, do a single workspace refresh
+ * instead of N bounded reads -- a git checkout or bulk agent rewrite otherwise
+ * turns into a per-file storm.
+ */
+const TRACKER_METADATA_BULK_THRESHOLD = 25;
+
+const TRACKER_METADATA_SUBSCRIBER_ID = 'tracker-metadata';
+
+interface TrackerMetadataWatch {
+  pendingPaths: Set<string>;
+  timer: NodeJS.Timeout | null;
+  needsFullRefresh: boolean;
+}
+
+const trackerMetadataWatches = new Map<string, TrackerMetadataWatch>();
+
+export async function startTrackerMetadataWatch(workspacePath: string): Promise<void> {
+  if (trackerMetadataWatches.has(workspacePath)) return;
+
+  const watch: TrackerMetadataWatch = {
+    pendingPaths: new Set(),
+    timer: null,
+    needsFullRefresh: false,
+  };
+  trackerMetadataWatches.set(workspacePath, watch);
+
+  const queue = (filePath: string, fullRefresh: boolean): void => {
+    if (!filePath.endsWith('.md')) return;
+
+    if (fullRefresh) {
+      watch.needsFullRefresh = true;
+    } else {
+      watch.pendingPaths.add(filePath);
+    }
+
+    if (watch.timer) return;
+    watch.timer = setTimeout(() => {
+      void flushTrackerMetadata(workspacePath);
+    }, TRACKER_METADATA_DEBOUNCE_MS);
+  };
+
+  try {
+    await workspaceEventBus.subscribe(workspacePath, TRACKER_METADATA_SUBSCRIBER_ID, {
+      onChange: (filePath) => queue(filePath, false),
+      onAdd: (filePath) => queue(filePath, false),
+      // There is no per-file removal API on the document service; a workspace
+      // refresh diffs mtimes and emits the `removed` metadata events the Tracker
+      // view already listens for.
+      onUnlink: (filePath) => queue(filePath, true),
+    });
+  } catch (error) {
+    // Drop the entry so a later start can retry rather than early-returning on
+    // a registration that never happened.
+    trackerMetadataWatches.delete(workspacePath);
+    throw error;
+  }
+}
+
+async function flushTrackerMetadata(workspacePath: string): Promise<void> {
+  const watch = trackerMetadataWatches.get(workspacePath);
+  if (!watch) return;
+
+  watch.timer = null;
+  const paths = [...watch.pendingPaths];
+  const fullRefresh = watch.needsFullRefresh || paths.length > TRACKER_METADATA_BULK_THRESHOLD;
+  watch.pendingPaths.clear();
+  watch.needsFullRefresh = false;
+
+  const documentService = documentServices.get(workspacePath);
+  if (!documentService) return;
+
+  try {
+    if (fullRefresh) {
+      await documentService.refreshWorkspaceData();
+      return;
+    }
+    // Bounded 4KB read behind a hash guard, so the echo of an in-app save that
+    // already updated the cache costs a stat and nothing else.
+    await Promise.all(paths.map((filePath) => documentService.refreshFileMetadata(filePath)));
+  } catch (error) {
+    logger.workspaceWatcher.error('Failed to refresh tracker metadata:', error);
+  }
+}
+
+export function stopTrackerMetadataWatch(workspacePath: string): void {
+  const watch = trackerMetadataWatches.get(workspacePath);
+  if (!watch) return;
+
+  if (watch.timer) clearTimeout(watch.timer);
+  trackerMetadataWatches.delete(workspacePath);
+  workspaceEventBus.unsubscribe(workspacePath, TRACKER_METADATA_SUBSCRIBER_ID);
 }
 
 // ============================================================================

--- a/packages/electron/src/main/file/__tests__/WorkspaceWatcher.trackerMetadata.test.ts
+++ b/packages/electron/src/main/file/__tests__/WorkspaceWatcher.trackerMetadata.test.ts
@@ -1,0 +1,237 @@
+/**
+ * The workspace watcher must keep ElectronDocumentService's metadata cache warm.
+ *
+ * A WorkspaceEventBus watcher already existed, but no subscriber told the
+ * document service anything, so an external edit to a tracker-backed .md left
+ * the open Tracker view showing pre-edit frontmatter until the app restarted.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'path';
+
+const mocks = vi.hoisted(() => ({
+  subscribe: vi.fn(async () => {}),
+  unsubscribe: vi.fn(),
+  refreshFileMetadata: vi.fn(async () => {}),
+  refreshWorkspaceData: vi.fn(async () => {}),
+  documentServices: new Map<string, any>(),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+vi.mock('../WorkspaceEventBus', () => ({
+  subscribe: mocks.subscribe,
+  unsubscribe: mocks.unsubscribe,
+  setGitignoreChangeHandler: vi.fn(),
+  stopAll: vi.fn(async () => {}),
+  getStats: vi.fn(() => ({})),
+}));
+
+vi.mock('../../window/WindowManager', () => ({
+  getWindowId: vi.fn(() => 1),
+  windowStates: new Map(),
+  documentServices: mocks.documentServices,
+}));
+
+vi.mock('../OptimizedWorkspaceWatcher', () => ({
+  optimizedWorkspaceWatcher: {
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopAll: vi.fn(async () => {}),
+    addWatchedFolder: vi.fn(),
+    removeWatchedFolder: vi.fn(),
+    getStats: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock('../GitRefWatcher', () => ({
+  gitRefWatcher: { start: vi.fn(async () => {}), stopAll: vi.fn(async () => {}) },
+}));
+
+vi.mock('../../ipc/GitStatusHandlers', () => ({ clearGitStatusCache: vi.fn() }));
+
+vi.mock('../../services/analytics/AnalyticsService', () => ({
+  AnalyticsService: { getInstance: () => ({ sendEvent: vi.fn() }) },
+}));
+
+vi.mock('../../services/ProjectFileSyncService', () => ({
+  getProjectFileSyncService: () => ({
+    isRecentlyWrittenFromRemote: () => false,
+    handleFileSaved: vi.fn(async () => {}),
+    handleFileDeletedByPath: vi.fn(),
+    syncProject: vi.fn(async () => {}),
+    disconnectProject: vi.fn(),
+    getProjectStats: () => ({ connected: false, fileCount: 0 }),
+    pushLocalFileNow: vi.fn(async () => {}),
+  }),
+}));
+
+// Project file sync is gated off so its own bus subscription doesn't appear
+// alongside the one under test.
+vi.mock('../../services/SyncManager', () => ({ isSyncEnabled: () => false }));
+
+vi.mock('../../utils/store', () => ({
+  getReleaseChannel: () => 'stable',
+  getSessionSyncConfig: () => ({ docSyncEnabledProjects: [] }),
+}));
+
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn(), safeOn: vi.fn() }));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    workspaceWatcher: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    main: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  },
+}));
+
+import {
+  startTrackerMetadataWatch,
+  stopTrackerMetadataWatch,
+  startWorkspaceWatcher,
+} from '../WorkspaceWatcher';
+
+const WORKSPACE = path.join(path.sep, 'tmp', 'workspace');
+
+/**
+ * Grab the listener the most recent tracker-metadata subscription registered.
+ * Most recent, not first: a subscription that failed still recorded a call on
+ * the mock, but its listener was never registered on the real bus.
+ */
+function trackerListener() {
+  const call = [...mocks.subscribe.mock.calls]
+    .reverse()
+    .find((c: any[]) => typeof c[1] === 'string' && c[1].startsWith('tracker-metadata'));
+  if (!call) throw new Error('tracker-metadata subscription was never registered');
+  return (call as any[])[2];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  mocks.documentServices.clear();
+  mocks.documentServices.set(WORKSPACE, {
+    refreshFileMetadata: mocks.refreshFileMetadata,
+    refreshWorkspaceData: mocks.refreshWorkspaceData,
+  });
+});
+
+afterEach(() => {
+  stopTrackerMetadataWatch(WORKSPACE);
+  vi.useRealTimers();
+});
+
+describe('workspace watcher -> document metadata', () => {
+  it('is wired into startWorkspaceWatcher', async () => {
+    startWorkspaceWatcher({ id: 1 } as any, WORKSPACE);
+    await vi.runAllTimersAsync();
+
+    const ids = mocks.subscribe.mock.calls.map((c: any[]) => c[1]);
+    expect(ids.some((id: string) => id.startsWith('tracker-metadata'))).toBe(true);
+  });
+
+  it('refreshes metadata for an externally changed .md file', async () => {
+    await startTrackerMetadataWatch(WORKSPACE);
+    const filePath = path.join(WORKSPACE, 'docs', 'facts', 'thing.md');
+
+    trackerListener().onChange(filePath);
+    // Debounced, so nothing synchronous.
+    expect(mocks.refreshFileMetadata).not.toHaveBeenCalled();
+
+    await vi.runAllTimersAsync();
+
+    expect(mocks.refreshFileMetadata).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshFileMetadata).toHaveBeenCalledWith(filePath);
+  });
+
+  it('adopts a newly added .md file', async () => {
+    await startTrackerMetadataWatch(WORKSPACE);
+    const filePath = path.join(WORKSPACE, 'docs', 'facts', 'new.md');
+
+    trackerListener().onAdd(filePath);
+    await vi.runAllTimersAsync();
+
+    expect(mocks.refreshFileMetadata).toHaveBeenCalledWith(filePath);
+  });
+
+  it('ignores files that cannot carry tracker frontmatter', async () => {
+    await startTrackerMetadataWatch(WORKSPACE);
+
+    trackerListener().onChange(path.join(WORKSPACE, 'src', 'index.ts'));
+    trackerListener().onChange(path.join(WORKSPACE, 'assets', 'logo.png'));
+    await vi.runAllTimersAsync();
+
+    expect(mocks.refreshFileMetadata).not.toHaveBeenCalled();
+    expect(mocks.refreshWorkspaceData).not.toHaveBeenCalled();
+  });
+
+  it('coalesces a burst of edits to one file into a single refresh', async () => {
+    await startTrackerMetadataWatch(WORKSPACE);
+    const filePath = path.join(WORKSPACE, 'docs', 'facts', 'thing.md');
+
+    for (let i = 0; i < 10; i++) trackerListener().onChange(filePath);
+    await vi.runAllTimersAsync();
+
+    expect(mocks.refreshFileMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to one full refresh when a bulk rewrite touches many files', async () => {
+    await startTrackerMetadataWatch(WORKSPACE);
+
+    // e.g. a git checkout / branch switch rewriting a whole docs tree.
+    for (let i = 0; i < 60; i++) {
+      trackerListener().onChange(path.join(WORKSPACE, 'docs', `doc-${i}.md`));
+    }
+    await vi.runAllTimersAsync();
+
+    expect(mocks.refreshWorkspaceData).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshFileMetadata).not.toHaveBeenCalled();
+  });
+
+  it('reconciles a deleted .md through a full refresh', async () => {
+    await startTrackerMetadataWatch(WORKSPACE);
+
+    trackerListener().onUnlink(path.join(WORKSPACE, 'docs', 'facts', 'thing.md'));
+    await vi.runAllTimersAsync();
+
+    // No per-path removal API exists; the scan's mtime diffing emits the
+    // `removed` metadata events the Tracker view already listens for.
+    expect(mocks.refreshWorkspaceData).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when no document service owns the workspace', async () => {
+    mocks.documentServices.clear();
+    await startTrackerMetadataWatch(WORKSPACE);
+
+    trackerListener().onChange(path.join(WORKSPACE, 'docs', 'thing.md'));
+    await expect(vi.runAllTimersAsync()).resolves.toBeDefined();
+
+    expect(mocks.refreshFileMetadata).not.toHaveBeenCalled();
+  });
+
+  it('can retry after a failed subscription', async () => {
+    mocks.subscribe.mockRejectedValueOnce(new Error('bus unavailable'));
+    await expect(startTrackerMetadataWatch(WORKSPACE)).rejects.toThrow('bus unavailable');
+
+    // A poisoned entry would make this a silent no-op and leave the workspace
+    // permanently unwatched.
+    await startTrackerMetadataWatch(WORKSPACE);
+    trackerListener().onChange(path.join(WORKSPACE, 'docs', 'thing.md'));
+    await vi.runAllTimersAsync();
+
+    expect(mocks.refreshFileMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops refreshing after the workspace is torn down', async () => {
+    await startTrackerMetadataWatch(WORKSPACE);
+    const filePath = path.join(WORKSPACE, 'docs', 'thing.md');
+
+    trackerListener().onChange(filePath);
+    stopTrackerMetadataWatch(WORKSPACE);
+    await vi.runAllTimersAsync();
+
+    expect(mocks.unsubscribe).toHaveBeenCalled();
+    expect(mocks.refreshFileMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/packages/electron/src/main/services/ElectronDocumentService.ts
+++ b/packages/electron/src/main/services/ElectronDocumentService.ts
@@ -1169,6 +1169,47 @@ export class ElectronDocumentService implements DocumentService {
     }
   }
 
+  /**
+   * Re-read frontmatter for tracker-backed files whose file mtime no longer
+   * matches the cached state, so a read reflects the file on disk even when no
+   * watcher event arrived for it.
+   *
+   * The workspace watcher (startTrackerMetadataWatch) keeps the cache warm for
+   * ordinary edits, but it cannot be the only guard: gitignored tracker files
+   * get no `change` events from the bus, OS watch events can be dropped, and
+   * the MCP tool path builds a throwaway ElectronDocumentService with no
+   * watcher at all when no window holds the workspace. Without this, an
+   * external edit stayed invisible to `tracker_list` until the next restart.
+   *
+   * Bounded by the number of full-document tracker items, not workspace size,
+   * and each hit is a 4KB bounded read behind refreshFileMetadata's hash guard.
+   * Cold services have an empty cache, so this is a no-op before the first scan
+   * rather than a reason to block on it.
+   */
+  private async revalidateFullDocumentMetadata(): Promise<void> {
+    const trackerPaths: string[] = [];
+    for (const metadata of this.metadataCache.values()) {
+      if (resolveFullDocumentFrontmatter(metadata.frontmatter)) {
+        trackerPaths.push(metadata.path);
+      }
+    }
+
+    await Promise.all(trackerPaths.map(async (relativePath) => {
+      const cachedState = this.fileStateCache.get(relativePath);
+      if (!cachedState) return;
+
+      try {
+        const stats = await fs.stat(path.join(this.workspacePath, relativePath));
+        // mtime only: a scan records `size: 0` for every file, so comparing
+        // size here would force a re-read on every single call.
+        if (stats.mtimeMs === cachedState.mtime) return;
+        await this.refreshFileMetadata(relativePath);
+      } catch {
+        // Unreadable or deleted since the scan; a full refresh reconciles it.
+      }
+    }));
+  }
+
   private async listFullDocumentTrackerItemsFromMetadata(): Promise<TrackerItem[]> {
     this.startScanIfNeeded();
 
@@ -1245,6 +1286,12 @@ export class ElectronDocumentService implements DocumentService {
   }
 
   private async listMergedTrackerItems(): Promise<TrackerItem[]> {
+    // Read path only. The scan path reaches
+    // listFullDocumentTrackerItemsFromMetadata directly, and it has just re-read
+    // every changed file itself -- revalidating there would be redundant work
+    // and would re-enter refreshFileMetadata mid-scan.
+    await this.revalidateFullDocumentMetadata();
+
     const result = await database.query<any>(
       `SELECT * FROM tracker_items WHERE workspace = $1 ORDER BY kanban_sort_order ASC NULLS LAST, last_indexed DESC`,
       [this.workspacePath]

--- a/packages/electron/src/main/services/__tests__/ElectronDocumentService.externalEdit.test.ts
+++ b/packages/electron/src/main/services/__tests__/ElectronDocumentService.externalEdit.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for full-document tracker freshness after an EXTERNAL edit -- the file
+ * on disk is rewritten by another editor or an agent, with no in-app save and
+ * no workspace rescan.
+ *
+ * Two read-path lies are covered:
+ *  1. `listTrackerItems` serves the pre-edit frontmatter out of `metadataCache`,
+ *     which nothing invalidates between the one-shot startup scan and a restart.
+ *  2. When a fresh DB projection row exists (any `tracker_get`/`tracker_update`
+ *     re-reads the file into one), the merge still overrides the core fields
+ *     with the stale cache value while letting the row's `customFields` through
+ *     -- an old status next to post-edit custom fields.
+ *
+ * Mocks: database, TrackerSyncManager, store, tracker registry.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+const {
+  mockQuery,
+  mockGetWorkspaceState,
+  mockGlobalRegistryGet,
+} = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockGetWorkspaceState: vi.fn((..._args: any[]) => ({})),
+  mockGlobalRegistryGet: vi.fn((..._args: any[]) => undefined as any),
+}));
+
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({
+  database: { query: mockQuery },
+}));
+
+vi.mock('../TrackerSyncManager', () => ({
+  syncTrackerItem: vi.fn(),
+  unsyncTrackerItem: vi.fn(),
+  isTrackerSyncActive: vi.fn(() => false),
+}));
+
+vi.mock('../../utils/store', () => ({
+  getWorkspaceState: mockGetWorkspaceState,
+  isAnalyticsEnabled: () => true,
+}));
+
+vi.mock('@nimbalyst/runtime/plugins/TrackerPlugin/models/TrackerDataModel', () => ({
+  globalRegistry: { get: mockGlobalRegistryGet },
+}));
+
+import { ElectronDocumentService } from '../ElectronDocumentService';
+
+const ITEM_PATH = 'docs/facts/thing.md';
+
+/** A custom `fullDocument` tracker type, as `.nimbalyst/trackers/fact.yaml` registers. */
+const FACT_MODEL = { modes: { fullDocument: true, inline: false } };
+
+function factDocument(status: string, source: string): string {
+  return `---
+title: A Fact
+trackerStatus:
+  type: fact
+  status: ${status}
+  source: ${source}
+---
+
+# A Fact
+`;
+}
+
+let tempDir: string;
+let service: ElectronDocumentService;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mockQuery.mockReset();
+  mockQuery.mockResolvedValue({ rows: [] });
+  mockGetWorkspaceState.mockReturnValue({});
+  // Only `fact` is a registered full-document type.
+  mockGlobalRegistryGet.mockImplementation((type: string) =>
+    type === 'fact' ? FACT_MODEL : undefined,
+  );
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'doc-service-external-edit-'));
+  await fs.mkdir(path.join(tempDir, 'docs', 'facts'), { recursive: true });
+});
+
+afterEach(async () => {
+  service?.destroy();
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+/** Rewrite the file on disk, bumping mtime so the change is detectable. */
+async function externallyEdit(status: string, source: string): Promise<void> {
+  const full = path.join(tempDir, ITEM_PATH);
+  await fs.writeFile(full, factDocument(status, source));
+  const future = new Date(Date.now() + 2000);
+  await fs.utimes(full, future, future);
+}
+
+describe('full-document tracker freshness after an external edit', () => {
+  beforeEach(async () => {
+    await fs.writeFile(path.join(tempDir, ITEM_PATH), factDocument('draft', 'pre-edit'));
+    service = new ElectronDocumentService(tempDir);
+    // The one-shot startup scan that seeds metadataCache.
+    await service.refreshWorkspaceData();
+  });
+
+  it('seeds the item from frontmatter on the initial scan', async () => {
+    const items = await service.listTrackerItems();
+
+    expect(items).toHaveLength(1);
+    expect(items[0].type).toBe('fact');
+    expect(items[0].status).toBe('draft');
+    expect(items[0].customFields?.source).toBe('pre-edit');
+  });
+
+  it('reports the on-disk status after an external edit, with no rescan', async () => {
+    await externallyEdit('verified', 'post-edit');
+
+    const items = await service.listTrackerItems();
+
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toBe('verified');
+    expect(items[0].customFields?.source).toBe('post-edit');
+  });
+
+  it('does not serve a stale status next to fresh custom fields', async () => {
+    await externallyEdit('verified', 'post-edit');
+
+    // A `tracker_get`/`tracker_update` touch re-reads the file into a DB
+    // projection row, so the row is fresh while metadataCache is not.
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          id: `fact-${ITEM_PATH.replace(/[/.]/g, '-')}`,
+          type: 'fact',
+          data: JSON.stringify({
+            title: 'A Fact',
+            status: 'verified',
+            customFields: { source: 'post-edit' },
+          }),
+          workspace: tempDir,
+          document_path: ITEM_PATH,
+          line_number: 0,
+          created: new Date().toISOString(),
+          updated: new Date().toISOString(),
+          last_indexed: new Date().toISOString(),
+          sync_status: 'local',
+          archived: false,
+          archived_at: null,
+          source: 'frontmatter',
+          source_ref: ITEM_PATH,
+        },
+      ],
+    });
+
+    const items = await service.listTrackerItems();
+    const item = items.find((i) => i.type === 'fact');
+
+    expect(item).toBeTruthy();
+    // The reported symptom: `source` came back post-edit while `status` did not.
+    expect(item!.customFields?.source).toBe('post-edit');
+    expect(item!.status).toBe('verified');
+  });
+
+  it('adopts a tracker file created after the initial scan', async () => {
+    const newPath = path.join(tempDir, 'docs', 'facts', 'second.md');
+    await fs.writeFile(newPath, factDocument('draft', 'brand-new'));
+
+    await service.refreshFileMetadata(newPath);
+
+    const items = await service.listTrackerItems();
+    expect(items.map((i) => i.module).sort()).toEqual([
+      'docs/facts/second.md',
+      'docs/facts/thing.md',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

A file-backed `fullDocument` tracker item served pre-edit frontmatter after its `.md` was changed outside the app: the open Tracker view never updated (only a restart did), and `tracker_list` reported the old status next to post-rewrite values for the item's other fields.

Both come from the same stale `metadataCache`. A `WorkspaceEventBus` watcher already existed, but none of its subscribers touched `ElectronDocumentService` — the file tree consumed `file-changed-on-disk` for open editors only, and `refreshFileMetadata` was reachable just from the in-app save path and `SessionFileTracker`. That left the cache with one refresh trigger, fired once per renderer lifetime ~3s after load, which is why restarting appeared to fix it.

Two changes:

- **`WorkspaceWatcher` subscribes to the bus** for `.md` add/change/unlink and feeds `refreshFileMetadata`, debounced 300ms per path. That method already fires the metadata and tracker-item watcher events the Tracker view subscribes to, so the view updates live with **no renderer changes**. This follows the `startProjectFileSync` subscription already in the same file. A burst past 25 distinct paths (git checkout, bulk agent rewrite) collapses to one workspace refresh instead of N reads, and unlink routes to a refresh because there is no per-file removal API — the scan's mtime diffing emits the `removed` events the view already handles.
- **The tracker read path revalidates by mtime.** `listMergedTrackerItems` stats each full-document item against the cached file state and re-reads only on a mismatch. The watcher can't be the only guard: gitignored tracker files get no `change` events from the bus, OS watch events can be dropped, and the MCP path builds a throwaway `ElectronDocumentService` with no watcher at all when no window holds the workspace. Cost is bounded by frontmatter-item count, not workspace size, and each hit is a 4KB bounded read behind the existing hash guard.

## Related issue

Fixes #1093

## Testing

- New `WorkspaceWatcher.trackerMetadata.test.ts` (10 tests) and `ElectronDocumentService.externalEdit.test.ts` (4 tests). Verified red first against stock code — the two bug tests failed with exactly the reported symptom, including the mixed case where the `customFields` assertion passed while `status` came back pre-edit — then green with the fix.
- Coverage includes debounce coalescing, non-`.md` rejection, the bulk-rewrite fallback, unlink, a workspace with no document service, teardown, and retry after a failed subscription.
- Monorepo `typecheck` green, and the electron file + document-service suites pass 187/187 on the current base.
- One local caveat, for transparency: a full `test:prepush` run showed 6 failures in `MarkdownRenderer.rtl.test.tsx` and `AgentTranscriptPanel.listenerCleanup.test.tsx` (`Cannot read properties of undefined (reading 'getItem')`, jsdom `localStorage`). They fail identically on stock `main` with this branch's changes stashed — local worktree environment, not this change.

## Notes for reviewers

Two deliberate choices worth a look:

The merge in `listMergedTrackerItems` overrides the DB projection row's core fields with the metadata-cache value, and I left that precedence alone. For a frontmatter-backed item the file *is* the source of truth, so preferring the file-derived value is correct by design — the defect was purely that the cached value was stale, and fixing the staleness makes the override a no-op. Changing the precedence instead would only mask the bug for items that happen to have a fresh projection row, i.e. only after a `tracker_get`/`tracker_update` touch; an item only ever edited on disk has no fresh row to prefer.

The revalidation is deliberately on the read path (`listMergedTrackerItems`) rather than in `listFullDocumentTrackerItemsFromMetadata`, which is shared with the scan. Hooking the shared function is redundant work during a scan that has just re-read every changed file, and it re-enters `refreshFileMetadata` mid-scan — that placement broke the NIM-879 extended-scan recovery test, which is what pointed me at the right seam.

No `CHANGELOG.md` entry is included: `[Unreleased]` conflicts on essentially every rebase, and the entry is a one-liner you may want to word yourself at release time. Happy to add it if you'd prefer — suggested wording: *"Editing a tracker document's file outside Nimbalyst now updates the open Tracker view without a restart, and tracker listings no longer report the old status alongside newly-changed fields."*

Alternative design, if you'd rather not add a watcher subscription: expose the refresh as an explicit lever instead — a `tracker_refresh` MCP tool and `nim tracker refresh` around the existing `document-service:refresh-workspace` handler. It's a few lines in the handler plus a CLI verb and both gateways, and I'm happy to switch or add it. I left it out because it leaves both symptoms in place by default and only gives users a manual recovery step, but it would help for the gitignored-tracker-file case where the bus delivers no `change` events and only the read-path revalidation currently covers it.
