### PR TITLE
fix(queue): preserve delivery truth across reconnects

### DIFF
--- a/packages/electron/src/main/database/sqlite/MigrationRunner.ts
+++ b/packages/electron/src/main/database/sqlite/MigrationRunner.ts
@@ -196,6 +196,11 @@ export function getMigrations(schemaDir: string): Migration[] {
       name: 'queued_prompt_dispatch_fencing',
       sqlFile: path.join(schemaDir, '0031_queued_prompt_dispatch_fencing.sql'),
     },
+    {
+      version: 32,
+      name: 'queued_prompt_truth_provenance',
+      sqlFile: path.join(schemaDir, '0032_queued_prompt_truth_provenance.sql'),
+    },
   ];
 }
 

--- a/packages/electron/src/main/database/sqlite/MigrationRunner.ts
+++ b/packages/electron/src/main/database/sqlite/MigrationRunner.ts
@@ -186,6 +186,16 @@ export function getMigrations(schemaDir: string): Migration[] {
       name: 'tracker_personal_snooze',
       sqlFile: path.join(schemaDir, '0029_tracker_personal_snooze.sql'),
     },
+    {
+      version: 30,
+      name: 'queued_prompt_priority_control',
+      sqlFile: path.join(schemaDir, '0030_queued_prompt_priority_control.sql'),
+    },
+    {
+      version: 31,
+      name: 'queued_prompt_dispatch_fencing',
+      sqlFile: path.join(schemaDir, '0031_queued_prompt_dispatch_fencing.sql'),
+    },
   ];
 }
 

--- a/packages/electron/src/main/database/sqlite/__tests__/MigrationRunner.test.ts
+++ b/packages/electron/src/main/database/sqlite/__tests__/MigrationRunner.test.ts
@@ -91,6 +91,8 @@ describe('runMigrations', () => {
     fs.writeFileSync(path.join(tmp, '0027_tool_usage_backfill_state.sql'), '-- noop\n');
     fs.writeFileSync(path.join(tmp, '0028_tracker_shared_saved_views.sql'), '-- noop\n');
     fs.writeFileSync(path.join(tmp, '0029_tracker_personal_snooze.sql'), '-- noop\n');
+    fs.writeFileSync(path.join(tmp, '0030_queued_prompt_priority_control.sql'), '-- noop\n');
+    fs.writeFileSync(path.join(tmp, '0031_queued_prompt_dispatch_fencing.sql'), '-- noop\n');
 
     const db = new FakeDb();
     // Hack: inject our own migration list via reflection-equivalent. Re-using
@@ -104,13 +106,13 @@ describe('runMigrations', () => {
     // a stand-in implementation; for now, test the file-backed path with the
     // bundled migrations.
     const result = runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
-    expect(result.applied).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]);
+    expect(result.applied).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
     expect(result.skipped).toEqual([]);
 
     // Second invocation: nothing to apply, all skipped.
     const result2 = runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
     expect(result2.applied).toEqual([]);
-    expect(result2.skipped).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]);
+    expect(result2.skipped).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
 
     // Anti-flake: unused locals lint silencer.
     void customs;
@@ -233,6 +235,8 @@ describe('runMigrations', () => {
       path.join(tmp, '0029_tracker_personal_snooze.sql'),
       '-- noop\n',
     );
+    fs.writeFileSync(path.join(tmp, '0030_queued_prompt_priority_control.sql'), '-- noop\n');
+    fs.writeFileSync(path.join(tmp, '0031_queued_prompt_dispatch_fencing.sql'), '-- noop\n');
     const db = new FakeDb();
     runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
     expect(db.execs.some((s) => s.includes('CREATE TABLE foo'))).toBe(true);

--- a/packages/electron/src/main/database/sqlite/__tests__/MigrationRunner.test.ts
+++ b/packages/electron/src/main/database/sqlite/__tests__/MigrationRunner.test.ts
@@ -93,6 +93,7 @@ describe('runMigrations', () => {
     fs.writeFileSync(path.join(tmp, '0029_tracker_personal_snooze.sql'), '-- noop\n');
     fs.writeFileSync(path.join(tmp, '0030_queued_prompt_priority_control.sql'), '-- noop\n');
     fs.writeFileSync(path.join(tmp, '0031_queued_prompt_dispatch_fencing.sql'), '-- noop\n');
+    fs.writeFileSync(path.join(tmp, '0032_queued_prompt_truth_provenance.sql'), '-- noop\n');
 
     const db = new FakeDb();
     // Hack: inject our own migration list via reflection-equivalent. Re-using
@@ -106,13 +107,13 @@ describe('runMigrations', () => {
     // a stand-in implementation; for now, test the file-backed path with the
     // bundled migrations.
     const result = runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
-    expect(result.applied).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
+    expect(result.applied).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
     expect(result.skipped).toEqual([]);
 
     // Second invocation: nothing to apply, all skipped.
     const result2 = runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
     expect(result2.applied).toEqual([]);
-    expect(result2.skipped).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
+    expect(result2.skipped).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
 
     // Anti-flake: unused locals lint silencer.
     void customs;
@@ -237,6 +238,7 @@ describe('runMigrations', () => {
     );
     fs.writeFileSync(path.join(tmp, '0030_queued_prompt_priority_control.sql'), '-- noop\n');
     fs.writeFileSync(path.join(tmp, '0031_queued_prompt_dispatch_fencing.sql'), '-- noop\n');
+    fs.writeFileSync(path.join(tmp, '0032_queued_prompt_truth_provenance.sql'), '-- noop\n');
     const db = new FakeDb();
     runMigrations(db as unknown as import('better-sqlite3').Database, tmp);
     expect(db.execs.some((s) => s.includes('CREATE TABLE foo'))).toBe(true);

--- a/packages/electron/src/main/database/sqlite/schemas/0030_queued_prompt_priority_control.sql
+++ b/packages/electron/src/main/database/sqlite/schemas/0030_queued_prompt_priority_control.sql
@@ -1,0 +1,21 @@
+-- Durable priority/control delivery metadata for agent-to-agent prompts.
+-- Ordinary rows retain priority_rank=0 and preserve FIFO ordering.
+
+ALTER TABLE queued_prompts ADD COLUMN delivery_class TEXT NOT NULL DEFAULT 'ordinary'
+  CHECK (delivery_class IN ('ordinary', 'control'));
+ALTER TABLE queued_prompts ADD COLUMN priority_rank INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE queued_prompts ADD COLUMN delivery_ready INTEGER NOT NULL DEFAULT 1
+  CHECK (delivery_ready IN (0, 1));
+ALTER TABLE queued_prompts ADD COLUMN producer TEXT;
+ALTER TABLE queued_prompts ADD COLUMN idempotency_key TEXT;
+ALTER TABLE queued_prompts ADD COLUMN request_digest TEXT;
+ALTER TABLE queued_prompts ADD COLUMN control_operation TEXT;
+ALTER TABLE queued_prompts ADD COLUMN interrupt_target_generation TEXT;
+ALTER TABLE queued_prompts ADD COLUMN interrupt_reservation_owner TEXT;
+ALTER TABLE queued_prompts ADD COLUMN interrupt_receipt TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_control_idempotency
+  ON queued_prompts(session_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_queued_prompts_priority_pending
+  ON queued_prompts(session_id, status, delivery_ready, priority_rank DESC, created_at ASC);

--- a/packages/electron/src/main/database/sqlite/schemas/0031_queued_prompt_dispatch_fencing.sql
+++ b/packages/electron/src/main/database/sqlite/schemas/0031_queued_prompt_dispatch_fencing.sql
@@ -1,0 +1,12 @@
+-- Persist queue ownership and dispatch provenance across process and owner races.
+-- Nullable defaults preserve legacy rows; new claims populate the token atomically.
+
+ALTER TABLE queued_prompts ADD COLUMN claim_token TEXT;
+ALTER TABLE queued_prompts ADD COLUMN dispatch_started_at TEXT;
+ALTER TABLE queued_prompts ADD COLUMN settlement_provenance TEXT;
+
+-- Exactly one control row may own native-interrupt admission for a target
+-- lifecycle generation. Losing rows replay that owner's durable receipt.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_interrupt_generation_owner
+  ON queued_prompts(session_id, interrupt_target_generation)
+  WHERE delivery_class = 'control' AND interrupt_target_generation IS NOT NULL;

--- a/packages/electron/src/main/database/sqlite/schemas/0032_queued_prompt_truth_provenance.sql
+++ b/packages/electron/src/main/database/sqlite/schemas/0032_queued_prompt_truth_provenance.sql
@@ -1,0 +1,36 @@
+-- Additive queue truth spine. Legacy rows are backfilled from their stable row
+-- identity and session; new rows receive all fields at admission.
+ALTER TABLE queued_prompts ADD COLUMN client_submission_id TEXT;
+ALTER TABLE queued_prompts ADD COLUMN source_session_id TEXT;
+ALTER TABLE queued_prompts ADD COLUMN source_room_id TEXT;
+ALTER TABLE queued_prompts ADD COLUMN submission_sequence INTEGER;
+ALTER TABLE queued_prompts ADD COLUMN payload_utf8_bytes INTEGER;
+ALTER TABLE queued_prompts ADD COLUMN payload_unicode_scalars INTEGER;
+ALTER TABLE queued_prompts ADD COLUMN payload_sha256 TEXT;
+ALTER TABLE queued_prompts ADD COLUMN claim_trigger TEXT;
+ALTER TABLE queued_prompts ADD COLUMN claim_triggered_at TEXT;
+ALTER TABLE queued_prompts ADD COLUMN turn_id TEXT;
+ALTER TABLE queued_prompts ADD COLUMN provider_input_message_id TEXT;
+ALTER TABLE queued_prompts ADD COLUMN provider_output_message_id TEXT;
+ALTER TABLE queued_prompts ADD COLUMN stream_event_sequence INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE queued_prompts ADD COLUMN terminal_status TEXT;
+ALTER TABLE queued_prompts ADD COLUMN terminal_at TEXT;
+
+UPDATE queued_prompts
+SET client_submission_id = COALESCE(client_submission_id, id),
+    source_session_id = COALESCE(source_session_id, session_id),
+    source_room_id = COALESCE(source_room_id, session_id),
+    submission_sequence = COALESCE(submission_sequence, rowid),
+    payload_utf8_bytes = COALESCE(payload_utf8_bytes, length(CAST(prompt AS BLOB))),
+    payload_unicode_scalars = COALESCE(payload_unicode_scalars, length(prompt)),
+    payload_sha256 = COALESCE(payload_sha256, 'legacy-unverified');
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_client_submission
+  ON queued_prompts(client_submission_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_source_sequence
+  ON queued_prompts(source_session_id, submission_sequence);
+
+CREATE TABLE IF NOT EXISTS queued_prompt_source_sequences (
+  source_session_id TEXT PRIMARY KEY,
+  next_sequence INTEGER NOT NULL
+);

--- a/packages/electron/src/main/database/worker.js
+++ b/packages/electron/src/main/database/worker.js
@@ -1700,6 +1700,21 @@ class PGLiteWorker {
           interrupt_target_generation TEXT,
           interrupt_reservation_owner TEXT,
           interrupt_receipt JSONB,
+          client_submission_id TEXT,
+          source_session_id TEXT,
+          source_room_id TEXT,
+          submission_sequence INTEGER,
+          payload_utf8_bytes INTEGER,
+          payload_unicode_scalars INTEGER,
+          payload_sha256 TEXT,
+          claim_trigger TEXT,
+          claim_triggered_at TIMESTAMPTZ,
+          turn_id TEXT,
+          provider_input_message_id TEXT,
+          provider_output_message_id TEXT,
+          stream_event_sequence INTEGER NOT NULL DEFAULT 0,
+          terminal_status TEXT,
+          terminal_at TIMESTAMPTZ,
           CONSTRAINT fk_queued_prompts_session
             FOREIGN KEY (session_id)
             REFERENCES ai_sessions(id)
@@ -1724,6 +1739,35 @@ class PGLiteWorker {
         ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS claim_token TEXT;
         ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS dispatch_started_at TIMESTAMPTZ;
         ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS settlement_provenance TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS client_submission_id TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS source_session_id TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS source_room_id TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS submission_sequence INTEGER;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS payload_utf8_bytes INTEGER;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS payload_unicode_scalars INTEGER;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS payload_sha256 TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS claim_trigger TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS claim_triggered_at TIMESTAMPTZ;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS turn_id TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS provider_input_message_id TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS provider_output_message_id TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS stream_event_sequence INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS terminal_status TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS terminal_at TIMESTAMPTZ;
+
+        WITH ranked AS (
+          SELECT id, ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY created_at, id) AS sequence
+          FROM queued_prompts
+        )
+        UPDATE queued_prompts q
+        SET client_submission_id = COALESCE(q.client_submission_id, q.id),
+            source_session_id = COALESCE(q.source_session_id, q.session_id),
+            source_room_id = COALESCE(q.source_room_id, q.session_id),
+            submission_sequence = COALESCE(q.submission_sequence, ranked.sequence),
+            payload_utf8_bytes = COALESCE(q.payload_utf8_bytes, octet_length(q.prompt)),
+            payload_unicode_scalars = COALESCE(q.payload_unicode_scalars, char_length(q.prompt)),
+            payload_sha256 = COALESCE(q.payload_sha256, 'legacy-unverified')
+        FROM ranked WHERE ranked.id = q.id;
 
         CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_control_idempotency
           ON queued_prompts(session_id, idempotency_key)
@@ -1733,6 +1777,14 @@ class PGLiteWorker {
         CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_interrupt_generation_owner
           ON queued_prompts(session_id, interrupt_target_generation)
           WHERE delivery_class = 'control' AND interrupt_target_generation IS NOT NULL;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_client_submission
+          ON queued_prompts(client_submission_id);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_source_sequence
+          ON queued_prompts(source_session_id, submission_sequence);
+        CREATE TABLE IF NOT EXISTS queued_prompt_source_sequences (
+          source_session_id TEXT PRIMARY KEY,
+          next_sequence INTEGER NOT NULL
+        );
       `);
       console.log('[PGLite Worker] queued_prompts table created successfully');
     } catch (error) {

--- a/packages/electron/src/main/database/worker.js
+++ b/packages/electron/src/main/database/worker.js
@@ -1684,8 +1684,22 @@ class PGLiteWorker {
           document_context JSONB,
           created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
           claimed_at TIMESTAMPTZ,
+          claim_token TEXT,
+          dispatch_started_at TIMESTAMPTZ,
+          settlement_provenance TEXT,
           completed_at TIMESTAMPTZ,
           error_message TEXT,
+          delivery_class TEXT NOT NULL DEFAULT 'ordinary'
+            CHECK (delivery_class IN ('ordinary', 'control')),
+          priority_rank INTEGER NOT NULL DEFAULT 0,
+          delivery_ready BOOLEAN NOT NULL DEFAULT TRUE,
+          producer TEXT,
+          idempotency_key TEXT,
+          request_digest TEXT,
+          control_operation TEXT,
+          interrupt_target_generation TEXT,
+          interrupt_reservation_owner TEXT,
+          interrupt_receipt JSONB,
           CONSTRAINT fk_queued_prompts_session
             FOREIGN KEY (session_id)
             REFERENCES ai_sessions(id)
@@ -1696,6 +1710,29 @@ class PGLiteWorker {
         CREATE INDEX IF NOT EXISTS idx_queued_prompts_status ON queued_prompts(status);
         CREATE INDEX IF NOT EXISTS idx_queued_prompts_session_status ON queued_prompts(session_id, status);
         CREATE INDEX IF NOT EXISTS idx_queued_prompts_created ON queued_prompts(created_at);
+
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS delivery_class TEXT NOT NULL DEFAULT 'ordinary';
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS priority_rank INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS delivery_ready BOOLEAN NOT NULL DEFAULT TRUE;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS producer TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS request_digest TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS control_operation TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS interrupt_target_generation TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS interrupt_reservation_owner TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS interrupt_receipt JSONB;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS claim_token TEXT;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS dispatch_started_at TIMESTAMPTZ;
+        ALTER TABLE queued_prompts ADD COLUMN IF NOT EXISTS settlement_provenance TEXT;
+
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_control_idempotency
+          ON queued_prompts(session_id, idempotency_key)
+          WHERE idempotency_key IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_queued_prompts_priority_pending
+          ON queued_prompts(session_id, status, delivery_ready, priority_rank DESC, created_at ASC);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_queued_prompts_interrupt_generation_owner
+          ON queued_prompts(session_id, interrupt_target_generation)
+          WHERE delivery_class = 'control' AND interrupt_target_generation IS NOT NULL;
       `);
       console.log('[PGLite Worker] queued_prompts table created successfully');
     } catch (error) {

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -2349,6 +2349,8 @@ app.whenReady().then(async () => {
       await driveStrandedQueuesOnBoot({
         listSessionIdsWithPending: () => getQueuedPromptsStore().listSessionIdsWithPending(),
         getWorkspacePath: async (sessionId) => (await AISessionsRepository.get(sessionId))?.workspacePath,
+        failAllPending: (sessionId, errorMessage) =>
+          getQueuedPromptsStore().failAllPendingForSession(sessionId, errorMessage),
         requestDrive: (sessionId, workspacePath) =>
           bootAiService.requestQueueDrive(sessionId, workspacePath, 'boot-recovery'),
         logInfo: (message) => logger.main.info(message),

--- a/packages/electron/src/main/mcp/__tests__/metaAgentServer.priorityDelivery.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/metaAgentServer.priorityDelivery.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/workspaceDetection', () => ({
+  resolveProjectPath: (workspacePath: string) => workspacePath,
+}));
+
+import {
+  META_AGENT_TOOL_DEFS,
+  dispatchMetaAgentTool,
+  getMetaAgentOpenAITools,
+  setMetaAgentToolFns,
+} from '../metaAgentServer';
+
+describe('send_prompt_now MCP parity', () => {
+  const sendPromptNow = vi.fn();
+
+  beforeEach(() => {
+    sendPromptNow.mockReset();
+    sendPromptNow.mockResolvedValue('{"ok":true}');
+    setMetaAgentToolFns({ sendPromptNow } as any);
+  });
+
+  it('appears exactly once on both surfaces with explicit waiting authority', () => {
+    const builtIn = META_AGENT_TOOL_DEFS.filter((tool) => tool.name === 'send_prompt_now');
+    const extension = getMetaAgentOpenAITools().filter(
+      (tool) => tool.function.name === 'send_prompt_now',
+    );
+
+    expect(builtIn).toHaveLength(1);
+    expect(extension).toHaveLength(1);
+    expect(builtIn[0].inputSchema.required).toEqual(['sessionId', 'prompt']);
+    expect(Object.keys(builtIn[0].inputSchema.properties)).toEqual([
+      'sessionId',
+      'prompt',
+      'idempotencyKey',
+      'controlOperation',
+      'interruptWaitingForInput',
+    ]);
+    expect(builtIn[0].description).toMatch(/priority/i);
+    expect(builtIn[0].description).toMatch(/interrupt/i);
+    expect(builtIn[0].description).toMatch(/FIFO send_prompt/i);
+  });
+
+  it('dispatches the raw argument object to the sendPromptNow binding', async () => {
+    const args = {
+      sessionId: 'target-session',
+      prompt: 'Act now',
+      idempotencyKey: 'control:key-1',
+      controlOperation: 'operator_directive',
+      interruptWaitingForInput: true,
+      producer: 'forged-producer',
+      priorityRank: -1,
+    };
+
+    await expect(dispatchMetaAgentTool(
+      'mcp__nimbalyst-host__send_prompt_now',
+      'caller-session',
+      'D:\\repo',
+      args,
+    )).resolves.toBe('{"ok":true}');
+
+    expect(sendPromptNow).toHaveBeenCalledWith(
+      'caller-session',
+      'D:\\repo',
+      args,
+    );
+  });
+});

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -86,6 +86,14 @@ type NotifyUserArgs = {
   urgency?: "normal" | "critical" | "low";
 };
 
+type SendPromptNowArgs = {
+  sessionId: string;
+  prompt: string;
+  idempotencyKey?: string;
+  controlOperation?: string;
+  interruptWaitingForInput?: boolean;
+};
+
 interface MetaAgentToolFns {
   listWorktrees: (
     metaSessionId: string,
@@ -123,6 +131,11 @@ interface MetaAgentToolFns {
     workspaceId: string,
     targetSessionId: string,
     prompt: string
+  ) => Promise<string>;
+  sendPromptNow: (
+    metaSessionId: string,
+    workspaceId: string,
+    args: SendPromptNowArgs,
   ) => Promise<string>;
   notifyUser: (
     metaSessionId: string,
@@ -349,6 +362,21 @@ export const META_AGENT_TOOL_DEFS: Array<{
     },
   },
   {
+    name: "send_prompt_now",
+    description: "Durably queue a priority control prompt and, when authorized, interrupt the target's current ordinary turn. Use FIFO send_prompt for ordinary delivery; structured interactive prompts must use respond_to_prompt.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: { type: "string", description: "The target child session ID." },
+        prompt: { type: "string", description: "The priority control prompt." },
+        idempotencyKey: { type: "string", description: "Optional stable request key for durable replay." },
+        controlOperation: { type: "string", description: "Optional audit label for the control action." },
+        interruptWaitingForInput: { type: "boolean", description: "Explicit authority to interrupt an ordinary-text waiting session." },
+      },
+      required: ["sessionId", "prompt"],
+    },
+  },
+  {
     name: "notify_user",
     description:
       "Show a local OS/system notification to get the human's attention. Use this for explicitly authorized asynchronous attention signals when chat may be missed. This is separate from voice mode; it respects the user's OS notification setting and returns JSON explaining whether the notification was shown or skipped.",
@@ -454,6 +482,7 @@ const EXTENSION_META_AGENT_ALLOWED_TOOLS = new Set<string>([
   "get_session_result",
   "list_queued_prompts",
   "send_prompt",
+  "send_prompt_now",
   "notify_user",
   "respond_to_prompt",
   "list_spawned_sessions",
@@ -535,6 +564,8 @@ export async function dispatchMetaAgentTool(
         (args?.sessionId as string) ?? "",
         (args?.prompt as string) ?? ""
       );
+    case "send_prompt_now":
+      return toolFns.sendPromptNow(aiSessionId, effectiveWorkspaceId, (args ?? {}) as SendPromptNowArgs);
     case "notify_user":
       return toolFns.notifyUser(aiSessionId, effectiveWorkspaceId, (args ?? {}) as NotifyUserArgs);
     case "respond_to_prompt":

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -916,6 +916,19 @@ export class MetaAgentService {
       includeCompleted: options.includeCompleted === true,
       prompts: prompts.map((prompt) => ({
         id: prompt.id,
+        clientSubmissionId: prompt.clientSubmissionId ?? prompt.id,
+        sourceSessionId: prompt.sourceSessionId ?? prompt.sessionId,
+        sourceRoomId: prompt.sourceRoomId ?? prompt.sessionId,
+        submissionSequence: prompt.submissionSequence ?? null,
+        producer: prompt.producer ?? null,
+        payloadReceipt: prompt.payloadReceipt ?? null,
+        claimTrigger: prompt.claimTrigger ?? null,
+        claimTriggeredAt: prompt.claimTriggeredAt ?? null,
+        turnId: prompt.turnId ?? null,
+        providerInputMessageId: prompt.providerInputMessageId ?? null,
+        providerOutputMessageId: prompt.providerOutputMessageId ?? null,
+        terminalStatus: prompt.terminalStatus ?? null,
+        terminalAt: prompt.terminalAt ?? null,
         status: prompt.status,
         deliveryClass: prompt.deliveryClass,
         priorityRank: prompt.priorityRank,
@@ -955,7 +968,8 @@ export class MetaAgentService {
       throw new Error(`Session ${sessionId} not found`);
     }
 
-    const normalizedPrompt = prompt.trim();
+    // Whitespace validation above is not payload normalization.
+    const normalizedPrompt = prompt;
     const shouldBypassExecution = this.shouldBypassChildAgentExecutionForTests();
     const statusRow = await this.getSessionStatusRow(sessionId, workspaceId);
     const statusBeforeQueue = (statusRow?.status || 'idle') as SessionStatusValue;

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -20,6 +20,12 @@ import { computeNotificationSignature } from './metaAgentNotificationSignature';
 import { extractMessageText, extractUserPrompts } from './metaAgentMessageText';
 import type { NotificationOptions, NotificationResult } from './NotificationService';
 import { composeNotificationTitle } from '../../shared/notificationTitle';
+import {
+  createPriorityPromptDeliveryService,
+  createPriorityTargetGeneration,
+  type PriorityControlPrompt,
+  type PriorityTargetState,
+} from './PriorityPromptDeliveryService';
 
 type SessionStatusValue = 'idle' | 'running' | 'waiting_for_input' | 'error' | 'interrupted';
 type PromptType = 'permission_request' | 'ask_user_question_request' | 'exit_plan_mode_request';
@@ -123,6 +129,14 @@ interface NotifyUserArgs {
   urgency?: 'normal' | 'critical' | 'low';
 }
 
+interface SendPromptNowArgs {
+  sessionId: string;
+  prompt: string;
+  idempotencyKey?: string;
+  controlOperation?: string;
+  interruptWaitingForInput?: boolean;
+}
+
 type ShowNotificationWithResult = (
   options: NotificationOptions
 ) => Promise<NotificationResult>;
@@ -210,6 +224,8 @@ export class MetaAgentService {
           this.listQueuedPromptsJson(targetSessionId, workspaceId, options),
         sendPrompt: (metaSessionId, workspaceId, targetSessionId, prompt) =>
           this.sendPromptToSession(metaSessionId, targetSessionId, workspaceId, prompt),
+        sendPromptNow: (metaSessionId, workspaceId, args) =>
+          this.sendPromptNowToSession(metaSessionId, workspaceId, args),
         notifyUser: (callerSessionId, workspaceId, args) =>
           this.notifyUserJson(callerSessionId, workspaceId, args),
         respondToPrompt: (_metaSessionId, workspaceId, args) =>
@@ -901,6 +917,14 @@ export class MetaAgentService {
       prompts: prompts.map((prompt) => ({
         id: prompt.id,
         status: prompt.status,
+        deliveryClass: prompt.deliveryClass,
+        priorityRank: prompt.priorityRank,
+        deliveryReady: prompt.deliveryReady,
+        claimTokenPresent: Boolean(prompt.claimToken),
+        dispatchStartedAt: prompt.dispatchStartedAt ?? null,
+        settlementProvenance: prompt.settlementProvenance ?? null,
+        interruptTargetGeneration: prompt.interruptTargetGeneration ?? null,
+        interruptReceipt: prompt.interruptReceipt ?? null,
         createdAt: prompt.createdAt,
         claimedAt: prompt.claimedAt ?? null,
         completedAt: prompt.completedAt ?? null,
@@ -977,6 +1001,68 @@ export class MetaAgentService {
       statusBeforeQueue: status,
       processingTriggered,
     }, null, 2);
+  }
+
+  private async getPriorityTargetState(sessionId: string, workspaceId: string): Promise<PriorityTargetState> {
+    const row = await this.getSessionStatusRow(sessionId, workspaceId);
+    if (!row) {
+      return { status: 'missing', generation: createPriorityTargetGeneration('missing', null, null), lastActivity: null, updatedAt: null };
+    }
+    const status = (['idle', 'running', 'waiting_for_input', 'error', 'interrupted'].includes(row.status)
+      ? row.status
+      : 'error') as PriorityTargetState['status'];
+    const lastActivity = toMillis(row.last_activity);
+    const updatedAt = toMillis(row.updated_at);
+    return { status, generation: createPriorityTargetGeneration(status, lastActivity, updatedAt), lastActivity, updatedAt };
+  }
+
+  private async sendPromptNowToSession(
+    callerSessionId: string,
+    workspaceId: string,
+    args: SendPromptNowArgs,
+  ): Promise<string> {
+    if (!this.aiService) throw new Error('AI service not initialized');
+    const sessionId = args.sessionId?.trim();
+    const prompt = args.prompt?.trim();
+    if (!sessionId) throw new Error('sessionId is required');
+    if (!prompt) throw new Error('prompt is required');
+    const session = await AISessionsRepository.get(sessionId);
+    if (!session || session.workspacePath !== workspaceId) throw new Error(`Session ${sessionId} not found`);
+
+    const { getQueuedPromptsStore } = await import('./RepositoryManager');
+    const queueStore = getQueuedPromptsStore();
+    const priorityService = createPriorityPromptDeliveryService({
+      createControlPrompt: async (input) => {
+        const created = await queueStore.createPriorityControlPrompt(input);
+        return { row: created.row as unknown as PriorityControlPrompt, replayed: created.replayed };
+      },
+      getTargetState: (targetSessionId, targetWorkspaceId) => this.getPriorityTargetState(targetSessionId, targetWorkspaceId),
+      hasStructuredPendingPrompt: async (targetSessionId) => (await this.getPendingInteractivePrompt(targetSessionId)) !== null,
+      reserveInterrupt: async (input) => {
+        const reserved = await queueStore.reservePriorityInterrupt(input);
+        return { row: reserved.row as unknown as PriorityControlPrompt, reserved: reserved.reserved };
+      },
+      recordInterruptReceipt: async (input) =>
+        await queueStore.recordPriorityInterruptReceipt(input) as unknown as PriorityControlPrompt,
+      interruptCurrentTurn: (targetSessionId, expectedState) =>
+        this.aiService!.interruptCurrentTurnForPriorityDelivery(targetSessionId, expectedState.generation),
+      triggerProcessing: (targetSessionId, targetWorkspaceId) => {
+        this.aiService!.releasePriorityQueueHandoffForDelivery(targetSessionId);
+        return this.aiService!.triggerQueuedPromptProcessingForSession(targetSessionId, targetWorkspaceId, 'meta-agent');
+      },
+      getControlPrompt: async (promptId) =>
+        await queueStore.get(promptId) as unknown as PriorityControlPrompt | null,
+    });
+    const receipt = await priorityService.deliver({
+      sessionId,
+      workspacePath: session.worktreePath || session.workspacePath || workspaceId,
+      prompt,
+      idempotencyKey: args.idempotencyKey?.trim() || `send_prompt_now:${callerSessionId}:${randomUUID()}`,
+      producer: `send_prompt_now:${callerSessionId}`,
+      controlOperation: args.controlOperation?.trim() || 'agent_priority_prompt',
+      interruptWaitingForInput: args.interruptWaitingForInput === true,
+    });
+    return JSON.stringify(receipt, null, 2);
   }
 
   private async notifyUserJson(

--- a/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
+++ b/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
@@ -7,6 +7,28 @@
 
 import { toMillis } from '../utils/timestampUtils';
 import type { PromptProvenance } from '@nimbalyst/runtime/ai/server/types';
+import { randomUUID } from 'crypto';
+
+export type QueueSettlementOutcome =
+  | 'settled'
+  | 'idempotent_same_claim'
+  | 'stale_owner'
+  | 'recovery_blocked'
+  | 'terminal_conflict';
+
+export interface QueueSettlementResult {
+  outcome: QueueSettlementOutcome;
+  row?: QueuedPrompt;
+}
+
+export interface QueueSweepResult {
+  completed: number;
+  failed: number;
+  rolledBack: number;
+  completedIds: string[];
+  failedIds: string[];
+  rolledBackIds: string[];
+}
 
 export interface QueuedPrompt {
   id: string;
@@ -24,8 +46,31 @@ export interface QueuedPrompt {
   };
   createdAt: number;  // epoch ms
   claimedAt?: number; // epoch ms
+  claimToken?: string;
+  dispatchStartedAt?: number;
+  settlementProvenance?: string;
   completedAt?: number; // epoch ms
   errorMessage?: string;
+  deliveryClass: 'ordinary' | 'control';
+  priorityRank: number;
+  deliveryReady: boolean;
+  producer?: string;
+  idempotencyKey?: string;
+  requestDigest?: string;
+  controlOperation?: string;
+  interruptTargetGeneration?: string;
+  interruptReservationOwner?: string;
+  interruptReceipt?: QueuedPromptInterruptReceipt;
+}
+
+export interface QueuedPromptInterruptReceipt {
+  generation: string;
+  attempted: boolean;
+  success: boolean;
+  method: string | null;
+  error: string | null;
+  nativeEntered: boolean;
+  recordedAt: number;
 }
 
 export interface CreateQueuedPromptInput {
@@ -43,9 +88,25 @@ export interface CreateQueuedPromptInput {
   };
 }
 
+export interface CreatePriorityControlQueuedPromptInput {
+  id: string;
+  sessionId: string;
+  prompt: string;
+  producer: string;
+  idempotencyKey: string;
+  requestDigest: string;
+  controlOperation: string;
+}
+
 export interface QueuedPromptsStore {
   /** Create a new queued prompt */
   create(input: CreateQueuedPromptInput): Promise<QueuedPrompt>;
+
+  /** Create or replay an idempotent high-priority control prompt. */
+  createPriorityControlPrompt(input: CreatePriorityControlQueuedPromptInput): Promise<{
+    row: QueuedPrompt;
+    replayed: boolean;
+  }>;
 
   /** Get a specific queued prompt by ID */
   get(id: string): Promise<QueuedPrompt | null>;
@@ -56,36 +117,61 @@ export interface QueuedPromptsStore {
   /** List pending prompts for a session (ready to execute) */
   listPending(sessionId: string): Promise<QueuedPrompt[]>;
 
-  /**
-   * Distinct session ids that currently have at least one `pending` row.
-   * Boot recovery uses this to re-drive every stranded queue: the boot sweep
-   * buckets `executing` rows back to `pending` and, before this existed,
-   * nothing ever claimed them (#962).
-   */
+  /** Discover pending work after a process restart without changing row state. */
+  listPendingSessionIds(options?: { deliveryClass?: 'ordinary' | 'control' }): Promise<string[]>;
+
+  /** Current-upstream queue-driver compatibility alias. */
   listSessionIdsWithPending(): Promise<string[]>;
 
-  /**
-   * Mark every pending row for a session failed. Used when delivery is
-   * terminally impossible (the project folder is gone), where deferring
-   * forever would leave the prompt silently stuck.
-   * Returns the number of rows failed.
-   */
+  /** Terminally fail every pending row when its workspace can no longer be delivered. */
   failAllPendingForSession(sessionId: string, errorMessage: string): Promise<number>;
+
+  /** Atomically reserve the one native interrupt allowed for a control row. */
+  reservePriorityInterrupt(input: {
+    promptId: string;
+    generation: string;
+    owner: string;
+  }): Promise<{ row: QueuedPrompt; reserved: boolean }>;
+
+  /** Persist the native interrupt result before queue processing is triggered. */
+  recordPriorityInterruptReceipt(input: {
+    promptId: string;
+    generation: string;
+    receipt: QueuedPromptInterruptReceipt;
+  }): Promise<QueuedPrompt>;
 
   /**
    * Atomically claim a pending prompt for execution.
    * Returns the prompt if successfully claimed, null if already claimed or not found.
    * This is the key atomic operation that prevents duplicate execution.
    */
-  claim(id: string): Promise<QueuedPrompt | null>;
+  claim(id: string, expectedSessionId?: string): Promise<QueuedPrompt | null>;
 
-  /** Mark a prompt as completed */
-  complete(id: string): Promise<void>;
+  /** Atomically mark an admitted prompt as completed for its owning session. */
+  /** Persist dispatch intent immediately before the provider/PTY boundary. */
+  beginDispatch(id: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
 
-  /** Mark a prompt as failed with an error message */
-  fail(id: string, errorMessage: string): Promise<void>;
+  /** Release an exact claim that failed before dispatch intent was persisted. */
+  releaseClaim(id: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
 
-  /** Delete a queued prompt */
+  /** Complete only the exact claim that owns the external dispatch. */
+  completeAfterDispatch(id: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
+
+  /** Fail only the exact claim that owns the external dispatch. */
+  failAfterDispatch(
+    id: string,
+    errorMessage: string,
+    expectedSessionId: string,
+    claimToken: string,
+  ): Promise<QueueSettlementResult>;
+
+  /** Atomically replace the contents of an admitted pending prompt. */
+  replacePending(input: CreateQueuedPromptInput): Promise<QueuedPrompt | null>;
+
+  /** Delete only an admitted pending prompt owned by the expected session. */
+  deletePending(id: string, expectedSessionId: string): Promise<boolean>;
+
+  /** Current-upstream explicit row deletion compatibility. */
   delete(id: string): Promise<void>;
 
   /**
@@ -125,7 +211,7 @@ export interface QueuedPromptsStore {
    *
    * Returns the count of rows in each bucket.
    */
-  sweepExecutingOnBoot(): Promise<{ completed: number; failed: number; rolledBack: number }>;
+  sweepExecutingOnBoot(): Promise<QueueSweepResult>;
 
   /**
    * Delivery-aware single-session variant of the boot sweep. Used by
@@ -140,7 +226,7 @@ export interface QueuedPromptsStore {
    * silently answered); roll back only rows that never made it to the
    * conversation.
    */
-  sweepExecutingForSession(sessionId: string): Promise<{ completed: number; failed: number; rolledBack: number }>;
+  sweepExecutingForSession(sessionId: string): Promise<QueueSweepResult>;
 
   /** Delete all completed/failed prompts older than a certain age */
   cleanup(olderThanMs: number): Promise<number>;
@@ -152,14 +238,14 @@ type PGliteLike = {
 
 type EnsureReadyFn = () => Promise<void>;
 
-/**
- * error_message written by the sweep passes for prompts that were
- * delivered (input row logged) but got no agent output before the turn
- * died (app quit / provider interrupt). Deliberately phrased so a user
- * reading the row knows the recovery action.
- */
-const SWEEP_UNANSWERED_ERROR =
+export const SWEEP_UNANSWERED_ERROR =
   'Prompt was delivered but the turn was interrupted before a response was recorded. Send it again to retry.';
+
+const PROVENANCE_DISPATCH_STARTED = 'dispatch_started';
+const PROVENANCE_DISPATCH_COMPLETED = 'dispatch_completed';
+const PROVENANCE_DISPATCH_FAILED = 'dispatch_failed';
+const PROVENANCE_SWEEP_INTERRUPT = 'sweep_interrupt';
+const PROVENANCE_SWEEP_BOOT = 'sweep_boot';
 
 function rowToQueuedPrompt(row: any): QueuedPrompt {
   // Parse JSONB fields
@@ -181,6 +267,15 @@ function rowToQueuedPrompt(row: any): QueuedPrompt {
     }
   }
 
+  let interruptReceipt = row.interrupt_receipt;
+  if (typeof interruptReceipt === 'string') {
+    try {
+      interruptReceipt = JSON.parse(interruptReceipt);
+    } catch {
+      interruptReceipt = undefined;
+    }
+  }
+
   return {
     id: row.id,
     sessionId: row.session_id,
@@ -190,8 +285,21 @@ function rowToQueuedPrompt(row: any): QueuedPrompt {
     documentContext,
     createdAt: toMillis(row.created_at)!,
     claimedAt: toMillis(row.claimed_at) ?? undefined,
+    claimToken: row.claim_token || undefined,
+    dispatchStartedAt: toMillis(row.dispatch_started_at) ?? undefined,
+    settlementProvenance: row.settlement_provenance || undefined,
     completedAt: toMillis(row.completed_at) ?? undefined,
     errorMessage: row.error_message || undefined,
+    deliveryClass: row.delivery_class === 'control' ? 'control' : 'ordinary',
+    priorityRank: Number(row.priority_rank ?? 0),
+    deliveryReady: row.delivery_ready !== false && row.delivery_ready !== 0,
+    producer: row.producer || undefined,
+    idempotencyKey: row.idempotency_key || undefined,
+    requestDigest: row.request_digest || undefined,
+    controlOperation: row.control_operation || undefined,
+    interruptTargetGeneration: row.interrupt_target_generation || undefined,
+    interruptReservationOwner: row.interrupt_reservation_owner || undefined,
+    interruptReceipt: interruptReceipt || undefined,
   };
 }
 
@@ -199,19 +307,156 @@ export function createPGLiteQueuedPromptsStore(
   db: PGliteLike,
   ensureDbReady?: EnsureReadyFn
 ): QueuedPromptsStore {
+  let dialectPromise: Promise<'pglite' | 'sqlite'> | null = null;
   const ensureReady = async () => {
     if (ensureDbReady) {
       await ensureDbReady();
     }
   };
 
+  const getDialect = (): Promise<'pglite' | 'sqlite'> => {
+    if (!dialectPromise) {
+      const probePromise = (async () => {
+        try {
+          const probe = await db.query<{ kind: string }>(
+            `SELECT jsonb_typeof('{}'::jsonb) AS kind`,
+          );
+          if (probe.rows[0]?.kind === 'object') return 'pglite';
+        } catch (pgliteError) {
+          try {
+            const probe = await db.query<{ valid: number | boolean }>(
+              `SELECT json_valid('{}') AS valid`,
+            );
+            if (probe.rows[0]?.valid === 1 || probe.rows[0]?.valid === true) return 'sqlite';
+          } catch {
+            // Preserve the first backend/readability failure. No queue state
+            // has changed, so callers fail closed without an ambiguous claim.
+            throw pgliteError;
+          }
+        }
+        throw new Error('Unable to determine queued-prompts database dialect');
+      })();
+      dialectPromise = probePromise;
+      void probePromise.catch(() => {
+        // A transient database outage must fail this claim closed without
+        // poisoning the store singleton forever. A later recovery gets a new
+        // read-only dialect probe before retrying the atomic UPDATE.
+        if (dialectPromise === probePromise) dialectPromise = null;
+      });
+    }
+    return dialectPromise;
+  };
+
+  const getMetadataReadyClause = async (): Promise<string> => {
+    const dialect = await getDialect();
+    return dialect === 'sqlite'
+      ? `(
+           s.metadata IS NULL
+           OR CASE
+                WHEN json_valid(s.metadata) = 1 THEN
+                  json_type(s.metadata) = 'object'
+                  AND (
+                    json_type(s.metadata, '$.modelChangeReconciliation') IS NULL
+                    OR json_type(s.metadata, '$.modelChangeReconciliation') = 'null'
+                  )
+                ELSE FALSE
+              END
+         )`
+      : `(
+           s.metadata IS NULL
+           OR (
+             jsonb_typeof(s.metadata) = 'object'
+             AND (
+               s.metadata->'modelChangeReconciliation' IS NULL
+               OR s.metadata->'modelChangeReconciliation' = 'null'::jsonb
+             )
+           )
+         )`;
+  };
+
+  const classifyMutationMiss = async (
+    id: string,
+    expectedSessionId: string,
+    claimToken: string,
+    isIdempotent: (row: QueuedPrompt) => boolean,
+  ): Promise<QueueSettlementResult> => {
+    const metadataReadyClause = await getMetadataReadyClause();
+    const { rows } = await db.query<any>(
+      `SELECT q.*,
+              EXISTS (
+                SELECT 1
+                FROM ai_sessions s
+                WHERE s.id = q.session_id
+                  AND ${metadataReadyClause}
+              ) AS metadata_ready
+       FROM queued_prompts q
+       WHERE q.id = $1
+       LIMIT 1`,
+      [id],
+    );
+    const raw = rows[0];
+    if (!raw || raw.session_id !== expectedSessionId || raw.claim_token !== claimToken) {
+      return { outcome: 'stale_owner' };
+    }
+    const row = rowToQueuedPrompt(raw);
+    if (raw.metadata_ready === false || raw.metadata_ready === 0) {
+      return { outcome: 'recovery_blocked', row };
+    }
+    if (isIdempotent(row)) {
+      return { outcome: 'idempotent_same_claim', row };
+    }
+    return { outcome: 'terminal_conflict', row };
+  };
+
+  const sweepExecuting = async (
+    sessionId: string | null,
+    provenance: typeof PROVENANCE_SWEEP_INTERRUPT | typeof PROVENANCE_SWEEP_BOOT,
+  ): Promise<QueueSweepResult> => {
+    await ensureReady();
+    const metadataReadyClause = await getMetadataReadyClause();
+    const { rows } = await db.query<{ id: string; status: QueuedPrompt['status'] }>(
+      `UPDATE queued_prompts
+       SET status = CASE WHEN dispatch_started_at IS NULL THEN 'pending' ELSE 'failed' END,
+           claimed_at = CASE WHEN dispatch_started_at IS NULL THEN NULL ELSE claimed_at END,
+           claim_token = CASE WHEN dispatch_started_at IS NULL THEN NULL ELSE claim_token END,
+           completed_at = CASE WHEN dispatch_started_at IS NULL THEN NULL ELSE CURRENT_TIMESTAMP END,
+           error_message = CASE WHEN dispatch_started_at IS NULL THEN NULL ELSE $3 END,
+           settlement_provenance = CASE WHEN dispatch_started_at IS NULL THEN NULL ELSE $2 END
+       WHERE status = 'executing'
+         AND claim_token IS NOT NULL
+         AND ($1::text IS NULL OR session_id = $1::text)
+         AND EXISTS (
+           SELECT 1
+           FROM ai_sessions s
+           WHERE s.id = queued_prompts.session_id
+             AND ${metadataReadyClause}
+         )
+       RETURNING id, status`,
+      [sessionId, provenance, SWEEP_UNANSWERED_ERROR],
+    );
+    const failedIds = rows.filter((row) => row.status === 'failed').map((row) => row.id);
+    const rolledBackIds = rows.filter((row) => row.status === 'pending').map((row) => row.id);
+    return {
+      completed: 0,
+      failed: failedIds.length,
+      rolledBack: rolledBackIds.length,
+      completedIds: [],
+      failedIds,
+      rolledBackIds,
+    };
+  };
+
   return {
     async create(input: CreateQueuedPromptInput): Promise<QueuedPrompt> {
       await ensureReady();
+      const metadataReadyClause = await getMetadataReadyClause();
 
       const { rows } = await db.query<any>(
         `INSERT INTO queued_prompts (id, session_id, prompt, attachments, document_context)
-         VALUES ($1, $2, $3, $4, $5)
+         SELECT $1, $2, $3, $4, $5
+         FROM ai_sessions s
+         WHERE s.id = $2
+           AND ${metadataReadyClause}
          RETURNING *`,
         [
           input.id,
@@ -223,11 +468,56 @@ export function createPGLiteQueuedPromptsStore(
       );
 
       if (rows.length === 0) {
-        throw new Error('Failed to create queued prompt');
+        throw new Error('Queued prompt creation was not admitted');
       }
 
       console.log(`[QueuedPromptsStore] Created prompt ${input.id} for session ${input.sessionId}`);
       return rowToQueuedPrompt(rows[0]);
+    },
+
+    async createPriorityControlPrompt(
+      input: CreatePriorityControlQueuedPromptInput
+    ): Promise<{ row: QueuedPrompt; replayed: boolean }> {
+      await ensureReady();
+
+      const { rows } = await db.query<any>(
+        `INSERT INTO queued_prompts (
+           id, session_id, prompt, delivery_class, priority_rank, delivery_ready, producer,
+           idempotency_key, request_digest, control_operation
+         )
+         VALUES ($1, $2, $3, 'control', 100, FALSE, $4, $5, $6, $7)
+         ON CONFLICT (session_id, idempotency_key)
+           WHERE idempotency_key IS NOT NULL
+         DO NOTHING
+         RETURNING *`,
+        [
+          input.id,
+          input.sessionId,
+          input.prompt,
+          input.producer,
+          input.idempotencyKey,
+          input.requestDigest,
+          input.controlOperation,
+        ]
+      );
+
+      if (rows.length > 0) {
+        return { row: rowToQueuedPrompt(rows[0]), replayed: false };
+      }
+
+      const existing = await db.query<any>(
+        `SELECT * FROM queued_prompts
+         WHERE session_id = $1 AND idempotency_key = $2
+         LIMIT 1`,
+        [input.sessionId, input.idempotencyKey]
+      );
+      if (existing.rows.length === 0) {
+        throw new Error('Failed to create or replay priority control prompt');
+      }
+      if (existing.rows[0].request_digest !== input.requestDigest) {
+        throw new Error('idempotency_conflict: key was already used for a different request');
+      }
+      return { row: rowToQueuedPrompt(existing.rows[0]), replayed: true };
     },
 
     async get(id: string): Promise<QueuedPrompt | null> {
@@ -253,7 +543,7 @@ export function createPGLiteQueuedPromptsStore(
       if (!includeCompleted) {
         query += ` AND status NOT IN ('completed', 'failed')`;
       }
-      query += ` ORDER BY created_at ASC`;
+      query += ` ORDER BY priority_rank DESC, created_at ASC, id ASC`;
 
       const { rows } = await db.query<any>(query, [sessionId]);
       return rows.map(rowToQueuedPrompt);
@@ -264,8 +554,8 @@ export function createPGLiteQueuedPromptsStore(
 
       const { rows } = await db.query<any>(
         `SELECT * FROM queued_prompts
-         WHERE session_id = $1 AND status = 'pending'
-         ORDER BY created_at ASC`,
+         WHERE session_id = $1 AND status = 'pending' AND delivery_ready = TRUE
+         ORDER BY priority_rank DESC, created_at ASC, id ASC`,
         [sessionId]
       );
 
@@ -274,45 +564,204 @@ export function createPGLiteQueuedPromptsStore(
 
     async listSessionIdsWithPending(): Promise<string[]> {
       await ensureReady();
-
       const { rows } = await db.query<{ session_id: string }>(
-        `SELECT DISTINCT session_id FROM queued_prompts WHERE status = 'pending'`
+        `SELECT DISTINCT session_id FROM queued_prompts WHERE status = 'pending'`,
       );
-
       return rows.map((row) => row.session_id);
     },
 
     async failAllPendingForSession(sessionId: string, errorMessage: string): Promise<number> {
       await ensureReady();
-
-      const { rows } = await db.query<any>(
+      const { rows } = await db.query<{ id: string }>(
         `UPDATE queued_prompts
          SET status = 'failed', completed_at = CURRENT_TIMESTAMP, error_message = $2
          WHERE session_id = $1 AND status = 'pending'
          RETURNING id`,
-        [sessionId, errorMessage]
+        [sessionId, errorMessage],
       );
-
-      if (rows.length > 0) {
-        console.log(
-          `[QueuedPromptsStore] Marked ${rows.length} pending prompt(s) for session ${sessionId} as failed: ${errorMessage}`
-        );
-      }
-
       return rows.length;
     },
 
-    async claim(id: string): Promise<QueuedPrompt | null> {
+    async listPendingSessionIds(
+      options?: { deliveryClass?: 'ordinary' | 'control' }
+    ): Promise<string[]> {
       await ensureReady();
 
-      // ATOMIC: Only update if status is still 'pending'
-      // This is the key operation that prevents duplicate execution
+      const deliveryClass = options?.deliveryClass;
+      const { rows } = await db.query<{ session_id: string }>(
+        `SELECT session_id
+         FROM queued_prompts
+         WHERE status = 'pending' AND delivery_ready = TRUE
+           AND ($1 IS NULL OR delivery_class = $1)
+         GROUP BY session_id
+         ORDER BY MIN(created_at) ASC, session_id ASC`,
+        [deliveryClass ?? null]
+      );
+      return rows.map((row) => row.session_id);
+    },
+
+    async reservePriorityInterrupt(input): Promise<{ row: QueuedPrompt; reserved: boolean }> {
+      await ensureReady();
+
+      let rows: any[] = [];
+      try {
+        const result = await db.query<any>(
+          `UPDATE queued_prompts AS target
+           SET interrupt_target_generation = $2,
+               interrupt_reservation_owner = $3
+           WHERE target.id = $1
+             AND target.delivery_class = 'control'
+             AND target.interrupt_receipt IS NULL
+             AND target.interrupt_reservation_owner IS NULL
+             AND NOT EXISTS (
+               SELECT 1
+               FROM queued_prompts AS incumbent
+               WHERE incumbent.session_id = target.session_id
+                 AND incumbent.interrupt_target_generation = $2
+                 AND incumbent.id <> target.id
+             )
+           RETURNING *`,
+          [input.promptId, input.generation, input.owner]
+        );
+        rows = result.rows;
+      } catch (error) {
+        const code = (error as { code?: string })?.code;
+        const message = error instanceof Error ? error.message : String(error);
+        if (code !== '23505' && code !== 'SQLITE_CONSTRAINT_UNIQUE' && !/unique|duplicate/i.test(message)) {
+          throw error;
+        }
+        // A concurrent row won the unique (session,generation) fence.
+      }
+      if (rows.length > 0) {
+        return { row: rowToQueuedPrompt(rows[0]), reserved: true };
+      }
+
+      await db.query<any>(
+        `UPDATE queued_prompts AS target
+         SET interrupt_reservation_owner = incumbent.interrupt_reservation_owner,
+             interrupt_receipt = incumbent.interrupt_receipt,
+             delivery_ready = CASE
+               WHEN incumbent.interrupt_receipt IS NULL THEN target.delivery_ready
+               ELSE incumbent.delivery_ready
+             END
+         FROM queued_prompts AS incumbent
+         WHERE target.id = $1
+           AND target.delivery_class = 'control'
+           AND target.interrupt_target_generation IS NULL
+           AND target.interrupt_reservation_owner IS NULL
+           AND target.interrupt_receipt IS NULL
+           AND incumbent.session_id = target.session_id
+           AND incumbent.interrupt_target_generation = $2
+           AND incumbent.interrupt_reservation_owner IS NOT NULL
+           AND incumbent.id <> target.id`,
+        [input.promptId, input.generation]
+      );
+
+      const existing = await db.query<any>(
+        `SELECT * FROM queued_prompts WHERE id = $1 LIMIT 1`,
+        [input.promptId]
+      );
+      if (existing.rows.length === 0) {
+        throw new Error(`Priority control prompt ${input.promptId} not found`);
+      }
+      return { row: rowToQueuedPrompt(existing.rows[0]), reserved: false };
+    },
+
+    async recordPriorityInterruptReceipt(input): Promise<QueuedPrompt> {
+      await ensureReady();
+
+      const reservation = await db.query<any>(
+        `SELECT * FROM queued_prompts
+         WHERE id = $1
+           AND interrupt_target_generation = $2
+         LIMIT 1`,
+        [input.promptId, input.generation]
+      );
+      if (reservation.rows.length === 0) {
+        throw new Error('Failed to record priority interrupt receipt');
+      }
+      const reservedRow = rowToQueuedPrompt(reservation.rows[0]);
+      if (reservedRow.interruptReceipt) {
+        return reservedRow;
+      }
+      if (!reservedRow.interruptReservationOwner) {
+        throw new Error('Failed to record priority interrupt receipt');
+      }
+
       const { rows } = await db.query<any>(
         `UPDATE queued_prompts
-         SET status = 'executing', claimed_at = CURRENT_TIMESTAMP
-         WHERE id = $1 AND status = 'pending'
+         SET interrupt_receipt = $3,
+             delivery_ready = $4
+         WHERE session_id = $5
+           AND interrupt_reservation_owner = $6
+           AND interrupt_receipt IS NULL
+           AND (
+             (id = $1 AND interrupt_target_generation = $2)
+             OR (id <> $1 AND interrupt_target_generation IS NULL)
+           )
          RETURNING *`,
-        [id]
+        [
+          input.promptId,
+          input.generation,
+          JSON.stringify(input.receipt),
+          input.receipt.success,
+          reservedRow.sessionId,
+          reservedRow.interruptReservationOwner,
+        ]
+      );
+      const winner = rows.find((row) => row.id === input.promptId);
+      if (winner) {
+        return rowToQueuedPrompt(winner);
+      }
+      const existing = await db.query<any>(
+        `SELECT * FROM queued_prompts WHERE id = $1 LIMIT 1`,
+        [input.promptId]
+      );
+      if (existing.rows.length === 0) {
+        throw new Error(`Priority control prompt ${input.promptId} not found`);
+      }
+      const row = rowToQueuedPrompt(existing.rows[0]);
+      if (
+        row.interruptTargetGeneration !== input.generation
+        || !row.interruptReceipt
+      ) {
+        throw new Error('Failed to record priority interrupt receipt');
+      }
+      return row;
+    },
+
+    async claim(id: string, expectedSessionId?: string): Promise<QueuedPrompt | null> {
+      await ensureReady();
+
+      const metadataReadyClause = await getMetadataReadyClause();
+      const claimToken = randomUUID();
+
+      // One UPDATE owns both queue reservation and durable recovery admission.
+      // The authoritative session comes from the row itself; expectedSessionId
+      // additionally prevents a public caller from claiming another session's
+      // row. A missing/unreadable session, malformed metadata, pending marker,
+      // lost delivery readiness, or concurrent claimant leaves the row pending.
+      const { rows } = await db.query<any>(
+        `UPDATE queued_prompts
+         SET status = 'executing',
+             claimed_at = CURRENT_TIMESTAMP,
+             claim_token = $3,
+             dispatch_started_at = NULL,
+             settlement_provenance = NULL,
+             completed_at = NULL,
+             error_message = NULL
+         WHERE id = $1
+           AND status = 'pending'
+           AND delivery_ready = TRUE
+           AND ($2::text IS NULL OR session_id = $2::text)
+           AND EXISTS (
+             SELECT 1
+             FROM ai_sessions s
+             WHERE s.id = queued_prompts.session_id
+               AND ${metadataReadyClause}
+           )
+         RETURNING *`,
+        [id, expectedSessionId ?? null, claimToken]
       );
 
       if (rows.length === 0) {
@@ -324,274 +773,224 @@ export function createPGLiteQueuedPromptsStore(
       return rowToQueuedPrompt(rows[0]);
     },
 
-    async complete(id: string): Promise<void> {
+    async beginDispatch(
+      id: string,
+      expectedSessionId: string,
+      claimToken: string,
+    ): Promise<QueueSettlementResult> {
       await ensureReady();
-
-      // error_message = NULL: a turn that resolves normally after a sweep
-      // provisionally failed the row (buffered output landing late) must
-      // not keep the stale sweep error alongside status 'completed'.
-      await db.query(
+      const metadataReadyClause = await getMetadataReadyClause();
+      const { rows } = await db.query<any>(
         `UPDATE queued_prompts
-         SET status = 'completed', completed_at = CURRENT_TIMESTAMP, error_message = NULL
-         WHERE id = $1`,
-        [id]
+         SET dispatch_started_at = CURRENT_TIMESTAMP,
+             settlement_provenance = $4
+         WHERE id = $1
+           AND session_id = $2::text
+           AND claim_token = $3
+           AND status = 'executing'
+           AND dispatch_started_at IS NULL
+           AND EXISTS (
+             SELECT 1 FROM ai_sessions s
+             WHERE s.id = queued_prompts.session_id
+               AND ${metadataReadyClause}
+           )
+         RETURNING *`,
+        [id, expectedSessionId, claimToken, PROVENANCE_DISPATCH_STARTED],
       );
-
-      // console.log(`[QueuedPromptsStore] Marked prompt ${id} as completed`);
+      if (rows.length > 0) return { outcome: 'settled', row: rowToQueuedPrompt(rows[0]) };
+      return classifyMutationMiss(
+        id,
+        expectedSessionId,
+        claimToken,
+        (row) => row.status === 'executing' && row.dispatchStartedAt !== undefined,
+      );
     },
 
-    async fail(id: string, errorMessage: string): Promise<void> {
+    async releaseClaim(
+      id: string,
+      expectedSessionId: string,
+      claimToken: string,
+    ): Promise<QueueSettlementResult> {
       await ensureReady();
-
-      await db.query(
+      const metadataReadyClause = await getMetadataReadyClause();
+      const { rows } = await db.query<any>(
         `UPDATE queued_prompts
-         SET status = 'failed', completed_at = CURRENT_TIMESTAMP, error_message = $2
-         WHERE id = $1`,
-        [id, errorMessage]
+         SET status = 'pending',
+             claimed_at = NULL,
+             claim_token = NULL,
+             dispatch_started_at = NULL,
+             settlement_provenance = NULL,
+             completed_at = NULL,
+             error_message = NULL
+         WHERE id = $1
+           AND session_id = $2::text
+           AND claim_token = $3
+           AND status = 'executing'
+           AND dispatch_started_at IS NULL
+           AND EXISTS (
+             SELECT 1 FROM ai_sessions s
+             WHERE s.id = queued_prompts.session_id
+               AND ${metadataReadyClause}
+           )
+         RETURNING *`,
+        [id, expectedSessionId, claimToken],
       );
+      if (rows.length > 0) return { outcome: 'settled', row: rowToQueuedPrompt(rows[0]) };
+      return classifyMutationMiss(id, expectedSessionId, claimToken, () => false);
+    },
 
-      console.log(`[QueuedPromptsStore] Marked prompt ${id} as failed: ${errorMessage}`);
+    async completeAfterDispatch(
+      id: string,
+      expectedSessionId: string,
+      claimToken: string,
+    ): Promise<QueueSettlementResult> {
+      await ensureReady();
+      const metadataReadyClause = await getMetadataReadyClause();
+      const { rows } = await db.query<any>(
+        `UPDATE queued_prompts
+         SET status = 'completed',
+             completed_at = CURRENT_TIMESTAMP,
+             error_message = NULL,
+             settlement_provenance = $4
+         WHERE id = $1
+           AND session_id = $2::text
+           AND claim_token = $3
+           AND dispatch_started_at IS NOT NULL
+           AND (
+             status = 'executing'
+             OR (
+               status = 'failed'
+               AND settlement_provenance IN ($5, $6)
+             )
+           )
+           AND EXISTS (
+             SELECT 1 FROM ai_sessions s
+             WHERE s.id = queued_prompts.session_id
+               AND ${metadataReadyClause}
+           )
+         RETURNING *`,
+        [
+          id,
+          expectedSessionId,
+          claimToken,
+          PROVENANCE_DISPATCH_COMPLETED,
+          PROVENANCE_SWEEP_INTERRUPT,
+          PROVENANCE_SWEEP_BOOT,
+        ],
+      );
+      if (rows.length > 0) return { outcome: 'settled', row: rowToQueuedPrompt(rows[0]) };
+      return classifyMutationMiss(
+        id,
+        expectedSessionId,
+        claimToken,
+        (row) => row.status === 'completed' && row.settlementProvenance === PROVENANCE_DISPATCH_COMPLETED,
+      );
+    },
+
+    async failAfterDispatch(
+      id: string,
+      errorMessage: string,
+      expectedSessionId: string,
+      claimToken: string,
+    ): Promise<QueueSettlementResult> {
+      await ensureReady();
+      const metadataReadyClause = await getMetadataReadyClause();
+      const { rows } = await db.query<any>(
+        `UPDATE queued_prompts
+         SET status = 'failed',
+             completed_at = CURRENT_TIMESTAMP,
+             error_message = $4,
+             settlement_provenance = $5
+         WHERE id = $1
+           AND session_id = $2::text
+           AND claim_token = $3
+           AND status = 'executing'
+           AND dispatch_started_at IS NOT NULL
+           AND EXISTS (
+             SELECT 1 FROM ai_sessions s
+             WHERE s.id = queued_prompts.session_id
+               AND ${metadataReadyClause}
+           )
+         RETURNING *`,
+        [id, expectedSessionId, claimToken, errorMessage, PROVENANCE_DISPATCH_FAILED],
+      );
+      if (rows.length > 0) return { outcome: 'settled', row: rowToQueuedPrompt(rows[0]) };
+      return classifyMutationMiss(
+        id,
+        expectedSessionId,
+        claimToken,
+        (row) => row.status === 'failed' && row.settlementProvenance === PROVENANCE_DISPATCH_FAILED,
+      );
+    },
+
+    async replacePending(input: CreateQueuedPromptInput): Promise<QueuedPrompt | null> {
+      await ensureReady();
+      const metadataReadyClause = await getMetadataReadyClause();
+      const { rows } = await db.query<any>(
+        `UPDATE queued_prompts
+         SET prompt = $3,
+             attachments = $4,
+             document_context = $5
+         WHERE id = $1
+           AND session_id = $2::text
+           AND status = 'pending'
+           AND EXISTS (
+             SELECT 1 FROM ai_sessions s
+             WHERE s.id = queued_prompts.session_id
+               AND ${metadataReadyClause}
+           )
+         RETURNING *`,
+        [
+          input.id,
+          input.sessionId,
+          input.prompt,
+          input.attachments !== undefined ? JSON.stringify(input.attachments) : null,
+          input.documentContext !== undefined ? JSON.stringify(input.documentContext) : null,
+        ],
+      );
+      return rows.length > 0 ? rowToQueuedPrompt(rows[0]) : null;
+    },
+
+    async deletePending(id: string, expectedSessionId: string): Promise<boolean> {
+      await ensureReady();
+      const metadataReadyClause = await getMetadataReadyClause();
+      const { rows } = await db.query<{ id: string }>(
+        `DELETE FROM queued_prompts
+         WHERE id = $1
+           AND session_id = $2::text
+           AND status = 'pending'
+           AND EXISTS (
+             SELECT 1 FROM ai_sessions s
+             WHERE s.id = queued_prompts.session_id
+               AND ${metadataReadyClause}
+           )
+         RETURNING id`,
+        [id, expectedSessionId],
+      );
+      return rows.length > 0;
     },
 
     async delete(id: string): Promise<void> {
       await ensureReady();
-
-      await db.query(
-        `DELETE FROM queued_prompts WHERE id = $1`,
-        [id]
-      );
-
-      console.log(`[QueuedPromptsStore] Deleted prompt ${id}`);
+      await db.query(`DELETE FROM queued_prompts WHERE id = $1`, [id]);
     },
 
     async rollbackExecuting(sessionId: string): Promise<number> {
-      await ensureReady();
-
-      const { rows } = await db.query<{ id: string }>(
-        `UPDATE queued_prompts
-         SET status = 'pending', claimed_at = NULL
-         WHERE session_id = $1 AND status = 'executing'
-         RETURNING id`,
-        [sessionId]
-      );
-
-      if (rows.length > 0) {
-        console.log(`[QueuedPromptsStore] Rolled back ${rows.length} executing prompt(s) for session ${sessionId}`);
-      }
-      return rows.length;
+      const result = await sweepExecuting(sessionId, PROVENANCE_SWEEP_INTERRUPT);
+      return result.rolledBack;
     },
 
     async rollbackAllExecuting(): Promise<number> {
-      await ensureReady();
-
-      const { rows } = await db.query<{ id: string }>(
-        `UPDATE queued_prompts
-         SET status = 'pending', claimed_at = NULL
-         WHERE status = 'executing'
-         RETURNING id`
-      );
-
-      if (rows.length > 0) {
-        console.log(`[QueuedPromptsStore] Boot sweep: rolled back ${rows.length} executing prompt(s) across all sessions`);
-      }
-      return rows.length;
+      const result = await sweepExecuting(null, PROVENANCE_SWEEP_BOOT);
+      return result.rolledBack;
     },
 
-    async sweepExecutingOnBoot(): Promise<{ completed: number; failed: number; rolledBack: number }> {
-      await ensureReady();
-
-      // Pass 1: rows whose user message was already logged to
-      // ai_agent_messages AND that have agent output after the claim --
-      // the prompt was delivered and the agent responded (or was paused
-      // on an interactive prompt, which also persists as an output row)
-      // when the app quit. Mark completed so the next session activation
-      // doesn't re-claim and re-send the original prompt.
-      //
-      // Three branches join in this update:
-      //
-      // (a) `executing` rows whose input arrived after `claimed_at` AND
-      //     that have at least one output row after `claimed_at` --
-      //     "delivered then answered/paused". The input row alone does
-      //     NOT prove the agent ever responded: a provider SIGTERM'd at
-      //     quit leaves the input logged and nothing else, and marking
-      //     that completed makes the session look silently answered
-      //     (#783). Those rows fall through to pass 2 instead.
-      // (b) `pending` rows whose prompt text appears in a later input
-      //     for the same session -- leftover corruption from older
-      //     builds that ran the blanket `rollbackAllExecuting` sweep on
-      //     boot. POSITION > 0 implies the text is already in the
-      //     conversation, so the row must not be re-delivered.
-      // (c) `pending` rows older than 24h -- abandoned. Catches the
-      //     long-tail of (b) where the content match misses because
-      //     JSON escaping (newlines, quotes, pasted attachments)
-      //     differs between the queued prompt and the logged input. A
-      //     legitimately-queued prompt is processed within seconds of
-      //     creation; a row sitting >24h pending is effectively
-      //     abandoned regardless of whether it was technically
-      //     delivered.
-      const completedResult = await db.query<{ id: string }>(
-        `UPDATE queued_prompts
-         SET status = 'completed', completed_at = CURRENT_TIMESTAMP
-         WHERE (
-           (status = 'executing' AND claimed_at IS NOT NULL
-            AND EXISTS (
-              SELECT 1 FROM ai_agent_messages m
-              WHERE m.session_id = queued_prompts.session_id
-                AND m.direction = 'input'
-                AND m.created_at >= queued_prompts.claimed_at
-            )
-            AND EXISTS (
-              SELECT 1 FROM ai_agent_messages m
-              WHERE m.session_id = queued_prompts.session_id
-                AND m.direction = 'output'
-                AND m.created_at >= queued_prompts.claimed_at
-            ))
-           OR
-           (status = 'pending'
-            AND EXISTS (
-              SELECT 1 FROM ai_agent_messages m
-              WHERE m.session_id = queued_prompts.session_id
-                AND m.direction = 'input'
-                AND m.created_at >= queued_prompts.created_at
-                AND POSITION(queued_prompts.prompt IN m.content) > 0
-            ))
-           OR
-           (status = 'pending'
-            AND created_at < NOW() - INTERVAL '1 day')
-         )
-         RETURNING id`
-      );
-
-      // Pass 2: still-executing rows whose input WAS delivered but that
-      // have no output evidence. The turn died between delivery and any
-      // response. Mark failed with a visible error, NOT completed (silent
-      // fake success, #783) and NOT pending (a re-claim would re-send the
-      // delivered input, regressing NIM-615). The NOT EXISTS makes this
-      // pass independently correct rather than relying on pass 1 having
-      // consumed the answered rows first (an output row committed between
-      // the two statements must not produce a failed-but-answered row).
-      const failedResult = await db.query<{ id: string }>(
-        `UPDATE queued_prompts
-         SET status = 'failed', completed_at = CURRENT_TIMESTAMP, error_message = $1
-         WHERE status = 'executing' AND claimed_at IS NOT NULL
-           AND EXISTS (
-             SELECT 1 FROM ai_agent_messages m
-             WHERE m.session_id = queued_prompts.session_id
-               AND m.direction = 'input'
-               AND m.created_at >= queued_prompts.claimed_at
-           )
-           AND NOT EXISTS (
-             SELECT 1 FROM ai_agent_messages m
-             WHERE m.session_id = queued_prompts.session_id
-               AND m.direction = 'output'
-               AND m.created_at >= queued_prompts.claimed_at
-           )
-         RETURNING id`,
-        [SWEEP_UNANSWERED_ERROR]
-      );
-
-      // Pass 3: anything still executing crashed before its input was
-      // ever logged. Roll back to pending so it can be retried.
-      const rolledBackResult = await db.query<{ id: string }>(
-        `UPDATE queued_prompts
-         SET status = 'pending', claimed_at = NULL
-         WHERE status = 'executing'
-         RETURNING id`
-      );
-
-      const completed = completedResult.rows.length;
-      const failed = failedResult.rows.length;
-      const rolledBack = rolledBackResult.rows.length;
-
-      if (completed > 0 || failed > 0 || rolledBack > 0) {
-        console.log(
-          `[QueuedPromptsStore] Boot sweep: marked ${completed} answered prompt(s) completed, ${failed} delivered-but-unanswered prompt(s) failed, rolled back ${rolledBack} undelivered prompt(s)`
-        );
-      }
-
-      return { completed, failed, rolledBack };
+    async sweepExecutingOnBoot(): Promise<QueueSweepResult> {
+      return sweepExecuting(null, PROVENANCE_SWEEP_BOOT);
     },
 
-    async sweepExecutingForSession(sessionId: string): Promise<{ completed: number; failed: number; rolledBack: number }> {
-      await ensureReady();
-
-      // Pass 1: same delivery + output-evidence check as
-      // sweepExecutingOnBoot, but scoped to a single session. Used on
-      // cancel/interrupt to avoid the immediate re-claim that follows
-      // when an already-delivered prompt is rolled back to pending.
-      const completedResult = await db.query<{ id: string }>(
-        `UPDATE queued_prompts
-         SET status = 'completed', completed_at = CURRENT_TIMESTAMP
-         WHERE status = 'executing'
-           AND session_id = $1
-           AND claimed_at IS NOT NULL
-           AND EXISTS (
-             SELECT 1 FROM ai_agent_messages m
-             WHERE m.session_id = queued_prompts.session_id
-               AND m.direction = 'input'
-               AND m.created_at >= queued_prompts.claimed_at
-           )
-           AND EXISTS (
-             SELECT 1 FROM ai_agent_messages m
-             WHERE m.session_id = queued_prompts.session_id
-               AND m.direction = 'output'
-               AND m.created_at >= queued_prompts.claimed_at
-           )
-         RETURNING id`,
-        [sessionId]
-      );
-
-      // Pass 2: delivered but no output before the interrupt -- the
-      // exact #790 shape ("why did you stop?" was claimed, never
-      // answered, and the interrupt sweep marked it completed). Fail it
-      // visibly instead; never roll back to pending (re-claim would
-      // re-send the delivered input, NIM-615). NOT EXISTS keeps this
-      // pass independently correct if an output row commits between the
-      // two statements; and if the turn later resolves normally anyway,
-      // complete() overwrites the provisional failed and clears the error.
-      const failedResult = await db.query<{ id: string }>(
-        `UPDATE queued_prompts
-         SET status = 'failed', completed_at = CURRENT_TIMESTAMP, error_message = $2
-         WHERE status = 'executing'
-           AND session_id = $1
-           AND claimed_at IS NOT NULL
-           AND EXISTS (
-             SELECT 1 FROM ai_agent_messages m
-             WHERE m.session_id = queued_prompts.session_id
-               AND m.direction = 'input'
-               AND m.created_at >= queued_prompts.claimed_at
-           )
-           AND NOT EXISTS (
-             SELECT 1 FROM ai_agent_messages m
-             WHERE m.session_id = queued_prompts.session_id
-               AND m.direction = 'output'
-               AND m.created_at >= queued_prompts.claimed_at
-           )
-         RETURNING id`,
-        [sessionId, SWEEP_UNANSWERED_ERROR]
-      );
-
-      // Pass 3: roll back anything still executing for this session that
-      // never made it to the conversation.
-      const rolledBackResult = await db.query<{ id: string }>(
-        `UPDATE queued_prompts
-         SET status = 'pending', claimed_at = NULL
-         WHERE status = 'executing' AND session_id = $1
-         RETURNING id`,
-        [sessionId]
-      );
-
-      const completed = completedResult.rows.length;
-      const failed = failedResult.rows.length;
-      const rolledBack = rolledBackResult.rows.length;
-
-      if (completed > 0 || failed > 0 || rolledBack > 0) {
-        console.log(
-          `[QueuedPromptsStore] Session sweep (${sessionId}): marked ${completed} answered prompt(s) completed, ${failed} delivered-but-unanswered prompt(s) failed, rolled back ${rolledBack} undelivered prompt(s)`
-        );
-      }
-
-      return { completed, failed, rolledBack };
+    async sweepExecutingForSession(sessionId: string): Promise<QueueSweepResult> {
+      return sweepExecuting(sessionId, PROVENANCE_SWEEP_INTERRUPT);
     },
 
     async cleanup(olderThanMs: number): Promise<number> {

--- a/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
+++ b/packages/electron/src/main/services/PGLiteQueuedPromptsStore.ts
@@ -8,6 +8,13 @@
 import { toMillis } from '../utils/timestampUtils';
 import type { PromptProvenance } from '@nimbalyst/runtime/ai/server/types';
 import { randomUUID } from 'crypto';
+import {
+  createQueuedPromptTruth,
+  payloadReceiptsMatch,
+  queueTruthMismatchError,
+  receiptQueuedPromptPayload,
+  type QueuedPromptPayloadReceipt,
+} from './ai/queuedPromptTruth';
 
 export type QueueSettlementOutcome =
   | 'settled'
@@ -19,6 +26,13 @@ export type QueueSettlementOutcome =
 export interface QueueSettlementResult {
   outcome: QueueSettlementOutcome;
   row?: QueuedPrompt;
+}
+
+/** Exact terminal boundary observed by the non-CLI streaming handler. */
+export interface QueueTerminalReceipt {
+  lifecycle: 'completed' | 'failed';
+  terminalAt: number;
+  eventSequence: number;
 }
 
 export interface QueueSweepResult {
@@ -61,6 +75,19 @@ export interface QueuedPrompt {
   interruptTargetGeneration?: string;
   interruptReservationOwner?: string;
   interruptReceipt?: QueuedPromptInterruptReceipt;
+  clientSubmissionId?: string;
+  sourceSessionId?: string;
+  sourceRoomId?: string;
+  submissionSequence?: number;
+  payloadReceipt?: QueuedPromptPayloadReceipt;
+  claimTrigger?: string;
+  claimTriggeredAt?: number;
+  turnId?: string;
+  providerInputMessageId?: string;
+  providerOutputMessageId?: string;
+  streamEventSequence?: number;
+  terminalStatus?: 'streaming' | 'completed' | 'failed';
+  terminalAt?: number;
 }
 
 export interface QueuedPromptInterruptReceipt {
@@ -77,6 +104,10 @@ export interface CreateQueuedPromptInput {
   id: string;
   sessionId: string;
   prompt: string;
+  /** Stable client identity; legacy callers may omit it and retain `id`. */
+  clientSubmissionId?: string;
+  sourceRoomId?: string;
+  producer?: string;
   attachments?: any[];
   documentContext?: {
     filePath?: string;
@@ -145,7 +176,7 @@ export interface QueuedPromptsStore {
    * Returns the prompt if successfully claimed, null if already claimed or not found.
    * This is the key atomic operation that prevents duplicate execution.
    */
-  claim(id: string, expectedSessionId?: string): Promise<QueuedPrompt | null>;
+  claim(id: string, expectedSessionId?: string, claimTrigger?: string): Promise<QueuedPrompt | null>;
 
   /** Atomically mark an admitted prompt as completed for its owning session. */
   /** Persist dispatch intent immediately before the provider/PTY boundary. */
@@ -155,7 +186,7 @@ export interface QueuedPromptsStore {
   releaseClaim(id: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
 
   /** Complete only the exact claim that owns the external dispatch. */
-  completeAfterDispatch(id: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
+  completeAfterDispatch(id: string, expectedSessionId: string, claimToken: string, terminal?: QueueTerminalReceipt): Promise<QueueSettlementResult>;
 
   /** Fail only the exact claim that owns the external dispatch. */
   failAfterDispatch(
@@ -163,6 +194,7 @@ export interface QueuedPromptsStore {
     errorMessage: string,
     expectedSessionId: string,
     claimToken: string,
+    terminal?: QueueTerminalReceipt,
   ): Promise<QueueSettlementResult>;
 
   /** Atomically replace the contents of an admitted pending prompt. */
@@ -300,6 +332,21 @@ function rowToQueuedPrompt(row: any): QueuedPrompt {
     interruptTargetGeneration: row.interrupt_target_generation || undefined,
     interruptReservationOwner: row.interrupt_reservation_owner || undefined,
     interruptReceipt: interruptReceipt || undefined,
+    clientSubmissionId: row.client_submission_id || undefined,
+    sourceSessionId: row.source_session_id || row.session_id,
+    sourceRoomId: row.source_room_id || row.session_id,
+    submissionSequence: row.submission_sequence == null ? undefined : Number(row.submission_sequence),
+    payloadReceipt: row.payload_utf8_bytes == null || row.payload_unicode_scalars == null || !row.payload_sha256 || row.payload_sha256 === 'legacy-unverified'
+      ? undefined
+      : { utf8Bytes: Number(row.payload_utf8_bytes), unicodeScalars: Number(row.payload_unicode_scalars), sha256: row.payload_sha256 },
+    claimTrigger: row.claim_trigger || undefined,
+    claimTriggeredAt: toMillis(row.claim_triggered_at) ?? undefined,
+    turnId: row.turn_id || undefined,
+    providerInputMessageId: row.provider_input_message_id || undefined,
+    providerOutputMessageId: row.provider_output_message_id || undefined,
+    streamEventSequence: row.stream_event_sequence == null ? undefined : Number(row.stream_event_sequence),
+    terminalStatus: row.terminal_status || undefined,
+    terminalAt: toMillis(row.terminal_at) ?? undefined,
   };
 }
 
@@ -450,10 +497,40 @@ export function createPGLiteQueuedPromptsStore(
     async create(input: CreateQueuedPromptInput): Promise<QueuedPrompt> {
       await ensureReady();
       const metadataReadyClause = await getMetadataReadyClause();
+      const truth = createQueuedPromptTruth({
+        queueRowId: input.id,
+        clientSubmissionId: input.clientSubmissionId,
+        sourceSessionId: input.sessionId,
+        sourceRoomId: input.sourceRoomId,
+        producer: input.producer ?? input.documentContext?.promptProvenance?.origin ?? 'unknown',
+        payload: input.prompt,
+      });
+
+      // This UPSERT is the sole allocator for a source session. It remains
+      // atomic under concurrent distinct submissions; a same-ID replay may
+      // consume a harmless gap but never creates another row.
+      const allocation = await db.query<{ submission_sequence: number }>(
+        `INSERT INTO queued_prompt_source_sequences (source_session_id, next_sequence)
+         VALUES ($1, 2)
+         ON CONFLICT (source_session_id)
+         DO UPDATE SET next_sequence = queued_prompt_source_sequences.next_sequence + 1
+         RETURNING next_sequence - 1 AS submission_sequence`,
+        [input.sessionId],
+      );
+      const submissionSequence = Number(allocation.rows[0]?.submission_sequence);
+      if (!Number.isSafeInteger(submissionSequence) || submissionSequence < 1) {
+        throw new Error('Unable to allocate queued prompt sequence');
+      }
 
       const { rows } = await db.query<any>(
-        `INSERT INTO queued_prompts (id, session_id, prompt, attachments, document_context)
-         SELECT $1, $2, $3, $4, $5
+        `INSERT INTO queued_prompts (
+           id, session_id, prompt, attachments, document_context, producer,
+           client_submission_id, source_session_id, source_room_id, submission_sequence,
+           payload_utf8_bytes, payload_unicode_scalars, payload_sha256
+         )
+         SELECT $1, $2, $3, $4, $5, $6, $7, $2, $8,
+           $9,
+           $10, $11, $12
          FROM ai_sessions s
          WHERE s.id = $2
            AND ${metadataReadyClause}
@@ -464,11 +541,25 @@ export function createPGLiteQueuedPromptsStore(
           input.prompt,
           input.attachments ? JSON.stringify(input.attachments) : null,
           input.documentContext ? JSON.stringify(input.documentContext) : null,
+          truth.producer,
+          truth.clientSubmissionId,
+          truth.sourceRoomId,
+          submissionSequence,
+          truth.payload.utf8Bytes,
+          truth.payload.unicodeScalars,
+          truth.payload.sha256,
         ]
       );
 
       if (rows.length === 0) {
-        throw new Error('Queued prompt creation was not admitted');
+        const existing = await db.query<any>(
+          `SELECT * FROM queued_prompts WHERE client_submission_id = $1 LIMIT 1`,
+          [truth.clientSubmissionId],
+        );
+        const row = existing.rows[0] ? rowToQueuedPrompt(existing.rows[0]) : null;
+        if (!row) throw new Error('Queued prompt creation was not admitted');
+        if (row.payloadReceipt && !payloadReceiptsMatch(input.prompt, row.payloadReceipt)) throw queueTruthMismatchError();
+        return row;
       }
 
       console.log(`[QueuedPromptsStore] Created prompt ${input.id} for session ${input.sessionId}`);
@@ -730,7 +821,7 @@ export function createPGLiteQueuedPromptsStore(
       return row;
     },
 
-    async claim(id: string, expectedSessionId?: string): Promise<QueuedPrompt | null> {
+    async claim(id: string, expectedSessionId?: string, claimTrigger = 'queue_driver'): Promise<QueuedPrompt | null> {
       await ensureReady();
 
       const metadataReadyClause = await getMetadataReadyClause();
@@ -749,7 +840,15 @@ export function createPGLiteQueuedPromptsStore(
              dispatch_started_at = NULL,
              settlement_provenance = NULL,
              completed_at = NULL,
-             error_message = NULL
+             error_message = NULL,
+             claim_trigger = $4,
+             claim_triggered_at = CURRENT_TIMESTAMP,
+             turn_id = 'turn:' || id || ':' || $3,
+             provider_input_message_id = 'input:' || id || ':' || $3,
+             provider_output_message_id = 'output:' || id || ':' || $3,
+             stream_event_sequence = 0,
+             terminal_status = 'streaming',
+             terminal_at = NULL
          WHERE id = $1
            AND status = 'pending'
            AND delivery_ready = TRUE
@@ -761,7 +860,7 @@ export function createPGLiteQueuedPromptsStore(
                AND ${metadataReadyClause}
            )
          RETURNING *`,
-        [id, expectedSessionId ?? null, claimToken]
+        [id, expectedSessionId ?? null, claimToken, claimTrigger]
       );
 
       if (rows.length === 0) {
@@ -843,15 +942,30 @@ export function createPGLiteQueuedPromptsStore(
       id: string,
       expectedSessionId: string,
       claimToken: string,
+      terminal?: QueueTerminalReceipt,
     ): Promise<QueueSettlementResult> {
       await ensureReady();
+      const dialect = await getDialect();
       const metadataReadyClause = await getMetadataReadyClause();
+      const terminalTimeSql = dialect === 'pglite'
+        ? 'COALESCE($7::timestamptz, CURRENT_TIMESTAMP)'
+        : 'COALESCE($7, CURRENT_TIMESTAMP)';
+      const terminalSequenceSql = dialect === 'pglite'
+        ? `CASE WHEN $8::integer IS NULL THEN stream_event_sequence + 1
+                WHEN stream_event_sequence >= $8::integer THEN stream_event_sequence
+                ELSE $8::integer END`
+        : `CASE WHEN $8 IS NULL THEN stream_event_sequence + 1
+                WHEN stream_event_sequence >= $8 THEN stream_event_sequence
+                ELSE $8 END`;
       const { rows } = await db.query<any>(
         `UPDATE queued_prompts
          SET status = 'completed',
-             completed_at = CURRENT_TIMESTAMP,
+             completed_at = ${terminalTimeSql},
              error_message = NULL,
-             settlement_provenance = $4
+             settlement_provenance = $4,
+             terminal_status = 'completed',
+             terminal_at = ${terminalTimeSql},
+             stream_event_sequence = ${terminalSequenceSql}
          WHERE id = $1
            AND session_id = $2::text
            AND claim_token = $3
@@ -876,6 +990,8 @@ export function createPGLiteQueuedPromptsStore(
           PROVENANCE_DISPATCH_COMPLETED,
           PROVENANCE_SWEEP_INTERRUPT,
           PROVENANCE_SWEEP_BOOT,
+          terminal ? new Date(terminal.terminalAt).toISOString() : null,
+          terminal?.eventSequence ?? null,
         ],
       );
       if (rows.length > 0) return { outcome: 'settled', row: rowToQueuedPrompt(rows[0]) };
@@ -892,15 +1008,30 @@ export function createPGLiteQueuedPromptsStore(
       errorMessage: string,
       expectedSessionId: string,
       claimToken: string,
+      terminal?: QueueTerminalReceipt,
     ): Promise<QueueSettlementResult> {
       await ensureReady();
+      const dialect = await getDialect();
       const metadataReadyClause = await getMetadataReadyClause();
+      const terminalTimeSql = dialect === 'pglite'
+        ? 'COALESCE($6::timestamptz, CURRENT_TIMESTAMP)'
+        : 'COALESCE($6, CURRENT_TIMESTAMP)';
+      const terminalSequenceSql = dialect === 'pglite'
+        ? `CASE WHEN $7::integer IS NULL THEN stream_event_sequence + 1
+                WHEN stream_event_sequence >= $7::integer THEN stream_event_sequence
+                ELSE $7::integer END`
+        : `CASE WHEN $7 IS NULL THEN stream_event_sequence + 1
+                WHEN stream_event_sequence >= $7 THEN stream_event_sequence
+                ELSE $7 END`;
       const { rows } = await db.query<any>(
         `UPDATE queued_prompts
          SET status = 'failed',
-             completed_at = CURRENT_TIMESTAMP,
+             completed_at = ${terminalTimeSql},
              error_message = $4,
-             settlement_provenance = $5
+             settlement_provenance = $5,
+             terminal_status = 'failed',
+             terminal_at = ${terminalTimeSql},
+             stream_event_sequence = ${terminalSequenceSql}
          WHERE id = $1
            AND session_id = $2::text
            AND claim_token = $3
@@ -912,7 +1043,15 @@ export function createPGLiteQueuedPromptsStore(
                AND ${metadataReadyClause}
            )
          RETURNING *`,
-        [id, expectedSessionId, claimToken, errorMessage, PROVENANCE_DISPATCH_FAILED],
+        [
+          id,
+          expectedSessionId,
+          claimToken,
+          errorMessage,
+          PROVENANCE_DISPATCH_FAILED,
+          terminal ? new Date(terminal.terminalAt).toISOString() : null,
+          terminal?.eventSequence ?? null,
+        ],
       );
       if (rows.length > 0) return { outcome: 'settled', row: rowToQueuedPrompt(rows[0]) };
       return classifyMutationMiss(
@@ -926,11 +1065,15 @@ export function createPGLiteQueuedPromptsStore(
     async replacePending(input: CreateQueuedPromptInput): Promise<QueuedPrompt | null> {
       await ensureReady();
       const metadataReadyClause = await getMetadataReadyClause();
+      const receipt = receiptQueuedPromptPayload(input.prompt);
       const { rows } = await db.query<any>(
         `UPDATE queued_prompts
          SET prompt = $3,
              attachments = $4,
-             document_context = $5
+             document_context = $5,
+             payload_utf8_bytes = $6,
+             payload_unicode_scalars = $7,
+             payload_sha256 = $8
          WHERE id = $1
            AND session_id = $2::text
            AND status = 'pending'
@@ -946,6 +1089,9 @@ export function createPGLiteQueuedPromptsStore(
           input.prompt,
           input.attachments !== undefined ? JSON.stringify(input.attachments) : null,
           input.documentContext !== undefined ? JSON.stringify(input.documentContext) : null,
+          receipt.utf8Bytes,
+          receipt.unicodeScalars,
+          receipt.sha256,
         ],
       );
       return rows.length > 0 ? rowToQueuedPrompt(rows[0]) : null;

--- a/packages/electron/src/main/services/PriorityPromptDeliveryService.ts
+++ b/packages/electron/src/main/services/PriorityPromptDeliveryService.ts
@@ -1,0 +1,141 @@
+import { createHash, randomUUID } from 'crypto';
+
+export type PriorityTargetStatus = 'idle' | 'running' | 'waiting_for_input' | 'error' | 'interrupted' | 'missing';
+
+export interface PriorityTargetState {
+  status: PriorityTargetStatus;
+  generation: string;
+  lastActivity: number | null;
+  updatedAt: number | null;
+}
+
+export function createPriorityTargetGeneration(status: PriorityTargetStatus, lastActivity: number | null, updatedAt: number | null): string {
+  return `${status}:${lastActivity ?? 'none'}:${updatedAt ?? 'none'}`;
+}
+
+export interface PriorityInterruptReceipt {
+  generation: string;
+  attempted: boolean;
+  success: boolean;
+  method: string | null;
+  error: string | null;
+  nativeEntered: boolean;
+  recordedAt: number;
+}
+
+export interface PriorityControlPrompt {
+  id: string;
+  sessionId: string;
+  status: 'pending' | 'executing' | 'completed' | 'failed';
+  deliveryClass: 'control';
+  priorityRank: number;
+  deliveryReady?: boolean;
+  interruptTargetGeneration: string | null;
+  interruptReservationOwner: string | null;
+  interruptReceipt: PriorityInterruptReceipt | null;
+}
+
+interface PriorityPromptDeliveryDependencies {
+  createControlPrompt(input: { id: string; sessionId: string; prompt: string; producer: string; idempotencyKey: string; requestDigest: string; controlOperation: string }): Promise<{ row: PriorityControlPrompt; replayed: boolean }>;
+  getTargetState(sessionId: string, workspacePath: string): Promise<PriorityTargetState>;
+  hasStructuredPendingPrompt(sessionId: string): Promise<boolean>;
+  reserveInterrupt(input: { promptId: string; generation: string; owner: string }): Promise<{ row: PriorityControlPrompt; reserved: boolean }>;
+  recordInterruptReceipt(input: { promptId: string; generation: string; receipt: PriorityInterruptReceipt }): Promise<PriorityControlPrompt>;
+  interruptCurrentTurn(sessionId: string, expectedState: PriorityTargetState): Promise<{ success: boolean; method?: string; error?: string; nativeEntered?: boolean }>;
+  triggerProcessing(sessionId: string, workspacePath: string): Promise<boolean>;
+  getControlPrompt(promptId: string): Promise<PriorityControlPrompt | null>;
+  createReservationOwner?(): string;
+  createControlPromptId?(): string;
+}
+
+export interface DeliverPriorityPromptInput {
+  sessionId: string;
+  workspacePath: string;
+  prompt: string;
+  idempotencyKey: string;
+  producer: string;
+  controlOperation: string;
+  interruptWaitingForInput: boolean;
+}
+
+export interface PriorityPromptDeliveryReceipt {
+  sessionId: string;
+  queuedPromptId: string;
+  deliveryClass: 'control';
+  priorityRank: number;
+  idempotencyKey: string;
+  producer: string;
+  controlOperation: string;
+  replayed: boolean;
+  action: 'processing_triggered' | 'queued_waiting_for_authority' | 'structured_prompt_requires_response' | 'interrupt_attempted' | 'interrupt_receipt_replayed' | 'interrupt_already_reserved' | 'stale_generation_rejected';
+  targetBefore: PriorityTargetState;
+  targetAfter: PriorityTargetState;
+  processingTriggerCalled: boolean;
+  processingTriggerAccepted: boolean;
+  interrupt: { attempted: boolean; success: boolean | null; method: string | null; error: string | null; nativeEntered: boolean; targetGeneration: string | null; reservationOwner: string | null };
+}
+
+function requireNonEmpty(value: string, field: string): string {
+  const normalized = value?.trim();
+  if (!normalized) throw new Error(`${field} is required`);
+  return normalized;
+}
+
+function requestDigest(input: { sessionId: string; prompt: string; producer: string; controlOperation: string }): string {
+  return createHash('sha256').update(JSON.stringify(input)).digest('hex');
+}
+
+function receiptInterrupt(row: PriorityControlPrompt, receipt: PriorityInterruptReceipt | null) {
+  return { attempted: receipt?.attempted ?? false, success: receipt?.success ?? null, method: receipt?.method ?? null, error: receipt?.error ?? null, nativeEntered: receipt?.nativeEntered ?? false, targetGeneration: row.interruptTargetGeneration ?? receipt?.generation ?? null, reservationOwner: row.interruptReservationOwner };
+}
+
+export function createPriorityPromptDeliveryService(deps: PriorityPromptDeliveryDependencies) {
+  return {
+    async deliver(raw: DeliverPriorityPromptInput): Promise<PriorityPromptDeliveryReceipt> {
+      const sessionId = requireNonEmpty(raw.sessionId, 'sessionId');
+      const workspacePath = requireNonEmpty(raw.workspacePath, 'workspacePath');
+      const prompt = requireNonEmpty(raw.prompt, 'prompt');
+      const idempotencyKey = requireNonEmpty(raw.idempotencyKey, 'idempotencyKey');
+      const producer = requireNonEmpty(raw.producer, 'producer');
+      const controlOperation = requireNonEmpty(raw.controlOperation, 'controlOperation');
+      const created = await deps.createControlPrompt({ id: deps.createControlPromptId?.() ?? `control-${randomUUID()}`, sessionId, prompt, producer, idempotencyKey, requestDigest: requestDigest({ sessionId, prompt, producer, controlOperation }), controlOperation });
+      let row = created.row;
+      const targetBefore = await deps.getTargetState(sessionId, workspacePath);
+      const result = (action: PriorityPromptDeliveryReceipt['action'], targetAfter: PriorityTargetState, processingTriggerCalled: boolean, processingTriggerAccepted: boolean): PriorityPromptDeliveryReceipt => ({ sessionId, queuedPromptId: row.id, deliveryClass: 'control', priorityRank: row.priorityRank, idempotencyKey, producer, controlOperation, replayed: created.replayed, action, targetBefore, targetAfter, processingTriggerCalled, processingTriggerAccepted, interrupt: receiptInterrupt(row, row.interruptReceipt) });
+
+      if (row.interruptReceipt) {
+        const retry = row.status === 'pending' && row.interruptReceipt.success;
+        const accepted = retry ? await deps.triggerProcessing(sessionId, workspacePath) : false;
+        return result('interrupt_receipt_replayed', retry ? await deps.getTargetState(sessionId, workspacePath) : targetBefore, retry, accepted);
+      }
+      if (targetBefore.status === 'waiting_for_input') {
+        if (await deps.hasStructuredPendingPrompt(sessionId)) return result('structured_prompt_requires_response', targetBefore, false, false);
+        if (!raw.interruptWaitingForInput) return result('queued_waiting_for_authority', targetBefore, false, false);
+      }
+      if (targetBefore.status === 'missing') throw new Error(`Session ${sessionId} disappeared before priority delivery`);
+      const needsInterrupt = targetBefore.status === 'running' || targetBefore.status === 'waiting_for_input';
+      const reservation = await deps.reserveInterrupt({ promptId: row.id, generation: targetBefore.generation, owner: deps.createReservationOwner?.() ?? randomUUID() });
+      row = reservation.row;
+      if (!reservation.reserved) {
+        row = (await deps.getControlPrompt(row.id)) ?? row;
+        const retry = Boolean(row.interruptReceipt?.success && row.status === 'pending');
+        const accepted = retry ? await deps.triggerProcessing(sessionId, workspacePath) : false;
+        return result(row.interruptReceipt ? 'interrupt_receipt_replayed' : 'interrupt_already_reserved', await deps.getTargetState(sessionId, workspacePath), retry, accepted);
+      }
+      const stateAtInterrupt = await deps.getTargetState(sessionId, workspacePath);
+      if (stateAtInterrupt.generation !== targetBefore.generation || stateAtInterrupt.status !== targetBefore.status) {
+        row = await deps.recordInterruptReceipt({ promptId: row.id, generation: targetBefore.generation, receipt: { generation: targetBefore.generation, attempted: false, success: false, method: null, error: 'stale lifecycle generation', nativeEntered: false, recordedAt: Date.now() } });
+        return result('stale_generation_rejected', await deps.getTargetState(sessionId, workspacePath), false, false);
+      }
+      if (!needsInterrupt) {
+        row = await deps.recordInterruptReceipt({ promptId: row.id, generation: targetBefore.generation, receipt: { generation: targetBefore.generation, attempted: false, success: true, method: 'not-required', error: null, nativeEntered: false, recordedAt: Date.now() } });
+        const accepted = await deps.triggerProcessing(sessionId, workspacePath);
+        return result('processing_triggered', await deps.getTargetState(sessionId, workspacePath), true, accepted);
+      }
+      const interrupted = await deps.interruptCurrentTurn(sessionId, targetBefore);
+      row = await deps.recordInterruptReceipt({ promptId: row.id, generation: targetBefore.generation, receipt: { generation: targetBefore.generation, attempted: true, success: interrupted.success, method: interrupted.method ?? null, error: interrupted.error ?? null, nativeEntered: interrupted.nativeEntered === true, recordedAt: Date.now() } });
+      const accepted = interrupted.success ? await deps.triggerProcessing(sessionId, workspacePath) : false;
+      return result('interrupt_attempted', await deps.getTargetState(sessionId, workspacePath), interrupted.success, accepted);
+    },
+  };
+}

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.projectTargeting.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.projectTargeting.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  hasLiveWindowForWorkspaceMock,
+  createWorktreeMock,
+  worktreeStoreCreateMock,
+  worktreeStoreListMock,
+  worktreeStoreGetMock,
+  worktreeStoreGetAllNamesMock,
+  worktreeStoreGetSessionsMock,
+  databaseQueryMock,
+  queuedPromptsListMock,
+  createPriorityControlPromptMock,
+  reservePriorityInterruptMock,
+  recordPriorityInterruptReceiptMock,
+  getQueuedPromptMock,
+  setMetaAgentToolFnsMock,
+  resolveClaudeCodeBackendMock,
+  resolveClaudeCodeBackendForConfigMock,
+  preflightOllamaClaudeCodeBackendMock,
+} = vi.hoisted(() => ({
+  hasLiveWindowForWorkspaceMock: vi.fn(),
+  createWorktreeMock: vi.fn(),
+  worktreeStoreCreateMock: vi.fn(),
+  worktreeStoreListMock: vi.fn(),
+  worktreeStoreGetMock: vi.fn(),
+  worktreeStoreGetAllNamesMock: vi.fn(),
+  worktreeStoreGetSessionsMock: vi.fn(),
+  databaseQueryMock: vi.fn(),
+  queuedPromptsListMock: vi.fn(),
+  createPriorityControlPromptMock: vi.fn(),
+  reservePriorityInterruptMock: vi.fn(),
+  recordPriorityInterruptReceiptMock: vi.fn(),
+  getQueuedPromptMock: vi.fn(),
+  setMetaAgentToolFnsMock: vi.fn(),
+  resolveClaudeCodeBackendMock: vi.fn(),
+  resolveClaudeCodeBackendForConfigMock: vi.fn(),
+  preflightOllamaClaudeCodeBackendMock: vi.fn(),
+}));
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: {
+    create: vi.fn(),
+    updateMetadata: vi.fn(),
+    get: vi.fn(),
+  },
+  AgentMessagesRepository: {
+    create: vi.fn(),
+    list: vi.fn().mockResolvedValue([]),
+  },
+  SessionFilesRepository: {
+    getFilesBySession: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  SessionManager: class {
+    async initialize() {}
+  },
+  resolveClaudeCodeBackend: resolveClaudeCodeBackendMock,
+  resolveClaudeCodeBackendForConfig: resolveClaudeCodeBackendForConfigMock,
+}));
+
+vi.mock('../ai/OllamaClaudeCodePreflight', () => ({
+  preflightOllamaClaudeCodeBackend: preflightOllamaClaudeCodeBackendMock,
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: {
+    parse: (id: string) => {
+      const split = id.indexOf(':');
+      if (split <= 0) throw new Error(`invalid model: ${id}`);
+      return { provider: id.slice(0, split), model: id.slice(split + 1), combined: id };
+    },
+    tryParse: (id: string) => {
+      const split = typeof id === 'string' ? id.indexOf(':') : -1;
+      return split > 0
+        ? { provider: id.slice(0, split), model: id.slice(split + 1), combined: id }
+        : null;
+    },
+    getDefaultModelId: (provider: string) => `${provider}:default`,
+  },
+}));
+
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn(() => () => {}) }),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+vi.mock('../../window/windowState', () => ({
+  hasLiveWindowForWorkspace: hasLiveWindowForWorkspaceMock,
+}));
+
+vi.mock('../../utils/workspaceDetection', () => ({
+  resolveProjectPath: (workspacePath: string) => workspacePath,
+}));
+
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({
+  getDefaultAIModel: () => 'openai-codex:gpt-5.6-terra',
+  getDefaultEffortLevel: () => undefined,
+}));
+vi.mock('../../utils/timestampUtils', () => ({ toMillis: (value: unknown) => value }));
+vi.mock('../WorktreeStore', () => ({
+  createWorktreeStore: () => ({
+    create: worktreeStoreCreateMock,
+    list: worktreeStoreListMock,
+    get: worktreeStoreGetMock,
+    getAllNames: worktreeStoreGetAllNamesMock,
+    getWorktreeSessions: worktreeStoreGetSessionsMock,
+  }),
+}));
+vi.mock('../GitWorktreeService', () => ({
+  GitWorktreeService: class {
+    createWorktree = createWorktreeMock;
+    getExistingWorktreeDirectories = vi.fn(() => []);
+    getAllBranchNames = vi.fn(async () => []);
+    generateUniqueWorktreeName = vi.fn(() => 'safe-route');
+  },
+}));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({
+  database: { query: databaseQueryMock },
+}));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => ({}) }));
+vi.mock('../../file/GitRefWatcher', () => ({
+  gitRefWatcher: { start: vi.fn(async () => undefined) },
+}));
+vi.mock('../RepositoryManager', () => ({
+  getQueuedPromptsStore: () => ({
+    listForSession: queuedPromptsListMock,
+    createPriorityControlPrompt: createPriorityControlPromptMock,
+    reservePriorityInterrupt: reservePriorityInterruptMock,
+    recordPriorityInterruptReceipt: recordPriorityInterruptReceiptMock,
+    get: getQueuedPromptMock,
+  }),
+}));
+vi.mock('../ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({ setMetaAgentToolFns: setMetaAgentToolFnsMock }));
+vi.mock('../metaAgentNotificationSignature', () => ({ computeNotificationSignature: vi.fn() }));
+vi.mock('../metaAgentMessageText', () => ({
+  extractMessageText: vi.fn(),
+  extractUserPrompts: vi.fn(() => []),
+}));
+
+import { AISessionsRepository } from '@nimbalyst/runtime';
+import { setMetaAgentToolFns } from '../../mcp/metaAgentServer';
+import { MetaAgentService } from '../MetaAgentService';
+
+const caller = {
+  id: 'caller',
+  workspacePath: '/project-a',
+  provider: 'openai-codex',
+  model: 'openai-codex:gpt-5.6-terra',
+  worktreeId: null,
+  parentSessionId: null,
+  sessionType: 'session',
+};
+
+const targetChild = {
+  id: 'target-child',
+  workspacePath: '/project-b',
+  provider: 'openai-codex',
+  model: 'openai-codex:gpt-5.6-terra',
+  createdBySessionId: 'caller',
+  worktreeId: 'target-worktree',
+  worktreePath: '/project-b_worktrees/safe-route',
+  title: 'Target child',
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+
+describe('MetaAgentService priority delivery custody', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    databaseQueryMock.mockReset().mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM ai_sessions')) {
+        return {
+          rows: [{
+            id: 'target-child',
+            title: 'Target child',
+            provider: 'openai-codex',
+            model: 'openai-codex:gpt-5.6-terra',
+            status: 'idle',
+            last_activity: 10,
+            updated_at: 20,
+            created_by_session_id: 'caller',
+            agent_role: 'standard',
+          }],
+        };
+      }
+      if (sql.includes('FROM ai_agent_messages')) return { rows: [] };
+      return { rows: [] };
+    });
+    vi.mocked(AISessionsRepository.get).mockReset();
+    createPriorityControlPromptMock.mockReset();
+    reservePriorityInterruptMock.mockReset();
+    recordPriorityInterruptReceiptMock.mockReset();
+    getQueuedPromptMock.mockReset();
+  });
+
+  it('fails closed when the target session belongs to another workspace', async () => {
+    const service = MetaAgentService.getInstance();
+    (service as any).aiService = {};
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(targetChild as any);
+
+    await expect((service as any).sendPromptNowToSession('caller', '/project-a', {
+      sessionId: 'target-child',
+      prompt: 'priority',
+      idempotencyKey: 'custody-1',
+    })).rejects.toThrow('Session target-child not found');
+    expect(createPriorityControlPromptMock).not.toHaveBeenCalled();
+  });
+
+  it('routes through the target workspace and replays one durable control identity', async () => {
+    const service = MetaAgentService.getInstance();
+    const trigger = vi.fn(async () => true);
+    const releaseHandoff = vi.fn();
+    (service as any).aiService = {
+      interruptCurrentTurnForPriorityDelivery: vi.fn(),
+      releasePriorityQueueHandoffForDelivery: releaseHandoff,
+      triggerQueuedPromptProcessingForSession: trigger,
+    };
+    vi.mocked(AISessionsRepository.get).mockResolvedValue(targetChild as any);
+
+    const receipt = {
+      generation: 'idle:10:20',
+      attempted: false,
+      success: true,
+      method: 'not-required',
+      error: null,
+      nativeEntered: false,
+      recordedAt: 30,
+    };
+    const row = {
+      id: 'control-project-b',
+      sessionId: 'target-child',
+      status: 'pending',
+      deliveryClass: 'control',
+      priorityRank: 100,
+      deliveryReady: true,
+      interruptTargetGeneration: 'idle:10:20',
+      interruptReservationOwner: 'owner-project-b',
+      interruptReceipt: receipt,
+    };
+    createPriorityControlPromptMock.mockResolvedValue({ row, replayed: true });
+    getQueuedPromptMock.mockResolvedValue(row);
+
+    const result = JSON.parse(await (service as any).sendPromptNowToSession('caller', '/project-b', {
+      sessionId: 'target-child',
+      prompt: 'priority',
+      idempotencyKey: 'custody-1',
+      controlOperation: 'owner_handoff',
+    }));
+
+    expect(result).toMatchObject({
+      sessionId: 'target-child',
+      queuedPromptId: 'control-project-b',
+      replayed: true,
+      action: 'interrupt_receipt_replayed',
+    });
+    expect(createPriorityControlPromptMock).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'target-child',
+      idempotencyKey: 'custody-1',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'owner_handoff',
+    }));
+    expect(trigger).toHaveBeenCalledWith(
+      'target-child',
+      '/project-b_worktrees/safe-route',
+      'meta-agent',
+    );
+    expect(releaseHandoff).toHaveBeenCalledWith('target-child');
+  });
+});

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.queuedPromptTruth.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.queuedPromptTruth.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { databaseQueryMock, queuePromptForSessionMock, triggerQueuedPromptProcessingMock } = vi.hoisted(() => ({
+  databaseQueryMock: vi.fn(),
+  queuePromptForSessionMock: vi.fn(),
+  triggerQueuedPromptProcessingMock: vi.fn(),
+}));
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AISessionsRepository: { get: vi.fn() },
+  AgentMessagesRepository: { create: vi.fn(), list: vi.fn().mockResolvedValue([]) },
+  SessionFilesRepository: { getFilesBySession: vi.fn().mockResolvedValue([]) },
+}));
+vi.mock('@nimbalyst/runtime/ai/server', () => ({
+  SessionManager: class { async initialize() {} },
+  resolveClaudeCodeBackend: vi.fn(),
+  resolveClaudeCodeBackendForConfig: vi.fn(),
+}));
+vi.mock('@nimbalyst/runtime/ai/server/types', () => ({
+  ModelIdentifier: { tryParse: vi.fn(), parse: vi.fn(), getDefaultModelId: vi.fn() },
+}));
+vi.mock('@nimbalyst/runtime/ai/server/SessionStateManager', () => ({
+  getSessionStateManager: () => ({ subscribe: vi.fn(() => () => {}) }),
+}));
+vi.mock('electron', () => ({ BrowserWindow: { getAllWindows: () => [] } }));
+vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
+vi.mock('../../utils/store', () => ({ getDefaultAIModel: vi.fn(), getDefaultEffortLevel: vi.fn() }));
+vi.mock('../../database/PGLiteDatabaseWorker', () => ({ database: { query: databaseQueryMock } }));
+vi.mock('../../database/initialize', () => ({ getDatabase: () => ({}) }));
+vi.mock('../WorktreeStore', () => ({ createWorktreeStore: () => ({}) }));
+vi.mock('../GitWorktreeService', () => ({ GitWorktreeService: class {} }));
+vi.mock('../RepositoryManager', () => ({ getQueuedPromptsStore: vi.fn() }));
+vi.mock('../ai/AIService', () => ({ AIService: class {} }));
+vi.mock('../../mcp/metaAgentServer', () => ({ setMetaAgentToolFns: vi.fn() }));
+vi.mock('../metaAgentNotificationSignature', () => ({ computeNotificationSignature: vi.fn() }));
+vi.mock('../metaAgentMessageText', () => ({ extractMessageText: vi.fn(), extractUserPrompts: vi.fn(() => []) }));
+
+import { AISessionsRepository } from '@nimbalyst/runtime';
+import { MetaAgentService } from '../MetaAgentService';
+
+describe('MetaAgentService queued prompt truth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    databaseQueryMock.mockResolvedValue({ rows: [{ status: 'idle' }] });
+    vi.mocked(AISessionsRepository.get).mockResolvedValue({
+      id: 'target-session',
+      workspacePath: '/workspace',
+      worktreePath: '/workspace',
+    } as any);
+    queuePromptForSessionMock.mockResolvedValue({
+      id: 'meta-stable-submission',
+      prompt: '  keep this exact payload\\n',
+      createdAt: 1,
+    });
+  });
+
+  it('validates whitespace without normalizing the queued orchestration payload', async () => {
+    const service = MetaAgentService.getInstance() as any;
+    service.shouldBypassChildAgentExecutionForTests = () => false;
+    service.aiService = {
+      queuePromptForSession: queuePromptForSessionMock,
+      triggerQueuedPromptProcessingForSession: triggerQueuedPromptProcessingMock,
+    };
+
+    const result = JSON.parse(await service.sendPromptToSession(
+      'origin-session',
+      'target-session',
+      '/workspace',
+      '  keep this exact payload\\n',
+    ));
+
+    expect(queuePromptForSessionMock).toHaveBeenCalledWith(
+      'target-session',
+      '  keep this exact payload\\n',
+      undefined,
+      expect.objectContaining({
+        promptProvenance: expect.objectContaining({
+          originSessionId: 'origin-session',
+          origin: 'session-orchestration',
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      queuedPromptId: 'meta-stable-submission',
+      prompt: '  keep this exact payload\\n',
+      processingTriggered: true,
+    });
+    expect(triggerQueuedPromptProcessingMock).toHaveBeenCalledWith(
+      'target-session',
+      '/workspace',
+      'meta-agent',
+    );
+  });
+});

--- a/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.priorityControl.sqlite.test.ts
+++ b/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.priorityControl.sqlite.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SQLiteDatabase } from '../../database/sqlite/SQLiteDatabase';
+import { createSQLiteStoreAdapter } from '../../database/sqlite/SQLiteStoreAdapter';
+import { createPGLiteQueuedPromptsStore } from '../PGLiteQueuedPromptsStore';
+
+describe('PGLiteQueuedPromptsStore SQLite parity', () => {
+  let tmpDir: string;
+  let database: SQLiteDatabase;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nim-priority-queue-'));
+    database = new SQLiteDatabase({
+      dbDir: tmpDir,
+      schemaDir: path.resolve(__dirname, '../../database/sqlite/schemas'),
+      slowQueryThresholdMs: 1000,
+      sampleRate: 0,
+    });
+    await database.initialize();
+    await database.query(
+      `INSERT INTO ai_sessions (id, workspace_id, provider, title, metadata)
+       VALUES ($1, $2, $3, $4, $5), ($6, $7, $8, $9, $10)`,
+      [
+        'session-1', 'D:\\repo', 'openai-codex', 'Target', '{}',
+        'blocked', 'D:\\repo', 'openai-codex', 'Blocked',
+        '{"modelChangeReconciliation":{"status":"pending"}}',
+      ],
+    );
+  });
+
+  afterEach(async () => {
+    await database.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('keeps ordinary FIFO and durable priority-control ordering', async () => {
+    const store = createPGLiteQueuedPromptsStore(createSQLiteStoreAdapter(database));
+    await store.create({ id: 'ordinary-1', sessionId: 'session-1', prompt: 'first' });
+    await store.create({ id: 'ordinary-2', sessionId: 'session-1', prompt: 'second' });
+    const input = {
+      id: 'control-1',
+      sessionId: 'session-1',
+      prompt: 'priority',
+      producer: 'send_prompt_now:caller',
+      idempotencyKey: 'priority:key-1',
+      requestDigest: 'digest-1',
+      controlOperation: 'operator_directive',
+    };
+    await expect(store.createPriorityControlPrompt(input)).resolves.toMatchObject({
+      replayed: false,
+      row: { id: 'control-1', deliveryReady: false },
+    });
+    await expect(
+      store.createPriorityControlPrompt({ ...input, id: 'control-replay' }),
+    ).resolves.toMatchObject({ replayed: true, row: { id: 'control-1' } });
+    await expect(
+      store.createPriorityControlPrompt({ ...input, id: 'control-conflict', requestDigest: 'other' }),
+    ).rejects.toThrow(/idempotency_conflict/);
+
+    await store.reservePriorityInterrupt({
+      promptId: 'control-1',
+      generation: 'running:10:20',
+      owner: 'owner-1',
+    });
+    await store.recordPriorityInterruptReceipt({
+      promptId: 'control-1',
+      generation: 'running:10:20',
+      receipt: {
+        generation: 'running:10:20', attempted: true, success: true,
+        method: 'interrupt', error: null, nativeEntered: true, recordedAt: 30,
+      },
+    });
+    expect((await store.listPending('session-1')).map((row) => row.id)).toEqual([
+      'control-1',
+      'ordinary-1',
+      'ordinary-2',
+    ]);
+  });
+
+  it('fences stale claims, supports provisional late success, and reports duplicate settlement', async () => {
+    const store = createPGLiteQueuedPromptsStore(createSQLiteStoreAdapter(database));
+    await store.create({ id: 'replaceable', sessionId: 'session-1', prompt: 'replaceable' });
+    const ownerA = await store.claim('replaceable', 'session-1');
+    expect(ownerA?.claimToken).toBeTruthy();
+    expect(await store.sweepExecutingForSession('session-1')).toMatchObject({
+      failed: 0,
+      rolledBack: 1,
+      rolledBackIds: ['replaceable'],
+    });
+    const ownerB = await store.claim('replaceable', 'session-1');
+    await expect(
+      store.beginDispatch('replaceable', 'session-1', ownerB!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'settled' });
+    await expect(
+      store.completeAfterDispatch('replaceable', 'session-1', ownerA!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'stale_owner' });
+
+    const swept = await store.sweepExecutingForSession('session-1');
+    expect(swept).toMatchObject({ failed: 1, failedIds: ['replaceable'], rolledBack: 0 });
+    await expect(
+      store.completeAfterDispatch('replaceable', 'session-1', ownerB!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'settled' });
+    await expect(
+      store.completeAfterDispatch('replaceable', 'session-1', ownerB!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'idempotent_same_claim' });
+  });
+
+  it('matches PGLite recovery, wrong-owner, ordinary-failure, and CRUD behavior', async () => {
+    const store = createPGLiteQueuedPromptsStore(createSQLiteStoreAdapter(database));
+    await expect(
+      store.create({ id: 'blocked-create', sessionId: 'blocked', prompt: 'blocked' }),
+    ).rejects.toThrow('not admitted');
+    await store.create({ id: 'owned', sessionId: 'session-1', prompt: 'owned' });
+    const claimed = await store.claim('owned', 'session-1');
+    const token = claimed!.claimToken!;
+    await store.beginDispatch('owned', 'session-1', token);
+    await expect(store.completeAfterDispatch('owned', 'wrong-session', token)).resolves.toMatchObject({
+      outcome: 'stale_owner',
+    });
+    await database.query(`UPDATE ai_sessions SET metadata = $1 WHERE id = $2`, [
+      '{"modelChangeReconciliation":{"status":"pending"}}',
+      'session-1',
+    ]);
+    await expect(store.completeAfterDispatch('owned', 'session-1', token)).resolves.toMatchObject({
+      outcome: 'recovery_blocked',
+    });
+    await database.query(`UPDATE ai_sessions SET metadata = $1 WHERE id = $2`, ['{}', 'session-1']);
+    await expect(
+      store.failAfterDispatch('owned', 'permanent failure', 'session-1', token),
+    ).resolves.toMatchObject({ outcome: 'settled' });
+    await expect(store.completeAfterDispatch('owned', 'session-1', token)).resolves.toMatchObject({
+      outcome: 'terminal_conflict',
+    });
+
+    await store.create({ id: 'editable', sessionId: 'session-1', prompt: 'one' });
+    await expect(
+      store.replacePending({ id: 'editable', sessionId: 'session-1', prompt: 'one\n\ntwo' }),
+    ).resolves.toMatchObject({ id: 'editable', prompt: 'one\n\ntwo' });
+    await expect(store.deletePending('editable', 'wrong-session')).resolves.toBe(false);
+    await expect(store.deletePending('editable', 'session-1')).resolves.toBe(true);
+    await expect(store.deletePending('owned', 'session-1')).resolves.toBe(false);
+  });
+
+  it('serializes distinct control rows on one target lifecycle generation', async () => {
+    const store = createPGLiteQueuedPromptsStore(createSQLiteStoreAdapter(database));
+    for (const [id, key] of [['control-a', 'key-a'], ['control-b', 'key-b']] as const) {
+      await store.createPriorityControlPrompt({
+        id,
+        sessionId: 'session-1',
+        prompt: id,
+        producer: 'test',
+        idempotencyKey: key,
+        requestDigest: `digest-${id}`,
+        controlOperation: 'priority',
+      });
+    }
+    const generation = 'running:10:20';
+    const reservations = await Promise.all([
+      store.reservePriorityInterrupt({ promptId: 'control-a', generation, owner: 'owner-a' }),
+      store.reservePriorityInterrupt({ promptId: 'control-b', generation, owner: 'owner-b' }),
+    ]);
+    expect(reservations.filter((entry) => entry.reserved)).toHaveLength(1);
+
+    const winner = reservations.find((entry) => entry.reserved)!.row;
+    const loserId = winner.id === 'control-a' ? 'control-b' : 'control-a';
+    await expect(store.get(loserId)).resolves.toMatchObject({
+      deliveryReady: false,
+      interruptReservationOwner: winner.interruptReservationOwner,
+    });
+    await store.recordPriorityInterruptReceipt({
+      promptId: winner.id,
+      generation,
+      receipt: {
+        generation, attempted: true, success: true, method: 'interrupt',
+        error: null, nativeEntered: true, recordedAt: 30,
+      },
+    });
+    await expect(store.get(loserId)).resolves.toMatchObject({
+      id: loserId,
+      deliveryReady: true,
+      interruptReceipt: { success: true },
+    });
+  });
+
+  it('atomically copies a receipt settled before the loser association executes', async () => {
+    const adapter = createSQLiteStoreAdapter(database);
+    const store = createPGLiteQueuedPromptsStore(adapter);
+    for (const [id, key] of [['control-a', 'key-a'], ['control-b', 'key-b']] as const) {
+      await store.createPriorityControlPrompt({
+        id,
+        sessionId: 'session-1',
+        prompt: id,
+        producer: 'test',
+        idempotencyKey: key,
+        requestDigest: `digest-${id}`,
+        controlOperation: 'priority',
+      });
+    }
+
+    const generation = 'running:10:20';
+    await expect(store.reservePriorityInterrupt({
+      promptId: 'control-a', generation, owner: 'winner-owner',
+    })).resolves.toMatchObject({ reserved: true });
+
+    let associationObserved!: () => void;
+    let releaseAssociation!: () => void;
+    const observed = new Promise<void>((resolve) => { associationObserved = resolve; });
+    const gate = new Promise<void>((resolve) => { releaseAssociation = resolve; });
+    const gatedStore = createPGLiteQueuedPromptsStore({
+      query: async (sql: string, params?: unknown[]) => {
+        if (sql.includes('SET interrupt_reservation_owner = incumbent.interrupt_reservation_owner')) {
+          associationObserved();
+          await gate;
+        }
+        return adapter.query(sql, params);
+      },
+    } as any);
+    const losingReservation = gatedStore.reservePriorityInterrupt({
+      promptId: 'control-b', generation, owner: 'loser-owner',
+    });
+    await observed;
+
+    await store.recordPriorityInterruptReceipt({
+      promptId: 'control-a',
+      generation,
+      receipt: {
+        generation, attempted: true, success: true, method: 'interrupt',
+        error: null, nativeEntered: true, recordedAt: 30,
+      },
+    });
+    releaseAssociation();
+
+    await expect(losingReservation).resolves.toMatchObject({
+      reserved: false,
+      row: {
+        id: 'control-b',
+        interruptReservationOwner: 'winner-owner',
+        deliveryReady: true,
+        interruptReceipt: { success: true },
+      },
+    });
+    await expect(store.get('control-b')).resolves.toMatchObject({
+      deliveryReady: true,
+      interruptReceipt: { success: true },
+    });
+  });
+});

--- a/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.test.ts
+++ b/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.test.ts
@@ -38,7 +38,22 @@ async function createDatabase(): Promise<PGlite> {
       control_operation TEXT,
       interrupt_target_generation TEXT,
       interrupt_reservation_owner TEXT,
-      interrupt_receipt JSONB
+      interrupt_receipt JSONB,
+      client_submission_id TEXT UNIQUE,
+      source_session_id TEXT,
+      source_room_id TEXT,
+      submission_sequence INTEGER,
+      payload_utf8_bytes INTEGER,
+      payload_unicode_scalars INTEGER,
+      payload_sha256 TEXT,
+      claim_trigger TEXT,
+      claim_triggered_at TIMESTAMPTZ,
+      turn_id TEXT,
+      provider_input_message_id TEXT,
+      provider_output_message_id TEXT,
+      stream_event_sequence INTEGER NOT NULL DEFAULT 0,
+      terminal_status TEXT,
+      terminal_at TIMESTAMPTZ
     );
     CREATE TABLE ai_agent_messages (
       id BIGSERIAL PRIMARY KEY,
@@ -47,6 +62,10 @@ async function createDatabase(): Promise<PGlite> {
       source TEXT NOT NULL,
       direction TEXT NOT NULL,
       content TEXT NOT NULL
+    );
+    CREATE TABLE queued_prompt_source_sequences (
+      source_session_id TEXT PRIMARY KEY,
+      next_sequence INTEGER NOT NULL
     );
     CREATE UNIQUE INDEX idx_queued_prompts_interrupt_generation_owner
       ON queued_prompts(session_id, interrupt_target_generation)
@@ -222,6 +241,22 @@ describe('PGLiteQueuedPromptsStore dispatch fencing', () => {
     await expect(
       store.completeAfterDispatch('started', 'session-a', started!.claimToken!),
     ).resolves.toMatchObject({ outcome: 'settled' });
+  });
+
+  it('persists the non-CLI handler terminal boundary without minting a second time or sequence', async () => {
+    const db = await createDatabase();
+    const store = createPGLiteQueuedPromptsStore(db as any);
+    await store.create({ id: 'bound-terminal', sessionId: 'session-a', prompt: 'bound' });
+    const claim = await store.claim('bound-terminal', 'session-a');
+    await store.beginDispatch('bound-terminal', 'session-a', claim!.claimToken!);
+
+    const terminalAt = Date.parse('2026-08-03T00:02:00.000Z');
+    await expect(store.completeAfterDispatch('bound-terminal', 'session-a', claim!.claimToken!, {
+      lifecycle: 'completed', terminalAt, eventSequence: 9,
+    })).resolves.toMatchObject({ outcome: 'settled' });
+    await expect(store.get('bound-terminal')).resolves.toMatchObject({
+      status: 'completed', terminalStatus: 'completed', terminalAt, streamEventSequence: 9,
+    });
   });
 
   it('atomically admits create, pending replacement, and expected-session delete', async () => {

--- a/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.test.ts
+++ b/packages/electron/src/main/services/__tests__/PGLiteQueuedPromptsStore.test.ts
@@ -1,350 +1,404 @@
-import { describe, expect, it, vi } from 'vitest';
-import { createPGLiteQueuedPromptsStore } from '../PGLiteQueuedPromptsStore';
+import { PGlite } from '@electric-sql/pglite';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createPGLiteQueuedPromptsStore,
+  SWEEP_UNANSWERED_ERROR,
+} from '../PGLiteQueuedPromptsStore';
 
-type DbStub = { query: <T = any>(sql: string, params?: any[]) => Promise<{ rows: T[] }> };
+const databases: PGlite[] = [];
 
-describe('PGLiteQueuedPromptsStore.rollbackExecuting', () => {
-  it('resets executing rows for the given session back to pending', async () => {
-    const query = vi.fn(async (sql: string, params?: any[]) => {
-      expect(sql).toContain("SET status = 'pending'");
-      expect(sql).toContain('claimed_at = NULL');
-      expect(sql).toContain("status = 'executing'");
-      expect(sql).toContain('WHERE session_id = $1');
-      expect(params).toEqual(['session-abc']);
-      return { rows: [{ id: 'prompt-1' }, { id: 'prompt-2' }] };
+async function createDatabase(): Promise<PGlite> {
+  const db = new PGlite();
+  databases.push(db);
+  await db.exec(`
+    CREATE TABLE ai_sessions (
+      id TEXT PRIMARY KEY,
+      metadata JSONB
+    );
+    CREATE TABLE queued_prompts (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      prompt TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      attachments JSONB,
+      document_context JSONB,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      claimed_at TIMESTAMPTZ,
+      claim_token TEXT,
+      dispatch_started_at TIMESTAMPTZ,
+      settlement_provenance TEXT,
+      completed_at TIMESTAMPTZ,
+      error_message TEXT,
+      delivery_class TEXT NOT NULL DEFAULT 'ordinary',
+      priority_rank INTEGER NOT NULL DEFAULT 0,
+      delivery_ready BOOLEAN NOT NULL DEFAULT TRUE,
+      producer TEXT,
+      idempotency_key TEXT,
+      request_digest TEXT,
+      control_operation TEXT,
+      interrupt_target_generation TEXT,
+      interrupt_reservation_owner TEXT,
+      interrupt_receipt JSONB
+    );
+    CREATE TABLE ai_agent_messages (
+      id BIGSERIAL PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      source TEXT NOT NULL,
+      direction TEXT NOT NULL,
+      content TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX idx_queued_prompts_interrupt_generation_owner
+      ON queued_prompts(session_id, interrupt_target_generation)
+      WHERE delivery_class = 'control' AND interrupt_target_generation IS NOT NULL;
+    CREATE UNIQUE INDEX idx_queued_prompts_control_idempotency
+      ON queued_prompts(session_id, idempotency_key)
+      WHERE idempotency_key IS NOT NULL;
+    INSERT INTO ai_sessions (id, metadata) VALUES
+      ('session-a', '{}'::jsonb),
+      ('session-b', '{}'::jsonb),
+      ('blocked', '{"modelChangeReconciliation":{"status":"pending"}}'::jsonb),
+      ('malformed', '[]'::jsonb);
+  `);
+  return db;
+}
+
+afterEach(async () => {
+  while (databases.length > 0) await databases.pop()!.close();
+});
+
+describe('PGLiteQueuedPromptsStore dispatch fencing', () => {
+  it('retries a transient dialect probe and generates a persisted opaque claim token', async () => {
+    let unavailable = true;
+    const query = vi.fn(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('UPDATE queued_prompts')) {
+        return {
+          rows: [{
+            id: 'retry', session_id: 'session-a', prompt: 'once', status: 'executing',
+            created_at: new Date(), claimed_at: new Date(), claim_token: params?.[2],
+            delivery_class: 'ordinary', priority_rank: 0, delivery_ready: true,
+          }],
+        };
+      }
+      if (sql.includes('jsonb_typeof')) {
+        if (unavailable) throw new Error('database unavailable');
+        return { rows: [{ kind: 'object' }] };
+      }
+      if (sql.includes('json_valid')) throw new Error('database unavailable');
+      throw new Error(`Unexpected query: ${sql}`);
     });
-    const db: DbStub = { query: query as any };
+    const store = createPGLiteQueuedPromptsStore({ query } as any);
 
-    const store = createPGLiteQueuedPromptsStore(db);
-    const rolledBack = await store.rollbackExecuting('session-abc');
-
-    expect(rolledBack).toBe(2);
-    expect(query).toHaveBeenCalledOnce();
+    await expect(store.claim('retry', 'session-a')).rejects.toThrow('database unavailable');
+    unavailable = false;
+    const claimed = await store.claim('retry', 'session-a');
+    expect(claimed?.claimToken).toMatch(/^[0-9a-f-]{36}$/i);
   });
 
-  it('returns 0 when no rows are stuck in executing', async () => {
-    const db: DbStub = { query: (async () => ({ rows: [] })) as any };
+  it('prevents stale owner A from mutating replacement owner B', async () => {
+    const db = await createDatabase();
+    const store = createPGLiteQueuedPromptsStore(db as any);
+    await store.create({ id: 'race', sessionId: 'session-a', prompt: 'race' });
 
-    const store = createPGLiteQueuedPromptsStore(db);
-    const rolledBack = await store.rollbackExecuting('session-no-rows');
-
-    expect(rolledBack).toBe(0);
-  });
-
-  it('is scoped to the given session id only', async () => {
-    let capturedParams: any[] | undefined;
-    const db: DbStub = {
-      query: (async (_sql: string, params?: any[]) => {
-        capturedParams = params;
-        return { rows: [] };
-      }) as any,
-    };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    await store.rollbackExecuting('session-only-this-one');
-
-    expect(capturedParams).toEqual(['session-only-this-one']);
-  });
-});
-
-describe('PGLiteQueuedPromptsStore.rollbackAllExecuting', () => {
-  it('resets every executing row across all sessions', async () => {
-    const query = vi.fn(async (sql: string, params?: any[]) => {
-      expect(sql).toContain("SET status = 'pending'");
-      expect(sql).toContain('claimed_at = NULL');
-      expect(sql).toContain("status = 'executing'");
-      expect(sql).not.toContain('session_id');
-      expect(params).toBeUndefined();
-      return { rows: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] };
-    });
-    const db: DbStub = { query: query as any };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    const rolledBack = await store.rollbackAllExecuting();
-
-    expect(rolledBack).toBe(3);
-  });
-
-  it('is idempotent when the table has no stuck rows', async () => {
-    const db: DbStub = { query: (async () => ({ rows: [] })) as any };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    expect(await store.rollbackAllExecuting()).toBe(0);
-    expect(await store.rollbackAllExecuting()).toBe(0);
-  });
-});
-
-describe('PGLiteQueuedPromptsStore.sweepExecutingOnBoot', () => {
-  it('completes answered rows, fails delivered-but-unanswered ones, rolls back undelivered ones', async () => {
-    const calls: { sql: string; params?: any[] }[] = [];
-    const db: DbStub = {
-      query: (async (sql: string, params?: any[]) => {
-        calls.push({ sql, params });
-        // Pass 1: completed-update returns rows with delivery AND output evidence
-        if (sql.includes("SET status = 'completed'")) {
-          return { rows: [{ id: 'answered-1' }, { id: 'answered-2' }] };
-        }
-        // Pass 2: failed-update returns delivered rows with no output evidence
-        if (sql.includes("SET status = 'failed'")) {
-          return { rows: [{ id: 'unanswered-1' }] };
-        }
-        // Pass 3: rollback-update returns the remaining stuck rows
-        if (sql.includes("SET status = 'pending'") && sql.includes('claimed_at = NULL')) {
-          return { rows: [{ id: 'undelivered-1' }] };
-        }
-        throw new Error(`Unexpected query: ${sql}`);
-      }) as any,
-    };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    const result = await store.sweepExecutingOnBoot();
-
-    expect(result).toEqual({ completed: 2, failed: 1, rolledBack: 1 });
-    expect(calls).toHaveLength(3);
-
-    // First pass: executing rows need BOTH the delivered input row AND
-    // output evidence after claimed_at to count as completed (#783: a
-    // delivered input alone does not prove the agent ever responded).
-    // Pending-with-content-match and 24h-abandoned branches stay.
-    expect(calls[0].sql).toContain("SET status = 'completed'");
-    expect(calls[0].sql).toContain("status = 'executing'");
-    expect(calls[0].sql).toContain("status = 'pending'");
-    expect(calls[0].sql).toContain('claimed_at IS NOT NULL');
-    expect(calls[0].sql).toContain('ai_agent_messages');
-    expect(calls[0].sql).toContain("direction = 'input'");
-    expect(calls[0].sql).toContain("direction = 'output'");
-    expect(calls[0].sql).toContain('m.created_at >= queued_prompts.claimed_at');
-    expect(calls[0].sql).toContain('m.created_at >= queued_prompts.created_at');
-    expect(calls[0].sql).toContain('POSITION(queued_prompts.prompt IN m.content)');
-
-    // Second pass: delivered-but-unanswered rows become a VISIBLE terminal
-    // state, never 'completed' (silent success) and never 'pending'
-    // (re-claim would re-send the delivered input, regressing NIM-615).
-    // The pass re-checks output absence itself (NOT EXISTS) so it stays
-    // correct even if an output row commits between the two statements.
-    expect(calls[1].sql).toContain("SET status = 'failed'");
-    expect(calls[1].sql).toContain('error_message');
-    expect(calls[1].sql).toContain("status = 'executing'");
-    expect(calls[1].sql).toContain('claimed_at IS NOT NULL');
-    expect(calls[1].sql).toContain("direction = 'input'");
-    expect(calls[1].sql).toContain('NOT EXISTS');
-    expect(calls[1].sql).toContain("direction = 'output'");
-
-    // Third pass: rolls back anything still executing (i.e. undelivered)
-    expect(calls[2].sql).toContain("SET status = 'pending'");
-    expect(calls[2].sql).toContain('claimed_at = NULL');
-    expect(calls[2].sql).toContain("status = 'executing'");
-  });
-
-  it('fails a delivered executing row with no output after claimed_at instead of completing it (#783)', async () => {
-    // Karl's forensic case: input row logged after claim, app quit
-    // SIGTERM'd the provider, zero output events persisted. The old sweep
-    // marked the row completed and the session looked answered-and-idle.
-    const calls: { sql: string; params?: any[] }[] = [];
-    const db: DbStub = {
-      query: (async (sql: string, params?: any[]) => {
-        calls.push({ sql, params });
-        if (sql.includes("SET status = 'completed'")) {
-          return { rows: [] };
-        }
-        if (sql.includes("SET status = 'failed'")) {
-          return { rows: [{ id: 'local-1783443721220-i0jrwc8' }] };
-        }
-        if (sql.includes("SET status = 'pending'")) {
-          return { rows: [] };
-        }
-        throw new Error(`Unexpected query: ${sql}`);
-      }) as any,
-    };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    const result = await store.sweepExecutingOnBoot();
-
-    expect(result).toEqual({ completed: 0, failed: 1, rolledBack: 0 });
-  });
-
-  it('returns zeros when nothing was executing', async () => {
-    const db: DbStub = { query: (async () => ({ rows: [] })) as any };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    expect(await store.sweepExecutingOnBoot()).toEqual({ completed: 0, failed: 0, rolledBack: 0 });
-  });
-
-  it('completes pending rows that match a delivered input message (leftover-corruption cleanup)', async () => {
-    // Simulates the leftover state after a pre-fix build's
-    // rollbackAllExecuting boot sweep set already-delivered rows back to
-    // pending. The new sweep should catch them by matching prompt text
-    // against ai_agent_messages content.
-    let completedSql = '';
-    const db: DbStub = {
-      query: (async (sql: string) => {
-        if (sql.includes("SET status = 'completed'")) {
-          completedSql = sql;
-          return { rows: [{ id: 'leftover-1' }, { id: 'leftover-2' }, { id: 'leftover-3' }] };
-        }
-        if (sql.includes("SET status = 'failed'") || sql.includes("SET status = 'pending'")) {
-          return { rows: [] };
-        }
-        throw new Error(`Unexpected query: ${sql}`);
-      }) as any,
-    };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    const result = await store.sweepExecutingOnBoot();
-
-    expect(result).toEqual({ completed: 3, failed: 0, rolledBack: 0 });
-    // The combined query must contain both branches so an existing
-    // pending row whose prompt text already appears in the conversation
-    // gets cleaned up alongside the executing-but-delivered case.
-    expect(completedSql).toContain("status = 'pending'");
-    expect(completedSql).toContain('POSITION(queued_prompts.prompt IN m.content)');
-  });
-
-  it('completes pending rows older than 24h regardless of content match (abandoned cleanup)', async () => {
-    let completedSql = '';
-    const db: DbStub = {
-      query: (async (sql: string) => {
-        if (sql.includes("SET status = 'completed'")) {
-          completedSql = sql;
-          return { rows: [{ id: 'abandoned-1' }, { id: 'abandoned-2' }] };
-        }
-        if (sql.includes("SET status = 'failed'") || sql.includes("SET status = 'pending'")) {
-          return { rows: [] };
-        }
-        throw new Error(`Unexpected query: ${sql}`);
-      }) as any,
-    };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    const result = await store.sweepExecutingOnBoot();
-
-    expect(result).toEqual({ completed: 2, failed: 0, rolledBack: 0 });
-    // Age branch: pending rows older than 24h are completed
-    // unconditionally. Handles content-match false negatives caused by
-    // JSON escaping (newlines / quotes / attachments) and genuinely
-    // abandoned prompts.
-    expect(completedSql).toContain("status = 'pending'");
-    expect(completedSql).toContain("created_at < NOW() - INTERVAL '1 day'");
-  });
-});
-
-describe('PGLiteQueuedPromptsStore.complete', () => {
-  it('clears error_message so a turn resolving after a provisional sweep-fail does not keep the stale error', async () => {
-    const query = vi.fn(async (sql: string, params?: any[]) => {
-      expect(sql).toContain("SET status = 'completed'");
-      expect(sql).toContain('error_message = NULL');
-      expect(params).toEqual(['prompt-1']);
-      return { rows: [] };
-    });
-    const db: DbStub = { query: query as any };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    await store.complete('prompt-1');
-
-    expect(query).toHaveBeenCalledOnce();
-  });
-});
-
-describe('PGLiteQueuedPromptsStore.sweepExecutingForSession', () => {
-  it('scopes all three passes to the given session id', async () => {
-    const calls: { sql: string; params?: any[] }[] = [];
-    const db: DbStub = {
-      query: (async (sql: string, params?: any[]) => {
-        calls.push({ sql, params });
-        if (sql.includes("SET status = 'completed'")) {
-          return { rows: [{ id: 'answered-1' }] };
-        }
-        if (sql.includes("SET status = 'failed'")) {
-          return { rows: [{ id: 'unanswered-1' }] };
-        }
-        if (sql.includes("SET status = 'pending'")) {
-          return { rows: [{ id: 'undelivered-1' }, { id: 'undelivered-2' }] };
-        }
-        throw new Error(`Unexpected query: ${sql}`);
-      }) as any,
-    };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    const result = await store.sweepExecutingForSession('session-xyz');
-
-    expect(result).toEqual({ completed: 1, failed: 1, rolledBack: 2 });
-    expect(calls).toHaveLength(3);
-
-    // Pass 1: completion needs input AND output evidence, session-scoped
-    // (#790: an interrupt sweep marked a delivered-but-never-answered
-    // prompt completed on the input row alone).
-    expect(calls[0].sql).toContain("SET status = 'completed'");
-    expect(calls[0].sql).toContain("session_id = $1");
-    expect(calls[0].sql).toContain('claimed_at IS NOT NULL');
-    expect(calls[0].sql).toContain('ai_agent_messages');
-    expect(calls[0].sql).toContain("direction = 'input'");
-    expect(calls[0].sql).toContain("direction = 'output'");
-    expect(calls[0].sql).toContain('m.created_at >= queued_prompts.claimed_at');
-    expect(calls[0].params).toEqual(['session-xyz']);
-
-    // Pass 2: delivered-but-unanswered rows go to a visible failed state,
-    // with an independent no-output recheck (NOT EXISTS)
-    expect(calls[1].sql).toContain("SET status = 'failed'");
-    expect(calls[1].sql).toContain('error_message');
-    expect(calls[1].sql).toContain('session_id = $1');
-    expect(calls[1].sql).toContain('NOT EXISTS');
-    expect(calls[1].params?.[0]).toBe('session-xyz');
-    expect(calls[1].params?.[1]).toContain('interrupted before a response was recorded');
-
-    // Pass 3: roll back undelivered executing rows for the same session
-    expect(calls[2].sql).toContain("SET status = 'pending'");
-    expect(calls[2].sql).toContain('claimed_at = NULL');
-    expect(calls[2].sql).toContain("status = 'executing'");
-    expect(calls[2].sql).toContain('session_id = $1');
-    expect(calls[2].params).toEqual(['session-xyz']);
-  });
-
-  it('returns zeros when the session has no executing rows', async () => {
-    const db: DbStub = { query: (async () => ({ rows: [] })) as any };
-
-    const store = createPGLiteQueuedPromptsStore(db);
-    expect(await store.sweepExecutingForSession('session-clean')).toEqual({
-      completed: 0,
+    const ownerA = await store.claim('race', 'session-a');
+    expect(ownerA?.claimToken).toBeTruthy();
+    expect(await store.sweepExecutingForSession('session-a')).toMatchObject({
       failed: 0,
-      rolledBack: 0,
+      rolledBack: 1,
+      rolledBackIds: ['race'],
     });
+    expect((await store.get('race'))?.claimToken).toBeUndefined();
+
+    const ownerB = await store.claim('race', 'session-a');
+    expect(ownerB?.claimToken).toBeTruthy();
+    expect(ownerB?.claimToken).not.toBe(ownerA?.claimToken);
+    await expect(
+      store.completeAfterDispatch('race', 'session-a', ownerA!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'stale_owner' });
+    await expect(
+      store.failAfterDispatch('race', 'late A', 'session-a', ownerA!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'stale_owner' });
+    await expect(
+      store.beginDispatch('race', 'session-a', ownerB!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'settled' });
+    await expect(
+      store.completeAfterDispatch('race', 'session-a', ownerB!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'settled' });
+    await expect(
+      store.completeAfterDispatch('race', 'session-a', ownerB!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'idempotent_same_claim' });
+  });
+
+  it('classifies wrong identity, recovery, and terminal conflicts without mutation', async () => {
+    const db = await createDatabase();
+    const store = createPGLiteQueuedPromptsStore(db as any);
+    await store.create({ id: 'owned', sessionId: 'session-a', prompt: 'owned' });
+    const claim = await store.claim('owned', 'session-a');
+    const token = claim!.claimToken!;
+    await expect(store.beginDispatch('owned', 'session-a', token)).resolves.toMatchObject({
+      outcome: 'settled',
+    });
+    await expect(store.completeAfterDispatch('owned', 'session-b', token)).resolves.toMatchObject({
+      outcome: 'stale_owner',
+    });
+    await expect(store.completeAfterDispatch('owned', 'session-a', 'random')).resolves.toMatchObject({
+      outcome: 'stale_owner',
+    });
+
+    await db.query(
+      `UPDATE ai_sessions
+       SET metadata = '{"modelChangeReconciliation":{"status":"pending"}}'::jsonb
+       WHERE id = $1`,
+      ['session-a'],
+    );
+    await expect(store.completeAfterDispatch('owned', 'session-a', token)).resolves.toMatchObject({
+      outcome: 'recovery_blocked',
+    });
+    await db.query(`UPDATE ai_sessions SET metadata = '{}'::jsonb WHERE id = $1`, ['session-a']);
+
+    await expect(
+      store.failAfterDispatch('owned', SWEEP_UNANSWERED_ERROR, 'session-a', token),
+    ).resolves.toMatchObject({ outcome: 'settled' });
+    await expect(store.completeAfterDispatch('owned', 'session-a', token)).resolves.toMatchObject({
+      outcome: 'terminal_conflict',
+    });
+    await expect(
+      store.failAfterDispatch('owned', 'different duplicate text', 'session-a', token),
+    ).resolves.toMatchObject({ outcome: 'idempotent_same_claim' });
+    await expect(store.get('owned')).resolves.toMatchObject({
+      status: 'failed',
+      settlementProvenance: 'dispatch_failed',
+      errorMessage: SWEEP_UNANSWERED_ERROR,
+    });
+  });
+
+  it('uses one token-fenced sweep statement and admits same-token late success only', async () => {
+    const db = await createDatabase();
+    const store = createPGLiteQueuedPromptsStore(db as any);
+    await store.create({ id: 'started', sessionId: 'session-a', prompt: 'started' });
+    await store.create({ id: 'not-started', sessionId: 'session-a', prompt: 'not started' });
+    await db.query(
+      `INSERT INTO queued_prompts (id, session_id, prompt)
+       VALUES ('blocked-row', 'blocked', 'blocked')`,
+    );
+    const started = await store.claim('started', 'session-a');
+    const notStarted = await store.claim('not-started', 'session-a');
+    const blocked = await db.query<{ claim_token: string }>(
+      `UPDATE queued_prompts
+       SET status = 'executing', claim_token = 'blocked-token', claimed_at = CURRENT_TIMESTAMP
+       WHERE id = 'blocked-row'
+       RETURNING claim_token`,
+    );
+    expect(blocked.rows[0].claim_token).toBe('blocked-token');
+    await store.beginDispatch('started', 'session-a', started!.claimToken!);
+    await db.query(
+      `INSERT INTO ai_agent_messages (session_id, source, direction, content)
+       VALUES ('session-a', 'unrelated', 'input', 'not either queued prompt')`,
+    );
+
+    const sweep = await store.sweepExecutingForSession('session-a');
+    expect(sweep).toEqual({
+      completed: 0,
+      failed: 1,
+      rolledBack: 1,
+      completedIds: [],
+      failedIds: ['started'],
+      rolledBackIds: ['not-started'],
+    });
+    await expect(store.get('started')).resolves.toMatchObject({
+      status: 'failed',
+      claimToken: started!.claimToken,
+      settlementProvenance: 'sweep_interrupt',
+    });
+    await expect(store.get('not-started')).resolves.toMatchObject({
+      status: 'pending',
+      claimToken: undefined,
+      settlementProvenance: undefined,
+    });
+    await expect(store.get('blocked-row')).resolves.toMatchObject({ status: 'executing' });
+    await expect(
+      store.completeAfterDispatch('started', 'session-a', notStarted!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'stale_owner' });
+    await expect(
+      store.completeAfterDispatch('started', 'session-a', started!.claimToken!),
+    ).resolves.toMatchObject({ outcome: 'settled' });
+  });
+
+  it('atomically admits create, pending replacement, and expected-session delete', async () => {
+    const db = await createDatabase();
+    const store = createPGLiteQueuedPromptsStore(db as any);
+    await expect(
+      store.create({ id: 'blocked-create', sessionId: 'blocked', prompt: 'no' }),
+    ).rejects.toThrow('not admitted');
+    await expect(
+      store.create({ id: 'malformed-create', sessionId: 'malformed', prompt: 'no' }),
+    ).rejects.toThrow('not admitted');
+    await expect(
+      store.create({ id: 'missing-create', sessionId: 'missing', prompt: 'no' }),
+    ).rejects.toThrow('not admitted');
+
+    await store.create({
+      id: 'editable',
+      sessionId: 'session-a',
+      prompt: 'first',
+      attachments: [{ id: 'a' }],
+      documentContext: { filePath: 'a.ts', content: 'a' },
+    });
+    await expect(
+      store.replacePending({
+        id: 'editable',
+        sessionId: 'session-b',
+        prompt: 'wrong',
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      store.replacePending({
+        id: 'editable',
+        sessionId: 'session-a',
+        prompt: 'first\n\nsecond',
+        attachments: [{ id: 'a' }, { id: 'b' }],
+        documentContext: { filePath: 'b.ts', content: 'b' },
+      }),
+    ).resolves.toMatchObject({
+      id: 'editable',
+      prompt: 'first\n\nsecond',
+      attachments: [{ id: 'a' }, { id: 'b' }],
+    });
+    await expect(store.deletePending('editable', 'session-b')).resolves.toBe(false);
+    await expect(store.deletePending('editable', 'session-a')).resolves.toBe(true);
+
+    await store.create({ id: 'claimed', sessionId: 'session-a', prompt: 'claimed' });
+    await store.claim('claimed', 'session-a');
+    await expect(store.deletePending('claimed', 'session-a')).resolves.toBe(false);
+    await expect(store.replacePending({ id: 'claimed', sessionId: 'session-a', prompt: 'lost' })).resolves.toBeNull();
+    await expect(store.get('claimed')).resolves.toMatchObject({ prompt: 'claimed', status: 'executing' });
   });
 });
 
-describe('PGLiteQueuedPromptsStore boot re-drive helpers', () => {
-  it('listSessionIdsWithPending returns each session once, pending rows only', async () => {
-    const query = vi.fn(async (sql: string, params?: any[]) => {
-      expect(sql).toContain('DISTINCT session_id');
-      expect(sql).toContain("status = 'pending'");
-      expect(params).toBeUndefined();
-      return { rows: [{ session_id: 'session-a' }, { session_id: 'session-b' }] };
+describe('PGLiteQueuedPromptsStore current-upstream queue-driver compatibility', () => {
+  it('admits one interrupt owner per session generation and replays its receipt to the loser', async () => {
+    const db = await createDatabase();
+    const store = createPGLiteQueuedPromptsStore(db as any);
+    for (const [id, key] of [['control-a', 'key-a'], ['control-b', 'key-b']] as const) {
+      await store.createPriorityControlPrompt({
+        id,
+        sessionId: 'session-a',
+        prompt: id,
+        producer: 'test',
+        idempotencyKey: key,
+        requestDigest: `digest-${id}`,
+        controlOperation: 'priority',
+      });
+    }
+
+    const generation = 'running:10:20';
+    const reservations = await Promise.all([
+      store.reservePriorityInterrupt({ promptId: 'control-a', generation, owner: 'owner-a' }),
+      store.reservePriorityInterrupt({ promptId: 'control-b', generation, owner: 'owner-b' }),
+    ]);
+    expect(reservations.filter((entry) => entry.reserved)).toHaveLength(1);
+
+    const winner = reservations.find((entry) => entry.reserved)!.row;
+    const loserId = winner.id === 'control-a' ? 'control-b' : 'control-a';
+    const loserBeforeReceipt = await store.get(loserId);
+    expect(loserBeforeReceipt).toMatchObject({
+      deliveryReady: false,
+      interruptReservationOwner: winner.interruptReservationOwner,
     });
-    const db: DbStub = { query: query as any };
+    const receipt = {
+      generation,
+      attempted: true,
+      success: true,
+      method: 'provider-interrupt',
+      error: null,
+      nativeEntered: true,
+      recordedAt: 30,
+    };
+    await store.recordPriorityInterruptReceipt({ promptId: winner.id, generation, receipt });
 
-    const store = createPGLiteQueuedPromptsStore(db);
-
-    expect(await store.listSessionIdsWithPending()).toEqual(['session-a', 'session-b']);
+    await expect(store.get(loserId)).resolves.toMatchObject({
+      id: loserId,
+      deliveryReady: true,
+      interruptReceipt: receipt,
+    });
   });
 
-  it('failAllPendingForSession fails only that session\'s pending rows', async () => {
-    const query = vi.fn(async (sql: string, params?: any[]) => {
-      expect(sql).toContain("SET status = 'failed'");
-      // Must not touch an executing row: that prompt is already in the
-      // conversation and failing it would contradict the boot sweep.
-      expect(sql).toContain("status = 'pending'");
-      expect(sql).toContain('session_id = $1');
-      expect(params).toEqual(['session-gone', 'Project folder is no longer available at /gone']);
-      return { rows: [{ id: 'p1' }, { id: 'p2' }] };
+  it('atomically copies a receipt settled before the loser association executes', async () => {
+    const db = await createDatabase();
+    const store = createPGLiteQueuedPromptsStore(db as any);
+    for (const [id, key] of [['control-a', 'key-a'], ['control-b', 'key-b']] as const) {
+      await store.createPriorityControlPrompt({
+        id,
+        sessionId: 'session-a',
+        prompt: id,
+        producer: 'test',
+        idempotencyKey: key,
+        requestDigest: `digest-${id}`,
+        controlOperation: 'priority',
+      });
+    }
+
+    const generation = 'running:10:20';
+    await expect(store.reservePriorityInterrupt({
+      promptId: 'control-a', generation, owner: 'winner-owner',
+    })).resolves.toMatchObject({ reserved: true });
+
+    let associationObserved!: () => void;
+    let releaseAssociation!: () => void;
+    const observed = new Promise<void>((resolve) => { associationObserved = resolve; });
+    const gate = new Promise<void>((resolve) => { releaseAssociation = resolve; });
+    const gatedStore = createPGLiteQueuedPromptsStore({
+      query: async (sql: string, params?: unknown[]) => {
+        if (sql.includes('SET interrupt_reservation_owner = incumbent.interrupt_reservation_owner')) {
+          associationObserved();
+          await gate;
+        }
+        return db.query(sql, params as any);
+      },
+    } as any);
+    const losingReservation = gatedStore.reservePriorityInterrupt({
+      promptId: 'control-b', generation, owner: 'loser-owner',
     });
-    const db: DbStub = { query: query as any };
+    await observed;
 
-    const store = createPGLiteQueuedPromptsStore(db);
+    await store.recordPriorityInterruptReceipt({
+      promptId: 'control-a',
+      generation,
+      receipt: {
+        generation, attempted: true, success: true, method: 'interrupt',
+        error: null, nativeEntered: true, recordedAt: 30,
+      },
+    });
+    releaseAssociation();
 
-    expect(
-      await store.failAllPendingForSession(
-        'session-gone',
-        'Project folder is no longer available at /gone',
-      ),
-    ).toBe(2);
+    await expect(losingReservation).resolves.toMatchObject({
+      reserved: false,
+      row: {
+        id: 'control-b',
+        interruptReservationOwner: 'winner-owner',
+        deliveryReady: true,
+        interruptReceipt: { success: true },
+      },
+    });
+    await expect(store.get('control-b')).resolves.toMatchObject({
+      deliveryReady: true,
+      interruptReceipt: { success: true },
+    });
+  });
+
+  it('lists distinct pending sessions through the current driver alias', async () => {
+    const query = vi.fn(async () => ({ rows: [{ session_id: 'a' }, { session_id: 'b' }] }));
+    const store = createPGLiteQueuedPromptsStore({ query } as any);
+    await expect(store.listSessionIdsWithPending()).resolves.toEqual(['a', 'b']);
+  });
+
+  it('terminally fails only pending rows for an undeliverable workspace', async () => {
+    const query = vi.fn(async (sql: string, params?: unknown[]) => {
+      expect(sql).toContain("status = 'pending'");
+      expect(params).toEqual(['session-gone', 'workspace missing']);
+      return { rows: [{ id: 'one' }, { id: 'two' }] };
+    });
+    const store = createPGLiteQueuedPromptsStore({ query } as any);
+    await expect(store.failAllPendingForSession('session-gone', 'workspace missing')).resolves.toBe(2);
   });
 });

--- a/packages/electron/src/main/services/__tests__/PriorityPromptDeliveryService.test.ts
+++ b/packages/electron/src/main/services/__tests__/PriorityPromptDeliveryService.test.ts
@@ -1,0 +1,346 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createPriorityPromptDeliveryService,
+  type PriorityControlPrompt,
+  type PriorityInterruptReceipt,
+  type PriorityTargetState,
+} from '../PriorityPromptDeliveryService';
+
+const SESSION_ID = 'target-session';
+const WORKSPACE = 'D:\\repo';
+
+function controlRow(overrides: Partial<PriorityControlPrompt> = {}): PriorityControlPrompt {
+  return {
+    id: 'control-row-1',
+    sessionId: SESSION_ID,
+    status: 'pending',
+    deliveryClass: 'control',
+    priorityRank: 100,
+    deliveryReady: false,
+    interruptTargetGeneration: null,
+    interruptReservationOwner: null,
+    interruptReceipt: null,
+    ...overrides,
+  };
+}
+
+function state(
+  status: PriorityTargetState['status'],
+  generation = `${status}:10:20`,
+): PriorityTargetState {
+  return {
+    status,
+    generation,
+    lastActivity: 10,
+    updatedAt: 20,
+  };
+}
+
+describe('PriorityPromptDeliveryService', () => {
+  const createControlPrompt = vi.fn();
+  const getTargetState = vi.fn();
+  const hasStructuredPendingPrompt = vi.fn();
+  const reserveInterrupt = vi.fn();
+  const recordInterruptReceipt = vi.fn();
+  const interruptCurrentTurn = vi.fn();
+  const triggerProcessing = vi.fn();
+  const getControlPrompt = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createControlPrompt.mockResolvedValue({
+      row: controlRow(),
+      replayed: false,
+    });
+    getTargetState.mockResolvedValue(state('idle'));
+    hasStructuredPendingPrompt.mockResolvedValue(false);
+    reserveInterrupt.mockImplementation(async ({ generation, owner }) => ({
+      row: controlRow({
+        interruptTargetGeneration: generation,
+        interruptReservationOwner: owner,
+      }),
+      reserved: true,
+    }));
+    recordInterruptReceipt.mockImplementation(async ({ receipt }) =>
+      controlRow({
+        status: 'executing',
+        interruptTargetGeneration: receipt.generation,
+        interruptReservationOwner: 'owner-1',
+        interruptReceipt: receipt,
+      }),
+    );
+    interruptCurrentTurn.mockResolvedValue({
+      success: true,
+      method: 'interrupt',
+      nativeEntered: true,
+    });
+    triggerProcessing.mockResolvedValue(true);
+    getControlPrompt.mockResolvedValue(controlRow({ status: 'executing' }));
+  });
+
+  function createService() {
+    return createPriorityPromptDeliveryService({
+      createControlPrompt,
+      getTargetState,
+      hasStructuredPendingPrompt,
+      reserveInterrupt,
+      recordInterruptReceipt,
+      interruptCurrentTurn,
+      triggerProcessing,
+      getControlPrompt,
+      createReservationOwner: () => 'owner-1',
+    });
+  }
+
+  it('interrupts an ordinary-text waiting session only with explicit authority', async () => {
+    getTargetState
+      .mockResolvedValueOnce(state('waiting_for_input'))
+      .mockResolvedValueOnce(state('waiting_for_input'))
+      .mockResolvedValueOnce(state('running', 'running:30:40'));
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Approved; continue',
+      idempotencyKey: 'reply-1',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'waiting_reply',
+      interruptWaitingForInput: true,
+    });
+
+    expect(hasStructuredPendingPrompt).toHaveBeenCalledWith(SESSION_ID);
+    expect(reserveInterrupt).toHaveBeenCalledWith(expect.objectContaining({
+      generation: 'waiting_for_input:10:20',
+    }));
+    expect(interruptCurrentTurn).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ generation: 'waiting_for_input:10:20' }),
+    );
+    expect(triggerProcessing).toHaveBeenCalledWith(SESSION_ID, WORKSPACE);
+    expect(result).toMatchObject({
+      action: 'interrupt_attempted',
+      processingTriggerCalled: true,
+      processingTriggerAccepted: true,
+      interrupt: {
+        attempted: true,
+        success: true,
+      },
+    });
+  });
+
+  it('durably releases an idle control row before triggering queue processing', async () => {
+    getTargetState
+      .mockResolvedValueOnce(state('idle'))
+      .mockResolvedValueOnce(state('idle'))
+      .mockResolvedValueOnce(state('running', 'running:30:40'));
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Start now',
+      idempotencyKey: 'idle-1',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'operator_directive',
+      interruptWaitingForInput: false,
+    });
+
+    expect(interruptCurrentTurn).not.toHaveBeenCalled();
+    expect(recordInterruptReceipt).toHaveBeenCalledWith(expect.objectContaining({
+      receipt: expect.objectContaining({
+        attempted: false,
+        success: true,
+        method: 'not-required',
+        nativeEntered: false,
+      }),
+    }));
+    expect(recordInterruptReceipt.mock.invocationCallOrder[0])
+      .toBeLessThan(triggerProcessing.mock.invocationCallOrder[0]);
+    expect(result).toMatchObject({
+      action: 'processing_triggered',
+      processingTriggerCalled: true,
+      processingTriggerAccepted: true,
+    });
+  });
+
+  it('leaves a waiting answer queued when interruption authority is absent', async () => {
+    getTargetState.mockResolvedValue(state('waiting_for_input'));
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Continue',
+      idempotencyKey: 'reply-2',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'waiting_reply',
+      interruptWaitingForInput: false,
+    });
+
+    expect(reserveInterrupt).not.toHaveBeenCalled();
+    expect(interruptCurrentTurn).not.toHaveBeenCalled();
+    expect(triggerProcessing).not.toHaveBeenCalled();
+    expect(result.action).toBe('queued_waiting_for_authority');
+  });
+
+  it('requires respond_to_prompt for a structured pending prompt', async () => {
+    getTargetState.mockResolvedValue(state('waiting_for_input'));
+    hasStructuredPendingPrompt.mockResolvedValue(true);
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Approve',
+      idempotencyKey: 'reply-3',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'waiting_reply',
+      interruptWaitingForInput: true,
+    });
+
+    expect(reserveInterrupt).not.toHaveBeenCalled();
+    expect(interruptCurrentTurn).not.toHaveBeenCalled();
+    expect(result.action).toBe('structured_prompt_requires_response');
+  });
+
+  it('fails closed when the lifecycle changes after reservation', async () => {
+    getTargetState
+      .mockResolvedValueOnce(state('running', 'running:10:20'))
+      .mockResolvedValueOnce(state('idle', 'idle:30:40'))
+      .mockResolvedValueOnce(state('idle', 'idle:30:40'));
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Act now',
+      idempotencyKey: 'directive-1',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'operator_directive',
+      interruptWaitingForInput: false,
+    });
+
+    expect(interruptCurrentTurn).not.toHaveBeenCalled();
+    expect(recordInterruptReceipt).toHaveBeenCalledWith(expect.objectContaining({
+      receipt: expect.objectContaining({
+        success: false,
+        nativeEntered: false,
+        error: 'stale lifecycle generation',
+      }),
+    }));
+    expect(result.action).toBe('stale_generation_rejected');
+  });
+
+  it('replays a durable interrupt receipt without interrupting twice', async () => {
+    const receipt: PriorityInterruptReceipt = {
+      generation: 'running:10:20',
+      attempted: true,
+      success: true,
+      method: 'interrupt',
+      error: null,
+      nativeEntered: true,
+      recordedAt: 30,
+    };
+    createControlPrompt.mockResolvedValue({
+      row: controlRow({
+        status: 'executing',
+        interruptTargetGeneration: receipt.generation,
+        interruptReceipt: receipt,
+      }),
+      replayed: true,
+    });
+    getControlPrompt.mockResolvedValue(controlRow({
+      status: 'executing',
+      interruptTargetGeneration: receipt.generation,
+      interruptReceipt: receipt,
+    }));
+
+    const result = await createService().deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'Act now',
+      idempotencyKey: 'directive-2',
+      producer: 'send_prompt_now:caller',
+      controlOperation: 'operator_directive',
+      interruptWaitingForInput: false,
+    });
+
+    expect(reserveInterrupt).not.toHaveBeenCalled();
+    expect(interruptCurrentTurn).not.toHaveBeenCalled();
+    expect(result.action).toBe('interrupt_receipt_replayed');
+    expect(result.interrupt).toMatchObject({ attempted: true, success: true });
+  });
+
+  it('enters the native interrupt rail once for concurrent distinct control rows', async () => {
+    let reservationWon = false;
+    let winningOwner: string | null = null;
+    let releaseNative!: () => void;
+    const nativeGate = new Promise<void>((resolve) => { releaseNative = resolve; });
+    const rows = new Map<string, PriorityControlPrompt>();
+    createControlPrompt.mockImplementation(async (input: { idempotencyKey: string }) => {
+      const row = controlRow({ id: `row-${input.idempotencyKey}` });
+      rows.set(row.id, row);
+      return { row, replayed: false };
+    });
+    getTargetState.mockResolvedValue(state('running', 'running:10:20'));
+    reserveInterrupt.mockImplementation(async ({ promptId, generation, owner }) => {
+      if (!reservationWon) {
+        reservationWon = true;
+        winningOwner = owner;
+        const row = controlRow({ id: promptId, interruptTargetGeneration: generation, interruptReservationOwner: owner });
+        rows.set(promptId, row);
+        return { row, reserved: true };
+      }
+      const row = controlRow({ id: promptId, interruptReservationOwner: winningOwner });
+      rows.set(promptId, row);
+      return { row, reserved: false };
+    });
+    getControlPrompt.mockImplementation(async (promptId: string) => rows.get(promptId) ?? null);
+    recordInterruptReceipt.mockImplementation(async ({ promptId, receipt }) => {
+      const winner = rows.get(promptId)!;
+      for (const [id, row] of rows) {
+        if (row.interruptReservationOwner === winner.interruptReservationOwner) {
+          rows.set(id, controlRow({
+            ...row,
+            deliveryReady: receipt.success,
+            interruptReceipt: receipt,
+          }));
+        }
+      }
+      return rows.get(promptId)!;
+    });
+    interruptCurrentTurn.mockImplementation(async () => {
+      await nativeGate;
+      return { success: true, method: 'interrupt', nativeEntered: true };
+    });
+
+    const service = createService();
+    const first = service.deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'first',
+      idempotencyKey: 'first',
+      producer: 'send_prompt_now:a',
+      controlOperation: 'operator_directive',
+      interruptWaitingForInput: false,
+    });
+    const second = service.deliver({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE,
+      prompt: 'second',
+      idempotencyKey: 'second',
+      producer: 'send_prompt_now:b',
+      controlOperation: 'operator_directive',
+      interruptWaitingForInput: false,
+    });
+
+    await vi.waitFor(() => expect(interruptCurrentTurn).toHaveBeenCalledTimes(1));
+    releaseNative();
+    const results = await Promise.all([first, second]);
+    expect(interruptCurrentTurn).toHaveBeenCalledTimes(1);
+    expect(results.map((result) => result.action).sort()).toEqual([
+      'interrupt_already_reserved',
+      'interrupt_attempted',
+    ]);
+    expect([...rows.values()]).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'row-first', deliveryReady: true, interruptReceipt: expect.objectContaining({ success: true }) }),
+      expect.objectContaining({ id: 'row-second', deliveryReady: true, interruptReceipt: expect.objectContaining({ success: true }) }),
+    ]));
+  });
+});

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -93,7 +93,7 @@ import { applyRemoteTrackerPersonalState } from '../../ipc/TrackerPersonalStateH
 import { normalizeCodexProviderConfig, omitModelsField, stripTransientProviderFields } from '@nimbalyst/runtime/ai/server/utils/modelConfigUtils';
 import { isFileInWorkspaceOrWorktree, resolveProjectPath } from '../../utils/workspaceDetection';
 import { inferWorktreePathFromFilePath, inferWorktreePathFromCommand } from './worktreeInference';
-import { SessionFilesRepository } from '@nimbalyst/runtime';
+import { AISessionsRepository, SessionFilesRepository } from '@nimbalyst/runtime';
 import { buildToolPermissionResponseRecord } from './claudeCliToolPermission';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -131,7 +131,7 @@ import {
 } from './askUserQuestionFallbackResolution';
 import { HooklessAgentFileWatcher } from './HooklessAgentFileWatcher';
 import { getAgentWorkflowService } from '../AgentWorkflowService';
-import { tryClaimAndDispatchNextQueuedPrompt } from './queuedPromptDispatcher';
+import { preflightSessionPromptDispatch, tryClaimAndDispatchNextQueuedPrompt } from './queuedPromptDispatcher';
 import {
   QueueDriveService,
   type DriveOutcome,
@@ -193,7 +193,10 @@ export class AIService {
   // Track sessions currently processing a queued prompt to prevent concurrent execution.
   // Without this, the completion handler and triggerQueueProcessing IPC can race,
   // each claiming a different prompt and sending both to the AI concurrently.
-  private sessionsProcessingQueue = new Set<string>();
+  // A lease, rather than a per-session flag: a stale interrupted turn must not
+  // clear or drain a newer priority control dispatch.
+  private queueProcessingLeases = new Map<string, symbol>();
+  private priorityQueueHandoffLeases = new Map<string, symbol>();
 
   // Track mobile session creation requests to prevent duplicate processing
   // (can happen if the same request is delivered multiple times)
@@ -426,7 +429,7 @@ export class AIService {
     return runQueueDriveAttempt<Electron.BrowserWindow>(
       {
         listPendingIds: async (id) => (await queueStore.listPending(id)).map((row) => row.id),
-        isChainActive: (id) => this.sessionsProcessingQueue.has(id),
+        isChainActive: (id) => this.queueProcessingLeases.has(id),
         isSessionBusy: (id) => {
           const liveState = getSessionStateManager().getSessionState(id);
           return !!liveState && (liveState.status === 'running' || liveState.isStreaming);
@@ -449,6 +452,84 @@ export class AIService {
   ): Promise<boolean> {
     const outcome = await this.driveQueuedPrompts(sessionId, workspacePath, reason);
     return outcome.kind === 'dispatched';
+  }
+
+  public hasActiveQueueLease(sessionId: string): boolean {
+    return this.queueProcessingLeases.has(sessionId);
+  }
+
+  private installPriorityQueueHandoff(sessionId: string): void {
+    const handoffLease = Symbol(`priority-handoff:${sessionId}`);
+    this.priorityQueueHandoffLeases.set(sessionId, handoffLease);
+    this.queueProcessingLeases.set(sessionId, handoffLease);
+  }
+
+  public releasePriorityQueueHandoffForDelivery(sessionId: string): void {
+    const handoffLease = this.priorityQueueHandoffLeases.get(sessionId);
+    this.priorityQueueHandoffLeases.delete(sessionId);
+    if (handoffLease && this.queueProcessingLeases.get(sessionId) === handoffLease) {
+      this.queueProcessingLeases.delete(sessionId);
+    }
+  }
+
+  /**
+   * Priority delivery's narrowly-scoped interrupt rail. It deliberately does
+   * not run cancel/stop recovery or queue draining: the durable control row
+   * is released only through its normal claim/settlement callbacks.
+   */
+  public async interruptCurrentTurnForPriorityDelivery(
+    sessionId: string,
+    expectedGeneration: string,
+  ): Promise<{ success: boolean; method?: string; error?: string; nativeEntered?: boolean }> {
+    if (!(await preflightSessionPromptDispatch(sessionId))) {
+      return { success: false, error: 'Session dispatch preflight rejected' };
+    }
+
+    const { database } = await import('../../database/PGLiteDatabaseWorker');
+    const readTarget = async () => {
+      const { rows } = await database.query<any>(
+        `SELECT provider, status, last_activity, updated_at FROM ai_sessions WHERE id = $1 LIMIT 1`,
+        [sessionId],
+      );
+      const row = rows[0];
+      const millis = (value: any) => value instanceof Date ? value.getTime() : value ? new Date(value).getTime() : null;
+      return row
+        ? { provider: row.provider as string, generation: `${row.status}:${millis(row.last_activity) ?? 'none'}:${millis(row.updated_at) ?? 'none'}` }
+        : null;
+    };
+
+    let nativeEntered = false;
+    try {
+      const target = await readTarget();
+      if (!target) return { success: false, error: 'Session not found' };
+      if (target.generation !== expectedGeneration) return { success: false, error: 'stale lifecycle generation' };
+
+      if (target.provider === 'claude-code-cli') {
+        const immediatelyBeforeEntry = await readTarget();
+        if (!immediatelyBeforeEntry || immediatelyBeforeEntry.generation !== expectedGeneration) {
+          return { success: false, error: 'stale lifecycle generation' };
+        }
+        const terminalManager = getTerminalSessionManager();
+        if (!terminalManager.isTerminalActive(sessionId)) return { success: false, error: 'No active terminal for session' };
+        nativeEntered = true;
+        terminalManager.writeToTerminal(sessionId, '\x03');
+        this.installPriorityQueueHandoff(sessionId);
+        return { success: true, method: 'terminal-ctrl-c', nativeEntered: true };
+      }
+
+      const provider = ProviderFactory.getProvider(target.provider as AIProviderType, sessionId);
+      if (!provider) return { success: false, error: 'No active provider for session' };
+      const immediatelyBeforeEntry = await readTarget();
+      if (!immediatelyBeforeEntry || immediatelyBeforeEntry.generation !== expectedGeneration) {
+        return { success: false, error: 'stale lifecycle generation' };
+      }
+      nativeEntered = true;
+      const result = await provider.interruptCurrentTurn();
+      this.installPriorityQueueHandoff(sessionId);
+      return { success: true, method: result.method, nativeEntered: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Interrupt failed', nativeEntered };
+    }
   }
 
   public async respondToInteractivePrompt(params: {
@@ -940,7 +1021,8 @@ export class AIService {
           promptId,
         });
       },
-      processingSet: this.sessionsProcessingQueue,
+      processingLeases: this.queueProcessingLeases,
+      preflight: preflightSessionPromptDispatch,
       queueStore,
       sendMessageHandler: this.sendMessageHandler,
       sessionId,
@@ -2312,9 +2394,20 @@ export class AIService {
       const queueStore = getQueuedPromptsStore();
 
       // Atomic claim - only succeeds if status is still 'pending'
-      const claimed = await queueStore.claim(promptId);
+      const claimed = await queueStore.claim(promptId, sessionId);
 
       if (claimed) {
+        if (!claimed.claimToken) {
+          throw new Error(`Queued prompt ${promptId} was claimed without an ownership token`);
+        }
+        const begun = await queueStore.beginDispatch(promptId, sessionId, claimed.claimToken);
+        if (begun.outcome !== 'settled' && begun.outcome !== 'idempotent_same_claim') {
+          const release = await queueStore.releaseClaim(promptId, sessionId, claimed.claimToken);
+          if (release.outcome !== 'settled' && release.outcome !== 'idempotent_same_claim') {
+            logger.main.error(`[AIService] claimQueuedPrompt: failed to release rejected claim ${promptId} (${release.outcome})`);
+          }
+          throw new Error(`Queued prompt dispatch intent rejected: ${begun.outcome}`);
+        }
         logger.main.info(`[AIService] claimQueuedPrompt: claimed ${promptId} for session ${sessionId}`);
         // Return in the format expected by the renderer
         return {
@@ -2323,6 +2416,7 @@ export class AIService {
           timestamp: claimed.createdAt,
           attachments: claimed.attachments,
           documentContext: claimed.documentContext,
+          claimToken: claimed.claimToken,
         };
       }
 
@@ -2333,23 +2427,33 @@ export class AIService {
     // Mark a queued prompt as completed
     safeHandle('ai:completeQueuedPrompt', async (
       event,
-      promptId: string
+      sessionId: string,
+      promptId: string,
+      claimToken: string,
     ) => {
       const { getQueuedPromptsStore } = await import('../RepositoryManager');
       const queueStore = getQueuedPromptsStore();
-      await queueStore.complete(promptId);
+      const settlement = await queueStore.completeAfterDispatch(promptId, sessionId, claimToken);
+      if (settlement.outcome !== 'settled' && settlement.outcome !== 'idempotent_same_claim') {
+        throw new Error(`Queued prompt completion rejected: ${settlement.outcome}`);
+      }
       logger.main.info(`[AIService] completeQueuedPrompt: ${promptId}`);
     });
 
     // Mark a queued prompt as failed
     safeHandle('ai:failQueuedPrompt', async (
       event,
+      sessionId: string,
       promptId: string,
-      errorMessage: string
+      errorMessage: string,
+      claimToken: string,
     ) => {
       const { getQueuedPromptsStore } = await import('../RepositoryManager');
       const queueStore = getQueuedPromptsStore();
-      await queueStore.fail(promptId, errorMessage);
+      const settlement = await queueStore.failAfterDispatch(promptId, errorMessage, sessionId, claimToken);
+      if (settlement.outcome !== 'settled' && settlement.outcome !== 'idempotent_same_claim') {
+        throw new Error(`Queued prompt failure settlement rejected: ${settlement.outcome}`);
+      }
       logger.main.info(`[AIService] failQueuedPrompt: ${promptId} - ${errorMessage}`);
     });
 
@@ -3044,7 +3148,7 @@ export class AIService {
         // marked completed instead of rolled back, so the queue trigger
         // that follows the abort doesn't immediately re-claim and re-send
         // the same input (NIM-615).
-        this.sessionsProcessingQueue.delete(sessionId);
+        this.queueProcessingLeases.delete(sessionId);
         try {
           const { getQueuedPromptsStore } = await import('../RepositoryManager');
           const queueStore = getQueuedPromptsStore();
@@ -3112,7 +3216,7 @@ export class AIService {
         return { success: false, error: 'No active provider for session' };
       }
 
-      this.sessionsProcessingQueue.delete(sessionId);
+      this.queueProcessingLeases.delete(sessionId);
       try {
         const { getQueuedPromptsStore } = await import('../RepositoryManager');
         const queueStore = getQueuedPromptsStore();

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -48,6 +48,8 @@ import {
 // MCP imports removed - no longer using MCP HTTP server
 import { ToolExecutor, toolRegistry, BUILT_IN_TOOLS } from './tools';
 import { initMobileSessionControlHandler } from './MobileSessionControlHandler';
+import type { QueuedPromptsStore } from '../PGLiteQueuedPromptsStore';
+import { payloadReceiptsMatch } from './queuedPromptTruth';
 import { handleMobileVoiceToolCall } from '../voice/mobileVoiceToolHandler';
 import { SoundNotificationService } from '../SoundNotificationService';
 import { getTerminalSessionManager } from '../TerminalSessionManager';
@@ -163,6 +165,48 @@ function scheduleMobileSettingsSync(): void {
       syncSettingsToMobile(apiKeys['openai']);
     }).catch(() => { /* sync manager may not be available */ });
   }, 500);
+}
+
+/**
+ * Publish the authoritative durable queue projection after any lifecycle
+ * mutation, including CLI-only claim/terminal transitions that do not flow
+ * through an AIService IPC handler.
+ */
+export async function publishQueuedPromptSnapshotForSession(
+  sessionId: string,
+  queueStore?: QueuedPromptsStore,
+): Promise<void> {
+  const syncProvider = getSyncProvider();
+  if (!syncProvider) return;
+
+  const store = queueStore ?? (await import('../RepositoryManager')).getQueuedPromptsStore();
+  const rows = await store.listForSession(sessionId, { includeCompleted: true });
+  syncProvider.pushChange(sessionId, {
+    type: 'metadata_updated',
+    metadata: {
+      queuedPrompts: rows.map((row) => ({
+        id: row.id,
+        clientSubmissionId: row.clientSubmissionId ?? row.id,
+        sourceSessionId: row.sourceSessionId ?? row.sessionId,
+        sourceRoomId: row.sourceRoomId ?? row.sessionId,
+        submissionSequence: row.submissionSequence,
+        producer: row.producer,
+        payloadUtf8Bytes: row.payloadReceipt?.utf8Bytes,
+        payloadUnicodeScalars: row.payloadReceipt?.unicodeScalars,
+        payloadSha256: row.payloadReceipt?.sha256,
+        claimTrigger: row.claimTrigger,
+        claimTriggeredAt: row.claimTriggeredAt,
+        turnId: row.turnId,
+        providerInputMessageId: row.providerInputMessageId,
+        providerOutputMessageId: row.providerOutputMessageId,
+        streamEventSequence: row.streamEventSequence,
+        terminalStatus: row.terminalStatus,
+        terminalAt: row.terminalAt,
+        prompt: row.prompt,
+        timestamp: row.createdAt,
+      })),
+    },
+  });
 }
 
 export class AIService {
@@ -304,10 +348,26 @@ export class AIService {
       id: promptId,
       sessionId,
       prompt,
+      clientSubmissionId: promptId,
+      producer: 'meta-agent',
       attachments,
       documentContext: queuedDocumentContext,
     });
+    await this.publishQueuedPromptSnapshot(sessionId, queueStore);
     return { id: created.id, prompt: created.prompt, createdAt: created.createdAt };
+  }
+
+  /**
+   * Publish the bounded durable queue projection after a lifecycle mutation.
+   * The encrypted sync transport is a replica, never a queue authority: every
+   * entry comes from the store's current full lifecycle snapshot so echoes are
+   * idempotent and terminals cannot be mistaken for fresh mobile input.
+   */
+  private async publishQueuedPromptSnapshot(
+    sessionId: string,
+    queueStore?: QueuedPromptsStore,
+  ): Promise<void> {
+    await publishQueuedPromptSnapshotForSession(sessionId, queueStore);
   }
 
   /**
@@ -1195,6 +1255,12 @@ export class AIService {
 
                 let newPromptsCount = 0;
                 for (const prompt of entry.queuedPrompts) {
+                  const supplied = prompt as any;
+                  // A sync echo carrying terminal truth is a snapshot, never
+                  // fresh executable mobile input.
+                  if (supplied.terminalStatus === 'completed' || supplied.terminalStatus === 'failed') {
+                    continue;
+                  }
                   // Skip prompts that were created locally (echoed back via Y.js sync)
                   // Local prompts have IDs starting with 'local-'
                   if (prompt.id.startsWith('local-')) {
@@ -1202,10 +1268,43 @@ export class AIService {
                     continue;
                   }
 
+                  const suppliedReceipt = (
+                    supplied.payloadUtf8Bytes === undefined &&
+                    supplied.payloadUnicodeScalars === undefined &&
+                    supplied.payloadSha256 === undefined
+                  ) ? undefined : {
+                    utf8Bytes: supplied.payloadUtf8Bytes,
+                    unicodeScalars: supplied.payloadUnicodeScalars,
+                    sha256: supplied.payloadSha256,
+                  };
+                  const receiptIsComplete = suppliedReceipt === undefined || (
+                    Number.isSafeInteger(suppliedReceipt.utf8Bytes) &&
+                    Number.isSafeInteger(suppliedReceipt.unicodeScalars) &&
+                    typeof suppliedReceipt.sha256 === 'string'
+                  );
+                  if (
+                    !receiptIsComplete ||
+                    (suppliedReceipt && !payloadReceiptsMatch(prompt.prompt, suppliedReceipt)) ||
+                    (supplied.sourceSessionId !== undefined && supplied.sourceSessionId !== sessionId)
+                  ) {
+                    logger.main.warn('[AIService] Rejected conflicting mobile queued prompt truth:', prompt.id);
+                    continue;
+                  }
+
                   // Check if prompt already exists
                   const existing = await queueStore.get(prompt.id);
                   if (existing) {
-                    // logger.main.info(`[AIService] Prompt ${prompt.id} already exists, skipping`);
+                    const conflict =
+                      existing.prompt !== prompt.prompt ||
+                      (supplied.clientSubmissionId !== undefined && existing.clientSubmissionId !== supplied.clientSubmissionId) ||
+                      (supplied.sourceSessionId !== undefined && existing.sourceSessionId !== supplied.sourceSessionId) ||
+                      (supplied.sourceRoomId !== undefined && existing.sourceRoomId !== supplied.sourceRoomId) ||
+                      (supplied.submissionSequence !== undefined && existing.submissionSequence !== supplied.submissionSequence) ||
+                      (supplied.producer !== undefined && existing.producer !== supplied.producer) ||
+                      (existing.payloadReceipt !== undefined && !payloadReceiptsMatch(prompt.prompt, existing.payloadReceipt));
+                    if (conflict) {
+                      logger.main.warn('[AIService] Rejected mobile queued prompt echo with conflicting truth:', prompt.id);
+                    }
                     continue;
                   }
 
@@ -1214,6 +1313,9 @@ export class AIService {
                     id: prompt.id,
                     sessionId,
                     prompt: prompt.prompt,
+                    clientSubmissionId: supplied.clientSubmissionId ?? prompt.id,
+                    sourceRoomId: supplied.sourceRoomId,
+                    producer: supplied.producer ?? 'mobile',
                     attachments: prompt.attachments,
                     documentContext: {
                       promptProvenance: {
@@ -1230,6 +1332,8 @@ export class AIService {
                   // logger.main.info('[AIService] No new prompts to process, all already exist');
                   return;
                 }
+
+                await this.publishQueuedPromptSnapshot(sessionId, queueStore);
 
                 logger.main.info(`[AIService] Inserted ${newPromptsCount} new prompts into queued_prompts table`);
 
@@ -2405,6 +2509,7 @@ export class AIService {
           }
           throw new Error(`Queued prompt dispatch intent rejected: ${begun.outcome}`);
         }
+        await this.publishQueuedPromptSnapshot(sessionId, queueStore);
         logger.main.info(`[AIService] claimQueuedPrompt: claimed ${promptId} for session ${sessionId}`);
         // Return in the format expected by the renderer
         return {
@@ -2434,6 +2539,7 @@ export class AIService {
       if (settlement.outcome !== 'settled' && settlement.outcome !== 'idempotent_same_claim') {
         throw new Error(`Queued prompt completion rejected: ${settlement.outcome}`);
       }
+      await this.publishQueuedPromptSnapshot(sessionId, queueStore);
       logger.main.info(`[AIService] completeQueuedPrompt: ${promptId}`);
     });
 
@@ -2451,6 +2557,7 @@ export class AIService {
       if (settlement.outcome !== 'settled' && settlement.outcome !== 'idempotent_same_claim') {
         throw new Error(`Queued prompt failure settlement rejected: ${settlement.outcome}`);
       }
+      await this.publishQueuedPromptSnapshot(sessionId, queueStore);
       logger.main.info(`[AIService] failQueuedPrompt: ${promptId} - ${errorMessage}`);
     });
 
@@ -2461,9 +2568,15 @@ export class AIService {
     ) => {
       const { getQueuedPromptsStore } = await import('../RepositoryManager');
       const queueStore = getQueuedPromptsStore();
-      const pending = await queueStore.listPending(sessionId);
+      // This is a bounded authoritative lifecycle snapshot, not merely a
+      // pending-list: renderer reconciliation must observe terminal rows.
+      const pending = await queueStore.listForSession(sessionId, { includeCompleted: true });
       return pending.map(p => ({
         id: p.id,
+        clientSubmissionId: p.clientSubmissionId,
+        submissionSequence: p.submissionSequence,
+        sourceSessionId: p.sourceSessionId,
+        status: p.status,
         prompt: p.prompt,
         timestamp: p.createdAt,
         attachments: p.attachments,
@@ -2477,14 +2590,18 @@ export class AIService {
       sessionId: string,
       prompt: string,
       attachments?: any[],
-      documentContext?: any
+      documentContext?: any,
+      clientSubmissionId?: string
     ) => {
       const { getQueuedPromptsStore } = await import('../RepositoryManager');
       const queueStore = getQueuedPromptsStore();
 
       // Generate a unique ID with 'local-' prefix to identify locally-created prompts
       // This prevents the mobile sync handler from re-broadcasting these prompts
-      const promptId = `local-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      // Renderer retries reuse this client identity after an accepted-but-lost
+      // IPC acknowledgement. Direct/legacy callers retain the safe fallback.
+      const stableSubmissionId = clientSubmissionId || `local-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      const promptId = stableSubmissionId.startsWith('local-') ? stableSubmissionId : `local-${stableSubmissionId}`;
       const queuedDocumentContext = {
         ...(documentContext ?? {}),
         promptProvenance: {
@@ -2499,9 +2616,13 @@ export class AIService {
         id: promptId,
         sessionId,
         prompt,
+        clientSubmissionId: stableSubmissionId,
+        producer: 'composer',
         attachments,
         documentContext: queuedDocumentContext,
       });
+
+      await this.publishQueuedPromptSnapshot(sessionId, queueStore);
 
       logger.main.info(`[AIService] createQueuedPrompt: created ${promptId} for session ${sessionId}`);
 
@@ -2572,6 +2693,9 @@ export class AIService {
 
       return {
         id: created.id,
+        clientSubmissionId: created.clientSubmissionId,
+        submissionSequence: created.submissionSequence,
+        sourceSessionId: created.sourceSessionId,
         prompt: created.prompt,
         timestamp: created.createdAt,
         attachments: created.attachments,

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -137,7 +137,7 @@ import {
   type DriveOutcome,
   type DriveReason,
 } from './QueueDriveService';
-import { createWorkspaceWindowResolver } from './resolveWorkspaceWindow';
+import { createWorkspaceWindowResolver, waitForWorkspaceWindowLoad } from './resolveWorkspaceWindow';
 import { runQueueDriveAttempt } from './queueDriveAttempt';
 import { onWorkspaceWindowAvailable } from '../../window/workspaceWindowAvailability';
 import { dispatchQueuedPromptToClaudeCli } from './claudeCliQueueDispatch';
@@ -320,10 +320,7 @@ export class AIService {
     isDestroyed: (window) => window.isDestroyed(),
     workspaceExists: (workspacePath) => fs.existsSync(workspacePath),
     createWindow: (workspacePath) => createWindow(false, true, workspacePath),
-    waitForLoad: (window) =>
-      new Promise<void>((resolve) => {
-        window.webContents.once('did-finish-load', () => resolve());
-      }),
+    waitForLoad: (window) => waitForWorkspaceWindowLoad(window),
     isQuitting: () => isAppQuitting(),
     now: () => Date.now(),
     logInfo: (message) => logger.main.info(message),

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -45,6 +45,7 @@ import {
 import { toolRegistry } from './tools';
 import type { DriveReason } from './QueueDriveService';
 import { resolveExtensionAgentRef } from './providerResolution';
+import { createQueuedStreamTruthBinder } from './queuedPromptTruth';
 import { getAgentProviderRegistry } from '../../extensions/AgentProviderRegistry';
 
 /**
@@ -141,7 +142,14 @@ export type SendMessageHandler = (
   documentContext?: DocumentContext,
   sessionId?: string,
   workspacePath?: string,
-) => Promise<{ content: string }>;
+) => Promise<{
+  content: string;
+  queuedPromptTerminal?: {
+    lifecycle: 'completed' | 'failed';
+    terminalAt: number;
+    eventSequence: number;
+  };
+}>;
 
 /**
  * Structural view of the AIService members this handler needs. Keeping it
@@ -327,6 +335,26 @@ export class MessageStreamingHandler {
   ) => {
     // Check for queued prompt deduplication - prevents duplicate execution from multiple renderer panels
     const queuedPromptId = (documentContext as any)?.queuedPromptId as string | undefined;
+    const queuedPromptTruth = (documentContext as any)?.queuedPromptTruth as Record<string, unknown> | undefined;
+    let queuedTerminalEmitted = false;
+    let queuedPromptTerminal: { lifecycle: 'completed' | 'failed'; terminalAt: number; eventSequence: number } | undefined;
+    const queueTruthMetadata = createQueuedStreamTruthBinder(queuedPromptTruth);
+    const queueStreamMetadata = (lifecycle: 'streaming' | 'completed' | 'failed') => {
+      const truth = queueTruthMetadata(lifecycle);
+      if (lifecycle !== 'streaming' && truth) {
+        queuedTerminalEmitted = true;
+        queuedPromptTerminal = {
+          lifecycle,
+          terminalAt: truth.terminalAt as number,
+          eventSequence: truth.eventSequence as number,
+        };
+      }
+      return truth ? { queuedPromptTruth: truth } : {};
+    };
+    const queueMessageMetadata = (lifecycle: 'streaming' | 'completed' | 'failed') => {
+      const truth = queueTruthMetadata(lifecycle);
+      return truth ? { metadata: { queuedPromptTruth: truth } } : {};
+    };
     if (queuedPromptId) {
       if (this.svc.processingQueuedPromptIds.has(queuedPromptId)) {
         logger.main.info(`[AIService] SKIPPING duplicate queued prompt: ${queuedPromptId}`);
@@ -447,6 +475,7 @@ export class MessageStreamingHandler {
       timestamp: Date.now(),
       attachments: attachments && attachments.length > 0 ? attachments : undefined,
       mode: documentContext?.mode,
+      ...queueMessageMetadata('streaming'),
     };
     // logger.main.info(`[AIService] Adding user message to session ${session.id}: "${message.substring(0, 50)}..." (queuedPromptId: ${queuedPromptId || 'none'}, mode: ${documentContext?.mode})`);
     await this.svc.sessionManager.addMessage(userMessage, session.id);
@@ -662,7 +691,8 @@ export class MessageStreamingHandler {
         const errorMessage: Message = {
           role: 'assistant',
           content: `I encountered an error connecting to ${session.provider}:\n\n${initError.message || String(initError)}`,
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          ...queueMessageMetadata('failed'),
         };
 
         await this.svc.sessionManager.addMessage(errorMessage, session.id);
@@ -672,7 +702,9 @@ export class MessageStreamingHandler {
           this.svc.processingQueuedPromptIds.delete(queuedPromptId);
         }
 
-        // Return empty response instead of throwing - the error message is now in the conversation
+        // Direct submissions preserve the existing recoverable error result.
+        // A queued turn must reject so its exact claim settles failed.
+        if (queuedPromptId) throw initError;
         return { content: '' };
       }
 
@@ -1583,7 +1615,8 @@ export class MessageStreamingHandler {
             safeSend(event, 'ai:streamResponse', {
               sessionId: session.id,
               partial: fullResponse,  // Send the full accumulated text
-              isComplete: false
+              isComplete: false,
+              ...queueStreamMetadata('streaming'),
             });
             break;
 
@@ -2027,7 +2060,8 @@ export class MessageStreamingHandler {
                       arguments: chunk.toolCall.arguments as Record<string, unknown> | undefined,
                       result: chunk.toolCall.result as string | ToolResult | undefined
                     },
-                    ...(toolResult !== undefined ? { errorMessage: toolResult?.error, isError: toolResult?.success === false } : {})
+                    ...(toolResult !== undefined ? { errorMessage: toolResult?.error, isError: toolResult?.success === false } : {}),
+                    ...queueMessageMetadata('streaming'),
                   };
                   await this.svc.sessionManager.addMessage(toolMessage, session.id);
                 }
@@ -2063,7 +2097,8 @@ export class MessageStreamingHandler {
                     partial: '',
                     isComplete: false,
                     edits: [edit],
-                    toolCalls: [chunk.toolCall]  // Also send as toolCall so it displays in chat
+                    toolCalls: [chunk.toolCall],  // Also send as toolCall so it displays in chat
+                    ...queueStreamMetadata('streaming'),
                   });
                 } else if (chunk.toolCall.name === 'streamContent') {
                   // Mark that we used streamContent AND track the tool call
@@ -2075,7 +2110,8 @@ export class MessageStreamingHandler {
                     sessionId: session.id,
                     partial: '',
                     isComplete: false,
-                    toolCalls: [chunk.toolCall]
+                    toolCalls: [chunk.toolCall],
+                    ...queueStreamMetadata('streaming'),
                   });
                 } else {
                   // For other tools, just send the tool call
@@ -2083,7 +2119,8 @@ export class MessageStreamingHandler {
                     sessionId: session.id,
                     partial: '',
                     isComplete: false,
-                    toolCalls: [chunk.toolCall]
+                    toolCalls: [chunk.toolCall],
+                    ...queueStreamMetadata('streaming'),
                   });
                 }
               }
@@ -2107,7 +2144,8 @@ export class MessageStreamingHandler {
                   result: chunk.toolError.result as string | ToolResult | undefined
                 },
                 isError: true,
-                errorMessage: chunk.toolError.error
+                errorMessage: chunk.toolError.error,
+                ...queueMessageMetadata('streaming'),
               };
               await this.svc.sessionManager.addMessage(errorMessage, session.id);
 
@@ -2115,7 +2153,8 @@ export class MessageStreamingHandler {
                 sessionId: session.id,
                 partial: '',
                 isComplete: false,
-                toolError: chunk.toolError
+                toolError: chunk.toolError,
+                ...queueStreamMetadata('streaming'),
               });
             }
             break;
@@ -2516,7 +2555,8 @@ export class MessageStreamingHandler {
                 ...(edits.length > 0 && { edits }),  // Include edits if any
                 // CRITICAL: Don't include tokenUsage from chunk.usage for claude-code provider
                 // Token usage for claude-code comes ONLY from /context command below
-                ...(tokenUsage && session.provider !== 'claude-code' && { tokenUsage })
+                ...(tokenUsage && session.provider !== 'claude-code' && { tokenUsage }),
+                ...queueMessageMetadata(providerError ? 'failed' : 'completed'),
               };
               await this.svc.sessionManager.addMessage(assistantMessage, session.id);
             } else if (edits.length > 0) {
@@ -2528,7 +2568,8 @@ export class MessageStreamingHandler {
                 edits,
                 // CRITICAL: Don't include tokenUsage from chunk.usage for claude-code provider
                 // Token usage for claude-code comes ONLY from /context command below
-                ...(tokenUsage && session.provider !== 'claude-code' && { tokenUsage })
+                ...(tokenUsage && session.provider !== 'claude-code' && { tokenUsage }),
+                ...queueMessageMetadata(providerError ? 'failed' : 'completed'),
               };
               await this.svc.sessionManager.addMessage(assistantMessage, session.id);
             } else if (hasStreamingContent) {
@@ -2546,7 +2587,8 @@ export class MessageStreamingHandler {
                 },
                 // CRITICAL: Don't include tokenUsage from chunk.usage for claude-code provider
                 // Token usage for claude-code comes ONLY from /context command below
-                ...(tokenUsage && session.provider !== 'claude-code' && { tokenUsage })
+                ...(tokenUsage && session.provider !== 'claude-code' && { tokenUsage }),
+                ...queueMessageMetadata(providerError ? 'failed' : 'completed'),
               };
               await this.svc.sessionManager.addMessage(assistantMessage, session.id);
             } else if (toolCalls.length > 0) {
@@ -2557,7 +2599,8 @@ export class MessageStreamingHandler {
                 timestamp: Date.now(),
                 // CRITICAL: Don't include tokenUsage from chunk.usage for claude-code provider
                 // Token usage for claude-code comes ONLY from /context command below
-                ...(tokenUsage && session.provider !== 'claude-code' && { tokenUsage })
+                ...(tokenUsage && session.provider !== 'claude-code' && { tokenUsage }),
+                ...queueMessageMetadata(providerError ? 'failed' : 'completed'),
               };
               await this.svc.sessionManager.addMessage(assistantMessage, session.id);
             }
@@ -2614,7 +2657,8 @@ export class MessageStreamingHandler {
               lastTextSection: lastTextSection.trim() || prevTextSection,
               isComplete: true,
               error: providerError,
-              autoContextPending: session.provider === 'claude-code'
+              autoContextPending: session.provider === 'claude-code',
+              ...queueStreamMetadata(providerError ? 'failed' : 'completed'),
             });
 
             // Mark session as complete so UI shows agent is ready.
@@ -2859,7 +2903,7 @@ export class MessageStreamingHandler {
         // logger.main.info(`[AIService] Cleared prompt tracking for ${queuedPromptId}`);
       }
 
-      return { content: fullResponse };
+      return { content: fullResponse, queuedPromptTerminal };
     } catch (error) {
       const errorTime = Date.now() - startTime;
       const isClaudeCode = session?.provider === 'claude-code';
@@ -2970,6 +3014,28 @@ export class MessageStreamingHandler {
           sessionId: session?.id,
           message: error instanceof Error ? error.message : 'Unknown error occurred'
         });
+
+        // The queue driver settles this exact thrown path as failed. Emit one
+        // terminal boundary with the same durable association so a renderer
+        // never upgrades an earlier bound fragment into a completed response.
+        if (queuedPromptTruth && session?.id && !queuedTerminalEmitted) {
+          const errorContent = error instanceof Error ? error.message : 'Unknown error occurred';
+          await this.svc.sessionManager.addMessage({
+            role: 'assistant',
+            content: errorContent,
+            timestamp: Date.now(),
+            isError: true,
+            errorMessage: errorContent,
+            ...queueMessageMetadata('failed'),
+          }, session.id);
+          safeSend(event, 'ai:streamResponse', {
+            sessionId: session.id,
+            content: '',
+            isComplete: true,
+            error: errorContent,
+            ...queueStreamMetadata('failed'),
+          });
+        }
       }
 
       // Clean up queued prompt tracking on error
@@ -2978,6 +3044,11 @@ export class MessageStreamingHandler {
         logger.main.info(`[AIService] Cleared prompt tracking for ${queuedPromptId} (error path)`);
       }
 
+      if (queuedPromptTerminal) {
+        const terminalError = error instanceof Error ? error : new Error(String(error));
+        (terminalError as Error & { queuedPromptTerminal?: typeof queuedPromptTerminal }).queuedPromptTerminal = queuedPromptTerminal;
+        throw terminalError;
+      }
       throw error;
     }
   };

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -156,7 +156,7 @@ interface AIServiceInternal {
   sendMessageHandler: SendMessageHandler | null;
   processingQueuedPromptIds: Set<string>;
   matchDebounceTimers: Map<string, ReturnType<typeof setTimeout>>;
-  sessionsProcessingQueue: Set<string>;
+  hasActiveQueueLease(sessionId: string): boolean;
   documentContextService: DocumentContextService;
   hooklessWatcher: HooklessAgentFileWatcher;
 
@@ -1153,7 +1153,7 @@ export class MessageStreamingHandler {
         return;
       }
       // A queued/continuation turn may already be taking over; let it own the end.
-      if (this.svc.sessionsProcessingQueue.has(data.sessionId)) return;
+      if (this.svc.hasActiveQueueLease(data.sessionId)) return;
 
       logger.main.info(`[AIService] Sub-agent drain settled for session ${data.sessionId}, ending deferred session`);
       await stateManager.endSession(data.sessionId);
@@ -2234,7 +2234,7 @@ export class MessageStreamingHandler {
             if (
               isExtensionAgentSession
               && session?.id
-              && !this.svc.sessionsProcessingQueue.has(session.id)
+              && !this.svc.hasActiveQueueLease(session.id)
             ) {
               try {
                 await stateManager.updateActivity({ sessionId: session.id, status: 'error' });
@@ -2631,7 +2631,7 @@ export class MessageStreamingHandler {
             const willResume = session.provider === 'claude-code'
               && typeof (provider as any).willResumeAfterCompletion === 'function'
               && (provider as any).willResumeAfterCompletion();
-            const queuedChainAlreadyActive = this.svc.sessionsProcessingQueue.has(session.id);
+            const queuedChainAlreadyActive = this.svc.hasActiveQueueLease(session.id);
             let queuedContinuationScheduled = false;
             if (!hasTeammates && !willResume && !queuedChainAlreadyActive) {
               queuedContinuationScheduled = await this.svc.tryDispatchNextQueuedPrompt(
@@ -2808,7 +2808,7 @@ export class MessageStreamingHandler {
         sawComplete: sawCompleteChunk,
         providerError,
         alreadySettled: settledOnErrorChunk,
-        queuedChainActive: this.svc.sessionsProcessingQueue.has(session.id),
+        queuedChainActive: this.svc.hasActiveQueueLease(session.id),
       })) {
         logger.main.warn(
           `[AIService] Provider stream for ${session.id} ended on an error chunk without completing -- settling session`
@@ -2846,7 +2846,7 @@ export class MessageStreamingHandler {
       }
 
       // Clear executing and pending prompt flags for mobile sync
-      if (syncProvider && !this.svc.sessionsProcessingQueue.has(session.id)) {
+      if (syncProvider && !this.svc.hasActiveQueueLease(session.id)) {
         syncProvider.pushChange(session.id, {
           type: 'metadata_updated',
           metadata: { isExecuting: false, hasPendingPrompt: false, updatedAt: Date.now() },
@@ -2913,7 +2913,7 @@ export class MessageStreamingHandler {
         const willResumeOnError = session.provider === 'claude-code'
           && typeof (provider as any).willResumeAfterCompletion === 'function'
           && (provider as any).willResumeAfterCompletion();
-        const queuedChainAlreadyActiveOnError = this.svc.sessionsProcessingQueue.has(session.id);
+        const queuedChainAlreadyActiveOnError = this.svc.hasActiveQueueLease(session.id);
         let queuedContinuationScheduledOnError = false;
         if (!hasTeammatesOnError && !willResumeOnError && !queuedChainAlreadyActiveOnError) {
           queuedContinuationScheduledOnError = await this.svc.tryDispatchNextQueuedPrompt(
@@ -2940,7 +2940,7 @@ export class MessageStreamingHandler {
         }
 
         // Clear executing and pending prompt flags for mobile sync on error
-        if (syncProvider && !this.svc.sessionsProcessingQueue.has(session.id)) {
+        if (syncProvider && !this.svc.hasActiveQueueLease(session.id)) {
           syncProvider.pushChange(session.id, {
             type: 'metadata_updated',
             metadata: { isExecuting: false, hasPendingPrompt: false, updatedAt: Date.now() },

--- a/packages/electron/src/main/services/ai/__tests__/MessageStreamingHandler.queueTruth.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/MessageStreamingHandler.queueTruth.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createQueuedStreamTruthBinder } from '../queuedPromptTruth';
+
+describe('MessageStreamingHandler queued truth spine', () => {
+  it('binds user, text, tool, edit, tool-error, and assistant variants to one monotonic turn', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-03T00:00:00.000Z'));
+    const nextTruth = createQueuedStreamTruthBinder({
+      clientSubmissionId: 'client-1',
+      queueRowId: 'row-1',
+      sourceSessionId: 'session-1',
+      sourceRoomId: 'room-1',
+      turnId: 'turn-1',
+      providerInputMessageId: 'input-1',
+      providerOutputMessageId: 'output-1',
+    });
+
+    const user = nextTruth('streaming')!;
+    const text = nextTruth('streaming')!;
+    const tool = nextTruth('streaming')!;
+    const edit = nextTruth('streaming')!;
+    const toolError = nextTruth('streaming')!;
+    const assistantText = nextTruth('completed')!;
+    vi.advanceTimersByTime(1_000);
+    const terminal = nextTruth('completed')!;
+
+    for (const truth of [user, text, tool, edit, toolError, assistantText, terminal]) {
+      expect(truth).toMatchObject({
+        clientSubmissionId: 'client-1', queueRowId: 'row-1', sourceSessionId: 'session-1',
+        sourceRoomId: 'room-1', turnId: 'turn-1', providerInputMessageId: 'input-1',
+        providerOutputMessageId: 'output-1',
+      });
+    }
+    expect([user, text, tool, edit, toolError, assistantText, terminal].map((truth) => truth.eventSequence))
+      .toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(assistantText).toMatchObject({ lifecycle: 'completed', terminalAt: Date.parse('2026-08-03T00:00:00.000Z') });
+    expect(terminal).toMatchObject({ lifecycle: 'completed', terminalAt: Date.parse('2026-08-03T00:00:00.000Z') });
+    vi.useRealTimers();
+  });
+
+  it('gives a thrown-exception terminal one failed identity and time', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-03T00:01:00.000Z'));
+    const nextTruth = createQueuedStreamTruthBinder({ queueRowId: 'row-2', turnId: 'turn-2' });
+    const partial = nextTruth('streaming')!;
+    const persistedError = nextTruth('failed')!;
+    const rendererTerminal = nextTruth('failed')!;
+
+    expect(partial).toMatchObject({ lifecycle: 'streaming', eventSequence: 1 });
+    expect(persistedError).toMatchObject({ lifecycle: 'failed', eventSequence: 2 });
+    expect(rendererTerminal).toMatchObject({ lifecycle: 'failed', eventSequence: 3 });
+    expect(persistedError.terminalAt).toBe(rendererTerminal.terminalAt);
+    vi.useRealTimers();
+  });
+});

--- a/packages/electron/src/main/services/ai/__tests__/bootQueueRecovery.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/bootQueueRecovery.test.ts
@@ -8,6 +8,7 @@ function createDeps(overrides: DepOverrides = {}) {
   return {
     listSessionIdsWithPending: vi.fn(async () => [] as string[]),
     getWorkspacePath: vi.fn(async () => '/ws' as string | null | undefined),
+    failAllPending: vi.fn(async () => 0),
     logInfo: vi.fn(),
     logWarn: vi.fn(),
     ...overrides,
@@ -44,7 +45,7 @@ describe('driveStrandedQueuesOnBoot', () => {
     expect(deps.logInfo).not.toHaveBeenCalled();
   });
 
-  it('skips a session with no workspace path instead of guessing a window', async () => {
+  it('fails every pending row once when a session has no workspace mapping', async () => {
     const deps = createDeps({
       listSessionIdsWithPending: vi.fn(async () => ['orphan', 'ok']),
       getWorkspacePath: vi.fn(async (sessionId: string) => (sessionId === 'ok' ? '/ws' : null)),
@@ -52,6 +53,49 @@ describe('driveStrandedQueuesOnBoot', () => {
 
     expect(await driveStrandedQueuesOnBoot(deps)).toBe(1);
     expect(deps.requestDrive).toHaveBeenCalledExactlyOnceWith('ok', '/ws');
+    expect(deps.failAllPending).toHaveBeenCalledExactlyOnceWith(
+      'orphan',
+      'Queued prompt delivery failed: workspace mapping unavailable',
+    );
     expect(deps.logWarn).toHaveBeenCalledOnce();
+  });
+
+  it('continues to a valid session when an earlier workspace lookup rejects', async () => {
+    const deps = createDeps({
+      listSessionIdsWithPending: vi.fn(async () => ['broken', 'ok']),
+      getWorkspacePath: vi.fn(async (sessionId: string) => {
+        if (sessionId === 'broken') {
+          throw new Error('workspace /private prompt text credential provider output');
+        }
+        return '/ws';
+      }),
+    });
+
+    expect(await driveStrandedQueuesOnBoot(deps)).toBe(1);
+    expect(deps.requestDrive).toHaveBeenCalledExactlyOnceWith('ok', '/ws');
+    expect(deps.failAllPending).not.toHaveBeenCalled();
+    expect(deps.logWarn).toHaveBeenCalledExactlyOnceWith(
+      '[Main] Boot recovery: failed to recover one session; continuing',
+    );
+  });
+
+  it('continues to a valid session when failing an unmapped session rejects', async () => {
+    const deps = createDeps({
+      listSessionIdsWithPending: vi.fn(async () => ['unmapped', 'ok']),
+      getWorkspacePath: vi.fn(async (sessionId: string) => (sessionId === 'ok' ? '/ws' : null)),
+      failAllPending: vi.fn(async () => {
+        throw new Error('workspace /private prompt text credential provider output');
+      }),
+    });
+
+    expect(await driveStrandedQueuesOnBoot(deps)).toBe(1);
+    expect(deps.failAllPending).toHaveBeenCalledExactlyOnceWith(
+      'unmapped',
+      'Queued prompt delivery failed: workspace mapping unavailable',
+    );
+    expect(deps.requestDrive).toHaveBeenCalledExactlyOnceWith('ok', '/ws');
+    expect(deps.logWarn).toHaveBeenCalledExactlyOnceWith(
+      '[Main] Boot recovery: failed to recover one session; continuing',
+    );
   });
 });

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliInputIntegrationRoundTrip.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliInputIntegrationRoundTrip.test.ts
@@ -101,8 +101,9 @@ function makePipeline() {
 
 /**
  * Minimal in-memory queued-prompt store matching QueuedPromptStoreLike's
- * relevant subset (listPending / claim / complete / fail). `claim` is atomic:
- * it only returns + marks a prompt if it is still `pending`.
+ * relevant dispatch subset. `claim` is atomic: it only returns + marks a
+ * prompt if it is still `pending`; terminal settlement mirrors the observed
+ * idle boundary that completes or fails the claimed token.
  */
 function makeQueueStore(
   seed: Array<{ id: string; prompt?: string | null; attachments?: unknown[] | null }>,
@@ -112,6 +113,7 @@ function makeQueueStore(
     prompt: s.prompt ?? '',
     attachments: s.attachments ?? null,
     status: 'pending' as 'pending' | 'executing' | 'completed' | 'failed',
+    claimToken: undefined as string | undefined,
     errorMessage: undefined as string | undefined,
   }));
 
@@ -125,18 +127,22 @@ function makeQueueStore(
       const item = find(promptId);
       if (!item || item.status !== 'pending') return null;
       item.status = 'executing';
-      return { id: item.id, prompt: item.prompt, attachments: item.attachments };
+      item.claimToken = `claim-${item.id}`;
+      return { id: item.id, prompt: item.prompt, attachments: item.attachments, claimToken: item.claimToken };
     },
-    complete: async (promptId: string): Promise<void> => {
+    beginDispatch: async () => ({ outcome: 'settled' as const }),
+    completeAfterDispatch: async (promptId: string, _sessionId: string, claimToken: string) => {
       const item = find(promptId);
-      if (item) item.status = 'completed';
+      if (item?.claimToken === claimToken) item.status = 'completed';
+      return { outcome: 'settled' as const };
     },
-    fail: async (promptId: string, errorMessage: string): Promise<void> => {
+    failAfterDispatch: async (promptId: string, errorMessage: string, _sessionId: string, claimToken: string) => {
       const item = find(promptId);
-      if (item) {
+      if (item?.claimToken === claimToken) {
         item.status = 'failed';
         item.errorMessage = errorMessage;
       }
+      return { outcome: 'settled' as const };
     },
   };
 }
@@ -263,11 +269,14 @@ describe('claude-code-cli input integration round-trip (attachments + queued pro
     ]);
 
     const deps = {
+      preflight: async (_sessionId: string) => true,
       listPending: store.listPending,
       claim: store.claim,
-      complete: store.complete,
-      fail: store.fail,
+      beginDispatch: store.beginDispatch,
+      completeAfterDispatch: store.completeAfterDispatch,
+      failAfterDispatch: store.failAfterDispatch,
       submit: pipe.submit,
+      registerQueuedTurn: () => true,
     };
 
     // First idle → claims q1 (oldest), writes 'first /tmp/a.png' + Enter.
@@ -276,6 +285,7 @@ describe('claude-code-cli input integration round-trip (attachments + queued pro
       deps,
     );
     expect(flushed1).toBe(true);
+    await store.completeAfterDispatch('q1', SESSION_ID, 'claim-q1');
     expect(store.items.find((i) => i.id === 'q1')?.status).toBe('completed');
     expect(pipe.ptyWrites).toEqual([
       ['s', pasted('first /tmp/a.png')],
@@ -291,6 +301,7 @@ describe('claude-code-cli input integration round-trip (attachments + queued pro
       deps,
     );
     expect(flushed2).toBe(true);
+    await store.completeAfterDispatch('q2', SESSION_ID, 'claim-q2');
     expect(store.items.find((i) => i.id === 'q2')?.status).toBe('completed');
     expect(pipe.ptyWrites.slice(2)).toEqual([
       ['s', pasted('second')],
@@ -319,13 +330,16 @@ describe('claude-code-cli input integration round-trip (attachments + queued pro
     const flushed = await flushNextClaudeCliQueuedPrompt(
       { sessionId: SESSION_ID, workspacePath: WORKSPACE },
       {
+        preflight: async (_sessionId: string) => true,
         listPending: store.listPending,
         claim: store.claim,
-        complete: store.complete,
-        fail: store.fail,
+        beginDispatch: store.beginDispatch,
+        completeAfterDispatch: store.completeAfterDispatch,
+        failAfterDispatch: store.failAfterDispatch,
         submit: async () => {
           throw new Error('pty exploded');
         },
+        registerQueuedTurn: () => true,
       },
     );
 

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliPromptComposer.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliPromptComposer.test.ts
@@ -5,8 +5,8 @@ import {
 } from '../claudeCliPromptComposer';
 
 describe('composeClaudeCliPtySubmission', () => {
-  it('returns just the trimmed prompt when there are no attachments', () => {
-    expect(composeClaudeCliPtySubmission({ prompt: '  fix the bug  ' })).toBe('fix the bug');
+  it('returns the exact prompt when there are no attachments', () => {
+    expect(composeClaudeCliPtySubmission({ prompt: '  fix the bug  ' })).toBe('  fix the bug  ');
   });
 
   it('appends absolute attachment paths after the prompt on one line', () => {
@@ -40,30 +40,28 @@ describe('composeClaudeCliPtySubmission', () => {
    * the PTY is Enter, which submits the turn early and drops everything after
    * it. The selection preamble was already flattened; the typed prompt was not.
    */
-  describe('newline flattening', () => {
-    it('flattens newlines in the typed prompt', () => {
+  describe('logical payload preservation', () => {
+    it('preserves newlines in the typed prompt', () => {
       expect(
         composeClaudeCliPtySubmission({ prompt: 'fix auth.ts\nalso update the tests' }),
-      ).toBe('fix auth.ts\\nalso update the tests');
+      ).toBe('fix auth.ts\nalso update the tests');
     });
 
-    it('flattens CRLF and bare CR the same way', () => {
-      expect(composeClaudeCliPtySubmission({ prompt: 'a\r\nb\rc' })).toBe('a\\nb\\nc');
+    it('preserves CRLF and bare CR exactly', () => {
+      expect(composeClaudeCliPtySubmission({ prompt: 'a\r\nb\rc' })).toBe('a\r\nb\rc');
     });
 
     it('keeps blank lines between paragraphs', () => {
-      expect(composeClaudeCliPtySubmission({ prompt: 'para one\n\npara two' })).toBe(
-        'para one\\n\\npara two',
-      );
+      expect(composeClaudeCliPtySubmission({ prompt: 'para one\n\npara two' })).toBe('para one\n\npara two');
     });
 
-    it('emits no real newline once attachments and context are appended', () => {
+    it('keeps logical newlines when attachments and context are appended', () => {
       const out = composeClaudeCliPtySubmission({
         prompt: 'line one\nline two',
         attachments: [{ filepath: '/tmp/a.png' }],
         documentContext: { filePath: '/ws/notes.md', textSelection: { text: 'sel\nected' } },
       });
-      expect(out).not.toMatch(/[\r\n]/);
+      expect(out).toContain('line one\nline two');
     });
   });
 

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliQueueFlush.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliQueueFlush.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { QueueSettlementResult } from '../../PGLiteQueuedPromptsStore';
 import { flushNextClaudeCliQueuedPrompt, type FlushQueuedPrompt } from '../claudeCliQueueFlush';
+import { receiptQueuedPromptPayload } from '../queuedPromptTruth';
 
 const settled: QueueSettlementResult = { outcome: 'settled' };
 
 function harness(pending: FlushQueuedPrompt[]) {
-  const claimed = pending.map((row) => ({ ...row, claimToken: `token-${row.id}` }));
+  const claimed = pending.map((row) => ({
+    ...row,
+    claimToken: `token-${row.id}`,
+    clientSubmissionId: row.clientSubmissionId ?? `client-${row.id}`,
+    sourceSessionId: row.sourceSessionId ?? 's1',
+    sourceRoomId: row.sourceRoomId ?? 'room-1',
+    submissionSequence: row.submissionSequence ?? 1,
+    producer: row.producer ?? 'composer',
+    claimTrigger: row.claimTrigger ?? 'claude_cli_idle_flush',
+    claimTriggeredAt: row.claimTriggeredAt ?? 1,
+    turnId: row.turnId ?? `turn-${row.id}`,
+    providerInputMessageId: row.providerInputMessageId ?? `input-${row.id}`,
+    providerOutputMessageId: row.providerOutputMessageId ?? `output-${row.id}`,
+    payloadReceipt: row.payloadReceipt ?? receiptQueuedPromptPayload(row.prompt ?? ''),
+  }));
   const deps = {
     preflight: vi.fn(async () => true),
     listPending: vi.fn(async () => pending),
@@ -14,23 +29,32 @@ function harness(pending: FlushQueuedPrompt[]) {
     completeAfterDispatch: vi.fn(async () => settled),
     failAfterDispatch: vi.fn(async () => settled),
     submit: vi.fn(async () => ({ submitted: true })),
+    registerQueuedTurn: vi.fn(() => true),
+    clearQueuedTurnRegistration: vi.fn(),
+    publishSnapshot: vi.fn(async () => undefined),
     notifyClaimed: vi.fn(),
   };
   return deps;
 }
 
 describe('flushNextClaudeCliQueuedPrompt', () => {
-  it('begins before submit and settles the exact token', async () => {
+  it('registers exact truth before submit and defers settlement to observed idle', async () => {
     const deps = harness([{ id: 'q1', prompt: 'first', attachments: [{ filepath: '/tmp/a.png' }] }]);
     const result = await flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, deps);
     expect(result).toBe(true);
-    expect(deps.claim).toHaveBeenCalledWith('q1', 's1');
+    expect(deps.claim).toHaveBeenCalledWith('q1', 's1', 'claude_cli_idle_flush');
     expect(deps.beginDispatch).toHaveBeenCalledWith('q1', 's1', 'token-q1');
     expect(deps.submit).toHaveBeenCalledWith({
       sessionId: 's1', workspacePath: '/w', prompt: 'first',
       attachments: [{ filepath: '/tmp/a.png' }], documentContext: undefined,
     });
-    expect(deps.completeAfterDispatch).toHaveBeenCalledWith('q1', 's1', 'token-q1');
+    expect(deps.registerQueuedTurn).toHaveBeenCalledWith(expect.objectContaining({
+      queueRowId: 'q1', claimToken: 'token-q1', clientSubmissionId: 'client-q1',
+      turnId: 'turn-q1', providerOutputMessageId: 'output-q1',
+    }));
+    expect(deps.claim).toHaveBeenCalledWith('q1', 's1', 'claude_cli_idle_flush');
+    expect(deps.publishSnapshot).toHaveBeenCalledWith('s1');
+    expect(deps.completeAfterDispatch).not.toHaveBeenCalled();
     expect(deps.failAfterDispatch).not.toHaveBeenCalled();
   });
 
@@ -41,7 +65,7 @@ describe('flushNextClaudeCliQueuedPrompt', () => {
       flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, deps),
     ).resolves.toBe(true);
     expect(deps.submit).toHaveBeenCalledTimes(1);
-    expect(deps.completeAfterDispatch).toHaveBeenCalledTimes(1);
+    expect(deps.completeAfterDispatch).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -87,7 +111,7 @@ describe('flushNextClaudeCliQueuedPrompt', () => {
     expect(deps.failAfterDispatch).toHaveBeenCalledWith('q1', 'pty gone', 's1', 'token-q1');
   });
 
-  it('surfaces begin, completion, and failure settlement conflicts', async () => {
+  it('surfaces begin, registration, and failure settlement conflicts', async () => {
     const begin = harness([{ id: 'begin', prompt: 'first' }]);
     begin.beginDispatch.mockResolvedValue({ outcome: 'stale_owner' });
     await expect(
@@ -96,10 +120,11 @@ describe('flushNextClaudeCliQueuedPrompt', () => {
     expect(begin.submit).not.toHaveBeenCalled();
 
     const complete = harness([{ id: 'complete', prompt: 'first' }]);
-    complete.completeAfterDispatch.mockResolvedValue({ outcome: 'terminal_conflict' });
+    complete.registerQueuedTurn.mockReturnValue(false);
     await expect(
       flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, complete),
-    ).rejects.toThrow(/completion was rejected: terminal_conflict/);
+    ).resolves.toBe(false);
+    expect(complete.submit).not.toHaveBeenCalled();
 
     const failure = harness([{ id: 'failure', prompt: 'first' }]);
     failure.submit.mockRejectedValue(new Error('pty gone'));

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliQueueFlush.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliQueueFlush.test.ts
@@ -1,77 +1,128 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import type { QueueSettlementResult } from '../../PGLiteQueuedPromptsStore';
 import { flushNextClaudeCliQueuedPrompt, type FlushQueuedPrompt } from '../claudeCliQueueFlush';
 
+const settled: QueueSettlementResult = { outcome: 'settled' };
+
 function harness(pending: FlushQueuedPrompt[]) {
-  const claim = vi.fn(async (id: string) => pending.find((p) => p.id === id) ?? null);
-  const complete = vi.fn(async () => undefined);
-  const fail = vi.fn(async () => undefined);
-  const submit = vi.fn(async () => ({ submitted: true }));
-  const notifyClaimed = vi.fn();
+  const claimed = pending.map((row) => ({ ...row, claimToken: `token-${row.id}` }));
   const deps = {
+    preflight: vi.fn(async () => true),
     listPending: vi.fn(async () => pending),
-    claim,
-    complete,
-    fail,
-    submit,
-    notifyClaimed,
+    claim: vi.fn(async (id: string, _sessionId: string) => claimed.find((row) => row.id === id) ?? null),
+    beginDispatch: vi.fn(async () => settled),
+    completeAfterDispatch: vi.fn(async () => settled),
+    failAfterDispatch: vi.fn(async () => settled),
+    submit: vi.fn(async () => ({ submitted: true })),
+    notifyClaimed: vi.fn(),
   };
-  return { deps, claim, complete, fail, submit, notifyClaimed };
+  return deps;
 }
 
 describe('flushNextClaudeCliQueuedPrompt', () => {
-  it('claims + submits the oldest pending prompt and marks it completed', async () => {
-    const h = harness([
-      { id: 'q1', prompt: 'first', attachments: [{ filepath: '/tmp/a.png' }] },
-      { id: 'q2', prompt: 'second' },
-    ]);
-    const result = await flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, h.deps);
+  it('begins before submit and settles the exact token', async () => {
+    const deps = harness([{ id: 'q1', prompt: 'first', attachments: [{ filepath: '/tmp/a.png' }] }]);
+    const result = await flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, deps);
     expect(result).toBe(true);
-    expect(h.claim).toHaveBeenCalledWith('q1');
-    expect(h.submit).toHaveBeenCalledWith({
-      sessionId: 's1',
-      workspacePath: '/w',
-      prompt: 'first',
-      attachments: [{ filepath: '/tmp/a.png' }],
+    expect(deps.claim).toHaveBeenCalledWith('q1', 's1');
+    expect(deps.beginDispatch).toHaveBeenCalledWith('q1', 's1', 'token-q1');
+    expect(deps.submit).toHaveBeenCalledWith({
+      sessionId: 's1', workspacePath: '/w', prompt: 'first',
+      attachments: [{ filepath: '/tmp/a.png' }], documentContext: undefined,
     });
-    expect(h.complete).toHaveBeenCalledWith('q1');
-    expect(h.fail).not.toHaveBeenCalled();
+    expect(deps.completeAfterDispatch).toHaveBeenCalledWith('q1', 's1', 'token-q1');
+    expect(deps.failAfterDispatch).not.toHaveBeenCalled();
   });
 
-  it('notifies the renderer (notifyClaimed) when a prompt is claimed so the queued-prompt UI clears', async () => {
-    // Regression for NIM-830: the CLI flush path drained the prompt (DB status
-    // -> completed) but never told the renderer, so it sat in the QUEUED list
-    // forever. notifyClaimed mirrors the SDK dispatcher's ai:promptClaimed.
-    const h = harness([{ id: 'q1', prompt: 'first' }]);
-    await flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, h.deps);
-    expect(h.notifyClaimed).toHaveBeenCalledWith('q1');
+  it('treats claim notification as best-effort', async () => {
+    const deps = harness([{ id: 'q1', prompt: 'first' }]);
+    deps.notifyClaimed.mockImplementation(() => { throw new Error('destroyed window'); });
+    await expect(
+      flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, deps),
+    ).resolves.toBe(true);
+    expect(deps.submit).toHaveBeenCalledTimes(1);
+    expect(deps.completeAfterDispatch).toHaveBeenCalledTimes(1);
   });
 
-  it('returns false and does nothing when the queue is empty', async () => {
-    const h = harness([]);
-    const result = await flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, h.deps);
-    expect(result).toBe(false);
-    expect(h.claim).not.toHaveBeenCalled();
-    expect(h.submit).not.toHaveBeenCalled();
-    expect(h.notifyClaimed).not.toHaveBeenCalled();
+  it.each([
+    ['empty', ''],
+    ['whitespace', '   \n'],
+  ])('visibly fails legacy %s input with zero submit side effects', async (_label, prompt) => {
+    const deps = harness([{ id: 'q1', prompt }]);
+    await expect(
+      flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, deps),
+    ).resolves.toBe(false);
+    expect(deps.submit).not.toHaveBeenCalled();
+    expect(deps.failAfterDispatch).toHaveBeenCalledWith(
+      'q1', 'Queued CLI prompt had no sendable content', 's1', 'token-q1',
+    );
   });
 
-  it('returns false when the prompt was already claimed by someone else', async () => {
-    const h = harness([{ id: 'q1', prompt: 'first' }]);
-    h.deps.claim = vi.fn(async () => null);
-    const result = await flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, h.deps);
-    expect(result).toBe(false);
-    expect(h.submit).not.toHaveBeenCalled();
+  it('admits attachment-only input', async () => {
+    const deps = harness([{ id: 'q1', prompt: '', attachments: [{ filepath: '/tmp/a.png' }] }]);
+    await expect(
+      flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, deps),
+    ).resolves.toBe(true);
+    expect(deps.submit).toHaveBeenCalledTimes(1);
   });
 
-  it('marks the prompt failed (not stuck executing) when submit throws', async () => {
-    const h = harness([{ id: 'q1', prompt: 'first' }]);
-    h.deps.submit = vi.fn(async () => { throw new Error('pty gone'); });
-    const result = await flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, h.deps);
-    expect(result).toBe(false);
-    expect(h.fail).toHaveBeenCalledWith('q1', 'pty gone');
-    expect(h.complete).not.toHaveBeenCalled();
-    // The claim succeeded, so the prompt already left the pending queue; the UI
-    // must clear it even though submit later failed.
-    expect(h.notifyClaimed).toHaveBeenCalledWith('q1');
+  it('fails a submitted:false result instead of completing it', async () => {
+    const deps = harness([{ id: 'q1', prompt: 'first' }]);
+    deps.submit.mockResolvedValue({ submitted: false });
+    await expect(
+      flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, deps),
+    ).resolves.toBe(false);
+    expect(deps.completeAfterDispatch).not.toHaveBeenCalled();
+    expect(deps.failAfterDispatch).toHaveBeenCalledWith(
+      'q1', 'CLI prompt submission produced no terminal input', 's1', 'token-q1',
+    );
+  });
+
+  it('same-token fails a PTY error and leaves no executing ambiguity', async () => {
+    const deps = harness([{ id: 'q1', prompt: 'first' }]);
+    deps.submit.mockRejectedValue(new Error('pty gone'));
+    await expect(
+      flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, deps),
+    ).resolves.toBe(false);
+    expect(deps.failAfterDispatch).toHaveBeenCalledWith('q1', 'pty gone', 's1', 'token-q1');
+  });
+
+  it('surfaces begin, completion, and failure settlement conflicts', async () => {
+    const begin = harness([{ id: 'begin', prompt: 'first' }]);
+    begin.beginDispatch.mockResolvedValue({ outcome: 'stale_owner' });
+    await expect(
+      flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, begin),
+    ).rejects.toThrow(/dispatch intent was rejected: stale_owner/);
+    expect(begin.submit).not.toHaveBeenCalled();
+
+    const complete = harness([{ id: 'complete', prompt: 'first' }]);
+    complete.completeAfterDispatch.mockResolvedValue({ outcome: 'terminal_conflict' });
+    await expect(
+      flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, complete),
+    ).rejects.toThrow(/completion was rejected: terminal_conflict/);
+
+    const failure = harness([{ id: 'failure', prompt: 'first' }]);
+    failure.submit.mockRejectedValue(new Error('pty gone'));
+    failure.failAfterDispatch.mockResolvedValue({ outcome: 'stale_owner' });
+    await expect(
+      flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, failure),
+    ).rejects.toThrow(/failure settlement was rejected: stale_owner/);
+  });
+
+  it('leaves rows pending when preflight or atomic claim rejects', async () => {
+    const blocked = harness([{ id: 'q1', prompt: 'first' }]);
+    blocked.preflight.mockResolvedValue(false);
+    await expect(
+      flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, blocked),
+    ).resolves.toBe(false);
+    expect(blocked.listPending).not.toHaveBeenCalled();
+
+    const raced = harness([{ id: 'q1', prompt: 'first' }]);
+    raced.claim.mockResolvedValue(null);
+    await expect(
+      flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, raced),
+    ).resolves.toBe(false);
+    expect(raced.beginDispatch).not.toHaveBeenCalled();
+    expect(raced.submit).not.toHaveBeenCalled();
   });
 });

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliSubmit.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliSubmit.test.ts
@@ -102,6 +102,15 @@ describe('submitClaudeCliPrompt', () => {
     expect(h.sendAnalytics).not.toHaveBeenCalled();
   });
 
+  it('keeps provider entry non-terminal when post-write prompt logging fails', async () => {
+    const h = harness();
+    h.logUserPrompt.mockRejectedValueOnce(new Error('disk unavailable'));
+    await expect(submitClaudeCliPrompt({ sessionId: 's1', workspacePath: '/w', prompt: 'already entered' }, h.deps))
+      .resolves.toEqual({ submitted: true });
+    expect(h.writes).toHaveLength(2);
+    expect(h.sendAnalytics).toHaveBeenCalledTimes(1);
+  });
+
   /**
    * NIM-819: the claude TUI only opens its slash/memory mode when / or # is
    * the FIRST interactive keystroke on an empty prompt — a bulk-pasted line is

--- a/packages/electron/src/main/services/ai/__tests__/queueDrainLiveness.integration.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queueDrainLiveness.integration.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { QueueDriveService, type DriveReason } from '../QueueDriveService';
+import { runQueueDriveAttempt } from '../queueDriveAttempt';
+
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('queue drain liveness', () => {
+  it('continues an ordinary FIFO of three rows with one dispatch per row', async () => {
+    const pending = ['p1', 'p2', 'p3'];
+    const dispatched: string[] = [];
+    let service!: QueueDriveService;
+
+    service = new QueueDriveService({
+      attempt: (input) =>
+        runQueueDriveAttempt(
+          {
+            listPendingIds: async () => [...pending],
+            isChainActive: () => false,
+            isSessionBusy: () => false,
+            resolveWindow: async () => ({ kind: 'window', window: { id: 1 }, opened: false }) as const,
+            failAllPending: async () => 0,
+            dispatch: async () => {
+              const promptId = pending.shift();
+              if (!promptId) return false;
+              dispatched.push(promptId);
+              if (pending.length > 0) {
+                service.requestDrive('s1', '/ws', 'fifo-continuation');
+              }
+              return true;
+            },
+            logWarn: () => {},
+          },
+          input,
+        ),
+      onWindowAvailable: () => () => {},
+      onSessionIdle: () => () => {},
+      logInfo: () => {},
+      logWarn: () => {},
+      logError: () => {},
+    });
+
+    await service.drive('s1', '/ws', 'mobile-control');
+
+    expect(dispatched).toEqual(['p1', 'p2', 'p3']);
+  });
+
+  it('re-drives after an ordinary active-turn terminal edge', async () => {
+    const pending = ['p1'];
+    const reasons: DriveReason[] = [];
+    let busy = true;
+    let onIdle: (() => void) | undefined;
+
+    const service = new QueueDriveService({
+      attempt: async (input) => {
+        reasons.push(input.reason);
+        return runQueueDriveAttempt(
+          {
+            listPendingIds: async () => [...pending],
+            isChainActive: () => false,
+            isSessionBusy: () => busy,
+            resolveWindow: async () => ({ kind: 'window', window: { id: 1 }, opened: false }) as const,
+            failAllPending: async () => 0,
+            dispatch: async () => {
+              pending.shift();
+              return true;
+            },
+            logWarn: () => {},
+          },
+          input,
+        );
+      },
+      onWindowAvailable: () => () => {},
+      onSessionIdle: (_sessionId, listener) => {
+        onIdle = listener;
+        return () => {
+          onIdle = undefined;
+        };
+      },
+      logInfo: () => {},
+      logWarn: () => {},
+      logError: () => {},
+    });
+
+    await service.drive('s1', '/ws', 'mobile-control');
+    expect(onIdle).toBeTypeOf('function');
+
+    busy = false;
+    onIdle?.();
+    await flush();
+
+    expect(reasons).toEqual(['mobile-control', 'session-idle']);
+    expect(pending).toEqual([]);
+  });
+
+  it('collapses concurrent ordinary triggers into one claim and dispatch', async () => {
+    const pending = ['p1'];
+    const dispatched: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const service = new QueueDriveService({
+      attempt: (input) =>
+        runQueueDriveAttempt(
+          {
+            listPendingIds: async () => [...pending],
+            isChainActive: () => false,
+            isSessionBusy: () => false,
+            resolveWindow: async () => ({ kind: 'window', window: { id: 1 }, opened: false }) as const,
+            failAllPending: async () => 0,
+            dispatch: async () => {
+              await gate;
+              const promptId = pending.shift();
+              if (!promptId) return false;
+              dispatched.push(promptId);
+              return true;
+            },
+            logWarn: () => {},
+          },
+          input,
+        ),
+      onWindowAvailable: () => () => {},
+      onSessionIdle: () => () => {},
+      logInfo: () => {},
+      logWarn: () => {},
+      logError: () => {},
+    });
+
+    const first = service.drive('s1', '/ws', 'mobile-control');
+    const second = service.drive('s1', '/ws', 'mobile-index');
+    const third = service.drive('s1', '/ws', 'renderer-trigger');
+    release();
+    await Promise.all([first, second, third]);
+
+    expect(dispatched).toEqual(['p1']);
+  });
+});

--- a/packages/electron/src/main/services/ai/__tests__/queueDriveAttempt.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queueDriveAttempt.test.ts
@@ -77,7 +77,7 @@ describe('runQueueDriveAttempt', () => {
     expect(await run(deps)).toEqual({ kind: 'failed', reason: 'workspace-missing' });
     expect(deps.failAllPending).toHaveBeenCalledExactlyOnceWith(
       's1',
-      'Project folder is no longer available at /ws',
+      'Queued prompt delivery failed: workspace is unavailable',
     );
   });
 

--- a/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
@@ -1,305 +1,207 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  createSessionPromptDispatchPreflight,
   tryClaimAndDispatchNextQueuedPrompt,
   type ClaimedQueuedPrompt,
   type QueuedPromptStoreLike,
 } from '../queuedPromptDispatcher';
 
-describe('queuedPromptDispatcher', () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+const settled = { outcome: 'settled' as const };
 
-  it('starts the session before dispatching a claimed queued prompt', async () => {
+function claimed(id = 'prompt-1', prompt = 'continue'): ClaimedQueuedPrompt {
+  return { id, prompt, claimToken: `token-${id}`, attachments: null, documentContext: null };
+}
+
+function queueStoreFor(row: ClaimedQueuedPrompt): QueuedPromptStoreLike {
+  return {
+    listPending: vi.fn(async () => [row]),
+    claim: vi.fn(async () => row),
+    beginDispatch: vi.fn(async () => settled),
+    releaseClaim: vi.fn(async () => settled),
+    completeAfterDispatch: vi.fn(async () => settled),
+    failAfterDispatch: vi.fn(async () => settled),
+  };
+}
+
+function windowFixture(): Electron.BrowserWindow {
+  return {
+    isDestroyed: () => false,
+    webContents: { send: vi.fn(), mainFrame: {} },
+  } as unknown as Electron.BrowserWindow;
+}
+
+function optionsFor(queueStore: QueuedPromptStoreLike, overrides: Record<string, unknown> = {}) {
+  return {
+    continueQueuedPromptChain: vi.fn(async () => {}),
+    logError: vi.fn(),
+    logInfo: vi.fn(),
+    onChainSettled: vi.fn(async () => {}),
+    onPromptClaimed: vi.fn(),
+    preflight: vi.fn(async () => true),
+    processingLeases: new Map<string, symbol>(),
+    queueStore,
+    sendMessageHandler: vi.fn(async () => ({ content: 'ok' })),
+    sessionId: 'session-1',
+    source: 'test queue',
+    startSession: vi.fn(async () => {}),
+    targetWindow: windowFixture(),
+    workspacePath: '/workspace/project',
+    ...overrides,
+  };
+}
+
+describe('queuedPromptDispatcher token owner', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('persists intent before send and settles the exact token before continuing', async () => {
     vi.useFakeTimers();
-
     const order: string[] = [];
-    const claimedPrompt: ClaimedQueuedPrompt = {
-      id: 'prompt-1',
-      prompt: 'continue',
-      attachments: null,
-      documentContext: { filePath: '/tmp/example.md' } as any,
-    };
-
-    const queueStore: QueuedPromptStoreLike = {
-      listPending: vi.fn(async () => [claimedPrompt]),
-      claim: vi.fn(async () => claimedPrompt),
-      complete: vi.fn(async () => {
-        order.push('complete');
-      }),
-      fail: vi.fn(async () => {
-        order.push('fail');
-      }),
-    };
-
-    const processingSet = new Set<string>();
-    const targetWindow = {
-      isDestroyed: () => false,
-      webContents: {
-        send: vi.fn(() => {
-          order.push('promptClaimed');
-        }),
-        mainFrame: {},
-      },
-    } as unknown as Electron.BrowserWindow;
-
-    const processed = await tryClaimAndDispatchNextQueuedPrompt({
-      continueQueuedPromptChain: vi.fn(async () => {
-        order.push('continue');
-      }),
-      logError: vi.fn(),
-      logInfo: vi.fn(),
-      onPromptClaimed: ({ sessionId, promptId }) => {
-        targetWindow.webContents.send('ai:promptClaimed', { sessionId, promptId });
-      },
-      processingSet,
-      queueStore,
-      sendMessageHandler: vi.fn(async () => {
-        order.push('sendMessage');
-        return { content: 'ok' };
-      }),
-      sessionId: 'session-1',
-      source: 'test queue',
-      startSession: vi.fn(async () => {
-        order.push('startSession');
-      }),
-      targetWindow,
-      workspacePath: '/workspace/project',
+    const row = claimed();
+    const store = queueStoreFor(row);
+    vi.mocked(store.beginDispatch).mockImplementation(async () => {
+      order.push('begin');
+      return settled;
+    });
+    vi.mocked(store.completeAfterDispatch).mockImplementation(async () => {
+      order.push('complete');
+      return settled;
+    });
+    const options = optionsFor(store, {
+      startSession: vi.fn(async () => { order.push('start'); }),
+      onPromptClaimed: vi.fn(() => { order.push('notify'); }),
+      sendMessageHandler: vi.fn(async () => { order.push('send'); return { content: 'ok' }; }),
+      continueQueuedPromptChain: vi.fn(async () => { order.push('continue'); }),
     });
 
-    expect(processed).toBe(true);
-    expect(order).toEqual(['startSession', 'promptClaimed']);
-    expect(processingSet.has('session-1')).toBe(true);
-
+    await expect(tryClaimAndDispatchNextQueuedPrompt(options)).resolves.toBe(true);
+    expect(order).toEqual(['start', 'notify']);
     await vi.runAllTimersAsync();
-
-    expect(order).toEqual(['startSession', 'promptClaimed', 'sendMessage', 'complete', 'continue']);
-    expect(processingSet.has('session-1')).toBe(false);
+    expect(order).toEqual(['start', 'notify', 'begin', 'send', 'complete', 'continue']);
+    expect(store.beginDispatch).toHaveBeenCalledWith('prompt-1', 'session-1', 'token-prompt-1');
+    expect(store.completeAfterDispatch).toHaveBeenCalledWith(
+      'prompt-1', 'session-1', 'token-prompt-1',
+    );
+    expect(options.onChainSettled).toHaveBeenCalledTimes(1);
   });
 
-  it('fires onChainSettled when no follow-on prompt is dispatched', async () => {
+  it('makes notification best-effort without releasing or wedging the claim', async () => {
     vi.useFakeTimers();
-
-    const claimedPrompt: ClaimedQueuedPrompt = {
-      id: 'prompt-1',
-      prompt: 'continue',
-      attachments: null,
-      documentContext: null,
-    };
-
-    const queueStore: QueuedPromptStoreLike = {
-      listPending: vi.fn(async () => [claimedPrompt]),
-      claim: vi.fn(async () => claimedPrompt),
-      complete: vi.fn(async () => {}),
-      fail: vi.fn(async () => {}),
-    };
-
-    const processingSet = new Set<string>();
-    const targetWindow = {
-      isDestroyed: () => false,
-      webContents: { send: vi.fn(), mainFrame: {} },
-    } as unknown as Electron.BrowserWindow;
-
-    const onChainSettled = vi.fn(async () => {});
-    // continueQueuedPromptChain doesn't dispatch a follow-on (no pending prompts).
-    const continueQueuedPromptChain = vi.fn(async () => {});
-
-    await tryClaimAndDispatchNextQueuedPrompt({
-      continueQueuedPromptChain,
-      logError: vi.fn(),
-      logInfo: vi.fn(),
-      onChainSettled,
-      onPromptClaimed: () => {},
-      processingSet,
-      queueStore,
-      sendMessageHandler: vi.fn(async () => ({ content: 'ok' })),
-      sessionId: 'session-1',
-      source: 'test queue',
-      startSession: vi.fn(async () => {}),
-      targetWindow,
-      workspacePath: '/workspace/project',
+    const store = queueStoreFor(claimed());
+    const options = optionsFor(store, {
+      onPromptClaimed: vi.fn(() => { throw new Error('destroyed window'); }),
     });
-
+    await expect(tryClaimAndDispatchNextQueuedPrompt(options)).resolves.toBe(true);
     await vi.runAllTimersAsync();
-
-    expect(processingSet.has('session-1')).toBe(false);
-    expect(onChainSettled).toHaveBeenCalledTimes(1);
-    expect(onChainSettled).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      workspacePath: '/workspace/project',
-      source: 'test queue',
-    });
+    expect(options.sendMessageHandler).toHaveBeenCalledTimes(1);
+    expect(store.completeAfterDispatch).toHaveBeenCalledTimes(1);
+    expect(store.releaseClaim).not.toHaveBeenCalled();
   });
 
-  it('dispatches once to a replacement window when the original window is destroyed', async () => {
-    vi.useFakeTimers();
-
-    // Regression: a long guarded/streaming prompt retains its original
-    // BrowserWindow. If that renderer dies or reloads, FIFO continuation must
-    // not bail just because the passed window is gone — a replacement window
-    // for the same workspace should receive the next queued prompt exactly once.
-    const claimedPrompt: ClaimedQueuedPrompt = {
-      id: 'prompt-1',
-      prompt: 'continue',
-      attachments: null,
-      documentContext: null,
-    };
-
-    const queueStore: QueuedPromptStoreLike = {
-      listPending: vi.fn(async () => [claimedPrompt]),
-      claim: vi.fn(async () => claimedPrompt),
-      complete: vi.fn(async () => {}),
-      fail: vi.fn(async () => {}),
-    };
-
-    const processingSet = new Set<string>();
-
-    // The original window is destroyed (renderer died/reloaded mid-stream).
-    const destroyedWindow = {
-      isDestroyed: () => true,
-      webContents: { send: vi.fn(), mainFrame: {} },
-    } as unknown as Electron.BrowserWindow;
-
-    // The replacement window for the same workspace is live.
-    const replacementWindow = {
-      isDestroyed: () => false,
-      webContents: { send: vi.fn(), mainFrame: {} },
-    } as unknown as Electron.BrowserWindow;
-
-    let dispatchedSender: Electron.WebContents | undefined;
-    const sendMessageHandler = vi.fn(async (event: Electron.IpcMainInvokeEvent) => {
-      dispatchedSender = event.sender;
-      return { content: 'ok' };
+  it('releases the exact undispatched token when session start fails', async () => {
+    const row = claimed();
+    const store = queueStoreFor(row);
+    const options = optionsFor(store, {
+      startSession: vi.fn(async () => { throw new Error('start failed'); }),
     });
-    const resolveLiveWindow = vi.fn((_workspacePath: string) => replacementWindow);
-
-    const processed = await tryClaimAndDispatchNextQueuedPrompt({
-      continueQueuedPromptChain: vi.fn(async () => {}),
-      logError: vi.fn(),
-      logInfo: vi.fn(),
-      onPromptClaimed: () => {},
-      processingSet,
-      queueStore,
-      sendMessageHandler,
-      resolveLiveWindow,
-      sessionId: 'session-1',
-      source: 'test queue',
-      startSession: vi.fn(async () => {}),
-      targetWindow: destroyedWindow,
-      workspacePath: '/workspace/project',
-    });
-
-    // Without the fix the dispatcher bails on the destroyed window and never
-    // resolves a replacement, so nothing is dispatched.
-    expect(processed).toBe(true);
-    expect(resolveLiveWindow).toHaveBeenCalledWith('/workspace/project');
-
-    await vi.runAllTimersAsync();
-
-    // Exactly-once after the deferred dispatch settles. The replacement
-    // window's webContents, not the destroyed original, is the IPC sender.
-    expect(sendMessageHandler).toHaveBeenCalledTimes(1);
-    expect(dispatchedSender).toBe(replacementWindow.webContents);
-    expect(queueStore.complete).toHaveBeenCalledTimes(1);
-    expect(queueStore.fail).not.toHaveBeenCalled();
-    expect(processingSet.has('session-1')).toBe(false);
+    await expect(tryClaimAndDispatchNextQueuedPrompt(options)).rejects.toThrow('start failed');
+    expect(store.releaseClaim).toHaveBeenCalledWith(row.id, 'session-1', row.claimToken);
+    expect(store.beginDispatch).not.toHaveBeenCalled();
+    expect(options.sendMessageHandler).not.toHaveBeenCalled();
+    expect(options.processingLeases.has('session-1')).toBe(false);
   });
 
-  it('bails (without dispatching) when the window is destroyed and no replacement exists', async () => {
-    vi.useFakeTimers();
-
-    const claimedPrompt: ClaimedQueuedPrompt = {
-      id: 'prompt-1',
-      prompt: 'continue',
-      attachments: null,
-      documentContext: null,
-    };
-
-    const queueStore: QueuedPromptStoreLike = {
-      listPending: vi.fn(async () => [claimedPrompt]),
-      claim: vi.fn(async () => claimedPrompt),
-      complete: vi.fn(async () => {}),
-      fail: vi.fn(async () => {}),
-    };
-
-    const processingSet = new Set<string>();
-
-    const destroyedWindow = {
-      isDestroyed: () => true,
-      webContents: { send: vi.fn(), mainFrame: {} },
-    } as unknown as Electron.BrowserWindow;
-
-    const sendMessageHandler = vi.fn(async () => ({ content: 'ok' }));
-
-    const processed = await tryClaimAndDispatchNextQueuedPrompt({
-      continueQueuedPromptChain: vi.fn(async () => {}),
-      logError: vi.fn(),
-      logInfo: vi.fn(),
-      onPromptClaimed: () => {},
-      processingSet,
-      queueStore,
-      sendMessageHandler,
-      resolveLiveWindow: vi.fn(() => null),
-      sessionId: 'session-1',
-      source: 'test queue',
-      startSession: vi.fn(async () => {}),
-      targetWindow: destroyedWindow,
-      workspacePath: '/workspace/project',
-    });
-
-    expect(processed).toBe(false);
-    expect(sendMessageHandler).not.toHaveBeenCalled();
-    expect(queueStore.claim).not.toHaveBeenCalled();
-    expect(processingSet.has('session-1')).toBe(false);
+  it('releases instead of failing when the production send handler is unavailable', async () => {
+    const row = claimed();
+    const store = queueStoreFor(row);
+    const options = optionsFor(store, { sendMessageHandler: null });
+    await expect(tryClaimAndDispatchNextQueuedPrompt(options)).resolves.toBe(false);
+    expect(store.releaseClaim).toHaveBeenCalledWith(row.id, 'session-1', row.claimToken);
+    expect(store.beginDispatch).not.toHaveBeenCalled();
   });
 
-  it('does NOT fire onChainSettled when a follow-on prompt is dispatched', async () => {
+  it('does not send or settle another owner when begin-dispatch is rejected', async () => {
     vi.useFakeTimers();
-
-    const claimedPrompt: ClaimedQueuedPrompt = {
-      id: 'prompt-1',
-      prompt: 'continue',
-      attachments: null,
-      documentContext: null,
-    };
-
-    const queueStore: QueuedPromptStoreLike = {
-      listPending: vi.fn(async () => [claimedPrompt]),
-      claim: vi.fn(async () => claimedPrompt),
-      complete: vi.fn(async () => {}),
-      fail: vi.fn(async () => {}),
-    };
-
-    const processingSet = new Set<string>();
-    const targetWindow = {
-      isDestroyed: () => false,
-      webContents: { send: vi.fn(), mainFrame: {} },
-    } as unknown as Electron.BrowserWindow;
-
-    const onChainSettled = vi.fn(async () => {});
-    // continueQueuedPromptChain dispatches a follow-on by re-adding to processingSet.
-    const continueQueuedPromptChain = vi.fn(async (sessionId: string) => {
-      processingSet.add(sessionId);
-    });
-
-    await tryClaimAndDispatchNextQueuedPrompt({
-      continueQueuedPromptChain,
-      logError: vi.fn(),
-      logInfo: vi.fn(),
-      onChainSettled,
-      onPromptClaimed: () => {},
-      processingSet,
-      queueStore,
-      sendMessageHandler: vi.fn(async () => ({ content: 'ok' })),
-      sessionId: 'session-1',
-      source: 'test queue',
-      startSession: vi.fn(async () => {}),
-      targetWindow,
-      workspacePath: '/workspace/project',
-    });
-
+    const store = queueStoreFor(claimed());
+    vi.mocked(store.beginDispatch).mockResolvedValue({ outcome: 'stale_owner' });
+    const options = optionsFor(store);
+    await expect(tryClaimAndDispatchNextQueuedPrompt(options)).resolves.toBe(true);
     await vi.runAllTimersAsync();
+    expect(options.sendMessageHandler).not.toHaveBeenCalled();
+    expect(store.completeAfterDispatch).not.toHaveBeenCalled();
+    expect(store.failAfterDispatch).not.toHaveBeenCalled();
+    expect(options.continueQueuedPromptChain).not.toHaveBeenCalled();
+    expect(options.onChainSettled).not.toHaveBeenCalled();
+  });
 
-    expect(onChainSettled).not.toHaveBeenCalled();
+  it('fails the same begun token on send error and only then continues', async () => {
+    vi.useFakeTimers();
+    const row = claimed();
+    const store = queueStoreFor(row);
+    const options = optionsFor(store, {
+      sendMessageHandler: vi.fn(async () => { throw new Error('provider failed'); }),
+    });
+    await tryClaimAndDispatchNextQueuedPrompt(options);
+    await vi.runAllTimersAsync();
+    expect(store.failAfterDispatch).toHaveBeenCalledWith(
+      row.id,
+      'provider failed',
+      'session-1',
+      row.claimToken,
+    );
+    expect(options.continueQueuedPromptChain).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not continue or end a replacement lifecycle after rejected completion', async () => {
+    vi.useFakeTimers();
+    const store = queueStoreFor(claimed());
+    vi.mocked(store.completeAfterDispatch).mockResolvedValue({ outcome: 'stale_owner' });
+    const options = optionsFor(store);
+    await tryClaimAndDispatchNextQueuedPrompt(options);
+    await vi.runAllTimersAsync();
+    expect(options.continueQueuedPromptChain).not.toHaveBeenCalled();
+    expect(options.onChainSettled).not.toHaveBeenCalled();
+  });
+
+  it('lets a late same-token owner settle but not continue after its lease was revoked', async () => {
+    let finishSend!: () => void;
+    const sendGate = new Promise<void>((resolve) => { finishSend = resolve; });
+    const row = claimed('owner-a');
+    const store = queueStoreFor(row);
+    const leases = new Map<string, symbol>();
+    const options = optionsFor(store, {
+      processingLeases: leases,
+      sendMessageHandler: vi.fn(async () => { await sendGate; return { content: 'late' }; }),
+    });
+    await tryClaimAndDispatchNextQueuedPrompt(options);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    leases.set('session-1', Symbol('owner-b'));
+    finishSend();
+    await vi.waitFor(() => expect(store.completeAfterDispatch).toHaveBeenCalledTimes(1));
+    expect(options.continueQueuedPromptChain).not.toHaveBeenCalled();
+    expect(leases.has('session-1')).toBe(true);
+  });
+
+  it.each([
+    ['missing', null],
+    ['pending marker', { metadata: { modelChangeReconciliation: { status: 'pending' } } }],
+    ['malformed metadata', { metadata: '{not-json' }],
+  ])('fails closed before list/claim/send for %s', async (_label, session) => {
+    const preflight = createSessionPromptDispatchPreflight(async () => session as any);
+    const store = queueStoreFor(claimed());
+    const options = optionsFor(store, { preflight });
+    await expect(tryClaimAndDispatchNextQueuedPrompt(options)).resolves.toBe(false);
+    expect(store.listPending).not.toHaveBeenCalled();
+    expect(store.claim).not.toHaveBeenCalled();
+    expect(options.sendMessageHandler).not.toHaveBeenCalled();
+  });
+
+  it('delegates a marker installed after listing to the atomic claim', async () => {
+    const row = claimed('race');
+    const store = queueStoreFor(row);
+    vi.mocked(store.claim).mockResolvedValue(null);
+    const options = optionsFor(store);
+    await expect(tryClaimAndDispatchNextQueuedPrompt(options)).resolves.toBe(false);
+    expect(store.claim).toHaveBeenCalledWith('race', 'session-1');
+    expect(store.beginDispatch).not.toHaveBeenCalled();
   });
 });

--- a/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedPromptDispatcher.test.ts
@@ -201,7 +201,7 @@ describe('queuedPromptDispatcher token owner', () => {
     vi.mocked(store.claim).mockResolvedValue(null);
     const options = optionsFor(store);
     await expect(tryClaimAndDispatchNextQueuedPrompt(options)).resolves.toBe(false);
-    expect(store.claim).toHaveBeenCalledWith('race', 'session-1');
+    expect(store.claim).toHaveBeenCalledWith('race', 'session-1', 'test queue');
     expect(store.beginDispatch).not.toHaveBeenCalled();
   });
 });

--- a/packages/electron/src/main/services/ai/__tests__/queuedPromptTruth.integration.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedPromptTruth.integration.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { QueueSettlementResult, QueueTerminalReceipt } from '../../PGLiteQueuedPromptsStore';
+
+type TerminalSettlementMock = (
+  rowId: string,
+  sessionId: string,
+  claimToken: string,
+  terminal: QueueTerminalReceipt,
+) => Promise<QueueSettlementResult>;
+
+function settledTerminalResult(
+  rowId: string,
+  sessionId: string,
+  claimToken: string,
+  terminal: QueueTerminalReceipt,
+): QueueSettlementResult {
+  return {
+    outcome: 'settled',
+    row: {
+      id: rowId,
+      sessionId,
+      prompt: '',
+      status: terminal.lifecycle,
+      createdAt: 0,
+      claimToken,
+      deliveryClass: 'ordinary',
+      priorityRank: 0,
+      deliveryReady: true,
+      terminalStatus: terminal.lifecycle,
+      terminalAt: terminal.terminalAt,
+      streamEventSequence: terminal.eventSequence,
+    },
+  };
+}
+
+const state = vi.hoisted(() => ({
+  callbacks: null as any,
+  rows: [] as any[],
+  complete: vi.fn<TerminalSettlementMock>(async (rowId, sessionId, claimToken, terminal) => settledTerminalResult(rowId, sessionId, claimToken, terminal)),
+  fail: vi.fn<TerminalSettlementMock>(async (rowId, sessionId, claimToken, terminal) => settledTerminalResult(rowId, sessionId, claimToken, terminal)),
+  publishSnapshot: vi.fn(async () => undefined),
+  reDrive: vi.fn(async () => false),
+  subAgentInFlight: false,
+}));
+
+vi.mock('@nimbalyst/runtime', () => ({
+  AgentMessagesRepository: { create: vi.fn(async (row) => { state.rows.push(row); }) },
+  AISessionsRepository: { get: vi.fn(async () => null) },
+  TrackerReferenceChip: () => null,
+  TrackerReferencePicker: () => null,
+  useResolvedTrackerReference: () => null,
+  navigateToTrackerReference: vi.fn(),
+}));
+vi.mock('../../RepositoryManager', () => ({
+  getQueuedPromptsStore: () => ({ completeAfterDispatch: state.complete, failAfterDispatch: state.fail }),
+}));
+vi.mock('../AIService', () => ({ publishQueuedPromptSnapshotForSession: state.publishSnapshot }));
+vi.mock('../../analytics/AnalyticsService', () => ({ AnalyticsService: { getInstance: () => ({ sendEvent: vi.fn() }) } }));
+vi.mock('../../NotificationService', () => ({ notificationService: { showNotification: vi.fn() } }));
+vi.mock('../../SoundNotificationService', () => ({ SoundNotificationService: { getInstance: () => ({ playCompletionSound: vi.fn() }) } }));
+vi.mock('../../SessionFileTracker', () => ({ sessionFileTracker: { trackToolExecution: vi.fn() } }));
+vi.mock('../../../window/WindowManager', () => ({ findWindowByWorkspace: vi.fn(() => null) }));
+vi.mock('../../SyncManager', () => ({ getSyncProvider: vi.fn(() => null), isDesktopTrulyAway: vi.fn(() => false) }));
+vi.mock('../../../utils/store', () => ({ getClaudeCodeApiUpstreamUrl: vi.fn(() => undefined) }));
+vi.mock('../claudeCliQueueFlushSingleton', () => ({ flushNextClaudeCliQueuedPromptForSession: state.reDrive }));
+vi.mock('../claudeCliUserPromptLog', () => ({ broadcastMessageLogged: vi.fn() }));
+vi.mock('../claudeCliToolResultLog', () => ({ logClaudeCliToolResults: vi.fn(), loadSeenToolResultIds: vi.fn(async () => []) }));
+vi.mock('../claudeCliToolResultSeen', () => ({ getSeenToolResultIds: vi.fn(() => new Set()), clearSeenToolResultIds: vi.fn() }));
+vi.mock('../claudeCliContextUsage', () => ({ clearClaudeCliObserved1mSupport: vi.fn(), logClaudeCliContextUsage: vi.fn(), noteClaudeCliObserved1mSupport: vi.fn() }));
+vi.mock('../claudeCliErrorClassifier', () => ({ classifyClaudeCliUpstreamError: vi.fn() }));
+vi.mock('../claudeCliErrorSurfacePolicy', () => ({ createClaudeCliErrorSurfacePolicy: () => ({ noteAssistantMessage: vi.fn(), shouldSurface: vi.fn(() => true) }) }));
+vi.mock('../claudeCliErrorLog', () => ({ buildClaudeCliErrorContent: vi.fn(() => JSON.stringify({ type: 'error' })), logClaudeCliUpstreamError: vi.fn() }));
+vi.mock('../claudeCliFileTracking', () => ({ trackClaudeCliFileEdits: vi.fn() }));
+vi.mock('../claudeCliSubAgentTracker', () => ({ isSubAgentTurnInFlight: vi.fn(() => state.subAgentInFlight), noteAssistantTaskCalls: vi.fn(), noteToolResultsCompleteTasks: vi.fn(), clearSubAgentTracking: vi.fn() }));
+vi.mock('../claudeCliTurnSummary', () => ({ recordClaudeCliTurnMessage: vi.fn(), takeClaudeCliTurnSummary: vi.fn(() => null), clearClaudeCliTurnSummary: vi.fn() }));
+vi.mock('../claudeCliTurnNotification', () => ({ extractAssistantText: vi.fn(() => 'answer'), buildTurnNotificationBody: vi.fn(() => 'answer') }));
+vi.mock('../claudeCliResponseAnalytics', () => ({ buildClaudeCliResponseEvent: vi.fn(() => ({})) }));
+vi.mock('../claudeCliObservation/claudeApiRequestParser', () => ({ extractToolResults: vi.fn(() => []) }));
+vi.mock('../claudeCliObservation/proxyPassthroughEnv', () => ({ buildProxyPassthroughEnv: vi.fn(() => ({})) }));
+vi.mock('../claudeCliObservation/claudeCliTranscriptBridge', () => ({ buildAssistantRawContent: vi.fn(() => JSON.stringify({ type: 'assistant', message: {} })) }));
+vi.mock('../claudeCliObservation/claudeCliProxyObservation', () => ({
+  ClaudeCliProxyObservation: class {
+    constructor(callbacks: any) { state.callbacks = callbacks; }
+    async start() { return { baseUrl: 'http://proxy.test' }; }
+    stop() {}
+  },
+}));
+
+import {
+  clearClaudeCliQueuedTurnRegistration,
+  fireClaudeCliTurnCompletion,
+  registerClaudeCliQueuedTurn,
+  startClaudeCliProxyObservation,
+} from '../claudeCliObservationSingleton';
+
+function registration(sessionId = 'session-1') {
+  return {
+    sessionId, workspacePath: '/workspace', queueRowId: `row-${sessionId}`, claimToken: `claim-${sessionId}`,
+    clientSubmissionId: `client-${sessionId}`, sourceSessionId: sessionId, sourceRoomId: `room-${sessionId}`,
+    submissionSequence: 1, producer: 'composer', claimTrigger: 'claude_cli_idle_flush', claimTriggeredAt: 1,
+    turnId: `turn-${sessionId}`, providerInputMessageId: `input-${sessionId}`,
+    providerOutputMessageId: `output-${sessionId}`, payloadReceipt: { utf8Bytes: 4, unicodeScalars: 4, sha256: 'a'.repeat(64) },
+  };
+}
+
+describe('queued CLI observed-output truth boundary', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    clearClaudeCliQueuedTurnRegistration('session-1');
+    clearClaudeCliQueuedTurnRegistration('session-2');
+    state.rows.length = 0;
+    state.complete.mockClear();
+    state.fail.mockClear();
+    state.publishSnapshot.mockClear();
+    state.reDrive.mockClear();
+    state.subAgentInFlight = false;
+  });
+
+  it('binds a visible observed output and settles exactly once at idle', async () => {
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    await startClaudeCliProxyObservation({ sessionId: 'session-1', workspacePath: '/workspace' });
+    state.callbacks.onAssistantMessage({ id: 'anthropic-1', model: 'claude', usage: {}, content: [] });
+    await vi.waitFor(() => expect(state.rows).toHaveLength(1));
+    expect(state.rows[0].metadata.queuedPromptTruth).toMatchObject({
+      queueRowId: 'row-session-1', clientSubmissionId: 'client-session-1', turnId: 'turn-session-1',
+      providerOutputMessageId: 'output-session-1', lifecycle: 'streaming', eventSequence: 1,
+    });
+
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(1));
+    expect(state.complete).toHaveBeenCalledWith('row-session-1', 'session-1', 'claim-session-1', expect.objectContaining({
+      lifecycle: 'completed', eventSequence: 2, terminalAt: expect.any(Number),
+    }));
+    await vi.waitFor(() => expect(state.publishSnapshot).toHaveBeenCalledWith('session-1', expect.anything()));
+    await vi.waitFor(() => expect(state.reDrive).toHaveBeenCalledTimes(1));
+  });
+
+  it('fences the association before terminal settlement awaits', async () => {
+    let releaseSettlement: (() => void) | undefined;
+    state.complete.mockImplementationOnce((rowId, sessionId, claimToken, terminal) => new Promise((resolve) => { releaseSettlement = () => resolve(settledTerminalResult(rowId, sessionId, claimToken, terminal)); }));
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    await startClaudeCliProxyObservation({ sessionId: 'session-1', workspacePath: '/workspace' });
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    state.callbacks.onAssistantMessage({ id: 'immediate-next-turn', model: 'claude', usage: {}, content: [] });
+    await vi.waitFor(() => expect(state.rows).toHaveLength(1));
+    expect(state.rows[0].metadata).toBeUndefined();
+    releaseSettlement?.();
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not let a hidden Task sub-agent error fail or surface the parent row', async () => {
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    await startClaudeCliProxyObservation({ sessionId: 'session-1', workspacePath: '/workspace' });
+    state.subAgentInFlight = true;
+    state.callbacks.onUpstreamError({ statusCode: 500, body: 'failure' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(state.rows).toHaveLength(0);
+    expect(state.fail).not.toHaveBeenCalled();
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(1));
+  });
+
+  it('reconciles an unresolved stale-owner result before permitting the next claim', async () => {
+    vi.useFakeTimers();
+    state.complete.mockResolvedValueOnce({ outcome: 'stale_owner' });
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    await startClaudeCliProxyObservation({ sessionId: 'session-1', workspacePath: '/workspace' });
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(1));
+    expect(state.reDrive).not.toHaveBeenCalled();
+    state.callbacks.onAssistantMessage({ id: 'post-reject', model: 'claude', usage: {}, content: [] });
+    await vi.waitFor(() => expect(state.rows).toHaveLength(1));
+    expect(state.rows[0].metadata).toBeUndefined();
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(false);
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(state.reDrive).toHaveBeenCalledTimes(1));
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+  });
+
+  it('fails closed at the finite ceiling for persistent thrown and stale terminal mutations', async () => {
+    vi.useFakeTimers();
+    state.complete
+      .mockRejectedValueOnce(new Error('one'))
+      .mockResolvedValueOnce({ outcome: 'stale_owner' })
+      .mockResolvedValueOnce({ outcome: 'terminal_conflict' });
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(25);
+    expect(state.complete).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(state.complete).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(state.complete).toHaveBeenCalledTimes(3);
+    expect(state.publishSnapshot).not.toHaveBeenCalled();
+    expect(state.reDrive).not.toHaveBeenCalled();
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(false);
+  });
+
+  it('reconciles a thrown terminal settlement with the immutable original receipt before progression', async () => {
+    vi.useFakeTimers();
+    state.complete.mockRejectedValueOnce(new Error('storage unavailable')).mockImplementationOnce(async (rowId, sessionId, claimToken, terminal) => settledTerminalResult(rowId, sessionId, claimToken, terminal));
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(1));
+    expect(state.publishSnapshot).not.toHaveBeenCalled();
+    expect(state.reDrive).not.toHaveBeenCalled();
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(false);
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(2));
+    expect(state.complete.mock.calls[1].slice(0, 3)).toEqual(state.complete.mock.calls[0].slice(0, 3));
+    expect(state.complete.mock.calls[1][3]).toEqual(state.complete.mock.calls[0][3]);
+    await vi.waitFor(() => expect(state.publishSnapshot).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(state.reDrive).toHaveBeenCalledTimes(1));
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+  });
+
+  it('keeps one bounded retry chain across repeated throws', async () => {
+    vi.useFakeTimers();
+    state.complete
+      .mockRejectedValueOnce(new Error('transient one'))
+      .mockRejectedValueOnce(new Error('transient two'))
+      .mockImplementationOnce(async (rowId, sessionId, claimToken, terminal) => settledTerminalResult(rowId, sessionId, claimToken, terminal));
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(1));
+    expect(state.reDrive).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(25);
+    expect(state.complete).toHaveBeenCalledTimes(2);
+    expect(state.reDrive).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(state.complete).toHaveBeenCalledTimes(3);
+    expect(state.publishSnapshot).toHaveBeenCalledTimes(1);
+    expect(state.reDrive).toHaveBeenCalledTimes(1);
+  });
+
+  it('matching teardown cancels a pending terminal retry before it can affect a newer claim', async () => {
+    vi.useFakeTimers();
+    state.complete.mockRejectedValueOnce(new Error('transient'));
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(1));
+    clearClaudeCliQueuedTurnRegistration('session-1', 'claim-session-1');
+    const next = { ...registration(), claimToken: 'claim-next', turnId: 'turn-next', providerInputMessageId: 'input-next', providerOutputMessageId: 'output-next' };
+    expect(registerClaudeCliQueuedTurn(next)).toBe(true);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(state.complete).toHaveBeenCalledTimes(1);
+    expect(state.publishSnapshot).not.toHaveBeenCalled();
+    expect(state.reDrive).not.toHaveBeenCalled();
+  });
+
+  it('discards an old in-flight terminal continuation after teardown and same-session replacement', async () => {
+    let releaseOldSettlement: (() => void) | undefined;
+    state.complete.mockImplementationOnce((rowId, sessionId, claimToken, terminal) => new Promise((resolve) => {
+      releaseOldSettlement = () => resolve(settledTerminalResult(rowId, sessionId, claimToken, terminal));
+    }));
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    await startClaudeCliProxyObservation({ sessionId: 'session-1', workspacePath: '/workspace' });
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(1));
+    clearClaudeCliQueuedTurnRegistration('session-1', 'claim-session-1');
+    const replacement = {
+      ...registration(), queueRowId: 'row-replacement', claimToken: 'claim-replacement',
+      clientSubmissionId: 'client-replacement', turnId: 'turn-replacement',
+      providerInputMessageId: 'input-replacement', providerOutputMessageId: 'output-replacement',
+    };
+    expect(registerClaudeCliQueuedTurn(replacement)).toBe(true);
+    releaseOldSettlement?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(state.publishSnapshot).not.toHaveBeenCalled();
+    expect(state.reDrive).not.toHaveBeenCalled();
+    state.callbacks.onAssistantMessage({ id: 'replacement-output', model: 'claude', usage: {}, content: [] });
+    await vi.waitFor(() => expect(state.rows).toHaveLength(1));
+    expect(state.rows[0].metadata.queuedPromptTruth.queueRowId).toBe('row-replacement');
+  });
+
+  it('discards a post-store teardown replacement before terminal snapshot publication', async () => {
+    let replaceOldTurn: (() => void) | undefined;
+    state.complete.mockImplementationOnce((rowId, sessionId, claimToken, terminal) =>
+      Promise.resolve(settledTerminalResult(rowId, sessionId, claimToken, terminal)).then((result) => {
+        queueMicrotask(() => queueMicrotask(() => replaceOldTurn?.()));
+        return result;
+      }),
+    );
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    await vi.waitFor(() => expect(state.complete).toHaveBeenCalledTimes(1));
+    replaceOldTurn = () => {
+      clearClaudeCliQueuedTurnRegistration('session-1', 'claim-session-1');
+      expect(registerClaudeCliQueuedTurn({
+        ...registration(), queueRowId: 'row-post-store-replacement', claimToken: 'claim-post-store-replacement',
+        clientSubmissionId: 'client-post-store-replacement', turnId: 'turn-post-store-replacement',
+        providerInputMessageId: 'input-post-store-replacement', providerOutputMessageId: 'output-post-store-replacement',
+      })).toBe(true);
+    };
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(state.publishSnapshot).not.toHaveBeenCalled();
+    expect(state.reDrive).not.toHaveBeenCalled();
+  });
+
+  it('does not let stale token cleanup clear a newer session fence', async () => {
+    state.complete.mockImplementationOnce(async (rowId, sessionId, claimToken, terminal) => ({
+      outcome: 'stale_owner',
+      row: settledTerminalResult(rowId, sessionId, claimToken, terminal).row,
+    }));
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    fireClaudeCliTurnCompletion('session-1', '/workspace');
+    await vi.waitFor(() => expect(state.reDrive).toHaveBeenCalledTimes(1));
+    const next = { ...registration(), claimToken: 'claim-next', turnId: 'turn-next', providerInputMessageId: 'input-next', providerOutputMessageId: 'output-next' };
+    expect(registerClaudeCliQueuedTurn(next)).toBe(true);
+    clearClaudeCliQueuedTurnRegistration('session-1', 'claim-session-1');
+    expect(registerClaudeCliQueuedTurn({ ...next, claimToken: 'claim-third', turnId: 'turn-third', providerInputMessageId: 'input-third', providerOutputMessageId: 'output-third' })).toBe(false);
+  });
+
+  it('fails closed for conflicting registration and leaves an immediate observed turn unbound', async () => {
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(true);
+    expect(registerClaudeCliQueuedTurn(registration())).toBe(false);
+    clearClaudeCliQueuedTurnRegistration('session-1', 'claim-session-1');
+    await startClaudeCliProxyObservation({ sessionId: 'session-1', workspacePath: '/workspace' });
+    state.callbacks.onAssistantMessage({ id: 'immediate-1', model: 'claude', usage: {}, content: [] });
+    await vi.waitFor(() => expect(state.rows).toHaveLength(1));
+    expect(state.rows[0].metadata).toBeUndefined();
+  });
+});

--- a/packages/electron/src/main/services/ai/__tests__/queuedPromptTruth.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/queuedPromptTruth.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { createQueuedPromptTruth, payloadReceiptsMatch, receiptQueuedPromptPayload } from '../queuedPromptTruth';
+
+describe('queued prompt payload truth', () => {
+  it('receipts paired same-millisecond bracket rows without final-character loss', () => {
+    const left = createQueuedPromptTruth({ queueRowId: 'row-left', sourceSessionId: 'session', producer: 'composer', payload: '[ex-CC' });
+    const right = createQueuedPromptTruth({ queueRowId: 'row-right', sourceSessionId: 'session', producer: 'composer', payload: '[ex-CC]' });
+    expect(left.clientSubmissionId).not.toBe(right.clientSubmissionId);
+    expect(left.payload.unicodeScalars).toBe(6);
+    expect(right.payload.unicodeScalars).toBe(7);
+    expect(left.payload.sha256).not.toBe(right.payload.sha256);
+  });
+
+  it('preserves whitespace, emoji, CRLF/LF and a final newline exactly', () => {
+    const payload = ' leading 😀\r\nline\n';
+    const receipt = receiptQueuedPromptPayload(payload);
+    expect(receipt.utf8Bytes).toBe(Buffer.from(payload, 'utf8').byteLength);
+    expect(receipt.unicodeScalars).toBe(Array.from(payload).length);
+    expect(payloadReceiptsMatch(payload, receipt)).toBe(true);
+    expect(payloadReceiptsMatch(payload.trim(), receipt)).toBe(false);
+  });
+});

--- a/packages/electron/src/main/services/ai/__tests__/resolveWorkspaceWindow.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/resolveWorkspaceWindow.test.ts
@@ -1,8 +1,11 @@
 // @vitest-environment node
+import { EventEmitter } from 'node:events';
 import { describe, expect, it, vi } from 'vitest';
 import {
   AUTO_OPEN_COOLDOWN_MS,
+  WORKSPACE_WINDOW_LOAD_TIMEOUT_MS,
   createWorkspaceWindowResolver,
+  waitForWorkspaceWindowLoad,
   type WorkspaceWindowResolverDeps,
 } from '../resolveWorkspaceWindow';
 
@@ -54,6 +57,34 @@ function createHarness(overrides: Partial<WorkspaceWindowResolverDeps<FakeWindow
   };
 }
 
+function createLoadHarness() {
+  const window = new EventEmitter() as EventEmitter & { destroyed: boolean; isDestroyed(): boolean };
+  const webContents = new EventEmitter() as EventEmitter & {
+    destroyed: boolean;
+    isDestroyed(): boolean;
+  };
+  window.destroyed = false;
+  window.isDestroyed = () => window.destroyed;
+  webContents.destroyed = false;
+  webContents.isDestroyed = () => webContents.destroyed;
+  Object.assign(window, { webContents });
+
+  const timerCalls: Array<{ fn: () => void; ms: number; handle: number }> = [];
+  const clearedHandles: unknown[] = [];
+  const timers = {
+    setTimeout: (fn: () => void, ms: number) => {
+      const handle = timerCalls.length + 1;
+      timerCalls.push({ fn, ms, handle });
+      return handle;
+    },
+    clearTimeout: (handle: unknown) => {
+      clearedHandles.push(handle);
+    },
+  };
+
+  return { window, webContents, timers, timerCalls, clearedHandles };
+}
+
 describe('resolveWorkspaceWindow', () => {
   it('uses the live window without opening anything', async () => {
     const harness = createHarness();
@@ -92,6 +123,35 @@ describe('resolveWorkspaceWindow', () => {
     expect(a.kind === 'window' && b.kind === 'window' && a.window.id).toBe(
       b.kind === 'window' ? b.window.id : -1,
     );
+  });
+
+  it('joins an opening window before applying a concurrent caller auto-open policy', async () => {
+    const harness = createHarness();
+
+    const first = harness.resolver.resolve('/ws');
+    const second = harness.resolver.resolve('/ws', { allowAutoOpen: false });
+
+    expect(harness.createWindow).toHaveBeenCalledTimes(1);
+    harness.finishLoad();
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(a.kind === 'window' && a.opened).toBe(true);
+    expect(b.kind === 'window' && b.opened).toBe(true);
+  });
+
+  it('preserves an existing live window even when the workspace folder is unavailable', async () => {
+    const existing = { id: 7, destroyed: false };
+    const harness = createHarness({
+      findWindow: vi.fn(() => existing),
+      workspaceExists: vi.fn(() => false),
+    });
+
+    await expect(harness.resolver.resolve('/ws')).resolves.toEqual({
+      kind: 'window',
+      window: existing,
+      opened: false,
+    });
+    expect(harness.createWindow).not.toHaveBeenCalled();
   });
 
   it('defers instead of re-opening while the auto-open cooldown is active', async () => {
@@ -137,5 +197,49 @@ describe('resolveWorkspaceWindow', () => {
       reason: 'workspace-missing',
     });
     expect(harness.createWindow).not.toHaveBeenCalled();
+  });
+
+  it('settles the production load waiter on a successful load and removes all resources', async () => {
+    const harness = createLoadHarness();
+    const pending = waitForWorkspaceWindowLoad(harness.window as never, harness.timers);
+
+    expect(harness.timerCalls).toHaveLength(1);
+    expect(harness.timerCalls[0].ms).toBe(WORKSPACE_WINDOW_LOAD_TIMEOUT_MS);
+    harness.webContents.emit('did-finish-load');
+    await expect(pending).resolves.toBeUndefined();
+
+    expect(harness.clearedHandles).toEqual([1]);
+    expect(harness.webContents.eventNames()).toHaveLength(0);
+    expect(harness.window.eventNames()).toHaveLength(0);
+  });
+
+  it.each([
+    ['failed load', 'webContents', 'did-fail-load'],
+    ['renderer loss', 'webContents', 'render-process-gone'],
+    ['renderer destruction', 'webContents', 'destroyed'],
+    ['window close', 'window', 'close'],
+    ['window destruction', 'window', 'closed'],
+  ])('settles and cleans up when there is %s', async (_label, target, event) => {
+    const harness = createLoadHarness();
+    const pending = waitForWorkspaceWindowLoad(harness.window as never, harness.timers);
+
+    (target === 'window' ? harness.window : harness.webContents).emit(event);
+    await expect(pending).rejects.toThrow();
+
+    expect(harness.clearedHandles).toEqual([1]);
+    expect(harness.webContents.eventNames()).toHaveLength(0);
+    expect(harness.window.eventNames()).toHaveLength(0);
+  });
+
+  it('settles and cleans up when the production load bound expires', async () => {
+    const harness = createLoadHarness();
+    const pending = waitForWorkspaceWindowLoad(harness.window as never, harness.timers);
+
+    harness.timerCalls[0].fn();
+    await expect(pending).rejects.toThrow('Workspace window load timed out');
+
+    expect(harness.clearedHandles).toEqual([1]);
+    expect(harness.webContents.eventNames()).toHaveLength(0);
+    expect(harness.window.eventNames()).toHaveLength(0);
   });
 });

--- a/packages/electron/src/main/services/ai/bootQueueRecovery.ts
+++ b/packages/electron/src/main/services/ai/bootQueueRecovery.ts
@@ -15,6 +15,7 @@
 export interface BootQueueRecoveryDeps {
   listSessionIdsWithPending(): Promise<string[]>;
   getWorkspacePath(sessionId: string): Promise<string | null | undefined>;
+  failAllPending(sessionId: string, errorMessage: string): Promise<number>;
   requestDrive(sessionId: string, workspacePath: string): void;
   logInfo(message: string): void;
   logWarn(message: string): void;
@@ -29,15 +30,27 @@ export async function driveStrandedQueuesOnBoot(deps: BootQueueRecoveryDeps): Pr
 
   let driven = 0;
   for (const sessionId of sessionIds) {
-    const workspacePath = await deps.getWorkspacePath(sessionId);
-    if (!workspacePath) {
-      // Routing needs a workspace; without one there is no window to deliver
-      // into and no honest way to pick a fallback.
-      deps.logWarn(`[Main] Boot recovery: session ${sessionId} has no workspacePath; skipping`);
-      continue;
+    try {
+      const workspacePath = await deps.getWorkspacePath(sessionId);
+      if (!workspacePath) {
+        // Routing needs a workspace; without one there is no window to deliver
+        // into and no honest way to pick a fallback. Fail atomically rather
+        // than silently leaving the rows pending forever.
+        await deps.failAllPending(
+          sessionId,
+          'Queued prompt delivery failed: workspace mapping unavailable',
+        );
+        deps.logWarn('[Main] Boot recovery: failed pending prompts for unmapped session');
+        continue;
+      }
+      deps.requestDrive(sessionId, workspacePath);
+      driven += 1;
+    } catch {
+      // One malformed or unavailable session must not prevent later pending
+      // rows from reaching their valid workspace driver. Do not expose the
+      // workspace, prompt, provider output, or raw exception in this warning.
+      deps.logWarn('[Main] Boot recovery: failed to recover one session; continuing');
     }
-    deps.requestDrive(sessionId, workspacePath);
-    driven += 1;
   }
 
   return driven;

--- a/packages/electron/src/main/services/ai/claudeCliObservationSingleton.ts
+++ b/packages/electron/src/main/services/ai/claudeCliObservationSingleton.ts
@@ -66,6 +66,237 @@ import { getSyncProvider, isDesktopTrulyAway } from '../SyncManager';
 import { AISessionsRepository } from '@nimbalyst/runtime';
 import { getClaudeCodeApiUpstreamUrl } from '../../utils/store';
 import type { AssembledAssistantMessage } from './claudeCliObservation/claudeApiMessageAssembler';
+import { getQueuedPromptsStore } from '../RepositoryManager';
+import { buildClaudeCliErrorContent } from './claudeCliErrorLog';
+
+type CliQueuedTurnLifecycle = 'streaming' | 'completed' | 'failed';
+
+interface RegisteredClaudeCliQueuedTurn {
+  sessionId: string;
+  workspacePath: string;
+  queueRowId: string;
+  claimToken: string;
+  clientSubmissionId: string;
+  sourceSessionId: string;
+  sourceRoomId: string;
+  submissionSequence: number;
+  producer: string;
+  claimTrigger: string;
+  claimTriggeredAt: number;
+  turnId: string;
+  providerInputMessageId: string;
+  providerOutputMessageId: string;
+  payloadReceipt: { utf8Bytes: number; unicodeScalars: number; sha256: string };
+  eventSequence: number;
+  terminalAt?: number;
+  terminalized: boolean;
+  failureMessage?: string;
+  terminalReceipt?: { lifecycle: 'completed' | 'failed'; terminalAt: number; eventSequence: number };
+  reconciliationInFlight?: boolean;
+  reconciliationAttempts?: number;
+  reconciliationTimer?: ReturnType<typeof setTimeout>;
+  reconciliationExhausted?: boolean;
+}
+
+const registeredQueuedTurns = new Map<string, RegisteredClaudeCliQueuedTurn>();
+/** Terminal rows keep settling here after their visible association is fenced. */
+const settlingQueuedTurns = new Map<string, RegisteredClaudeCliQueuedTurn>();
+const TERMINAL_RECONCILIATION_INITIAL_DELAY_MS = 25;
+const TERMINAL_RECONCILIATION_MAX_DELAY_MS = 1_000;
+const TERMINAL_RECONCILIATION_MAX_ATTEMPTS = 3;
+
+function nextQueuedTurnTruth(
+  turn: RegisteredClaudeCliQueuedTurn,
+  lifecycle: CliQueuedTurnLifecycle,
+): Record<string, unknown> {
+  if (lifecycle !== 'streaming') turn.terminalAt ??= Date.now();
+  return {
+    clientSubmissionId: turn.clientSubmissionId,
+    queueRowId: turn.queueRowId,
+    sourceSessionId: turn.sourceSessionId,
+    sourceRoomId: turn.sourceRoomId,
+    submissionSequence: turn.submissionSequence,
+    producer: turn.producer,
+    claimTrigger: turn.claimTrigger,
+    claimTriggeredAt: turn.claimTriggeredAt,
+    turnId: turn.turnId,
+    providerInputMessageId: turn.providerInputMessageId,
+    providerOutputMessageId: turn.providerOutputMessageId,
+    payloadReceipt: turn.payloadReceipt,
+    lifecycle,
+    eventSequence: ++turn.eventSequence,
+    ...(turn.terminalAt === undefined ? {} : { terminalAt: turn.terminalAt }),
+  };
+}
+
+function attachQueuedTurnTruth(content: string, truth: Record<string, unknown>): string {
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return JSON.stringify({ ...parsed, queuedPromptTruth: truth });
+  } catch {
+    // A queue-truth claim must never fabricate a second transcript shape.
+    // The known CLI bridges all emit JSON, so fail closed by retaining content
+    // without association if an unexpected producer changes that invariant.
+    return content;
+  }
+}
+
+/** Register one claimed queued CLI turn before its PTY provider-entry write. */
+export function registerClaudeCliQueuedTurn(input: Omit<RegisteredClaudeCliQueuedTurn, 'eventSequence' | 'terminalized' | 'terminalAt' | 'failureMessage'>): boolean {
+  if (registeredQueuedTurns.has(input.sessionId) || settlingQueuedTurns.has(input.sessionId)) return false;
+  const required = [
+    input.queueRowId, input.claimToken, input.clientSubmissionId,
+    input.sourceSessionId, input.sourceRoomId, input.producer,
+    input.claimTrigger, input.turnId, input.providerInputMessageId,
+    input.providerOutputMessageId, input.payloadReceipt?.sha256,
+  ];
+  if (required.some((value) => typeof value !== 'string' || value.length === 0) ||
+      !Number.isSafeInteger(input.submissionSequence) || input.submissionSequence < 1 ||
+      !Number.isFinite(input.claimTriggeredAt)) return false;
+  registeredQueuedTurns.set(input.sessionId, { ...input, eventSequence: 0, terminalized: false });
+  return true;
+}
+
+/** Clear an abandoned registration without allowing it to bind a later turn. */
+export function clearClaudeCliQueuedTurnRegistration(sessionId: string, claimToken?: string): void {
+  const current = registeredQueuedTurns.get(sessionId);
+  if (current && (!claimToken || current.claimToken === claimToken)) registeredQueuedTurns.delete(sessionId);
+  const settling = settlingQueuedTurns.get(sessionId);
+  if (settling && (!claimToken || settling.claimToken === claimToken)) {
+    if (settling.reconciliationTimer) clearTimeout(settling.reconciliationTimer);
+    settlingQueuedTurns.delete(sessionId);
+  }
+}
+
+function releaseSettlingQueuedTurn(sessionId: string, claimToken: string): boolean {
+  const settling = settlingQueuedTurns.get(sessionId);
+  if (!settling || settling.claimToken !== claimToken) return false;
+  if (settling.reconciliationTimer) clearTimeout(settling.reconciliationTimer);
+  settlingQueuedTurns.delete(sessionId);
+  return true;
+}
+
+function isCurrentSettlingQueuedTurn(
+  sessionId: string,
+  claimToken: string,
+  expectedTurn: RegisteredClaudeCliQueuedTurn,
+): boolean {
+  return settlingQueuedTurns.get(sessionId) === expectedTurn && expectedTurn.claimToken === claimToken;
+}
+
+function scheduleTerminalReconciliation(sessionId: string, claimToken: string): void {
+  const turn = settlingQueuedTurns.get(sessionId);
+  if (!turn || turn.claimToken !== claimToken || turn.reconciliationTimer || turn.reconciliationInFlight || turn.reconciliationExhausted) return;
+  const attempts = turn.reconciliationAttempts ?? 0;
+  if (attempts >= TERMINAL_RECONCILIATION_MAX_ATTEMPTS) {
+    turn.reconciliationExhausted = true;
+    console.warn('[ClaudeCliObservation] Observed queued CLI terminal reconciliation exhausted');
+    return;
+  }
+  const delay = Math.min(
+    TERMINAL_RECONCILIATION_MAX_DELAY_MS,
+    TERMINAL_RECONCILIATION_INITIAL_DELAY_MS * 2 ** Math.min(Math.max(attempts - 1, 0), 5),
+  );
+  turn.reconciliationTimer = setTimeout(() => {
+    const current = settlingQueuedTurns.get(sessionId);
+    if (!current || current.claimToken !== claimToken) return;
+    current.reconciliationTimer = undefined;
+    void reconcileSettlingQueuedTurn(sessionId, claimToken);
+  }, delay);
+}
+
+function hasExactDurableTerminalReceipt(
+  turn: RegisteredClaudeCliQueuedTurn,
+  sessionId: string,
+  claimToken: string,
+  result: { row?: { id: string; sessionId: string; claimToken?: string; status: string; terminalStatus?: string; terminalAt?: number; streamEventSequence?: number } },
+): boolean {
+  const row = result.row;
+  const receipt = turn.terminalReceipt;
+  return !!row && !!receipt &&
+    row.id === turn.queueRowId &&
+    row.sessionId === sessionId &&
+    row.claimToken === claimToken &&
+    row.status === receipt.lifecycle &&
+    row.terminalStatus === receipt.lifecycle &&
+    row.terminalAt === receipt.terminalAt &&
+    row.streamEventSequence === receipt.eventSequence;
+}
+
+async function reDriveSettledClaudeCliQueue(sessionId: string, workspacePath: string): Promise<void> {
+  try {
+    const { flushNextClaudeCliQueuedPromptForSession } = await import('./claudeCliQueueFlushSingleton');
+    void flushNextClaudeCliQueuedPromptForSession(sessionId, workspacePath);
+  } catch {
+    console.warn('[ClaudeCliObservation] Failed to re-drive queued CLI turn');
+  }
+}
+
+async function reconcileSettlingQueuedTurn(sessionId: string, claimToken: string): Promise<void> {
+  const turn = settlingQueuedTurns.get(sessionId);
+  if (!turn || turn.claimToken !== claimToken || turn.reconciliationInFlight || turn.reconciliationExhausted || !turn.terminalReceipt) return;
+  if ((turn.reconciliationAttempts ?? 0) >= TERMINAL_RECONCILIATION_MAX_ATTEMPTS) {
+    scheduleTerminalReconciliation(sessionId, claimToken);
+    return;
+  }
+  turn.reconciliationInFlight = true;
+  turn.reconciliationAttempts = (turn.reconciliationAttempts ?? 0) + 1;
+  try {
+    const store = getQueuedPromptsStore();
+    const result = turn.terminalReceipt.lifecycle === 'completed'
+      ? await store.completeAfterDispatch(turn.queueRowId, sessionId, claimToken, turn.terminalReceipt)
+      : await store.failAfterDispatch(turn.queueRowId, turn.failureMessage!, sessionId, claimToken, turn.terminalReceipt);
+    if (!isCurrentSettlingQueuedTurn(sessionId, claimToken, turn)) return;
+    if (hasExactDurableTerminalReceipt(turn, sessionId, claimToken, result)) {
+      try {
+        const { publishQueuedPromptSnapshotForSession } = await import('./AIService');
+        // The import itself yields. A matching teardown and replacement can
+        // therefore take ownership after durable settlement but before the
+        // replica is published.
+        if (!isCurrentSettlingQueuedTurn(sessionId, claimToken, turn)) return;
+        await publishQueuedPromptSnapshotForSession(sessionId, store);
+      } catch {
+        // Durable settlement remains authoritative; a transient replica publish
+        // must not strand the next queued row.
+        console.warn('[ClaudeCliObservation] Failed to publish queued CLI terminal snapshot');
+      }
+      if (!isCurrentSettlingQueuedTurn(sessionId, claimToken, turn)) return;
+      if (releaseSettlingQueuedTurn(sessionId, claimToken)) {
+        await reDriveSettledClaudeCliQueue(sessionId, turn.workspacePath);
+      }
+    } else {
+      console.warn('[ClaudeCliObservation] Observed queued CLI terminal settlement remains unresolved');
+      turn.reconciliationInFlight = false;
+      scheduleTerminalReconciliation(sessionId, claimToken);
+    }
+  } catch {
+    if (!isCurrentSettlingQueuedTurn(sessionId, claimToken, turn)) return;
+    console.warn('[ClaudeCliObservation] Failed to settle observed queued CLI turn');
+    turn.reconciliationInFlight = false;
+    scheduleTerminalReconciliation(sessionId, claimToken);
+  } finally {
+    const current = settlingQueuedTurns.get(sessionId);
+    if (current === turn && current.claimToken === claimToken) current.reconciliationInFlight = false;
+  }
+}
+
+async function settleRegisteredClaudeCliQueuedTurn(sessionId: string): Promise<void> {
+  const turn = registeredQueuedTurns.get(sessionId);
+  if (!turn || turn.terminalized) return;
+  turn.terminalized = true;
+  // PID idle is the terminal boundary. Fence the visible association before
+  // awaiting disk I/O so an immediate next CLI turn cannot inherit this row.
+  registeredQueuedTurns.delete(sessionId);
+  settlingQueuedTurns.set(sessionId, turn);
+  const lifecycle: 'completed' | 'failed' = turn.failureMessage ? 'failed' : 'completed';
+  const truth = nextQueuedTurnTruth(turn, lifecycle);
+  turn.terminalReceipt = {
+    lifecycle,
+    terminalAt: truth.terminalAt as number,
+    eventSequence: truth.eventSequence as number,
+  };
+  await reconcileSettlingQueuedTurn(sessionId, turn.claimToken);
+}
 
 /**
  * Fire the completion sound + "Response Ready" OS notification (+ mobile push when
@@ -118,16 +349,18 @@ async function notifyClaudeCliTurnComplete(
  */
 export function fireClaudeCliTurnCompletion(sessionId: string, workspacePath: string): void {
   const summary = takeClaudeCliTurnSummary(sessionId);
-  if (!summary) return;
-  void notifyClaudeCliTurnComplete(sessionId, workspacePath, summary.lastAssistantText);
-  try {
-    AnalyticsService.getInstance().sendEvent(
-      'ai_response_received',
-      buildClaudeCliResponseEvent({ toolNames: summary.toolNames, finalText: summary.lastAssistantText }),
-    );
-  } catch {
-    // analytics is best-effort
+  if (summary) {
+    void notifyClaudeCliTurnComplete(sessionId, workspacePath, summary.lastAssistantText);
+    try {
+      AnalyticsService.getInstance().sendEvent(
+        'ai_response_received',
+        buildClaudeCliResponseEvent({ toolNames: summary.toolNames, finalText: summary.lastAssistantText }),
+      );
+    } catch {
+      // analytics is best-effort
+    }
   }
+  void settleRegisteredClaudeCliQueuedTurn(sessionId);
 }
 
 async function persistAssistantTurn(
@@ -136,6 +369,8 @@ async function persistAssistantTurn(
   msg: AssembledAssistantMessage,
   hidden: boolean,
 ): Promise<void> {
+  const queuedTurn = hidden ? undefined : registeredQueuedTurns.get(sessionId);
+  const queuedPromptTruth = queuedTurn ? nextQueuedTurnTruth(queuedTurn, 'streaming') : undefined;
   try {
     await AgentMessagesRepository.create({
       sessionId,
@@ -145,9 +380,12 @@ async function persistAssistantTurn(
       // the visible transcript (the B3 wire has no parent_tool_use_id to filter
       // on — see claudeCliSubAgentTracker). File-edit attribution below still runs
       // for them, so a sub-agent's edits are tracked.
-      content: buildAssistantRawContent(msg),
+      content: queuedPromptTruth
+        ? attachQueuedTurnTruth(buildAssistantRawContent(msg), queuedPromptTruth)
+        : buildAssistantRawContent(msg),
       hidden,
       createdAt: new Date(),
+      ...(queuedPromptTruth ? { metadata: { queuedPromptTruth } } : {}),
     });
     notifyMessageLogged(sessionId, workspacePath);
   } catch (err) {
@@ -301,7 +539,27 @@ export async function startClaudeCliProxyObservation(opts: {
         return;
       }
 
-      void logClaudeCliUpstreamError({ sessionId, workspacePath, failure });
+      // Task traffic is hidden and must never consume, fail, or surface the
+      // parent queued-turn association.
+      if (isSubAgentTurnInFlight(sessionId)) return;
+      const queuedTurn = registeredQueuedTurns.get(sessionId);
+      if (!queuedTurn) {
+        void logClaudeCliUpstreamError({ sessionId, workspacePath, failure });
+        return;
+      }
+      queuedTurn.failureMessage ??= failure.message;
+      const queuedPromptTruth = nextQueuedTurnTruth(queuedTurn, 'streaming');
+      void AgentMessagesRepository.create({
+        sessionId,
+        source: 'claude-code',
+        direction: 'output',
+        content: attachQueuedTurnTruth(buildClaudeCliErrorContent(failure), queuedPromptTruth),
+        hidden: false,
+        createdAt: new Date(),
+        metadata: { queuedPromptTruth },
+      }).then(() => notifyMessageLogged(sessionId, workspacePath)).catch((err) => {
+        console.warn('[ClaudeCliObservation] Failed to persist queued CLI error:', err);
+      });
     },
   });
 
@@ -322,6 +580,7 @@ export async function startClaudeCliProxyObservation(opts: {
       clearClaudeCliTurnSummary(sessionId);
       clearSubAgentTracking(sessionId);
       clearClaudeCliObserved1mSupport(sessionId);
+      clearClaudeCliQueuedTurnRegistration(sessionId);
     },
   };
 }

--- a/packages/electron/src/main/services/ai/claudeCliPromptComposer.ts
+++ b/packages/electron/src/main/services/ai/claudeCliPromptComposer.ts
@@ -56,8 +56,8 @@ export interface ComposeClaudeCliInput {
 /** Selections longer than this are truncated in the PTY line (the CLI can re-read the file). */
 const MAX_SELECTION_CHARS = 2000;
 
-/** Flatten to one logical line: the composer never sends real newlines through the PTY. */
-function flattenToSingleLine(text: string): string {
+/** Context is framing, so flatten only it; never transform the logical prompt. */
+function flattenContextToSingleLine(text: string): string {
   return text.replace(/\r\n|\r|\n/g, '\\n');
 }
 
@@ -89,7 +89,7 @@ export function composeClaudeCliContextPreamble(
   }
 
   if (rawSelection) {
-    let selection = flattenToSingleLine(rawSelection);
+    let selection = flattenContextToSingleLine(rawSelection);
     if (selection.length > MAX_SELECTION_CHARS) {
       selection = `${selection.slice(0, MAX_SELECTION_CHARS)} …(selection truncated)`;
     }
@@ -105,7 +105,7 @@ export function composeClaudeCliContextPreamble(
 /**
  * Build the single-line PTY submission: `<prompt> <context block> <path1> <path2> …`.
  *
- * - No attachments/context → just the trimmed prompt.
+ * - No attachments/context → exactly the submitted prompt.
  * - Document context (NIM-818) → compact context block after the prompt.
  * - Attachments → space-separated absolute paths at the end.
  * - Attachments without a usable `filepath` are skipped.
@@ -113,20 +113,20 @@ export function composeClaudeCliContextPreamble(
  *   context alone is not a submission.
  */
 export function composeClaudeCliPtySubmission(input: ComposeClaudeCliInput): string {
-  // Flatten the typed prompt for the same reason the selection is flattened: a
-  // real newline is Enter to the CLI's readline, so a multi-line prompt submits
-  // at the first line break and the rest is lost.
-  const trimmed = flattenToSingleLine((input.prompt ?? '').trim());
+  // Bracketed paste framing in the caller preserves real newlines. Do not trim,
+  // flatten, normalize, or otherwise change the user's logical payload here.
+  const prompt = input.prompt ?? '';
 
   const paths = (input.attachments ?? [])
     .map((a) => (a && typeof a.filepath === 'string' ? a.filepath.trim() : ''))
     .filter((p) => p.length > 0);
 
-  if (!trimmed && paths.length === 0) {
+  if (!prompt.trim() && paths.length === 0) {
     return '';
   }
 
   const preamble = composeClaudeCliContextPreamble(input.documentContext);
 
-  return [trimmed, preamble, ...paths].filter((part) => part.length > 0).join(' ');
+  if (!preamble && paths.length === 0) return prompt;
+  return [prompt, preamble, ...paths].filter((part) => part.length > 0).join(' ');
 }

--- a/packages/electron/src/main/services/ai/claudeCliQueueFlush.ts
+++ b/packages/electron/src/main/services/ai/claudeCliQueueFlush.ts
@@ -20,6 +20,7 @@ import type { ChatAttachment } from '@nimbalyst/runtime/ai/server/types';
 import type { QueueSettlementResult } from '../PGLiteQueuedPromptsStore';
 import type { SessionPromptDispatchPreflight } from './queuedPromptDispatcher';
 import type { ClaudeCliDocumentContext } from './claudeCliPromptComposer';
+import { payloadReceiptsMatch, queueTruthMismatchError, type QueuedPromptPayloadReceipt } from './queuedPromptTruth';
 
 export interface FlushQueuedPrompt {
   id: string;
@@ -28,12 +29,23 @@ export interface FlushQueuedPrompt {
   attachments?: unknown[] | null;
   /** Active-doc/selection context captured at queue time (NIM-818). */
   documentContext?: ClaudeCliDocumentContext | null;
+  payloadReceipt?: QueuedPromptPayloadReceipt;
+  clientSubmissionId?: string;
+  sourceSessionId?: string;
+  sourceRoomId?: string;
+  submissionSequence?: number;
+  producer?: string;
+  claimTrigger?: string;
+  claimTriggeredAt?: number;
+  turnId?: string;
+  providerInputMessageId?: string;
+  providerOutputMessageId?: string;
 }
 
 export interface FlushClaudeCliQueueDeps {
   preflight: SessionPromptDispatchPreflight;
   listPending: (sessionId: string) => Promise<FlushQueuedPrompt[]>;
-  claim: (promptId: string, expectedSessionId: string) => Promise<FlushQueuedPrompt | null>;
+  claim: (promptId: string, expectedSessionId: string, claimTrigger?: string) => Promise<FlushQueuedPrompt | null>;
   beginDispatch: (promptId: string, expectedSessionId: string, claimToken: string) => Promise<QueueSettlementResult>;
   completeAfterDispatch: (promptId: string, expectedSessionId: string, claimToken: string) => Promise<QueueSettlementResult>;
   failAfterDispatch: (promptId: string, errorMessage: string, expectedSessionId: string, claimToken: string) => Promise<QueueSettlementResult>;
@@ -44,6 +56,27 @@ export interface FlushClaudeCliQueueDeps {
     attachments?: ChatAttachment[];
     documentContext?: ClaudeCliDocumentContext | null;
   }) => Promise<{ submitted: boolean }>;
+  /** Register durable truth before the PTY write; false fails closed. */
+  registerQueuedTurn?: (input: {
+    sessionId: string;
+    workspacePath: string;
+    queueRowId: string;
+    claimToken: string;
+    clientSubmissionId: string;
+    sourceSessionId: string;
+    sourceRoomId: string;
+    submissionSequence: number;
+    producer: string;
+    claimTrigger: string;
+    claimTriggeredAt: number;
+    turnId: string;
+    providerInputMessageId: string;
+    providerOutputMessageId: string;
+    payloadReceipt: QueuedPromptPayloadReceipt;
+  }) => boolean;
+  clearQueuedTurnRegistration?: (sessionId: string, claimToken: string) => void;
+  /** Publish the durable queue lifecycle projection after a CLI claim. */
+  publishSnapshot?: (sessionId: string) => Promise<void>;
   /**
    * Tell the renderer a queued prompt has left the pending queue, so it drops
    * the row from the queued-prompts UI (NIM-830). Mirrors the SDK dispatcher's
@@ -70,7 +103,7 @@ export async function flushNextClaudeCliQueuedPrompt(
   const pending = await deps.listPending(args.sessionId);
   if (pending.length === 0) return false;
 
-  const claimed = await deps.claim(pending[0].id, args.sessionId);
+  const claimed = await deps.claim(pending[0].id, args.sessionId, 'claude_cli_idle_flush');
   if (!claimed) return false;
   if (!claimed.claimToken) throw new Error(`Queued prompt ${claimed.id} was claimed without an ownership token`);
   const claimToken = claimed.claimToken;
@@ -82,15 +115,21 @@ export async function flushNextClaudeCliQueuedPrompt(
   }
 
   let dispatchBegun = false;
+  let registered = false;
+  let clearQueuedTurnRegistration: ((sessionId: string, claimToken: string) => void) | undefined;
   try {
     const begun = await deps.beginDispatch(claimed.id, args.sessionId, claimToken);
     if (!settlementAccepted(begun)) {
       throw new QueueSettlementRejectedError(`Queued prompt dispatch intent was rejected: ${begun.outcome}`);
     }
     dispatchBegun = true;
+    await deps.publishSnapshot?.(args.sessionId);
 
     const prompt = claimed.prompt ?? '';
     const attachments = (claimed.attachments as ChatAttachment[] | undefined) ?? undefined;
+    if (claimed.payloadReceipt && !payloadReceiptsMatch(prompt, claimed.payloadReceipt)) {
+      throw queueTruthMismatchError();
+    }
     if (!prompt.trim() && (!attachments || attachments.length === 0)) {
       const rejected = await deps.failAfterDispatch(claimed.id, 'Queued CLI prompt had no sendable content', args.sessionId, claimToken);
       if (!settlementAccepted(rejected)) {
@@ -98,6 +137,35 @@ export async function flushNextClaudeCliQueuedPrompt(
       }
       return false;
     }
+
+    const observation = deps.registerQueuedTurn
+      ? {
+          register: deps.registerQueuedTurn,
+          clear: deps.clearQueuedTurnRegistration,
+        }
+      : await import('./claudeCliObservationSingleton').then((module) => ({
+          register: module.registerClaudeCliQueuedTurn,
+          clear: module.clearClaudeCliQueuedTurnRegistration,
+        }));
+    clearQueuedTurnRegistration = observation.clear;
+    registered = observation.register({
+      sessionId: args.sessionId,
+      workspacePath: args.workspacePath,
+      queueRowId: claimed.id,
+      claimToken,
+      clientSubmissionId: claimed.clientSubmissionId ?? '',
+      sourceSessionId: claimed.sourceSessionId ?? '',
+      sourceRoomId: claimed.sourceRoomId ?? '',
+      submissionSequence: claimed.submissionSequence ?? 0,
+      producer: claimed.producer ?? '',
+      claimTrigger: claimed.claimTrigger ?? '',
+      claimTriggeredAt: claimed.claimTriggeredAt ?? Number.NaN,
+      turnId: claimed.turnId ?? '',
+      providerInputMessageId: claimed.providerInputMessageId ?? '',
+      providerOutputMessageId: claimed.providerOutputMessageId ?? '',
+      payloadReceipt: claimed.payloadReceipt ?? { utf8Bytes: -1, unicodeScalars: -1, sha256: '' },
+    });
+    if (!registered) throw new Error('Queued CLI prompt truth registration was rejected');
 
     const { submitted } = await deps.submit({
       sessionId: args.sessionId,
@@ -107,19 +175,28 @@ export async function flushNextClaudeCliQueuedPrompt(
       documentContext: claimed.documentContext ?? undefined,
     });
     if (!submitted) {
+      observation.clear?.(args.sessionId, claimToken);
+      registered = false;
       const rejected = await deps.failAfterDispatch(claimed.id, 'CLI prompt submission produced no terminal input', args.sessionId, claimToken);
       if (!settlementAccepted(rejected)) {
         throw new Error(`Queued prompt no-op settlement was rejected: ${rejected.outcome}`);
       }
       return false;
     }
-    const completed = await deps.completeAfterDispatch(claimed.id, args.sessionId, claimToken);
-    if (!settlementAccepted(completed)) {
-      throw new QueueSettlementRejectedError(`Queued prompt completion was rejected: ${completed.outcome}`);
-    }
+    // The PTY entry has started, not completed. The observer's authoritative
+    // whole-turn idle boundary settles this same token after visible output is
+    // bound, so it cannot be truthfully completed at submit time.
     return true;
   } catch (error) {
     if (!dispatchBegun || error instanceof QueueSettlementRejectedError) throw error;
+    if (registered) {
+      if (clearQueuedTurnRegistration) {
+        clearQueuedTurnRegistration(args.sessionId, claimToken);
+      } else {
+        const { clearClaudeCliQueuedTurnRegistration } = await import('./claudeCliObservationSingleton');
+        clearClaudeCliQueuedTurnRegistration(args.sessionId, claimToken);
+      }
+    }
     const failure = await deps.failAfterDispatch(
       claimed.id,
       error instanceof Error ? error.message : 'Unknown error',

--- a/packages/electron/src/main/services/ai/claudeCliQueueFlush.ts
+++ b/packages/electron/src/main/services/ai/claudeCliQueueFlush.ts
@@ -17,10 +17,13 @@
  */
 
 import type { ChatAttachment } from '@nimbalyst/runtime/ai/server/types';
+import type { QueueSettlementResult } from '../PGLiteQueuedPromptsStore';
+import type { SessionPromptDispatchPreflight } from './queuedPromptDispatcher';
 import type { ClaudeCliDocumentContext } from './claudeCliPromptComposer';
 
 export interface FlushQueuedPrompt {
   id: string;
+  claimToken?: string;
   prompt?: string | null;
   attachments?: unknown[] | null;
   /** Active-doc/selection context captured at queue time (NIM-818). */
@@ -28,10 +31,12 @@ export interface FlushQueuedPrompt {
 }
 
 export interface FlushClaudeCliQueueDeps {
+  preflight: SessionPromptDispatchPreflight;
   listPending: (sessionId: string) => Promise<FlushQueuedPrompt[]>;
-  claim: (promptId: string) => Promise<FlushQueuedPrompt | null>;
-  complete: (promptId: string) => Promise<void>;
-  fail: (promptId: string, errorMessage: string) => Promise<void>;
+  claim: (promptId: string, expectedSessionId: string) => Promise<FlushQueuedPrompt | null>;
+  beginDispatch: (promptId: string, expectedSessionId: string, claimToken: string) => Promise<QueueSettlementResult>;
+  completeAfterDispatch: (promptId: string, expectedSessionId: string, claimToken: string) => Promise<QueueSettlementResult>;
+  failAfterDispatch: (promptId: string, errorMessage: string, expectedSessionId: string, claimToken: string) => Promise<QueueSettlementResult>;
   submit: (input: {
     sessionId: string;
     workspacePath: string;
@@ -47,6 +52,11 @@ export interface FlushClaudeCliQueueDeps {
   notifyClaimed?: (promptId: string) => void;
 }
 
+const settlementAccepted = (result: QueueSettlementResult) =>
+  result.outcome === 'settled' || result.outcome === 'idempotent_same_claim';
+
+class QueueSettlementRejectedError extends Error {}
+
 /**
  * Claim + submit the oldest pending queued prompt for the session. Returns true
  * iff a prompt was claimed and written to the PTY. Marks the prompt completed on
@@ -56,26 +66,69 @@ export async function flushNextClaudeCliQueuedPrompt(
   args: { sessionId: string; workspacePath: string },
   deps: FlushClaudeCliQueueDeps,
 ): Promise<boolean> {
+  if (!(await deps.preflight(args.sessionId))) return false;
   const pending = await deps.listPending(args.sessionId);
   if (pending.length === 0) return false;
 
-  const claimed = await deps.claim(pending[0].id);
+  const claimed = await deps.claim(pending[0].id, args.sessionId);
   if (!claimed) return false;
-
-  deps.notifyClaimed?.(claimed.id);
+  if (!claimed.claimToken) throw new Error(`Queued prompt ${claimed.id} was claimed without an ownership token`);
+  const claimToken = claimed.claimToken;
 
   try {
+    deps.notifyClaimed?.(claimed.id);
+  } catch {
+    // Renderer projection is best-effort and never owns durable settlement.
+  }
+
+  let dispatchBegun = false;
+  try {
+    const begun = await deps.beginDispatch(claimed.id, args.sessionId, claimToken);
+    if (!settlementAccepted(begun)) {
+      throw new QueueSettlementRejectedError(`Queued prompt dispatch intent was rejected: ${begun.outcome}`);
+    }
+    dispatchBegun = true;
+
+    const prompt = claimed.prompt ?? '';
+    const attachments = (claimed.attachments as ChatAttachment[] | undefined) ?? undefined;
+    if (!prompt.trim() && (!attachments || attachments.length === 0)) {
+      const rejected = await deps.failAfterDispatch(claimed.id, 'Queued CLI prompt had no sendable content', args.sessionId, claimToken);
+      if (!settlementAccepted(rejected)) {
+        throw new Error(`Queued prompt empty-input settlement was rejected: ${rejected.outcome}`);
+      }
+      return false;
+    }
+
     const { submitted } = await deps.submit({
       sessionId: args.sessionId,
       workspacePath: args.workspacePath,
-      prompt: claimed.prompt ?? '',
-      attachments: (claimed.attachments as ChatAttachment[] | undefined) ?? undefined,
+      prompt,
+      attachments,
       documentContext: claimed.documentContext ?? undefined,
     });
-    await deps.complete(claimed.id);
-    return submitted;
+    if (!submitted) {
+      const rejected = await deps.failAfterDispatch(claimed.id, 'CLI prompt submission produced no terminal input', args.sessionId, claimToken);
+      if (!settlementAccepted(rejected)) {
+        throw new Error(`Queued prompt no-op settlement was rejected: ${rejected.outcome}`);
+      }
+      return false;
+    }
+    const completed = await deps.completeAfterDispatch(claimed.id, args.sessionId, claimToken);
+    if (!settlementAccepted(completed)) {
+      throw new QueueSettlementRejectedError(`Queued prompt completion was rejected: ${completed.outcome}`);
+    }
+    return true;
   } catch (error) {
-    await deps.fail(claimed.id, error instanceof Error ? error.message : 'Unknown error');
+    if (!dispatchBegun || error instanceof QueueSettlementRejectedError) throw error;
+    const failure = await deps.failAfterDispatch(
+      claimed.id,
+      error instanceof Error ? error.message : 'Unknown error',
+      args.sessionId,
+      claimToken,
+    );
+    if (!settlementAccepted(failure)) {
+      throw new Error(`Queued prompt failure settlement was rejected: ${failure.outcome}`);
+    }
     return false;
   }
 }

--- a/packages/electron/src/main/services/ai/claudeCliQueueFlushSingleton.ts
+++ b/packages/electron/src/main/services/ai/claudeCliQueueFlushSingleton.ts
@@ -35,13 +35,17 @@ export async function flushNextClaudeCliQueuedPromptForSession(
       {
         preflight: preflightSessionPromptDispatch,
         listPending: (s) => store.listPending(s),
-        claim: (id, expectedSessionId) => store.claim(id, expectedSessionId),
+        claim: (id, expectedSessionId, claimTrigger) => store.claim(id, expectedSessionId, claimTrigger),
         beginDispatch: (id, expectedSessionId, claimToken) =>
           store.beginDispatch(id, expectedSessionId, claimToken),
         completeAfterDispatch: (id, expectedSessionId, claimToken) =>
           store.completeAfterDispatch(id, expectedSessionId, claimToken),
         failAfterDispatch: (id, message, expectedSessionId, claimToken) =>
           store.failAfterDispatch(id, message, expectedSessionId, claimToken),
+        publishSnapshot: async (claimedSessionId) => {
+          const { publishQueuedPromptSnapshotForSession } = await import('./AIService');
+          await publishQueuedPromptSnapshotForSession(claimedSessionId, store);
+        },
         submit: (i) => submitClaudeCliPromptProduction(i),
         // The flush runs from the PID-idle transition with no originating IPC
         // event, so there is no single target window; broadcasting is safe

--- a/packages/electron/src/main/services/ai/claudeCliQueueFlushSingleton.ts
+++ b/packages/electron/src/main/services/ai/claudeCliQueueFlushSingleton.ts
@@ -13,6 +13,7 @@ import { BrowserWindow } from 'electron';
 import { getQueuedPromptsStore } from '../RepositoryManager';
 import { submitClaudeCliPromptProduction } from './claudeCliSubmitSingleton';
 import { flushNextClaudeCliQueuedPrompt } from './claudeCliQueueFlush';
+import { preflightSessionPromptDispatch } from './queuedPromptDispatcher';
 
 /** Per-session guard so two close `idle` events can't double-flush. */
 const flushInFlight = new Set<string>();
@@ -32,10 +33,15 @@ export async function flushNextClaudeCliQueuedPromptForSession(
     return await flushNextClaudeCliQueuedPrompt(
       { sessionId, workspacePath },
       {
+        preflight: preflightSessionPromptDispatch,
         listPending: (s) => store.listPending(s),
-        claim: (id) => store.claim(id),
-        complete: (id) => store.complete(id),
-        fail: (id, m) => store.fail(id, m),
+        claim: (id, expectedSessionId) => store.claim(id, expectedSessionId),
+        beginDispatch: (id, expectedSessionId, claimToken) =>
+          store.beginDispatch(id, expectedSessionId, claimToken),
+        completeAfterDispatch: (id, expectedSessionId, claimToken) =>
+          store.completeAfterDispatch(id, expectedSessionId, claimToken),
+        failAfterDispatch: (id, message, expectedSessionId, claimToken) =>
+          store.failAfterDispatch(id, message, expectedSessionId, claimToken),
         submit: (i) => submitClaudeCliPromptProduction(i),
         // The flush runs from the PID-idle transition with no originating IPC
         // event, so there is no single target window; broadcasting is safe

--- a/packages/electron/src/main/services/ai/claudeCliSubmit.ts
+++ b/packages/electron/src/main/services/ai/claudeCliSubmit.ts
@@ -90,7 +90,9 @@ export async function submitClaudeCliPrompt(
   input: SubmitClaudeCliPromptInput,
   deps: SubmitClaudeCliPromptDeps,
 ): Promise<{ submitted: boolean }> {
-  const prompt = (input.prompt ?? '').trim();
+  // Validation may inspect trim(), but the logical payload itself must remain
+  // byte-for-byte unchanged through the queue and provider boundary.
+  const prompt = input.prompt ?? '';
   const attachments = input.attachments ?? [];
 
   // NIM-819: the claude TUI only opens its slash-command/memory mode when
@@ -134,7 +136,7 @@ export async function submitClaudeCliPrompt(
       attachments,
       documentContext: input.documentContext,
     });
-    if (!ptyText) {
+    if (!prompt.trim() && attachments.length === 0) {
       return { submitted: false };
     }
 
@@ -151,13 +153,19 @@ export async function submitClaudeCliPrompt(
 
   // Log the CLEAN typed prompt (+ attachment chips), NOT the path-augmented PTY
   // line. Best-effort: the CLI turn already started.
-  await deps.logUserPrompt({
-    sessionId: input.sessionId,
-    workspacePath: input.workspacePath,
-    prompt,
-    attachments,
-    promptProvenance: input.documentContext?.promptProvenance,
-  });
+  try {
+    await deps.logUserPrompt({
+      sessionId: input.sessionId,
+      workspacePath: input.workspacePath,
+      prompt,
+      attachments,
+      promptProvenance: input.documentContext?.promptProvenance,
+    });
+  } catch (error) {
+    // Provider entry already happened. Do not report a false terminal failure
+    // to the queue; observed CLI output still owns the durable settlement.
+    console.warn('[ClaudeCliSubmit] Failed to persist submitted user prompt:', error);
+  }
 
   deps.sendAnalytics({
     messageLength: prompt.length,

--- a/packages/electron/src/main/services/ai/queueDriveAttempt.ts
+++ b/packages/electron/src/main/services/ai/queueDriveAttempt.ts
@@ -58,7 +58,7 @@ export async function runQueueDriveAttempt<W>(
   if (resolved.kind === 'terminal') {
     const failed = await deps.failAllPending(
       sessionId,
-      `Project folder is no longer available at ${workspacePath}`,
+      'Queued prompt delivery failed: workspace is unavailable',
     );
     deps.logWarn(
       `[AIService] queue drive (${reason}): workspace missing for session ${sessionId}; failed ${failed} pending prompt(s)`,

--- a/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
+++ b/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
@@ -1,18 +1,60 @@
 import type { DocumentContext } from '@nimbalyst/runtime/ai/server/types';
+import type { QueueSettlementResult } from '../PGLiteQueuedPromptsStore';
+import { AISessionsRepository } from '@nimbalyst/runtime/storage/repositories/AISessionsRepository';
+export type SessionPromptDispatchPreflight = (sessionId: string) => Promise<boolean>;
+
+interface SessionWithDispatchMetadata {
+  metadata?: unknown;
+}
+
+export function createSessionPromptDispatchPreflight(
+  loadSession: (sessionId: string) => Promise<SessionWithDispatchMetadata | null>,
+): SessionPromptDispatchPreflight {
+  return async (sessionId: string): Promise<boolean> => {
+    try {
+      const session = await loadSession(sessionId);
+      if (!session) return false;
+
+      let metadata = session.metadata;
+      if (metadata === null || metadata === undefined) return true;
+      if (typeof metadata === 'string') {
+        try {
+          metadata = JSON.parse(metadata) as unknown;
+        } catch {
+          return false;
+        }
+      }
+      if (typeof metadata !== 'object' || Array.isArray(metadata)) return false;
+      return (metadata as Record<string, unknown>).modelChangeReconciliation == null;
+    } catch {
+      return false;
+    }
+  };
+}
+
+export const preflightSessionPromptDispatch = createSessionPromptDispatchPreflight(
+  (sessionId) => AISessionsRepository.get(sessionId),
+);
 
 export interface ClaimedQueuedPrompt {
   id: string;
   prompt: string;
+  claimToken?: string;
   attachments?: unknown[] | null;
   documentContext?: DocumentContext | null;
 }
 
 export interface QueuedPromptStoreLike {
   listPending(sessionId: string): Promise<ClaimedQueuedPrompt[]>;
-  claim(promptId: string): Promise<ClaimedQueuedPrompt | null>;
-  complete(promptId: string): Promise<void>;
-  fail(promptId: string, errorMessage: string): Promise<void>;
+  claim(promptId: string, expectedSessionId: string): Promise<ClaimedQueuedPrompt | null>;
+  beginDispatch(promptId: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
+  releaseClaim(promptId: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
+  completeAfterDispatch(promptId: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
+  failAfterDispatch(promptId: string, errorMessage: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
 }
+
+const settlementAccepted = (result: QueueSettlementResult) =>
+  result.outcome === 'settled' || result.outcome === 'idempotent_same_claim';
 
 interface DispatchClaimedQueuedPromptOptions {
   claimed: ClaimedQueuedPrompt;
@@ -26,7 +68,7 @@ interface DispatchClaimedQueuedPromptOptions {
   onAfterSettled?: () => Promise<void>;
   onChainSettled?: (payload: { sessionId: string; workspacePath: string; source: string }) => Promise<void>;
   onPromptClaimed: (payload: { sessionId: string; promptId: string }) => void;
-  processingSet: Set<string>;
+  processingLeases: Map<string, symbol>;
   queueStore: QueuedPromptStoreLike;
   sendMessageHandler: (
     event: Electron.IpcMainInvokeEvent,
@@ -52,7 +94,7 @@ export async function dispatchClaimedQueuedPrompt(
     onAfterSettled,
     onChainSettled,
     onPromptClaimed,
-    processingSet,
+    processingLeases,
     queueStore,
     sendMessageHandler,
     sessionId,
@@ -62,16 +104,29 @@ export async function dispatchClaimedQueuedPrompt(
     workspacePath,
   } = options;
 
-  processingSet.add(sessionId);
+  const dispatchLease = Symbol(`queued-prompt:${sessionId}:${claimed.id}`);
+  const claimToken = claimed.claimToken;
+  if (!claimToken) {
+    throw new Error(`Queued prompt ${claimed.id} was claimed without an ownership token`);
+  }
+  processingLeases.set(sessionId, dispatchLease);
 
   try {
     await startSession({ sessionId, workspacePath });
   } catch (error) {
-    processingSet.delete(sessionId);
+    const release = await queueStore.releaseClaim(claimed.id, sessionId, claimToken);
+    if (!settlementAccepted(release)) {
+      logError(`[AIService] Failed to release pre-dispatch claim ${claimed.id} (${release.outcome})`, error);
+    }
+    if (processingLeases.get(sessionId) === dispatchLease) processingLeases.delete(sessionId);
     throw error;
   }
 
-  onPromptClaimed({ sessionId, promptId: claimed.id });
+  try {
+    onPromptClaimed({ sessionId, promptId: claimed.id });
+  } catch (notificationError) {
+    logError(`[AIService] Failed to notify renderer of claimed prompt ${claimed.id}:`, notificationError);
+  }
 
   const docContext = {
     ...(claimed.documentContext || {}),
@@ -80,22 +135,41 @@ export async function dispatchClaimedQueuedPrompt(
   } as DocumentContext;
 
   setImmediate(async () => {
+    let dispatchStarted = false;
+    let compatibleSettlement = false;
     try {
+      if (processingLeases.get(sessionId) !== dispatchLease) return;
+      const begin = await queueStore.beginDispatch(claimed.id, sessionId, claimToken);
+      if (!settlementAccepted(begin)) {
+        logError(`[AIService] Dispatch intent rejected for queued prompt ${claimed.id} (${begin.outcome})`, new Error(begin.outcome));
+        return;
+      }
+      dispatchStarted = true;
+      if (processingLeases.get(sessionId) !== dispatchLease) return;
       const mockEvent = {
         sender: targetWindow.webContents,
         senderFrame: targetWindow.webContents.mainFrame,
       } as Electron.IpcMainInvokeEvent;
 
       await sendMessageHandler(mockEvent, claimed.prompt, docContext, sessionId, workspacePath);
-      await queueStore.complete(claimed.id);
+      const completion = await queueStore.completeAfterDispatch(claimed.id, sessionId, claimToken);
+      compatibleSettlement = settlementAccepted(completion);
+      if (!compatibleSettlement) {
+        logError(`[AIService] Completion rejected for queued prompt ${claimed.id} (${completion.outcome})`, new Error(completion.outcome));
+      }
     } catch (queueError) {
       logError(`[AIService] Failed to process queued prompt ${claimed.id}:`, queueError);
-      await queueStore.fail(
-        claimed.id,
-        queueError instanceof Error ? queueError.message : 'Unknown error',
-      );
+      const settlement = dispatchStarted
+        ? await queueStore.failAfterDispatch(claimed.id, queueError instanceof Error ? queueError.message : 'Unknown error', sessionId, claimToken)
+        : await queueStore.releaseClaim(claimed.id, sessionId, claimToken);
+      compatibleSettlement = settlementAccepted(settlement);
+      if (!compatibleSettlement) {
+        logError(`[AIService] Failure settlement rejected for queued prompt ${claimed.id} (${settlement.outcome})`, queueError);
+      }
     } finally {
-      processingSet.delete(sessionId);
+      if (processingLeases.get(sessionId) !== dispatchLease) return;
+      processingLeases.delete(sessionId);
+      if (!compatibleSettlement) return;
       try {
         await continueQueuedPromptChain(
           sessionId,
@@ -110,7 +184,7 @@ export async function dispatchClaimedQueuedPrompt(
       // The inner sendMessage's completion handler deferred endSession because
       // processingSet still contained this session (we hadn't reached this
       // delete yet), so nobody has marked the session idle. Do it now.
-      if (!processingSet.has(sessionId) && onChainSettled) {
+      if (!processingLeases.has(sessionId) && onChainSettled) {
         try {
           await onChainSettled({ sessionId, workspacePath, source });
         } catch (settledErr) {
@@ -135,7 +209,8 @@ interface TryClaimAndDispatchNextQueuedPromptOptions {
   onAfterSettled?: DispatchClaimedQueuedPromptOptions['onAfterSettled'];
   onChainSettled?: DispatchClaimedQueuedPromptOptions['onChainSettled'];
   onPromptClaimed: DispatchClaimedQueuedPromptOptions['onPromptClaimed'];
-  processingSet: Set<string>;
+  processingLeases: Map<string, symbol>;
+  preflight: SessionPromptDispatchPreflight;
   queueStore: QueuedPromptStoreLike;
   sendMessageHandler: DispatchClaimedQueuedPromptOptions['sendMessageHandler'] | null;
   sessionId: string;
@@ -156,7 +231,8 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
     onAfterSettled,
     onChainSettled,
     onPromptClaimed,
-    processingSet,
+    processingLeases,
+    preflight,
     queueStore,
     sendMessageHandler,
     sessionId,
@@ -177,8 +253,13 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
     return false;
   }
 
-  if (processingSet.has(sessionId)) {
+  if (processingLeases.has(sessionId)) {
     logInfo(`[AIService] ${source}: session ${sessionId} already processing a queued prompt, skipping`);
+    return false;
+  }
+
+  if (!(await preflight(sessionId))) {
+    logInfo(`[AIService] ${source}: session admission preflight rejected ${sessionId}`);
     return false;
   }
 
@@ -191,14 +272,18 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
   const nextPrompt = pendingPrompts[0];
   logInfo(`[AIService] ${source}: processing prompt ${nextPrompt.id} for session ${sessionId}`);
 
-  const claimed = await queueStore.claim(nextPrompt.id);
+  const claimed = await queueStore.claim(nextPrompt.id, sessionId);
   if (!claimed) {
     logInfo(`[AIService] ${source}: prompt ${nextPrompt.id} already claimed`);
     return false;
   }
 
   if (!sendMessageHandler) {
-    await queueStore.fail(claimed.id, 'sendMessageHandler not initialized');
+    if (!claimed.claimToken) throw new Error(`Queued prompt ${claimed.id} was claimed without an ownership token`);
+    const release = await queueStore.releaseClaim(claimed.id, sessionId, claimed.claimToken);
+    if (!settlementAccepted(release)) {
+      logError(`[AIService] Failed to release uninitialized-handler claim ${claimed.id} (${release.outcome})`, new Error(release.outcome));
+    }
     logError('[AIService] Failed to process queued prompt because sendMessageHandler is not initialized', new Error('sendMessageHandler not initialized'));
     return false;
   }
@@ -210,7 +295,7 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
     onAfterSettled,
     onChainSettled,
     onPromptClaimed,
-    processingSet,
+    processingLeases,
     queueStore,
     sendMessageHandler,
     sessionId,

--- a/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
+++ b/packages/electron/src/main/services/ai/queuedPromptDispatcher.ts
@@ -1,5 +1,6 @@
 import type { DocumentContext } from '@nimbalyst/runtime/ai/server/types';
 import type { QueueSettlementResult } from '../PGLiteQueuedPromptsStore';
+import { payloadReceiptsMatch, queueTruthMismatchError, type QueuedPromptPayloadReceipt } from './queuedPromptTruth';
 import { AISessionsRepository } from '@nimbalyst/runtime/storage/repositories/AISessionsRepository';
 export type SessionPromptDispatchPreflight = (sessionId: string) => Promise<boolean>;
 
@@ -42,15 +43,32 @@ export interface ClaimedQueuedPrompt {
   claimToken?: string;
   attachments?: unknown[] | null;
   documentContext?: DocumentContext | null;
+  payloadReceipt?: QueuedPromptPayloadReceipt;
+  clientSubmissionId?: string;
+  sourceSessionId?: string;
+  sourceRoomId?: string;
+  submissionSequence?: number;
+  producer?: string;
+  claimTrigger?: string;
+  claimTriggeredAt?: number;
+  turnId?: string;
+  providerInputMessageId?: string;
+  providerOutputMessageId?: string;
 }
 
 export interface QueuedPromptStoreLike {
   listPending(sessionId: string): Promise<ClaimedQueuedPrompt[]>;
-  claim(promptId: string, expectedSessionId: string): Promise<ClaimedQueuedPrompt | null>;
+  claim(promptId: string, expectedSessionId: string, claimTrigger?: string): Promise<ClaimedQueuedPrompt | null>;
   beginDispatch(promptId: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
   releaseClaim(promptId: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
-  completeAfterDispatch(promptId: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
-  failAfterDispatch(promptId: string, errorMessage: string, expectedSessionId: string, claimToken: string): Promise<QueueSettlementResult>;
+  completeAfterDispatch(promptId: string, expectedSessionId: string, claimToken: string, terminal?: QueuedPromptTerminalReceipt): Promise<QueueSettlementResult>;
+  failAfterDispatch(promptId: string, errorMessage: string, expectedSessionId: string, claimToken: string, terminal?: QueuedPromptTerminalReceipt): Promise<QueueSettlementResult>;
+}
+
+export interface QueuedPromptTerminalReceipt {
+  lifecycle: 'completed' | 'failed';
+  terminalAt: number;
+  eventSequence: number;
 }
 
 const settlementAccepted = (result: QueueSettlementResult) =>
@@ -76,7 +94,7 @@ interface DispatchClaimedQueuedPromptOptions {
     documentContext?: DocumentContext,
     sessionId?: string,
     workspacePath?: string,
-  ) => Promise<{ content: string }>;
+  ) => Promise<{ content: string; queuedPromptTerminal?: QueuedPromptTerminalReceipt }>;
   sessionId: string;
   source: string;
   startSession: (options: { sessionId: string; workspacePath: string }) => Promise<void>;
@@ -132,6 +150,24 @@ export async function dispatchClaimedQueuedPrompt(
     ...(claimed.documentContext || {}),
     queuedPromptId: claimed.id,
     attachments: claimed.attachments,
+    // This travels with the persisted input message. It binds the source and
+    // terminal-output identities without using timestamps, prompt text, or
+    // array position as a proxy.
+    queuedPromptTruth: {
+      clientSubmissionId: claimed.clientSubmissionId ?? claimed.id,
+      queueRowId: claimed.id,
+      sourceSessionId: claimed.sourceSessionId ?? sessionId,
+      sourceRoomId: claimed.sourceRoomId ?? sessionId,
+      submissionSequence: claimed.submissionSequence,
+      producer: claimed.producer,
+      claimTrigger: claimed.claimTrigger,
+      claimTriggeredAt: claimed.claimTriggeredAt,
+      turnId: claimed.turnId,
+      providerInputMessageId: claimed.providerInputMessageId,
+      providerOutputMessageId: claimed.providerOutputMessageId,
+      payloadReceipt: claimed.payloadReceipt,
+      lifecycle: 'streaming' as const,
+    },
   } as DocumentContext;
 
   setImmediate(async () => {
@@ -139,6 +175,9 @@ export async function dispatchClaimedQueuedPrompt(
     let compatibleSettlement = false;
     try {
       if (processingLeases.get(sessionId) !== dispatchLease) return;
+      if (claimed.payloadReceipt && !payloadReceiptsMatch(claimed.prompt, claimed.payloadReceipt)) {
+        throw queueTruthMismatchError();
+      }
       const begin = await queueStore.beginDispatch(claimed.id, sessionId, claimToken);
       if (!settlementAccepted(begin)) {
         logError(`[AIService] Dispatch intent rejected for queued prompt ${claimed.id} (${begin.outcome})`, new Error(begin.outcome));
@@ -151,16 +190,40 @@ export async function dispatchClaimedQueuedPrompt(
         senderFrame: targetWindow.webContents.mainFrame,
       } as Electron.IpcMainInvokeEvent;
 
-      await sendMessageHandler(mockEvent, claimed.prompt, docContext, sessionId, workspacePath);
-      const completion = await queueStore.completeAfterDispatch(claimed.id, sessionId, claimToken);
+      const result = await sendMessageHandler(mockEvent, claimed.prompt, docContext, sessionId, workspacePath);
+      const completion = result.queuedPromptTerminal?.lifecycle === 'failed'
+        ? await queueStore.failAfterDispatch(
+            claimed.id,
+            'Provider returned a terminal error',
+            sessionId,
+            claimToken,
+            result.queuedPromptTerminal,
+          )
+        : result.queuedPromptTerminal
+          ? await queueStore.completeAfterDispatch(claimed.id, sessionId, claimToken, result.queuedPromptTerminal)
+          : await queueStore.completeAfterDispatch(claimed.id, sessionId, claimToken);
       compatibleSettlement = settlementAccepted(completion);
       if (!compatibleSettlement) {
         logError(`[AIService] Completion rejected for queued prompt ${claimed.id} (${completion.outcome})`, new Error(completion.outcome));
       }
     } catch (queueError) {
       logError(`[AIService] Failed to process queued prompt ${claimed.id}:`, queueError);
+      const terminal = (queueError as Error & { queuedPromptTerminal?: QueuedPromptTerminalReceipt }).queuedPromptTerminal;
       const settlement = dispatchStarted
-        ? await queueStore.failAfterDispatch(claimed.id, queueError instanceof Error ? queueError.message : 'Unknown error', sessionId, claimToken)
+        ? terminal
+          ? await queueStore.failAfterDispatch(
+              claimed.id,
+              queueError instanceof Error ? queueError.message : 'Unknown error',
+              sessionId,
+              claimToken,
+              terminal,
+            )
+          : await queueStore.failAfterDispatch(
+              claimed.id,
+              queueError instanceof Error ? queueError.message : 'Unknown error',
+              sessionId,
+              claimToken,
+            )
         : await queueStore.releaseClaim(claimed.id, sessionId, claimToken);
       compatibleSettlement = settlementAccepted(settlement);
       if (!compatibleSettlement) {
@@ -272,7 +335,7 @@ export async function tryClaimAndDispatchNextQueuedPrompt(
   const nextPrompt = pendingPrompts[0];
   logInfo(`[AIService] ${source}: processing prompt ${nextPrompt.id} for session ${sessionId}`);
 
-  const claimed = await queueStore.claim(nextPrompt.id, sessionId);
+  const claimed = await queueStore.claim(nextPrompt.id, sessionId, source);
   if (!claimed) {
     logInfo(`[AIService] ${source}: prompt ${nextPrompt.id} already claimed`);
     return false;

--- a/packages/electron/src/main/services/ai/queuedPromptTruth.ts
+++ b/packages/electron/src/main/services/ai/queuedPromptTruth.ts
@@ -1,0 +1,88 @@
+import { createHash, randomUUID } from 'crypto';
+
+/** Durable, content-free receipts for the logical composer payload. */
+export interface QueuedPromptPayloadReceipt {
+  utf8Bytes: number;
+  unicodeScalars: number;
+  sha256: string;
+}
+
+export interface QueuedPromptTruth {
+  clientSubmissionId: string;
+  queueRowId: string;
+  sourceSessionId: string;
+  sourceRoomId: string;
+  producer: string;
+  payload: QueuedPromptPayloadReceipt;
+}
+
+export type QueuedPromptLifecycle = 'streaming' | 'completed' | 'failed';
+
+/**
+ * One queued turn has one monotonic event spine. Both persisted transcript
+ * messages and renderer stream events take their association from this binder;
+ * terminal records share a single timestamp instead of inventing one per sink.
+ */
+export function createQueuedStreamTruthBinder(seed?: Record<string, unknown>) {
+  let eventSequence = 0;
+  let terminalAt: number | undefined;
+  return (lifecycle: QueuedPromptLifecycle): Record<string, unknown> | undefined => {
+    if (!seed) return undefined;
+    if (lifecycle !== 'streaming') terminalAt ??= Date.now();
+    return {
+      ...seed,
+      lifecycle,
+      eventSequence: ++eventSequence,
+      ...(terminalAt === undefined ? {} : { terminalAt }),
+    };
+  };
+}
+
+/**
+ * Receipt the exact JS string supplied by the composer. Array.from counts
+ * Unicode scalars (not UTF-16 code units) and Buffer supplies the exact UTF-8
+ * bytes that are hashed. Never trim or normalize this input.
+ */
+export function receiptQueuedPromptPayload(payload: string): QueuedPromptPayloadReceipt {
+  const bytes = Buffer.from(payload, 'utf8');
+  return {
+    utf8Bytes: bytes.byteLength,
+    unicodeScalars: Array.from(payload).length,
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+  };
+}
+
+export function payloadReceiptsMatch(
+  payload: string,
+  receipt: QueuedPromptPayloadReceipt,
+): boolean {
+  const actual = receiptQueuedPromptPayload(payload);
+  return actual.utf8Bytes === receipt.utf8Bytes
+    && actual.unicodeScalars === receipt.unicodeScalars
+    && actual.sha256 === receipt.sha256;
+}
+
+/** Generate identities once at the producer boundary; callers may supply legacy IDs. */
+export function createQueuedPromptTruth(input: {
+  queueRowId?: string;
+  clientSubmissionId?: string;
+  sourceSessionId: string;
+  sourceRoomId?: string;
+  producer: string;
+  payload: string;
+}): QueuedPromptTruth {
+  const queueRowId = input.queueRowId ?? randomUUID();
+  return {
+    queueRowId,
+    clientSubmissionId: input.clientSubmissionId ?? queueRowId,
+    sourceSessionId: input.sourceSessionId,
+    sourceRoomId: input.sourceRoomId ?? input.sourceSessionId,
+    producer: input.producer,
+    payload: receiptQueuedPromptPayload(input.payload),
+  };
+}
+
+export function queueTruthMismatchError(): Error {
+  // Deliberately content-free: prompt text must never escape through errors/logs.
+  return new Error('Queued prompt payload receipt mismatch');
+}

--- a/packages/electron/src/main/services/ai/resolveWorkspaceWindow.ts
+++ b/packages/electron/src/main/services/ai/resolveWorkspaceWindow.ts
@@ -14,6 +14,90 @@
 /** At most one auto-open per workspace per this window, so a burst of mobile
  *  prompts across projects can't open a wall of windows. */
 export const AUTO_OPEN_COOLDOWN_MS = 30_000;
+export const WORKSPACE_WINDOW_LOAD_TIMEOUT_MS = 15_000;
+
+interface LoadEventSource {
+  isDestroyed(): boolean;
+  once(event: string, listener: (...args: never[]) => void): unknown;
+  removeListener(event: string, listener: (...args: never[]) => void): unknown;
+}
+
+export interface WorkspaceWindowLoadTarget extends LoadEventSource {
+  webContents: LoadEventSource;
+}
+
+export interface WorkspaceWindowLoadTimers {
+  setTimeout(fn: () => void, ms: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+/**
+ * Wait for a newly-created workspace window to become dispatchable. Every
+ * terminal route removes every listener and the timeout, so an opening window
+ * can never strand the resolver or retain stale wakeups.
+ */
+export function waitForWorkspaceWindowLoad(
+  window: WorkspaceWindowLoadTarget,
+  timers: WorkspaceWindowLoadTimers = {
+    setTimeout: (fn, ms) => setTimeout(fn, ms),
+    clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+  },
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let timeoutHandle: unknown | null = null;
+    const listeners: Array<{
+      source: LoadEventSource;
+      event: string;
+      listener: (...args: never[]) => void;
+    }> = [];
+
+    const cleanup = () => {
+      if (timeoutHandle !== null) {
+        timers.clearTimeout(timeoutHandle);
+        timeoutHandle = null;
+      }
+      for (const { source, event, listener } of listeners) {
+        source.removeListener(event, listener);
+      }
+      listeners.length = 0;
+    };
+
+    const settle = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error) reject(error);
+      else resolve();
+    };
+    const failLoad = () => settle(new Error('Workspace window failed to load'));
+    const lostWindow = () => settle(new Error('Workspace window closed before load'));
+    const listen = (
+      source: LoadEventSource,
+      event: string,
+      listener: (...args: never[]) => void,
+    ) => {
+      listeners.push({ source, event, listener });
+      source.once(event, listener);
+    };
+
+    if (window.isDestroyed() || window.webContents.isDestroyed()) {
+      lostWindow();
+      return;
+    }
+
+    listen(window.webContents, 'did-finish-load', () => settle());
+    listen(window.webContents, 'did-fail-load', failLoad);
+    listen(window.webContents, 'render-process-gone', failLoad);
+    listen(window.webContents, 'destroyed', lostWindow);
+    listen(window, 'close', lostWindow);
+    listen(window, 'closed', lostWindow);
+    timeoutHandle = timers.setTimeout(
+      () => settle(new Error('Workspace window load timed out')),
+      WORKSPACE_WINDOW_LOAD_TIMEOUT_MS,
+    );
+  });
+}
 
 export type WorkspaceWindowResolution<W> =
   | { kind: 'window'; window: W; opened: boolean }
@@ -57,6 +141,17 @@ export function createWorkspaceWindowResolver<W>(
 
   return {
     async resolve(workspacePath, options): Promise<WorkspaceWindowResolution<W>> {
+      // A second prompt arriving while the first is still opening must join
+      // that open, not start another.
+      const pending = openInFlight.get(workspacePath);
+      if (pending) {
+        const window = await pending;
+        const ready = window && !deps.isDestroyed(window) ? window : liveWindow(workspacePath);
+        return ready
+          ? { kind: 'window', window: ready, opened: true }
+          : { kind: 'deferred', reason: 'no-window' };
+      }
+
       const existing = liveWindow(workspacePath);
       if (existing) {
         return { kind: 'window', window: existing, opened: false };
@@ -70,16 +165,6 @@ export function createWorkspaceWindowResolver<W>(
 
       if (options?.allowAutoOpen === false || deps.isQuitting()) {
         return { kind: 'deferred', reason: 'no-window' };
-      }
-
-      // A second prompt arriving while the first is still opening must join
-      // that open, not start another.
-      const pending = openInFlight.get(workspacePath);
-      if (pending) {
-        const window = await pending;
-        return window && !deps.isDestroyed(window)
-          ? { kind: 'window', window, opened: true }
-          : { kind: 'deferred', reason: 'no-window' };
       }
 
       const lastOpen = lastAutoOpenAt.get(workspacePath);
@@ -112,10 +197,11 @@ export function createWorkspaceWindowResolver<W>(
       openInFlight.set(workspacePath, openPromise);
 
       const created = await openPromise;
-      if (!created || deps.isDestroyed(created)) {
+      const ready = created && !deps.isDestroyed(created) ? created : liveWindow(workspacePath);
+      if (!ready) {
         return { kind: 'deferred', reason: 'no-window' };
       }
-      return { kind: 'window', window: created, opened: true };
+      return { kind: 'window', window: ready, opened: true };
     },
   };
 }

--- a/packages/electron/src/renderer/components/UnifiedAI/PromptQueueList.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/PromptQueueList.tsx
@@ -8,6 +8,10 @@ interface QueuedPromptAttachment {
 
 export interface QueuedPrompt {
   id: string;
+  clientSubmissionId?: string;
+  submissionSequence?: number;
+  sourceSessionId?: string;
+  status?: 'awaiting_ack' | 'pending' | 'executing' | 'completed' | 'failed';
   prompt: string;
   timestamp: number;
   attachments?: QueuedPromptAttachment[];
@@ -69,11 +73,6 @@ export function PromptQueueList({ queue, onCancel, onEdit, onSendNow }: PromptQu
           <div key={item.id} className="prompt-queue-item flex items-center gap-2 px-2 py-1.5 bg-nim-tertiary border border-nim rounded text-[13px]">
             <span className="prompt-queue-number shrink-0 w-[18px] h-[18px] flex items-center justify-center bg-nim-tertiary rounded-full text-[11px] font-medium text-nim-muted">{index + 1}</span>
             <span className="prompt-queue-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-nim-primary" title={item.prompt}>{item.prompt}</span>
-            {item.prompt.includes('\n') && (
-              <span className="prompt-queue-lines shrink-0 text-[10px] text-nim-muted bg-nim-secondary rounded px-1 py-0.5" title={`${item.prompt.split('\n\n').length} messages bundled`}>
-                +{item.prompt.split('\n\n').length - 1} more
-              </span>
-            )}
             {item.attachments && item.attachments.length > 0 && (
               <AttachmentIndicator attachments={item.attachments} />
             )}

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -26,6 +26,7 @@ import type { TodoItem } from '@nimbalyst/runtime/ui/AgentTranscript/types';
 import { isToolLikeMessage } from '@nimbalyst/runtime/ui/AgentTranscript/utils/messageTypeHelpers';
 import { AIInput, AIInputRef } from './AIInput';
 import { PromptQueueList } from './PromptQueueList';
+import { projectQueuedPrompts } from './queuedPromptProjection';
 import { TranscriptEmbeddedFileCard } from './TranscriptEmbeddedFileCard';
 import { getDiffPeekSizeForInteractiveWidgetHost } from './interactiveWidgetHostProxy';
 import { customEditorRegistry } from '../CustomEditors/registry';
@@ -50,27 +51,17 @@ import { expandSessionMentions } from './sessionMentions';
 import { diffTreeGroupByDirectoryAtom, setDiffTreeGroupByDirectoryAtom } from '../../store/atoms/projectState';
 import { openSettingsCommandAtom } from '../../store/atoms/settingsNavigation';
 import {
-  sessionDraftInputAtom,
-  sessionDraftHydratedAtom,
-  sessionDraftAttachmentsAtom,
-  sessionStoreAtom,
   sessionLoadedAtom,
-  sessionMessagesAtom,
-  sessionProviderAtom,
   sessionTokenUsageAtom,
   sessionStatusAtom,
   sessionCurrentTeammatesAtom,
   sessionCurrentTodosAtom,
-  sessionWorktreePathAtom,
-  sessionDocumentContextAtom,
   sessionEffortLevelRawAtom,
   sessionThinkingModeRawAtom,
-  sessionLoadingAtom,
   sessionModeAtom,
   sessionModelAtom,
   sessionArchivedAtom,
   sessionProcessingAtom,
-  sessionHasPendingInteractivePromptAtom,
   sessionWorktreeIdAtom,
   sessionPhaseAtom,
   sessionRegistryAtom,
@@ -94,7 +85,19 @@ import {
   clearSessionError,
   loadInitialQueuedPrompts,
 } from '../../store';
-import { streamCompletionSignalAtom } from '../../store/atoms/sessionTranscript';
+import {
+  sessionDraftInputAtom,
+  sessionDraftHydratedAtom,
+  sessionDraftAttachmentsAtom,
+  sessionStoreAtom,
+  sessionMessagesAtom,
+  sessionProviderAtom,
+  sessionWorktreePathAtom,
+  sessionDocumentContextAtom,
+  sessionLoadingAtom,
+  sessionHasPendingInteractivePromptAtom,
+} from '../../store/atoms/sessions';
+import { streamCompletionSignalAtom, type QueuedPrompt } from '../../store/atoms/sessionTranscript';
 import { canPersistSessionDraft, convertToWorkstreamAtom, sessionPromptAdditionsAtom, sessionLastSubmitAtAtom, sessionDraftLocalModifiedAtAtom, nextOptimisticId } from '../../store/atoms/sessions';
 import { clearAIInputHistoryAtom } from '../../store/atoms/aiInputUndo';
 import {
@@ -118,6 +121,31 @@ import { diffPeekSizeAtom, setDiffPeekSizeAtom } from '../../store/atoms/diffPee
 import { registerSessionWorkspace, loadInitialSessionFileState } from '../../store/listeners/fileStateListeners';
 import { sessionFileEditsAtom } from '../../store/atoms/sessionFiles';
 import { SESSION_PHASE_COLUMNS, setSessionPhaseAtom, type SessionPhase } from '../../store/atoms/sessionKanban';
+
+function isSessionDataValue(value: unknown): value is SessionData {
+  return typeof value === 'object' && value !== null;
+}
+
+function readSessionData(sessionId: string): SessionData | null {
+  const value = store.get(sessionStoreAtom(sessionId));
+  return isSessionDataValue(value) ? value : null;
+}
+
+function isChatAttachmentValue(value: unknown): value is ChatAttachment {
+  return typeof value === 'object' && value !== null &&
+    typeof (value as { id?: unknown }).id === 'string' &&
+    typeof (value as { filename?: unknown }).filename === 'string';
+}
+
+function readDraftAttachments(sessionId: string): ChatAttachment[] {
+  const value = store.get(sessionDraftAttachmentsAtom(sessionId));
+  return Array.isArray(value) ? value.filter(isChatAttachmentValue) : [];
+}
+
+function readDraftInput(sessionId: string): string {
+  const value = store.get(sessionDraftInputAtom(sessionId));
+  return typeof value === 'string' ? value : '';
+}
 
 /**
  * Detect a metadata value that's the artifact of `{...stringValue, ...}` -
@@ -302,7 +330,7 @@ async function updateSessionMetadataField<T>(
 ): Promise<void> {
   try {
     // Update local store FIRST (before async IPC) to ensure immediate availability
-    const currentSessionData = store.get(sessionStoreAtom(sessionId));
+    const currentSessionData = readSessionData(sessionId);
 
     if (currentSessionData) {
       const newMetadata = {
@@ -468,7 +496,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
 
   const sessionData = useMemo(() => {
     if (!hasSessionData) return null;
-    const snapshot = store.get(sessionStoreAtom(sessionId));
+    const snapshot = readSessionData(sessionId);
     // Guard against corrupted metadata: some legacy rows have a metadata
     // value that's the result of `{...stringValue, ...}`, producing an
     // object with millions of numeric-string keys (each char of the
@@ -675,7 +703,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
   const cliTerminalHydratedRef = useRef<string | null>(null);
   useEffect(() => {
     if (cliTerminalHydratedRef.current === sessionId) return;
-    const meta = store.get(sessionStoreAtom(sessionId))?.metadata as
+    const meta = readSessionData(sessionId)?.metadata as
       | Record<string, unknown>
       | undefined;
     if (!meta) return; // session data not loaded yet; retry on next render
@@ -743,7 +771,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
     // Keep the in-memory session store's metadata in sync so a remount's
     // hydration doesn't restore a stale collapsed state.
     const isNowCollapsed = !store.get(cliTerminalExpandedAtom(sessionId));
-    const currentSessionData = store.get(sessionStoreAtom(sessionId));
+    const currentSessionData = readSessionData(sessionId);
     if (currentSessionData) {
       updateSessionStore({
         sessionId,
@@ -1051,11 +1079,11 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
   // Handlers
   // ============================================================
   const handleAttachmentAdd = useCallback((attachment: ChatAttachment) => {
-    setDraftAttachments(prev => [...prev, attachment]);
+    setDraftAttachments((prev: ChatAttachment[]) => [...prev, attachment]);
   }, [setDraftAttachments]);
 
   const handleAttachmentRemove = useCallback((attachmentId: string) => {
-    setDraftAttachments(prev => prev.filter(a => a.id !== attachmentId));
+    setDraftAttachments((prev: ChatAttachment[]) => prev.filter((a: ChatAttachment) => a.id !== attachmentId));
   }, [setDraftAttachments]);
 
   const handleQueue = useCallback(async (message: string) => {
@@ -1063,47 +1091,57 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
     setIsQueueing(true);
 
     try {
+      const clientSubmissionId = crypto.randomUUID();
       // Get fresh document context at queue time (reads from disk)
       const effectiveContext = await getEffectiveDocumentContext();
       const serializableContext = serializeDocumentContext(effectiveContext);
 
       // Read attachments imperatively — we don't subscribe to keep typing
       // from re-rendering the entire transcript.
-      const currentAttachments = store.get(sessionDraftAttachmentsAtom(sessionId)) ?? [];
+      const currentAttachments = readDraftAttachments(sessionId);
 
-      // If there's already a pending queued prompt, append to it instead of
-      // creating a separate entry. This bundles multiple queued messages into
-      // one prompt, matching how Claude Code handles stacked queries.
-      const lastQueued = queuedPrompts[queuedPrompts.length - 1];
-      let combinedPrompt = message.trim();
-      let combinedAttachments = currentAttachments;
-
-      if (lastQueued) {
-        // Delete the existing queued prompt so we can replace it
-        await window.electronAPI.invoke('ai:deleteQueuedPrompt', lastQueued.id);
-        combinedPrompt = lastQueued.prompt + '\n\n' + message.trim();
-        // Merge attachments from both prompts
-        combinedAttachments = [...(lastQueued.attachments || []), ...currentAttachments];
-      }
+      // The bubble exists before IPC acknowledgement. If the response is
+      // lost, a retry of this ID converges to the already durable row.
+      const optimisticTimestamp = Date.now();
+      setQueuedPrompts((prev: QueuedPrompt[]) => projectQueuedPrompts(sessionId, prev, [{
+        id: `optimistic-${clientSubmissionId}`,
+        clientSubmissionId,
+        sourceSessionId: sessionId,
+        status: 'awaiting_ack',
+        prompt: message,
+        timestamp: optimisticTimestamp,
+        documentContext: serializableContext,
+        attachments: currentAttachments,
+      }]));
 
       const result = await window.electronAPI.invoke(
         'ai:createQueuedPrompt',
         sessionId,
-        combinedPrompt,
-        combinedAttachments,
-        serializableContext
-      ) as { id: string; prompt: string; timestamp: number };
+        message,
+        currentAttachments,
+        serializableContext,
+        clientSubmissionId,
+      ) as {
+        id: string;
+        clientSubmissionId?: string;
+        submissionSequence?: number;
+        sourceSessionId?: string;
+        prompt: string;
+        timestamp: number;
+      };
 
-      setQueuedPrompts(prev => {
-        // Remove the old queued prompt (if we merged into it) and add the new combined one
-        const filtered = lastQueued ? prev.filter(p => p.id !== lastQueued.id) : prev;
-        return [...filtered, {
+      setQueuedPrompts((prev: QueuedPrompt[]) => {
+        return projectQueuedPrompts(sessionId, prev, [{
           id: result.id,
-          prompt: combinedPrompt,
+          clientSubmissionId: result.clientSubmissionId,
+          submissionSequence: result.submissionSequence,
+          sourceSessionId: result.sourceSessionId,
+          status: 'pending',
+          prompt: result.prompt,
           timestamp: result.timestamp,
           documentContext: serializableContext,
-          attachments: combinedAttachments
-        }];
+          attachments: currentAttachments
+        }]);
       });
 
       setLastSubmitAt(Date.now());
@@ -1115,12 +1153,12 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
     } finally {
       setIsQueueing(false);
     }
-  }, [sessionId, getEffectiveDocumentContext, setDraftInput, setDraftAttachments, setLastSubmitAt, isQueueing, queuedPrompts, clearAIInputHistory]);
+  }, [sessionId, getEffectiveDocumentContext, setDraftInput, setDraftAttachments, setLastSubmitAt, isQueueing, clearAIInputHistory]);
 
   const handleSend = useCallback(async () => {
     // Read draft state imperatively — we deliberately don't subscribe to
     // these atoms in SessionTranscript (see SessionAIInput).
-    const currentDraftInput = store.get(sessionDraftInputAtom(sessionId)) ?? '';
+    const currentDraftInput = readDraftInput(sessionId);
     if (!currentDraftInput.trim() || !sessionData) return;
 
     // claude-code-cli (subscription, NIM-806): the genuine `claude` CLI runs in
@@ -1148,7 +1186,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
         handleQueue(cliMessage);
         return;
       }
-      const attachments = store.get(sessionDraftAttachmentsAtom(sessionId)) ?? [];
+      const attachments = readDraftAttachments(sessionId);
       setDraftInput('');
       setDraftAttachments([]);
       clearAIInputHistory(sessionId);
@@ -1186,7 +1224,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
     }
 
     let message = currentDraftInput.trim();
-    const attachments = store.get(sessionDraftAttachmentsAtom(sessionId)) ?? [];
+    const attachments = readDraftAttachments(sessionId);
 
     // Intercept /plan command - strip it and switch to planning mode
     // Match "/plan" only when followed by whitespace or end of string (not "/planning" or "/planify")
@@ -1460,25 +1498,11 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
   const handleCancelQueuedPrompt = useCallback(async (id: string) => {
     try {
       await window.electronAPI.invoke('ai:deleteQueuedPrompt', id);
-      setQueuedPrompts(prev => prev.filter(p => p.id !== id));
+      setQueuedPrompts((prev: QueuedPrompt[]) => prev.filter((p: QueuedPrompt) => p.id !== id));
     } catch (error) {
       console.error('[SessionTranscript] Failed to cancel queued prompt:', error);
     }
   }, []);
-
-  const handleEditQueuedPrompt = useCallback(async (id: string, prompt: string) => {
-    try {
-      await window.electronAPI.invoke('ai:deleteQueuedPrompt', id);
-      setQueuedPrompts(prev => prev.filter(p => p.id !== id));
-      // Append to any existing draft so editing multiple queued items doesn't
-      // clobber prior text; matches how handleQueue bundles consecutive
-      // queued prompts with a blank-line separator.
-      setDraftInput(prev => prev.trim().length > 0 ? `${prev}\n\n${prompt}` : prompt);
-      inputRef.current?.focus();
-    } catch (error) {
-      console.error('[SessionTranscript] Failed to edit queued prompt:', error);
-    }
-  }, [setDraftInput]);
 
   const handleSendNowQueuedPrompt = useCallback(async (_id: string, _prompt: string) => {
     try {
@@ -2203,7 +2227,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
     const { timestamp } = scrollToMessage;
 
     // Find the user message whose timestamp matches the prompt's createdAt.
-    const targetIdx = messages.findIndex(msg =>
+    const targetIdx = messages.findIndex((msg: TranscriptViewMessage) =>
       msg.type === 'user_message' && Math.abs((msg.createdAt?.getTime() || 0) - timestamp) < 1000
     );
 
@@ -2606,7 +2630,6 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
       <PromptQueueList
         queue={queuedPrompts}
         onCancel={handleCancelQueuedPrompt}
-        onEdit={handleEditQueuedPrompt}
         onSendNow={isLoading && !isClaudeCliTerminalSession(provider) ? handleSendNowQueuedPrompt : undefined}
       />
 

--- a/packages/electron/src/renderer/components/UnifiedAI/__tests__/queuedPromptProjection.test.ts
+++ b/packages/electron/src/renderer/components/UnifiedAI/__tests__/queuedPromptProjection.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { projectQueuedPrompts } from '../queuedPromptProjection';
+
+describe('queued prompt projection', () => {
+  it('dedupes retries by stable submission identity and clears a stale local failure', () => {
+    const result = projectQueuedPrompts('source-a', [
+      { id: 'optimistic', clientSubmissionId: 'submission-a', sourceSessionId: 'source-a', prompt: 'same', timestamp: 2, status: 'failed', errorMessage: 'not sent' },
+    ], [
+      { id: 'durable', clientSubmissionId: 'submission-a', sourceSessionId: 'source-a', submissionSequence: 1, prompt: 'same', timestamp: 1, status: 'completed' },
+      { id: 'other', clientSubmissionId: 'submission-b', sourceSessionId: 'source-b', prompt: 'other', timestamp: 1, status: 'pending' },
+    ]);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/electron/src/renderer/components/UnifiedAI/queuedPromptProjection.ts
+++ b/packages/electron/src/renderer/components/UnifiedAI/queuedPromptProjection.ts
@@ -1,0 +1,38 @@
+export interface DurableQueuedPromptProjection {
+  id: string;
+  clientSubmissionId?: string;
+  submissionSequence?: number;
+  sourceSessionId?: string;
+  status?: 'awaiting_ack' | 'pending' | 'executing' | 'completed' | 'failed';
+  prompt: string;
+  timestamp: number;
+  attachments?: any[];
+  documentContext?: any;
+  errorMessage?: string;
+}
+
+/**
+ * Backend truth wins over optimistic state. The stable client submission ID is
+ * the reconciliation key, with the row ID retained for legacy clients.
+ */
+export function projectQueuedPrompts(
+  sourceSessionId: string,
+  previous: DurableQueuedPromptProjection[],
+  durable: DurableQueuedPromptProjection[],
+): DurableQueuedPromptProjection[] {
+  const byIdentity = new Map<string, DurableQueuedPromptProjection>();
+  for (const row of previous) {
+    if ((row.sourceSessionId ?? sourceSessionId) === sourceSessionId) {
+      byIdentity.set(row.clientSubmissionId ?? row.id, row);
+    }
+  }
+  for (const row of durable) {
+    if ((row.sourceSessionId ?? sourceSessionId) !== sourceSessionId) continue;
+    const key = row.clientSubmissionId ?? row.id;
+    // A durable accepted/completed receipt clears stale local failure state.
+    byIdentity.set(key, { ...byIdentity.get(key), ...row, errorMessage: row.status === 'failed' ? row.errorMessage : undefined });
+  }
+  return [...byIdentity.values()]
+    .filter((row) => row.status !== 'completed' && row.status !== 'failed')
+    .sort((a, b) => (a.submissionSequence ?? a.timestamp) - (b.submissionSequence ?? b.timestamp) || a.id.localeCompare(b.id));
+}

--- a/packages/electron/src/renderer/store/atoms/sessionTranscript.ts
+++ b/packages/electron/src/renderer/store/atoms/sessionTranscript.ts
@@ -39,6 +39,10 @@ export const sessionErrorAtom = atomFamily((_sessionId: string) =>
  */
 export interface QueuedPrompt {
   id: string;
+  clientSubmissionId?: string;
+  submissionSequence?: number;
+  sourceSessionId?: string;
+  status?: 'awaiting_ack' | 'pending' | 'executing' | 'completed' | 'failed';
   prompt: string;
   timestamp: number;
   documentContext?: any;

--- a/packages/electron/src/renderer/store/listeners/sessionTranscriptListeners.ts
+++ b/packages/electron/src/renderer/store/listeners/sessionTranscriptListeners.ts
@@ -21,13 +21,20 @@
  */
 
 import { store } from '@nimbalyst/runtime/store';
+import type { SessionData } from '@nimbalyst/runtime/ai/server/types';
 import { updateSessionStoreAtom, sessionStoreAtom, sessionPromptAdditionsAtom } from '../atoms/sessions';
 import {
   sessionErrorAtom,
   sessionQueuedPromptsAtom,
   streamCompletionSignalAtom,
   transcriptEventSignalAtom,
+  type QueuedPrompt,
 } from '../atoms/sessionTranscript';
+import { projectQueuedPrompts } from '../../components/UnifiedAI/queuedPromptProjection';
+
+function isSessionDataValue(value: unknown): value is SessionData {
+  return typeof value === 'object' && value !== null;
+}
 
 /**
  * Initialize session transcript IPC listeners.
@@ -79,7 +86,7 @@ export function initSessionTranscriptListeners(): () => void {
       store.set(sessionErrorAtom(sessionId), { message, isAuthError, isBedrockToolError, isServerError, isCodexAuthRequired });
 
       // Signal stream completion so awaiters (e.g. superLoopBlockedFeedback) unblock
-      store.set(streamCompletionSignalAtom(sessionId), (prev) => prev + 1);
+      store.set(streamCompletionSignalAtom(sessionId), (prev: number) => prev + 1);
     })
   );
 
@@ -95,7 +102,7 @@ export function initSessionTranscriptListeners(): () => void {
       if (!sessionId || !isComplete) return;
 
       // Signal stream completion so awaiters (e.g. superLoopBlockedFeedback) unblock
-      store.set(streamCompletionSignalAtom(sessionId), (prev) => prev + 1);
+      store.set(streamCompletionSignalAtom(sessionId), (prev: number) => prev + 1);
     })
   );
 
@@ -121,7 +128,7 @@ export function initSessionTranscriptListeners(): () => void {
       // Get current messages to find last user message index
       // Using the atoms approach avoids stale closure issues
       const sessionData = store.get(sessionStoreAtom(sessionId));
-      const messages = sessionData?.messages || [];
+      const messages = isSessionDataValue(sessionData) ? sessionData.messages : [];
       let lastUserIdx = -1;
       for (let i = messages.length - 1; i >= 0; i--) {
         if (messages[i].type === 'user_message') {
@@ -149,7 +156,7 @@ export function initSessionTranscriptListeners(): () => void {
     window.electronAPI.on('transcript:event', (event: { sessionId?: string }) => {
       const sessionId = event?.sessionId;
       if (!sessionId) return;
-      store.set(transcriptEventSignalAtom(sessionId), (prev) => prev + 1);
+      store.set(transcriptEventSignalAtom(sessionId), (prev: number) => prev + 1);
     })
   );
 
@@ -157,7 +164,7 @@ export function initSessionTranscriptListeners(): () => void {
     window.electronAPI.on('transcript:session-reparsed', (event: { sessionId?: string }) => {
       const sessionId = event?.sessionId;
       if (!sessionId) return;
-      store.set(transcriptEventSignalAtom(sessionId), (prev) => prev + 1);
+      store.set(transcriptEventSignalAtom(sessionId), (prev: number) => prev + 1);
     })
   );
 
@@ -172,7 +179,9 @@ export function initSessionTranscriptListeners(): () => void {
       // Refresh queued prompts from the database
       try {
         const pending = await window.electronAPI.invoke('ai:listPendingPrompts', sessionId);
-        store.set(sessionQueuedPromptsAtom(sessionId), pending || []);
+        store.set(sessionQueuedPromptsAtom(sessionId), (previous: QueuedPrompt[]) =>
+          projectQueuedPrompts(sessionId, previous, pending || [])
+        );
       } catch (error) {
         console.error('[sessionTranscriptListeners] Failed to load queued prompts:', error);
         store.set(sessionQueuedPromptsAtom(sessionId), []);
@@ -181,18 +190,14 @@ export function initSessionTranscriptListeners(): () => void {
   );
 
   // =========================================================================
-  // Prompt Claimed (remove from queue)
-  // This is a custom DOM event, not an IPC event
+  // A claim is transient. Durable state wins on the next queue refresh; never
+  // remove an optimistic row merely because a DOM event said it was claimed.
   // =========================================================================
   const handlePromptClaimed = (event: CustomEvent<{ sessionId: string; promptId: string }>) => {
     const { sessionId, promptId } = event.detail;
     if (!sessionId || !promptId) return;
 
-    const currentQueue = store.get(sessionQueuedPromptsAtom(sessionId));
-    store.set(
-      sessionQueuedPromptsAtom(sessionId),
-      currentQueue.filter(p => p.id !== promptId)
-    );
+    void promptId;
   };
 
   window.addEventListener('ai:promptClaimed', handlePromptClaimed as EventListener);
@@ -212,7 +217,9 @@ export function initSessionTranscriptListeners(): () => void {
 export async function loadInitialQueuedPrompts(sessionId: string): Promise<void> {
   try {
     const pending = await window.electronAPI.invoke('ai:listPendingPrompts', sessionId);
-    store.set(sessionQueuedPromptsAtom(sessionId), pending || []);
+    store.set(sessionQueuedPromptsAtom(sessionId), (previous: QueuedPrompt[]) =>
+      projectQueuedPrompts(sessionId, previous, pending || [])
+    );
   } catch (error) {
     console.error('[sessionTranscriptListeners] Failed to load initial queued prompts:', error);
     store.set(sessionQueuedPromptsAtom(sessionId), []);

--- a/packages/runtime/src/sync/CollabV3Sync.ts
+++ b/packages/runtime/src/sync/CollabV3Sync.ts
@@ -77,6 +77,22 @@ interface EncryptedQueuedPrompt {
   /** IV for prompt decryption (base64) */
   iv: string;
   timestamp: number;
+  clientSubmissionId?: string;
+  sourceSessionId?: string;
+  sourceRoomId?: string;
+  submissionSequence?: number;
+  producer?: string;
+  payloadUtf8Bytes?: number;
+  payloadUnicodeScalars?: number;
+  payloadSha256?: string;
+  claimTrigger?: string;
+  claimTriggeredAt?: number;
+  turnId?: string;
+  providerInputMessageId?: string;
+  providerOutputMessageId?: string;
+  streamEventSequence?: number;
+  terminalStatus?: 'streaming' | 'completed' | 'failed';
+  terminalAt?: number;
   /** Encrypted image attachments from mobile (each independently encrypted) */
   encryptedAttachments?: WireEncryptedAttachment[];
 }
@@ -101,6 +117,22 @@ interface PlaintextQueuedPrompt {
   id: string;
   prompt: string;
   timestamp: number;
+  clientSubmissionId?: string;
+  sourceSessionId?: string;
+  sourceRoomId?: string;
+  submissionSequence?: number;
+  producer?: string;
+  payloadUtf8Bytes?: number;
+  payloadUnicodeScalars?: number;
+  payloadSha256?: string;
+  claimTrigger?: string;
+  claimTriggeredAt?: number;
+  turnId?: string;
+  providerInputMessageId?: string;
+  providerOutputMessageId?: string;
+  streamEventSequence?: number;
+  terminalStatus?: 'streaming' | 'completed' | 'failed';
+  terminalAt?: number;
   /** Decrypted image attachments from mobile */
   attachments?: EncryptedAttachment[];
 }
@@ -505,6 +537,22 @@ async function encryptQueuedPrompts(
         encryptedPrompt: encrypted,
         iv,
         timestamp: prompt.timestamp,
+        clientSubmissionId: prompt.clientSubmissionId,
+        sourceSessionId: prompt.sourceSessionId,
+        sourceRoomId: prompt.sourceRoomId,
+        submissionSequence: prompt.submissionSequence,
+        producer: prompt.producer,
+        payloadUtf8Bytes: prompt.payloadUtf8Bytes,
+        payloadUnicodeScalars: prompt.payloadUnicodeScalars,
+        payloadSha256: prompt.payloadSha256,
+        claimTrigger: prompt.claimTrigger,
+        claimTriggeredAt: prompt.claimTriggeredAt,
+        turnId: prompt.turnId,
+        providerInputMessageId: prompt.providerInputMessageId,
+        providerOutputMessageId: prompt.providerOutputMessageId,
+        streamEventSequence: prompt.streamEventSequence,
+        terminalStatus: prompt.terminalStatus,
+        terminalAt: prompt.terminalAt,
       };
     })
   );
@@ -525,6 +573,22 @@ async function decryptQueuedPrompts(
         id: prompt.id,
         prompt: decryptedPrompt,
         timestamp: prompt.timestamp,
+        clientSubmissionId: prompt.clientSubmissionId,
+        sourceSessionId: prompt.sourceSessionId,
+        sourceRoomId: prompt.sourceRoomId,
+        submissionSequence: prompt.submissionSequence,
+        producer: prompt.producer,
+        payloadUtf8Bytes: prompt.payloadUtf8Bytes,
+        payloadUnicodeScalars: prompt.payloadUnicodeScalars,
+        payloadSha256: prompt.payloadSha256,
+        claimTrigger: prompt.claimTrigger,
+        claimTriggeredAt: prompt.claimTriggeredAt,
+        turnId: prompt.turnId,
+        providerInputMessageId: prompt.providerInputMessageId,
+        providerOutputMessageId: prompt.providerOutputMessageId,
+        streamEventSequence: prompt.streamEventSequence,
+        terminalStatus: prompt.terminalStatus,
+        terminalAt: prompt.terminalAt,
       };
       // Pass through encrypted attachments (desktop decrypts them when processing)
       if (prompt.encryptedAttachments && prompt.encryptedAttachments.length > 0) {

--- a/packages/runtime/src/sync/__tests__/CollabV3Sync.queuedPromptTruth.test.ts
+++ b/packages/runtime/src/sync/__tests__/CollabV3Sync.queuedPromptTruth.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCollabV3Sync } from '../CollabV3Sync';
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+  readyState = 0;
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => { this.readyState = 3; });
+
+  constructor(readonly url: string) { FakeWebSocket.instances.push(this); }
+  open(): void { this.readyState = FakeWebSocket.OPEN; this.onopen?.(new Event('open')); }
+  receive(message: unknown): void { this.onmessage?.({ data: JSON.stringify(message) } as MessageEvent); }
+}
+
+function jwtFor(subject: string): string {
+  const payload = btoa(JSON.stringify({ sub: subject })).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `header.${payload}.signature`;
+}
+
+function latestIndexUpdate(socket: FakeWebSocket): Record<string, any> {
+  return socket.send.mock.calls
+    .map(([payload]) => JSON.parse(payload as string))
+    .filter((message) => message.type === 'indexUpdate')
+    .at(-1);
+}
+
+describe('CollabV3 queued prompt truth', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('round-trips queue provenance and terminal truth through encrypted sync', async () => {
+    const encryptionKey = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
+    const sender = createCollabV3Sync({
+      serverUrl: 'wss://sync.example.test', orgId: 'org-1', userId: 'sender',
+      getJwt: async () => jwtFor('sender'), encryptionKey,
+    });
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    const senderIndex = FakeWebSocket.instances[0];
+    senderIndex.open();
+    sender.syncSessionsToIndex?.([{
+      id: 'session-1', title: 'Queue truth', provider: 'openai-codex', mode: 'agent', workspaceId: '/workspace',
+      messageCount: 0, updatedAt: 1, createdAt: 1,
+    }]);
+    await vi.waitFor(() => expect(latestIndexUpdate(senderIndex)).toBeTruthy());
+
+    sender.pushChange('session-1', {
+      type: 'metadata_updated',
+      metadata: { queuedPrompts: [{
+        id: 'row-1', clientSubmissionId: 'client-1', sourceSessionId: 'session-1', sourceRoomId: 'room-1',
+        submissionSequence: 7, producer: 'meta-agent', payloadUtf8Bytes: 18, payloadUnicodeScalars: 16,
+        payloadSha256: 'a'.repeat(64), claimTrigger: 'meta-agent', claimTriggeredAt: 2,
+        turnId: 'turn-1', providerInputMessageId: 'input-1', providerOutputMessageId: 'output-1',
+        streamEventSequence: 3, terminalStatus: 'completed', terminalAt: 4,
+        prompt: ' exact\\ntext ', timestamp: 1,
+      }] },
+    });
+    await vi.waitFor(() => expect(latestIndexUpdate(senderIndex)?.session.encryptedQueuedPrompts).toHaveLength(1));
+    const encryptedQueuedPrompts = latestIndexUpdate(senderIndex).session.encryptedQueuedPrompts;
+
+    const receiver = createCollabV3Sync({
+      serverUrl: 'wss://sync.example.test', orgId: 'org-1', userId: 'receiver',
+      getJwt: async () => jwtFor('receiver'), encryptionKey,
+    });
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2));
+    FakeWebSocket.instances[1].open();
+    const connect = receiver.connect('session-1');
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(3));
+    const receiverSession = FakeWebSocket.instances[2];
+    receiverSession.open();
+    await connect;
+
+    const changes: any[] = [];
+    receiver.onRemoteChange('session-1', (change) => changes.push(change));
+    receiverSession.receive({
+      type: 'metadataBroadcast',
+      metadata: { provider: 'openai-codex', encryptedQueuedPrompts },
+    });
+
+    await vi.waitFor(() => expect(changes).toHaveLength(1));
+    expect(changes[0].metadata.queuedPrompts).toEqual([expect.objectContaining({
+      id: 'row-1', clientSubmissionId: 'client-1', sourceSessionId: 'session-1', sourceRoomId: 'room-1',
+      submissionSequence: 7, producer: 'meta-agent', payloadUtf8Bytes: 18, payloadUnicodeScalars: 16,
+      payloadSha256: 'a'.repeat(64), claimTrigger: 'meta-agent', claimTriggeredAt: 2,
+      turnId: 'turn-1', providerInputMessageId: 'input-1', providerOutputMessageId: 'output-1',
+      streamEventSequence: 3, terminalStatus: 'completed', terminalAt: 4, prompt: ' exact\\ntext ', timestamp: 1,
+    })]);
+    sender.disconnectAll();
+    receiver.disconnectAll();
+  });
+});

--- a/packages/runtime/src/sync/types.ts
+++ b/packages/runtime/src/sync/types.ts
@@ -435,6 +435,23 @@ export type SessionChange =
 /** Queued prompt for cross-device sync */
 export interface SyncedQueuedPrompt {
   id: string;           // Unique ID for this queued item
+  /** Stable producer-side identity; defaults to id for legacy clients. */
+  clientSubmissionId?: string;
+  sourceSessionId?: string;
+  sourceRoomId?: string;
+  submissionSequence?: number;
+  producer?: string;
+  payloadUtf8Bytes?: number;
+  payloadUnicodeScalars?: number;
+  payloadSha256?: string;
+  claimTrigger?: string;
+  claimTriggeredAt?: number;
+  turnId?: string;
+  providerInputMessageId?: string;
+  providerOutputMessageId?: string;
+  streamEventSequence?: number;
+  terminalStatus?: 'streaming' | 'completed' | 'failed';
+  terminalAt?: number;
   prompt: string;       // The user's message
   timestamp: number;    // When queued
   // Note: documentContext is NOT synced - it's device-local


### PR DESCRIPTION
## Summary
- harden ordinary and priority queued-prompt claim/control delivery
- keep FIFO drainage live across active turns, window loss, boot, cancellation, and settlement
- preserve stable submission/message identity, payload integrity, provenance, and projection truth

## Existing lineage
Refs #1011. Extends NIM-465, NIM-471, and NIM-472 without creating a duplicate issue. This is the shared queue/backend and desktop projection contract; it does not claim a native-iOS fix.

## Verification
The three-commit candidate was independently reviewed in bounded B1/B2/B3 gates. This PR must pass the repository's Node-24 Unit Tests, TypeScript Check, and Transcript Bundle before the fresh complete-candidate regression gate.

## Why this is worth merging

Reconnects are exactly when queue state is least reliable and most important. This patch keeps claims, leases, and UI state aligned across disconnect and replacement-window paths so a prompt is neither declared absent while still pending nor replayed after a newer owner takes over. It protects both delivery and the user's trust in the queue.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
