### PR TITLE
fix(electron): resolve the Windows taskbar icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Menus and popups that open over the title bar respond to clicks again on Windows and Linux, including "Open folder…" in the project switcher (#1052).
 - Tracker types defined in one project no longer overwrite another open project's identically-named types (#1035).
 - Codex sessions now reach for Nimbalyst's browser tools instead of dead-ending on the ChatGPT desktop app's in-app browser plugin.
+- Windows shows the correct app icon in the taskbar and window chrome, checking the packaged `.ico` and current logo asset instead of only a `icon.png` name that no longer matches the packaged asset.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/window/WindowManager.ts
+++ b/packages/electron/src/main/window/WindowManager.ts
@@ -183,17 +183,7 @@ export function createWindow(
     try {
         // console.log('[MAIN] Creating window at', new Date().toISOString());
 
-        // Set up icon path - icon.png is at the package root in both dev and packaged builds
-        // (included in electron-builder's `files` array, so it's inside the ASAR at the root)
-        let iconPath: string | undefined = join(app.getAppPath(), 'icon.png');
-
-        // Check if icon exists
-        if (!existsSync(iconPath)) {
-            console.log('[MAIN] Icon not found at:', iconPath);
-            iconPath = undefined;
-        } else {
-            // console.log('[MAIN] Using icon at:', iconPath);
-        }
+        const iconPath = resolveWindowIconPath();
 
         // Calculate window position with cascading effect
         let x: number | undefined;
@@ -747,6 +737,26 @@ export function createWindow(
         console.error('Error creating window:', error);
         throw error;
     }
+}
+
+function resolveWindowIconPath(): string | undefined {
+    const candidates = [
+        // Windows taskbar/window chrome needs the packaged ICO. In unpacked
+        // builds this lives next to app.asar under resources.
+        ...(process.platform === 'win32' ? [join(process.resourcesPath, 'icon.ico')] : []),
+        // Packaged ASAR currently carries nimbalyst-logo.png, not icon.png.
+        join(app.getAppPath(), 'nimbalyst-logo.png'),
+        join(app.getAppPath(), 'icon.png'),
+    ];
+
+    for (const candidate of candidates) {
+        if (candidate && existsSync(candidate)) {
+            return candidate;
+        }
+    }
+
+    console.log('[MAIN] Window icon not found in candidates:', candidates);
+    return undefined;
 }
 
 // Find window by file path


### PR DESCRIPTION
## Summary
- prefer the packaged Windows `.ico` for taskbar and window chrome
- fall back to the current `nimbalyst-logo.png`, then the legacy `icon.png`

## Verification
- 8 window-focused test files, 68 tests passed
- Electron typecheck completed with the repository's existing baseline diagnostics and zero diagnostics for `WindowManager.ts`
- `git diff --check` passed

This is a focused replay of the fork-shipped taskbar fix onto current upstream `main` with no provider, credential, build, or overlay policy.

## Why this is worth merging

The Windows taskbar icon is part of application identity and recovery: users rely on it to distinguish, switch to, and restore the right window. Resolving the packaged icon through the correct runtime path removes a visible platform defect without changing application behavior elsewhere.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
