### PR TITLE
fix(sessions): preserve active content search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Menus and popups that open over the title bar respond to clicks again on Windows and Linux, including "Open folder…" in the project switcher (#1052).
 - Tracker types defined in one project no longer overwrite another open project's identically-named types (#1035).
 - Codex sessions now reach for Nimbalyst's browser tools instead of dead-ending on the ChatGPT desktop app's in-app browser plugin.
+- An active content search no longer gets silently reset to zero results by unrelated session activity elsewhere in the workspace.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/renderer/components/AgenticCoding/SessionHistory.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/SessionHistory.tsx
@@ -411,6 +411,10 @@ const SessionHistoryComponent: React.FC = () => {
   const [selectedSessionIds, setSelectedSessionIds] = useState<Set<string>>(new Set());
   const [selectedGroupIds, setSelectedGroupIds] = useState<Set<string>>(new Set()); // Format: "blitz:id", "worktree:id", "workstream:id", "superloop:id", "meta-agent:id"
   const lastSelectedIdRef = useRef<string | null>(null); // For shift+click range selection
+  // Tracks the last searchQuery|tagFilter|mode combination the title-filter effect ran for, so
+  // it can tell a real user-driven filter change apart from an unrelated `allSessions` reference
+  // change (see the effect below and bug_session_search_contents_reset_to_zero.md).
+  const prevSessionFilterKeyRef = useRef<string>('');
   const [worktreeCache, setWorktreeCache] = useState<Map<string, WorktreeWithStatus>>(new Map()); // Cache worktree data
   const [workstreamChildrenCache, setWorkstreamChildrenCache] = useState<Map<string, SessionItem[]>>(new Map()); // Cache workstream children
   const [blitzCache, setBlitzCache] = useState<Map<string, BlitzData>>(new Map()); // Cache blitz data
@@ -800,8 +804,26 @@ const SessionHistoryComponent: React.FC = () => {
 
   // Client-side title filtering (instant, no database query)
   // Note: Archived session filtering is handled by sessionListRootAtom based on showArchivedSessionsAtom
+  //
+  // Bug fix (Temp/yogi_v0681/bug_session_search_contents_reset_to_zero.md): this effect used to
+  // unconditionally reset `contentSearchTriggered` and overwrite `sessions` with a title-only
+  // re-filter every time `allSessions` changed reference -- which happens on ANY session's
+  // metadata update anywhere in the workspace, not just the one being searched. That silently
+  // cancelled an active content search and reset the visible results to zero within seconds of
+  // unrelated background session activity. `prevSessionFilterKeyRef` tracks only the inputs a
+  // user action can actually change (searchQuery/tagFilter/mode); when none of those changed and
+  // a content search is active, this effect leaves `sessions` (already populated by
+  // executeSearch) alone instead of clobbering it.
   useEffect(() => {
-    // Reset content search trigger when query changes
+    const filterKey = `${searchQuery}|${tagFilter.tags.join(',')}|${mode}`;
+    const userFilterInputsChanged = prevSessionFilterKeyRef.current !== filterKey;
+    prevSessionFilterKeyRef.current = filterKey;
+
+    if (contentSearchTriggered && !userFilterInputsChanged) {
+      return;
+    }
+
+    // Reset content search trigger when the query/tags/mode actually change.
     setContentSearchTriggered(false);
 
     // Filter out sessions that belong to worktrees (they're shown in WorktreeGroup instead)
@@ -831,7 +853,7 @@ const SessionHistoryComponent: React.FC = () => {
       return true;
     });
     setSessions(filtered.sort(compareSessionOrder));
-  }, [searchQuery, tagFilter.tags, allSessions, mode, compareSessionOrder, sessionRegistry]);
+  }, [searchQuery, tagFilter.tags, allSessions, mode, compareSessionOrder, sessionRegistry, contentSearchTriggered]);
 
   useEffect(() => {
     const commitOrderMap = (nextMap: Map<string, number>) => {


### PR DESCRIPTION
## Summary
- preserve active content-search results when unrelated session metadata changes
- reset content-search mode only when the user changes query, tags, or session mode

## Verification
- Electron typecheck completed with the repository's existing baseline diagnostics and zero diagnostics for `SessionHistory.tsx`
- `git diff --check` passed

This is a focused replay of the already-shipped fork behavior onto current upstream `main`; it contains no fork-only provider, credential, build, or overlay policy.