### PR TITLE
fix: restore sidebar extension panel visibility after reload

### DIFF
--- a/packages/electron/src/renderer/App.tsx
+++ b/packages/electron/src/renderer/App.tsx
@@ -26,6 +26,7 @@ import { useOnboarding } from './hooks/useOnboarding';
 import { handleWorkspaceFileSelect as handleWorkspaceFileSelectUtil } from './utils/workspaceFileOperations';
 import { createInitialFileContent } from './utils/fileUtils';
 import { resolveHistoryDocumentPath } from './utils/historyDocumentResolver';
+import { loadActiveExtensionPanel, persistActiveExtensionPanel } from './utils/activeExtensionPanelPersistence';
 import { aiToolService } from './services/AIToolService';
 import { editorRegistry } from '@nimbalyst/runtime/ai/EditorRegistry';
 import { WorkspaceWelcome } from './components/WorkspaceWelcome.tsx';
@@ -558,6 +559,9 @@ export default function App() {
 
   // Active extension panel (for sidebar or fullscreen panels from extensions)
   const [activeExtensionPanel, setActiveExtensionPanel] = useState<string | null>(null);
+  // Guards the write-back effect below from firing with the initial `null`
+  // before the hydration effect has had a chance to restore a stored value.
+  const activeExtensionPanelHydratedRef = useRef(false);
 
   // Active extension bottom panel (for bottom-placement panels from extensions)
   const [activeExtensionBottomPanel, setActiveExtensionBottomPanel] = useState<string | null>(null);
@@ -826,6 +830,36 @@ export default function App() {
         console.error('[App] Failed to load workspace state:', error);
       });
   }, [workspacePath, setDiffTreeGroupByDirectory, setAgentFileScopeMode, hydrateFileGutterCollapsed]);
+
+  // Restore the active sidebar extension panel. Gated on `extensionsReady`,
+  // not just `workspacePath`: eager extensions load asynchronously in
+  // parallel at startup, so checking getPanelById before they've registered
+  // would always miss a panel that hadn't loaded yet (e.g. Session Tree) --
+  // restore would silently never fire even though the id was persisted fine.
+  useEffect(() => {
+    activeExtensionPanelHydratedRef.current = false;
+    if (!workspacePath || !window.electronAPI || !extensionsReady) return;
+    let cancelled = false;
+    void loadActiveExtensionPanel(workspacePath, (panelId) => getPanelById(panelId)?.placement === 'sidebar')
+      .then((restored) => {
+        if (!cancelled && restored) {
+          setActiveExtensionPanel(restored);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) activeExtensionPanelHydratedRef.current = true;
+      });
+    return () => { cancelled = true; };
+  }, [workspacePath, extensionsReady]);
+
+  // Write the active sidebar panel back to workspace state so it survives a
+  // reload. Gated on the hydration effect above finishing first -- otherwise
+  // this fires with the initial `null` and overwrites the stored value before
+  // it's ever read.
+  useEffect(() => {
+    if (!workspacePath || !window.electronAPI || !activeExtensionPanelHydratedRef.current) return;
+    void persistActiveExtensionPanel(workspacePath, activeExtensionPanel);
+  }, [activeExtensionPanel, workspacePath]);
 
   // Initialize tracker panel state from workspace state
   useEffect(() => {

--- a/packages/electron/src/renderer/utils/__tests__/activeExtensionPanelPersistence.test.ts
+++ b/packages/electron/src/renderer/utils/__tests__/activeExtensionPanelPersistence.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression test for "the session tree panel's visibility isn't restored
+ * after a window reload."
+ *
+ * `activeExtensionPanel` in App.tsx used to be a plain useState with no
+ * round-trip through workspace state -- unlike `extensionPanelWidth`, which
+ * already persists. So a sidebar extension panel open at reload time was
+ * always lost. These helpers are the round-trip; `resolveActiveExtensionPanel`
+ * is the pure restore-decision used by the hydration effect.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  loadActiveExtensionPanel,
+  persistActiveExtensionPanel,
+  resolveActiveExtensionPanel,
+} from '../activeExtensionPanelPersistence';
+
+interface MockState {
+  activeExtensionPanel?: string | null;
+}
+
+function installMockElectronAPI(initialState: MockState = {}) {
+  let state: MockState = { ...initialState };
+  const invoke = vi.fn(async (channel: string, _workspacePath: string, patch?: MockState) => {
+    if (channel === 'workspace:get-state') return state;
+    if (channel === 'workspace:update-state' && patch) {
+      state = { ...state, ...patch };
+      return undefined;
+    }
+    throw new Error(`unexpected channel ${channel}`);
+  });
+  (globalThis as any).window = { electronAPI: { invoke } };
+  return {
+    invoke,
+    getState: () => state,
+  };
+}
+
+describe('activeExtensionPanelPersistence', () => {
+  beforeEach(() => {
+    delete (globalThis as any).window;
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as any).window;
+  });
+
+  it('round-trips a sidebar panel id across a save/load cycle', async () => {
+    installMockElectronAPI();
+    const isSidebarPanel = () => true;
+
+    await persistActiveExtensionPanel('/ws', 'com.nimbalyst.session-tree.tree');
+    const loaded = await loadActiveExtensionPanel('/ws', isSidebarPanel);
+
+    expect(loaded).toBe('com.nimbalyst.session-tree.tree');
+  });
+
+  it('round-trips closing the panel back to null', async () => {
+    const harness = installMockElectronAPI({ activeExtensionPanel: 'com.nimbalyst.session-tree.tree' });
+
+    await persistActiveExtensionPanel('/ws', null);
+
+    expect(harness.getState().activeExtensionPanel).toBeNull();
+    expect(await loadActiveExtensionPanel('/ws', () => true)).toBeNull();
+  });
+
+  it('does not restore a panel whose id no longer resolves to a sidebar placement', () => {
+    // Covers an extension that was disabled/removed, or a panel that changed
+    // placement to fullscreen/bottom since it was last persisted.
+    const restored = resolveActiveExtensionPanel(
+      { activeExtensionPanel: 'com.nimbalyst.removed-extension.panel' },
+      () => false,
+    );
+    expect(restored).toBeNull();
+  });
+
+  it('returns null when nothing was ever persisted', () => {
+    expect(resolveActiveExtensionPanel(undefined, () => true)).toBeNull();
+    expect(resolveActiveExtensionPanel({}, () => true)).toBeNull();
+  });
+
+  it('ignores a malformed stored value instead of restoring garbage', () => {
+    expect(resolveActiveExtensionPanel(
+      { activeExtensionPanel: 42 as any },
+      () => true,
+    )).toBeNull();
+  });
+});

--- a/packages/electron/src/renderer/utils/activeExtensionPanelPersistence.ts
+++ b/packages/electron/src/renderer/utils/activeExtensionPanelPersistence.ts
@@ -1,0 +1,55 @@
+/**
+ * Persistence for which sidebar extension panel (if any) is open, so it
+ * survives a full window reload. Fullscreen and bottom-placement panels are
+ * intentionally not restored -- only a `sidebar` panel is safe to reopen
+ * automatically, since fullscreen panels replace the whole content area.
+ */
+interface WorkspaceState {
+  activeExtensionPanel?: unknown;
+  [key: string]: unknown;
+}
+
+/** Save the active sidebar extension panel id (or its absence) to workspace state. */
+export async function persistActiveExtensionPanel(
+  workspacePath: string,
+  panelId: string | null,
+): Promise<void> {
+  try {
+    await window.electronAPI?.invoke?.('workspace:update-state', workspacePath, {
+      activeExtensionPanel: panelId,
+    });
+  } catch (err) {
+    console.warn('[activeExtensionPanelPersistence] Failed to persist active extension panel:', err);
+  }
+}
+
+/**
+ * Load the persisted panel id. `isSidebarPanel` is called to confirm the
+ * stored id still resolves to a registered `sidebar`-placement panel --
+ * guards against a stale id from an extension that was since disabled,
+ * removed, or changed placement.
+ */
+export async function loadActiveExtensionPanel(
+  workspacePath: string,
+  isSidebarPanel: (panelId: string) => boolean,
+): Promise<string | null> {
+  try {
+    const state = (await window.electronAPI?.invoke?.(
+      'workspace:get-state',
+      workspacePath,
+    )) as WorkspaceState | undefined;
+    return resolveActiveExtensionPanel(state, isSidebarPanel);
+  } catch {
+    return null;
+  }
+}
+
+/** Internal: decide whether the persisted id should be restored. Exported for tests. */
+export function resolveActiveExtensionPanel(
+  state: WorkspaceState | undefined,
+  isSidebarPanel: (panelId: string) => boolean,
+): string | null {
+  const stored = state?.activeExtensionPanel;
+  if (typeof stored !== 'string' || !stored) return null;
+  return isSidebarPanel(stored) ? stored : null;
+}


### PR DESCRIPTION
## Summary
- A sidebar-placement extension panel left open (e.g. a third-party extension's panel) closed silently on window reload instead of reopening.
- `activeExtensionPanel` in `App.tsx` was a plain `useState`, never seeded from or written back to workspace state.
- Restore is gated on the existing `extensionsReady` flag, not just `workspacePath`: eager extensions load asynchronously in parallel at startup, so checking `getPanelById` before they've registered would silently miss a panel that hadn't loaded yet.

## Changes
- `packages/electron/src/renderer/utils/activeExtensionPanelPersistence.ts` (new): persist/load/resolve helpers, restores only if the id still resolves to a registered `sidebar`-placement panel.
- `packages/electron/src/renderer/App.tsx`: hydration effect (gated on `workspacePath` + `extensionsReady`) and write-back effect, guarded by a ref so write-back can't fire with the initial `null` before hydration completes.

## Test plan
- [x] Unit test: `packages/electron/src/renderer/utils/__tests__/activeExtensionPanelPersistence.test.ts`
- [x] `npm run typecheck`
- [x] `npm run test:prepush`

Fixes #1114