### PR TITLE
Route notification clicks to the session's own project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Clicking a session notification now brings up the project that session belongs to, instead of landing on a missing chat in whichever project was on screen.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/services/NotificationService.ts
+++ b/packages/electron/src/main/services/NotificationService.ts
@@ -8,6 +8,7 @@ import { Notification, BrowserWindow, app, ipcMain, shell } from 'electron';
 import { logger } from '../utils/logger';
 import { isOSNotificationsEnabled, isNotifyWhenFocusedEnabled, isSessionBlockedNotificationsEnabled } from '../utils/store';
 import { findWindowByWorkspace } from '../window/WindowManager';
+import { resolveProjectPath } from '../utils/workspaceDetection';
 
 const NOTIFICATION_OUTCOME_TIMEOUT_MS = 2_000;
 
@@ -342,10 +343,16 @@ class NotificationService {
     targetWindow.focus();
     targetWindow.show();
 
-    // If session ID provided, send IPC event to switch to that session
+    // If session ID provided, send IPC event to switch to that session.
+    // The owning project path travels with it: in the multi-project rail one
+    // window hosts several projects, and without it the renderer would select
+    // the session inside whichever project happens to be visible. Worktree
+    // sessions notify from the worktree directory, which is not a rail entry,
+    // so resolve to the parent project the way window lookup already does.
     if (options.sessionId) {
       targetWindow.webContents.send('notification-clicked', {
         sessionId: options.sessionId,
+        workspacePath: resolveProjectPath(options.workspacePath),
       });
     }
   }

--- a/packages/electron/src/renderer/store/__tests__/sessionStateListeners.notificationWorkspace.test.ts
+++ b/packages/electron/src/renderer/store/__tests__/sessionStateListeners.notificationWorkspace.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Regression tests for notification-click routing across projects.
+ *
+ * In the multi-project rail one window hosts several projects, and the click
+ * used to select the notified session inside whichever project was visible —
+ * landing on a session id that does not exist there, and persisting that
+ * selection into the wrong project's workspace state.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { store } from '@nimbalyst/runtime/store';
+import {
+  resetSessionListInit,
+  selectedWorkstreamAtom,
+  sessionListWorkspaceAtom,
+  sessionRegistryAtom,
+} from '../atoms/sessions';
+import {
+  activeWorkspacePathAtom,
+  multiProjectModeAtom,
+  openProjectsAtom,
+} from '../atoms/openProjects';
+import { initWorkstreamState } from '../atoms/workstreamState';
+
+type EventHandler = (...args: any[]) => void;
+
+const VISIBLE_WS = '/ws/visible-project';
+const NOTIFIED_WS = '/ws/notified-project';
+const NOTIFIED_SESSION = 'session-in-notified-project';
+
+let handlers: Map<string, EventHandler>;
+let cleanup: (() => void) | null = null;
+
+function makeApi() {
+  return {
+    on: vi.fn((channel: string, handler: EventHandler) => {
+      handlers.set(channel, handler);
+      return () => handlers.delete(channel);
+    }),
+    invoke: vi.fn(async (channel: string, arg?: unknown) => {
+      if (channel === 'sessions:list') {
+        // Only the notified project has the session; this mirrors the real
+        // registry, which is replaced wholesale on every workspace switch.
+        const sessions = arg === NOTIFIED_WS
+          ? [{
+              id: NOTIFIED_SESSION,
+              title: 'Notified session',
+              createdAt: 1,
+              updatedAt: 1,
+              provider: 'claude-code',
+              sessionType: 'session',
+              parentSessionId: null,
+            }]
+          : [];
+        return { success: true, sessions };
+      }
+      return { success: true };
+    }),
+    send: vi.fn(),
+    sessionState: {
+      subscribe: vi.fn().mockResolvedValue({ success: true }),
+      unsubscribe: vi.fn().mockResolvedValue({ success: true }),
+      getTrackedSessionIds: vi.fn().mockResolvedValue({ success: true, sessionIds: [] }),
+      getRunningSessionIds: vi.fn().mockResolvedValue({ success: true, sessionIds: [] }),
+      onStateChange: vi.fn((handler: EventHandler) => {
+        handlers.set('ai-session-state:event', handler);
+        return () => handlers.delete('ai-session-state:event');
+      }),
+    },
+  };
+}
+
+function clickNotification(data: { sessionId: string; workspacePath?: string }): void {
+  const handler = handlers.get('notification-clicked');
+  expect(handler).toBeTypeOf('function');
+  handler!(data);
+}
+
+beforeEach(async () => {
+  handlers = new Map();
+  resetSessionListInit();
+  store.set(sessionRegistryAtom, new Map());
+  store.set(selectedWorkstreamAtom(VISIBLE_WS), null);
+  store.set(selectedWorkstreamAtom(NOTIFIED_WS), null);
+  store.set(sessionListWorkspaceAtom, VISIBLE_WS);
+  store.set(activeWorkspacePathAtom, VISIBLE_WS);
+  // AgentMode points the workstream module at the mounted project; model that
+  // so the fallback paths do not depend on a previous test having done it.
+  initWorkstreamState(VISIBLE_WS);
+  store.set(multiProjectModeAtom, true);
+  store.set(openProjectsAtom, [
+    { path: VISIBLE_WS, name: 'visible', openedAt: 1 },
+    { path: NOTIFIED_WS, name: 'notified', openedAt: 2 },
+  ]);
+
+  vi.stubGlobal('window', { electronAPI: makeApi() });
+  const mod = await import('../sessionStateListeners');
+  cleanup = mod.initSessionStateListeners();
+});
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = null;
+  resetSessionListInit();
+  vi.unstubAllGlobals();
+});
+
+describe('notification click across projects', () => {
+  it('activates the notified project instead of staying on the visible one', async () => {
+    clickNotification({ sessionId: NOTIFIED_SESSION, workspacePath: NOTIFIED_WS });
+
+    await vi.waitFor(() => {
+      expect(store.get(activeWorkspacePathAtom)).toBe(NOTIFIED_WS);
+    });
+  });
+
+  it('selects the session in the notified project', async () => {
+    clickNotification({ sessionId: NOTIFIED_SESSION, workspacePath: NOTIFIED_WS });
+
+    await vi.waitFor(() => {
+      expect(store.get(selectedWorkstreamAtom(NOTIFIED_WS))).toEqual({
+        type: 'session',
+        id: NOTIFIED_SESSION,
+      });
+    });
+  });
+
+  it('never writes the foreign session id into the visible project', async () => {
+    clickNotification({ sessionId: NOTIFIED_SESSION, workspacePath: NOTIFIED_WS });
+
+    await vi.waitFor(() => {
+      expect(store.get(selectedWorkstreamAtom(NOTIFIED_WS))).not.toBeNull();
+    });
+    expect(store.get(selectedWorkstreamAtom(VISIBLE_WS))).toBeNull();
+  });
+
+  it('does not switch projects when the notification targets the visible one', async () => {
+    store.set(sessionRegistryAtom, new Map([[
+      'local-session',
+      {
+        id: 'local-session',
+        title: 'Local',
+        provider: 'claude-code',
+        sessionType: 'session',
+        workspaceId: VISIBLE_WS,
+        worktreeId: null,
+        parentSessionId: null,
+        childCount: 0,
+        uncommittedCount: 0,
+        createdAt: 1,
+        updatedAt: 1,
+        messageCount: 0,
+        isArchived: false,
+        isPinned: false,
+      },
+    ]]) as never);
+
+    clickNotification({ sessionId: 'local-session', workspacePath: VISIBLE_WS });
+
+    await vi.waitFor(() => {
+      expect(store.get(selectedWorkstreamAtom(VISIBLE_WS))).toEqual({
+        type: 'session',
+        id: 'local-session',
+      });
+    });
+    expect(store.get(activeWorkspacePathAtom)).toBe(VISIBLE_WS);
+  });
+
+  it('falls back to the visible project when the payload carries no path', async () => {
+    clickNotification({ sessionId: 'legacy-session', workspacePath: '' });
+
+    await vi.waitFor(() => {
+      expect(store.get(selectedWorkstreamAtom(VISIBLE_WS))).toEqual({
+        type: 'session',
+        id: 'legacy-session',
+      });
+    });
+    expect(store.get(activeWorkspacePathAtom)).toBe(VISIBLE_WS);
+  });
+
+  it('falls back to the visible project when the target is not open in this window', async () => {
+    store.set(openProjectsAtom, [{ path: VISIBLE_WS, name: 'visible', openedAt: 1 }]);
+
+    clickNotification({ sessionId: NOTIFIED_SESSION, workspacePath: NOTIFIED_WS });
+
+    await vi.waitFor(() => {
+      expect(store.get(selectedWorkstreamAtom(VISIBLE_WS))).not.toBeNull();
+    });
+    expect(store.get(activeWorkspacePathAtom)).toBe(VISIBLE_WS);
+    expect(store.get(selectedWorkstreamAtom(NOTIFIED_WS))).toBeNull();
+  });
+});

--- a/packages/electron/src/renderer/store/sessionStateListeners.ts
+++ b/packages/electron/src/renderer/store/sessionStateListeners.ts
@@ -41,12 +41,18 @@ import {
   sessionDraftInputAtom,
   sessionLastSubmitAtAtom,
   sessionDraftLocalModifiedAtAtom,
+  initSessionList,
   type PendingPrompt,
 } from './atoms/sessions';
-import { workstreamActiveChildAtom, workstreamStateAtom } from './atoms/workstreamState';
-import { setWindowModeAtom } from './atoms/windowMode';
+import {
+  initWorkstreamState,
+  loadWorkstreamStates,
+  workstreamActiveChildAtom,
+  workstreamStateAtom,
+} from './atoms/workstreamState';
+import { initWindowMode, setWindowModeAtom } from './atoms/windowMode';
 import { triggerWorktreeRefreshAtom } from './atoms/gitOperations';
-import { multiProjectModeAtom, openProjectsAtom } from './atoms/openProjects';
+import { activeWorkspacePathAtom, multiProjectModeAtom, openProjectsAtom } from './atoms/openProjects';
 import {
   markSessionStreamingAtom,
   clearSessionStreamingAtom,
@@ -910,15 +916,55 @@ export function initSessionStateListeners(): () => void {
   };
 
   /**
+   * Resolve which project the clicked notification belongs to, bringing it to
+   * the front first when the rail is showing a different one.
+   *
+   * The switch must complete before the caller reads session state: the
+   * registry is replaced wholesale per workspace, so until the new list loads
+   * it still holds the previous project's sessions. `activeWorkspacePathAtom`
+   * is the single funnel for activation — its subscriber notifies the main
+   * process. The mode and workstream modules are re-pointed here rather than
+   * left to AgentMode's mount effect, which only runs on the next render:
+   * without that, the `agent` switch and the workstream state below would be
+   * persisted against the project the user just left.
+   *
+   * Returns the workspace to select in, or null when there is none.
+   */
+  const activateNotificationWorkspace = async (requested?: string): Promise<string | null> => {
+    const visible = store.get(sessionListWorkspaceAtom);
+    // Some `showBlockedNotification` callers pass an empty path; those clicks
+    // keep their previous behaviour of landing in the visible project.
+    if (!requested || requested === visible) return visible;
+
+    const isOpenHere = store.get(openProjectsAtom).some((project) => project.path === requested);
+    if (store.get(multiProjectModeAtom) && isOpenHere) {
+      store.set(activeWorkspacePathAtom, requested);
+      initWorkstreamState(requested);
+      await Promise.all([
+        initWindowMode(requested),
+        loadWorkstreamStates(requested),
+        initSessionList(requested),
+      ]);
+      return requested;
+    }
+
+    // A path this window cannot bring forward — a single-project window, or one
+    // opened directly on a worktree whose parent is not a rail entry. The main
+    // process routed the click here deliberately, so fall back to the visible
+    // project rather than dropping the click.
+    return visible;
+  };
+
+  /**
    * Handle notification click events.
    * Switches to the session that was clicked in the OS notification.
    * If the session is a child of a workstream, selects the parent instead.
    */
-  const handleNotificationClicked = (data: { sessionId: string }) => {
+  const handleNotificationClicked = async (data: { sessionId: string; workspacePath?: string }) => {
     const { sessionId } = data;
     if (!sessionId) return;
 
-    const workspacePath = store.get(sessionListWorkspaceAtom);
+    const workspacePath = await activateNotificationWorkspace(data.workspacePath);
     if (!workspacePath) {
       console.warn('[sessionStateListeners] No workspace path available for notification click');
       return;
@@ -1128,7 +1174,9 @@ export function initSessionStateListeners(): () => void {
     cleanupGitCommitProposalResolved = window.electronAPI.on('ai:gitCommitProposalResolved', handleGitCommitProposalResolved);
     cleanupRequestUserInput = window.electronAPI.on('ai:requestUserInput', handleRequestUserInput);
     cleanupRequestUserInputResolved = window.electronAPI.on('ai:requestUserInputResolved', handleRequestUserInputResolved);
-    cleanupNotificationClicked = window.electronAPI.on('notification-clicked', handleNotificationClicked);
+    cleanupNotificationClicked = window.electronAPI.on('notification-clicked', (data) => {
+      void handleNotificationClicked(data);
+    });
     cleanupSyncReadState = window.electronAPI.on('sessions:sync-read-state', handleSyncReadState);
     cleanupSyncDraftInput = window.electronAPI.on('sessions:sync-draft-input', handleSyncDraftInput);
   }


### PR DESCRIPTION
## Summary

In the multi-project rail one window hosts several projects, and a notification click used to select the notified session inside whichever project was visible — a session id that does not exist there, so the chat came up empty.

`handleNotificationClick` already knows the session's workspace (it routes the window by it), but the `notification-clicked` event carried only `sessionId`. The renderer then fell back to `sessionListWorkspaceAtom`, the visible project.

The fix sends the owning project path with the event and activates that project before selecting:

- The path is resolved through `resolveProjectPath`, the same helper window lookup uses, so worktree sessions — which notify from the worktree directory, not a rail entry — map to their parent project.
- Activation goes through `activeWorkspacePathAtom`, the single funnel whose subscriber notifies the main process, then waits for the window mode, workstream states and session list of the new path before the session type is read. The registry is replaced wholesale per workspace, so reading it earlier would still see the previous project.
- `initWorkstreamState` / `initWindowMode` are re-pointed in the same step rather than left to AgentMode's mount effect, which only runs on the next render. Without that, the `agent` mode switch and the workstream state would be persisted against the project the user just left.

Two knock-on effects go away with it: the foreign selection is no longer persisted into the wrong project's workspace state, and a child session is correctly resolved to its parent workstream instead of being mis-selected as a root session.

Unchanged on purpose: when the target is not a project this window hosts — a single-project window, or one opened directly on a worktree whose parent is not a rail entry — the click still selects in the visible project rather than being dropped. The main process routed it here deliberately. Callers that pass an empty workspace path (some `showBlockedNotification` call sites) take the same path.

## Related issue

Closes #1108

## Testing

New `sessionStateListeners.notificationWorkspace.test.ts`: the rail activates the notified project, the session is selected there, and the foreign id is never written into the visible project's selection — plus the three fallbacks (same-project notification does not switch, empty path, target not open in this window).

- `npm run typecheck` — clean
- `npm run test:prepush` — 906 files / 7071 tests passed, 7 files / 26 tests skipped

## Notes for reviewers

The fallback branch is the judgement call worth a look: dropping the click when the project cannot be brought forward would be stricter, but it would regress windows opened directly on a worktree, which work today.

I have not exercised the flow against a packaged build — the diagnosis and the tests come from the code paths. If you would rather see a manual repro before merging, say so and I will run one.
