### PR TITLE
fix: prevent quick open shortcut overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Unified Quick Open tabs now keep keyboard shortcuts inside their badges and scroll instead of overlapping at narrow widths. (#1102)
 - Desktop AI notifications now lead with the originating session name and open that exact session and project, including child sessions, instead of following whichever project is currently visible.
 - File reveal menus now name Finder on macOS, Explorer on Windows, and the containing folder on Linux.
 - AI sessions that preview a web page no longer strand a blank, unclosable window on a second monitor.

--- a/packages/electron/e2e/core/unified-quick-open.spec.ts
+++ b/packages/electron/e2e/core/unified-quick-open.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from 'playwright';
+import * as fs from 'fs/promises';
+import {
+  createTempWorkspace,
+  dismissProjectTrustToast,
+  getKeyboardShortcut,
+  launchElectronApp,
+  waitForAppReady,
+} from '../helpers';
+import { PLAYWRIGHT_TEST_SELECTORS } from '../utils/testHelpers';
+
+let electronApp: ElectronApplication;
+let page: Page;
+let workspaceDir: string;
+
+async function overflowingShortcuts(): Promise<string[]> {
+  return page
+    .locator(PLAYWRIGHT_TEST_SELECTORS.unifiedQuickOpenTabShortcut)
+    .evaluateAll((shortcuts, tabSelector) =>
+      shortcuts.flatMap((shortcut) => {
+        const badgeBounds = shortcut.getBoundingClientRect();
+        const tabBounds = shortcut.closest(tabSelector)?.getBoundingClientRect();
+        const textRange = document.createRange();
+        textRange.selectNodeContents(shortcut);
+        const textBounds = textRange.getBoundingClientRect();
+        const overflows =
+          !tabBounds ||
+          textBounds.left < badgeBounds.left ||
+          textBounds.right > badgeBounds.right ||
+          badgeBounds.left < tabBounds.left ||
+          badgeBounds.right > tabBounds.right;
+
+        return overflows ? [shortcut.textContent ?? 'unknown shortcut'] : [];
+      }),
+      PLAYWRIGHT_TEST_SELECTORS.unifiedQuickOpenTab,
+    );
+}
+
+test.beforeAll(async () => {
+  workspaceDir = await createTempWorkspace();
+  electronApp = await launchElectronApp({ workspace: workspaceDir, env: { NODE_ENV: 'test' } });
+  page = await electronApp.firstWindow();
+  await waitForAppReady(page);
+  await dismissProjectTrustToast(page);
+});
+
+test.afterAll(async ({}, testInfo) => {
+  testInfo.setTimeout(30_000);
+  await electronApp?.close();
+  if (workspaceDir) await fs.rm(workspaceDir, { recursive: true, force: true });
+});
+
+test('Unified Quick Open keeps shortcut text inside its tab at wide and narrow widths', async () => {
+  await page.setViewportSize({ width: 2560, height: 1400 });
+  await page.keyboard.press(getKeyboardShortcut('Mod+Shift+P'));
+
+  const tabStrip = page.locator(PLAYWRIGHT_TEST_SELECTORS.unifiedQuickOpenTabs);
+  await expect(tabStrip).toBeVisible();
+  await expect.poll(overflowingShortcuts).toEqual([]);
+
+  await page.setViewportSize({ width: 700, height: 800 });
+  await expect.poll(overflowingShortcuts).toEqual([]);
+
+  const stripWidths = await tabStrip.evaluate((strip) => ({
+    client: strip.clientWidth,
+    scroll: strip.scrollWidth,
+    overflowX: getComputedStyle(strip).overflowX,
+  }));
+  expect(stripWidths.scroll).toBeGreaterThan(stripWidths.client);
+  expect(stripWidths.overflowX).toBe('auto');
+});

--- a/packages/electron/e2e/utils/testHelpers.ts
+++ b/packages/electron/e2e/utils/testHelpers.ts
@@ -60,6 +60,11 @@ export const PLAYWRIGHT_TEST_SELECTORS = {
   apiKeyDialogOverlay: '.api-key-dialog-overlay',
   apiKeyDialogDismissButton: '.api-key-dialog-button.secondary',
 
+  // Unified Quick Open
+  unifiedQuickOpenTabs: '.unified-quick-open-tabs',
+  unifiedQuickOpenTab: '.unified-quick-open-tab',
+  unifiedQuickOpenTabShortcut: '.unified-quick-open-tab-shortcut',
+
   // Discord invitation overlay (appears after N launches, intercepts pointer events)
   discordInvitationOverlay: '.discord-invitation-overlay',
 

--- a/packages/electron/src/renderer/components/UnifiedQuickOpen.tsx
+++ b/packages/electron/src/renderer/components/UnifiedQuickOpen.tsx
@@ -547,10 +547,9 @@ export const UnifiedQuickOpen: React.FC<UnifiedQuickOpenProps> = ({
         className="unified-quick-open-modal fixed top-[15%] left-1/2 -translate-x-1/2 w-[92%] max-w-[820px] max-h-[70vh] flex flex-col overflow-hidden rounded-lg z-[99999] bg-nim border border-nim shadow-[0_20px_60px_rgba(0,0,0,0.3)]"
         data-testid="unified-quick-open"
       >
-        {/* Tab strip — equal-width tabs so the row stays stable when switching
-            (the kbd chip widths varied otherwise). */}
+        {/* Tabs share spare space but keep their contents intact; narrow strips scroll. */}
         <div
-          className="unified-quick-open-tabs flex items-stretch border-b border-nim bg-nim-secondary"
+          className="unified-quick-open-tabs flex items-stretch overflow-x-auto border-b border-nim bg-nim-secondary"
           role="tablist"
         >
           {visibleTabs.map((tab) => {
@@ -561,7 +560,7 @@ export const UnifiedQuickOpen: React.FC<UnifiedQuickOpenProps> = ({
                 role="tab"
                 aria-selected={active}
                 data-tab={tab.id}
-                className={`unified-quick-open-tab flex-1 min-w-0 flex items-center justify-center gap-1.5 px-2 py-1.5 text-[13px] font-medium whitespace-nowrap border-b-2 cursor-pointer transition-colors duration-100 ${
+                className={`unified-quick-open-tab flex-auto min-w-max flex items-center justify-center gap-1.5 px-2 py-1.5 text-[13px] font-medium whitespace-nowrap border-b-2 cursor-pointer transition-colors duration-100 ${
                   active
                     ? 'text-nim border-[var(--nim-primary)] bg-nim'
                     : 'text-nim-muted border-transparent hover:text-nim hover:bg-nim-hover'
@@ -572,7 +571,7 @@ export const UnifiedQuickOpen: React.FC<UnifiedQuickOpenProps> = ({
                 <span>{tab.label}</span>
                 {tab.shortcut && (
                   <kbd
-                    className={`unified-quick-open-tab-shortcut font-mono text-[10px] px-1.5 py-0.5 rounded border min-w-[26px] text-center ${
+                    className={`unified-quick-open-tab-shortcut shrink-0 font-mono text-[10px] px-1.5 py-0.5 rounded border min-w-[26px] text-center ${
                       active
                         ? 'text-[var(--nim-primary)] border-[var(--nim-primary)] bg-transparent'
                         : 'text-nim-faint border-nim bg-nim-secondary'
@@ -587,7 +586,7 @@ export const UnifiedQuickOpen: React.FC<UnifiedQuickOpenProps> = ({
           {FUTURE_TABS.map((tab) => (
             <div
               key={tab.id}
-              className="unified-quick-open-tab future flex-1 min-w-0 flex items-center justify-center gap-1.5 px-2 py-1.5 text-[13px] font-medium whitespace-nowrap border-b-2 border-transparent text-nim-faint italic cursor-not-allowed opacity-60"
+              className="unified-quick-open-tab future flex-auto min-w-max flex items-center justify-center gap-1.5 px-2 py-1.5 text-[13px] font-medium whitespace-nowrap border-b-2 border-transparent text-nim-faint italic cursor-not-allowed opacity-60"
               title="Coming soon"
             >
               <span>{tab.label}</span>

--- a/packages/electron/src/renderer/components/__tests__/UnifiedQuickOpen.test.tsx
+++ b/packages/electron/src/renderer/components/__tests__/UnifiedQuickOpen.test.tsx
@@ -144,6 +144,31 @@ describe('UnifiedQuickOpen — Projects tab', () => {
     expect(await screen.findByText('crystal')).toBeTruthy();
   });
 
+  it('keeps tab shortcuts at intrinsic width with a scroll fallback', async () => {
+    const { UnifiedQuickOpen } = await import('../UnifiedQuickOpen');
+
+    render(
+      <JotaiProvider store={createStore()}>
+        <UnifiedQuickOpen
+          isOpen={true}
+          onClose={vi.fn()}
+          workspacePath="/Users/ghinkle/sources/crystal"
+          initialTab="files"
+          onFileSelect={vi.fn()}
+          onSessionSelect={vi.fn()}
+          onPromptSelect={vi.fn()}
+        />
+      </JotaiProvider>
+    );
+
+    expect(screen.getByRole('tablist').className).toContain('overflow-x-auto');
+    for (const tab of screen.getAllByRole('tab')) {
+      expect(tab.className).toContain('min-w-max');
+      const shortcut = tab.querySelector('kbd');
+      if (shortcut) expect(shortcut.className).toContain('shrink-0');
+    }
+  });
+
   it('does not filter hidden projects while typing in the Files tab', async () => {
     const { UnifiedQuickOpen } = await import('../UnifiedQuickOpen');
     const store = createStore();


### PR DESCRIPTION
  ## Summary

  Prevents keyboard shortcut badges in Unified Quick Open from shrinking beyond their
  contents and overlapping adjacent tabs.

  Tabs now keep their intrinsic minimum width, and the tab strip scrolls horizontally when
  the available width is insufficient.

  ## Related issue

  Fixes #1102

  ## Testing

  Verified with:

  - 16 focused Unified Quick Open unit tests
  - Electron Playwright E2E coverage at 2560px and 700px widths
  - `npm run typecheck:prepush`
  - Production Electron build

  ## Notes for reviewers

  The responsive fallback uses horizontal scrolling so tab labels and shortcuts remain
  visible instead of being hidden.

  Before:
<img width="820" height="387" alt="before" src="https://github.com/user-attachments/assets/aac1b0f6-4fa8-4314-a706-46188cbefe9a"/>



  After:

<img width="820" height="387" alt="after" src="https://github.com/user-attachments/assets/7f90d092-501f-4f3c-8e7c-9fd5a763e584"/>

