### PR TITLE
fix: protect the running app from second-instance cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Menus and popups that open over the title bar respond to clicks again on Windows and Linux, including "Open folder…" in the project switcher (#1052).
 - Tracker types defined in one project no longer overwrite another open project's identically-named types (#1035).
 - Codex sessions now reach for Nimbalyst's browser tools instead of dead-ending on the ChatGPT desktop app's in-app browser plugin.
+- Opening a second Nimbalyst instance no longer disrupts the running app's agent controls.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/__tests__/singleInstanceLifecycle.test.ts
+++ b/packages/electron/src/main/__tests__/singleInstanceLifecycle.test.ts
@@ -1,0 +1,263 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  resolveSingleInstanceLifecycleOwnership,
+  runIfSingleInstanceLifecycleOwner,
+  startLosingSecondaryControlPath,
+} from '../singleInstanceLifecycle';
+
+describe('single-instance lifecycle ownership', () => {
+  it('keeps multiple-instance development and test processes as lifecycle owners', () => {
+    const ownership = resolveSingleInstanceLifecycleOwnership({
+      allowMultipleInstances: true,
+      acquiredSingleInstanceLock: null,
+    });
+
+    expect(ownership).toEqual({
+      mode: 'multiple-instance-owner',
+      ownsPrimaryLifecycle: true,
+    });
+  });
+
+  it('makes the packaged lock winner the primary lifecycle owner', () => {
+    const ownership = resolveSingleInstanceLifecycleOwnership({
+      allowMultipleInstances: false,
+      acquiredSingleInstanceLock: true,
+    });
+
+    expect(ownership).toEqual({
+      mode: 'single-instance-primary',
+      ownsPrimaryLifecycle: true,
+    });
+  });
+
+  it('denies both initialization and cleanup ownership to a packaged lock loser', () => {
+    const ownership = resolveSingleInstanceLifecycleOwnership({
+      allowMultipleInstances: false,
+      acquiredSingleInstanceLock: false,
+    });
+
+    expect(ownership).toEqual({
+      mode: 'single-instance-secondary',
+      ownsPrimaryLifecycle: false,
+    });
+  });
+
+  it('requires an explicit lock result for packaged single-instance processes', () => {
+    expect(() =>
+      resolveSingleInstanceLifecycleOwnership({
+        allowMultipleInstances: false,
+        acquiredSingleInstanceLock: null,
+      }),
+    ).toThrow('Packaged single-instance lifecycle requires a lock result');
+  });
+});
+
+describe('single-instance lifecycle effect gate', () => {
+  it('initializes and cleans up a winning primary exactly once per requested lifecycle step', () => {
+    const ownership = resolveSingleInstanceLifecycleOwnership({
+      allowMultipleInstances: false,
+      acquiredSingleInstanceLock: true,
+    });
+    const writeDescriptor = vi.fn();
+    const initializePrimary = vi.fn(() => writeDescriptor());
+    const removeDescriptor = vi.fn();
+    const cleanupPrimary = vi.fn(() => removeDescriptor());
+
+    expect(runIfSingleInstanceLifecycleOwner(ownership, initializePrimary)).toBe(true);
+    expect(runIfSingleInstanceLifecycleOwner(ownership, cleanupPrimary)).toBe(true);
+    expect(initializePrimary).toHaveBeenCalledOnce();
+    expect(writeDescriptor).toHaveBeenCalledOnce();
+    expect(cleanupPrimary).toHaveBeenCalledOnce();
+    expect(removeDescriptor).toHaveBeenCalledOnce();
+  });
+
+  it('keeps every primary initialization and cleanup side effect out of a losing secondary', () => {
+    const ownership = resolveSingleInstanceLifecycleOwnership({
+      allowMultipleInstances: false,
+      acquiredSingleInstanceLock: false,
+    });
+    const primaryEffects = {
+      initializePrimary: vi.fn(),
+      writeDescriptor: vi.fn(),
+      removeDescriptor: vi.fn(),
+      stopMcpServer: vi.fn(),
+      stopSessionWakeScheduler: vi.fn(),
+      stopFileWatchers: vi.fn(),
+      stopWorkspaceWatchers: vi.fn(),
+      closeSharedSessionState: vi.fn(),
+      closeSharedDatabase: vi.fn(),
+    };
+
+    const initialized = runIfSingleInstanceLifecycleOwner(ownership, () => {
+      primaryEffects.initializePrimary();
+      primaryEffects.writeDescriptor();
+    });
+    const cleanedUp = runIfSingleInstanceLifecycleOwner(ownership, () => {
+      primaryEffects.stopMcpServer();
+      primaryEffects.stopSessionWakeScheduler();
+      primaryEffects.stopFileWatchers();
+      primaryEffects.stopWorkspaceWatchers();
+      primaryEffects.closeSharedSessionState();
+      primaryEffects.closeSharedDatabase();
+      primaryEffects.removeDescriptor();
+    });
+
+    expect(initialized).toBe(false);
+    expect(cleanedUp).toBe(false);
+    for (const effect of Object.values(primaryEffects)) {
+      expect(effect).not.toHaveBeenCalled();
+    }
+  });
+});
+
+describe('main-process lifecycle wiring', () => {
+  it('retains ownership across lock acquisition, readiness, and before-quit cleanup', () => {
+    const indexSource = readFileSync(
+      fileURLToPath(new URL('../index.ts', import.meta.url)),
+      'utf8',
+    );
+
+    expect(indexSource).toContain(
+      'const singleInstanceLifecycle = resolveSingleInstanceLifecycleOwnership({',
+    );
+    expect(indexSource).toMatch(
+      /runIfSingleInstanceLifecycleOwner\(singleInstanceLifecycle, \(\) => \{\s+void app\.whenReady\(\)\.then/,
+    );
+    expect(indexSource).toMatch(
+      /app\.on\('before-quit', async \(event\) => \{\s+if \(!singleInstanceLifecycle\.ownsPrimaryLifecycle\) \{[\s\S]*?return;\s+\}\s+getCollabOutboxDrainCoordinator\(\)\.stop\(\)/,
+    );
+  });
+});
+
+describe('losing-secondary relay and exit path (no Electron process)', () => {
+  function createHarness(argv: string[]) {
+    let openFileHandler: ((filePath: string) => void) | null = null;
+    let timeoutHandler: (() => void) | null = null;
+    const relayFile = vi.fn();
+    const quit = vi.fn();
+    const onDeepLinkExit = vi.fn();
+    const onTimeoutExit = vi.fn();
+
+    const result = startLosingSecondaryControlPath({
+      argv,
+      isAbsolutePath: (candidate) => /^[A-Z]:\\/i.test(candidate),
+      relayFile,
+      registerOpenFileHandler: (handler) => {
+        openFileHandler = handler;
+      },
+      scheduleExitTimeout: (handler, delayMs) => {
+        expect(delayMs).toBe(5000);
+        timeoutHandler = handler;
+      },
+      quit,
+      onDeepLinkExit,
+      onTimeoutExit,
+    });
+
+    return {
+      result,
+      relayFile,
+      quit,
+      onDeepLinkExit,
+      onTimeoutExit,
+      emitOpenFile: (filePath: string) => openFileHandler?.(filePath),
+      expireTimeout: () => timeoutHandler?.(),
+    };
+  }
+
+  it('relays an absolute argv file and exits immediately', () => {
+    const harness = createHarness(['Nimbalyst.exe', 'D:\\project\\note.md']);
+
+    expect(harness.result).toBe('relayed-argv-file');
+    expect(harness.relayFile).toHaveBeenCalledOnce();
+    expect(harness.relayFile).toHaveBeenCalledWith('D:\\project\\note.md');
+    expect(harness.quit).toHaveBeenCalledOnce();
+  });
+
+  it('exits immediately for a deep link already forwarded by Electron', () => {
+    const harness = createHarness(['Nimbalyst.exe', 'nimbalyst://doc/abc']);
+
+    expect(harness.result).toBe('deep-link-exit');
+    expect(harness.onDeepLinkExit).toHaveBeenCalledOnce();
+    expect(harness.relayFile).not.toHaveBeenCalled();
+    expect(harness.quit).toHaveBeenCalledOnce();
+  });
+
+  it('waits for an OS open-file event, relays it, and does not exit twice on timeout', () => {
+    const harness = createHarness(['Nimbalyst.exe']);
+
+    expect(harness.result).toBe('waiting-for-open-file');
+    expect(harness.quit).not.toHaveBeenCalled();
+
+    harness.emitOpenFile('D:\\project\\from-shell.md');
+    harness.expireTimeout();
+
+    expect(harness.relayFile).toHaveBeenCalledOnce();
+    expect(harness.relayFile).toHaveBeenCalledWith('D:\\project\\from-shell.md');
+    expect(harness.onTimeoutExit).not.toHaveBeenCalled();
+    expect(harness.quit).toHaveBeenCalledOnce();
+  });
+
+  it('exits after the bounded wait when no OS open-file event arrives', () => {
+    const harness = createHarness(['Nimbalyst.exe']);
+
+    harness.expireTimeout();
+
+    expect(harness.relayFile).not.toHaveBeenCalled();
+    expect(harness.onTimeoutExit).toHaveBeenCalledOnce();
+    expect(harness.quit).toHaveBeenCalledOnce();
+  });
+
+  it('waits and exits without initializing or cleaning up shared primary state', () => {
+    const ownership = resolveSingleInstanceLifecycleOwnership({
+      allowMultipleInstances: false,
+      acquiredSingleInstanceLock: false,
+    });
+    const initializePrimary = vi.fn();
+    const cleanupPrimary = vi.fn();
+    const writeDescriptor = vi.fn();
+    const removeDescriptor = vi.fn();
+    const stopMcpServer = vi.fn();
+    const stopSessionWakeScheduler = vi.fn();
+    const stopFileWatchers = vi.fn();
+    const stopWorkspaceWatchers = vi.fn();
+    const closeSharedSessionState = vi.fn();
+    const closeSharedDatabase = vi.fn();
+    const harness = createHarness(['Nimbalyst.exe']);
+
+    runIfSingleInstanceLifecycleOwner(ownership, () => {
+      initializePrimary();
+      writeDescriptor();
+    });
+    harness.expireTimeout();
+    runIfSingleInstanceLifecycleOwner(ownership, () => {
+      cleanupPrimary();
+      removeDescriptor();
+      stopMcpServer();
+      stopSessionWakeScheduler();
+      stopFileWatchers();
+      stopWorkspaceWatchers();
+      closeSharedSessionState();
+      closeSharedDatabase();
+    });
+
+    expect(harness.result).toBe('waiting-for-open-file');
+    expect(harness.quit).toHaveBeenCalledOnce();
+    for (const primaryEffect of [
+      initializePrimary,
+      cleanupPrimary,
+      writeDescriptor,
+      removeDescriptor,
+      stopMcpServer,
+      stopSessionWakeScheduler,
+      stopFileWatchers,
+      stopWorkspaceWatchers,
+      closeSharedSessionState,
+      closeSharedDatabase,
+    ]) {
+      expect(primaryEffect).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -134,6 +134,11 @@ import { cliManager, initEnhancedPath, getEnhancedPath, getShellEnvironment } fr
 import { registerWorkspaceWindow, registerExtensionTools, shutdownHttpServer, startMcpHttpServer, updateDocumentState, getActiveExtensionShortNames } from './mcp/httpServer';
 import { writeMcpEndpointDescriptor, removeMcpEndpointDescriptor, type EndpointWorkspace } from './mcp/mcpEndpointDescriptor';
 import {
+  resolveSingleInstanceLifecycleOwnership,
+  runIfSingleInstanceLifecycleOwner,
+  startLosingSecondaryControlPath,
+} from './singleInstanceLifecycle';
+import {
   startWorkspaceBackendModules,
   syncEnabledBackendModulesOnStartup,
   getDefaultBackendModuleLifecycleDeps,
@@ -631,11 +636,16 @@ registerLinuxAppImageProtocolHandler();
 // (e.g., from a file double-click), it forwards its context to the primary instance.
 // Skip for multi-instance dev mode and Playwright tests.
 const allowMultipleInstances = !!process.env.NIMBALYST_USER_DATA_DIR || !!process.env.PLAYWRIGHT;
+const acquiredSingleInstanceLock = allowMultipleInstances
+    ? null
+    : app.requestSingleInstanceLock();
+const singleInstanceLifecycle = resolveSingleInstanceLifecycleOwnership({
+    allowMultipleInstances,
+    acquiredSingleInstanceLock,
+});
 
 if (!allowMultipleInstances) {
-    const gotTheLock = app.requestSingleInstanceLock();
-
-    if (!gotTheLock) {
+    if (!acquiredSingleInstanceLock) {
         // Another instance holds the lock. On macOS, when the OS launches the
         // packaged app to open a file, the path comes via Apple Events which
         // Electron delivers as the open-file event. But open-file only fires
@@ -646,44 +656,37 @@ if (!allowMultipleInstances) {
 
         logger.main.info(`[SingleInstance] Second instance launched, waiting for open-file. argv=${JSON.stringify(process.argv)}`);
 
-        // Also check argv for file paths (Windows/Linux, or CLI open --args)
-        const fileArg = process.argv.find(arg =>
-            !arg.startsWith('-') &&
-            arg !== process.argv[0] &&
-            path.isAbsolute(arg)
-        );
-        if (fileArg) {
-            logger.main.info(`[SingleInstance] Found file in argv: ${fileArg}`);
-            try { writeFileSync(pendingOpenFilePath, fileArg, 'utf-8'); } catch (_) {}
-            app.quit();
-        } else if (process.argv.find(arg => arg.startsWith('nimbalyst://'))) {
-            // Primary instance will handle via second-instance event; quit immediately
-            logger.main.info('[SingleInstance] Second instance has deep link arg, quitting immediately');
-            app.quit();
-        } else {
-            // No file in argv -- wait for open-file Apple Event
-            let gotFile = false;
-            app.on('open-file', (event, filePath) => {
-                event.preventDefault();
-                gotFile = true;
-                logger.main.info(`[SingleInstance] Second instance received open-file: ${filePath}`);
+        startLosingSecondaryControlPath({
+            argv: process.argv,
+            isAbsolutePath: path.isAbsolute,
+            relayFile: (filePath) => {
+                logger.main.info(`[SingleInstance] Relaying file to primary: ${filePath}`);
                 try {
                     writeFileSync(pendingOpenFilePath, filePath, 'utf-8');
                     logger.main.info(`[SingleInstance] Wrote signal file: ${pendingOpenFilePath}`);
                 } catch (err) {
                     logger.main.error('[SingleInstance] Failed to write signal file:', err);
                 }
-                app.quit();
-            });
-
-            // Fallback timeout -- if open-file never fires, quit anyway
-            setTimeout(() => {
-                if (!gotFile) {
-                    logger.main.info('[SingleInstance] No open-file after timeout, quitting');
-                    app.quit();
-                }
-            }, 5000);
-        }
+            },
+            registerOpenFileHandler: (handler) => {
+              app.on('open-file', (event, filePath) => {
+                event.preventDefault();
+                logger.main.info(`[SingleInstance] Second instance received open-file: ${filePath}`);
+                handler(filePath);
+              });
+            },
+            scheduleExitTimeout: (handler, delayMs) => {
+                setTimeout(handler, delayMs);
+            },
+            quit: () => app.quit(),
+            onDeepLinkExit: () => {
+                // Primary instance handles the URL via the second-instance event.
+                logger.main.info('[SingleInstance] Second instance has deep link arg, quitting immediately');
+            },
+            onTimeoutExit: () => {
+                logger.main.info('[SingleInstance] No open-file after timeout, quitting');
+            },
+        });
     } else {
         // We are the primary instance. When a second instance tries to launch,
         // extract any deep link URL or file path and handle it here.
@@ -732,7 +735,7 @@ if (!allowMultipleInstances) {
 // Workaround for dev mode: watch a signal file that the second instance writes.
 // Currently only works for CLI invocations where the path is in argv.
 // For Finder double-click during dev, quit the packaged app first.
-{
+runIfSingleInstanceLifecycleOwner(singleInstanceLifecycle, () => {
     const pendingOpenFilePath = path.join(app.getPath('userData'), '.pending-open-file');
 
     // Check for a stale signal file on startup (second instance may have written
@@ -769,7 +772,7 @@ if (!allowMultipleInstances) {
     } catch (err) {
         logger.main.warn('[SingleInstance] Failed to watch for open-file signals:', err);
     }
-}
+});
 
 // Track pending deep link URL
 let pendingDeepLinkUrl: string | null = null;
@@ -1433,7 +1436,8 @@ BrowserWindow.prototype.focus = function(this: BrowserWindow) {
 // --- END ACTIVATION DEBUGGING ---
 
 // App ready handler
-app.whenReady().then(async () => {
+runIfSingleInstanceLifecycleOwner(singleInstanceLifecycle, () => {
+  void app.whenReady().then(async () => {
     checkpoint('app-ready');
 
     // The default renderer session may use the microphone after Voice Mode has
@@ -2908,22 +2912,30 @@ app.whenReady().then(async () => {
             });
         }
     });
+  });
 });
 
 // Activate handler (macOS)
-app.on('activate', () => {
-    // Avoid resurrecting windows while quitting
-    if (isAppQuitting) return;
-    // Only create window if app is ready (screen module requires app to be ready)
-    if (!app.isReady()) return;
-    // On macOS, show WorkspaceManager when dock icon is clicked and no windows are open
-    if (BrowserWindow.getAllWindows().length === 0) {
-        createWorkspaceManagerWindow();
-    }
+runIfSingleInstanceLifecycleOwner(singleInstanceLifecycle, () => {
+  app.on('activate', () => {
+      // Avoid resurrecting windows while quitting
+      if (isAppQuitting) return;
+      // Only create window if app is ready (screen module requires app to be ready)
+      if (!app.isReady()) return;
+      // On macOS, show WorkspaceManager when dock icon is clicked and no windows are open
+      if (BrowserWindow.getAllWindows().length === 0) {
+          createWorkspaceManagerWindow();
+      }
+  });
 });
 
 // Before quit handler
 app.on('before-quit', async (event) => {
+    if (!singleInstanceLifecycle.ownsPrimaryLifecycle) {
+        logger.main.info('[SingleInstance] Secondary exit bypasses primary lifecycle cleanup');
+        return;
+    }
+
     getCollabOutboxDrainCoordinator().stop();
     getCollabAssetOutboxDrainCoordinator().stop();
     console.log('[QUIT] before-quit event triggered');

--- a/packages/electron/src/main/singleInstanceLifecycle.ts
+++ b/packages/electron/src/main/singleInstanceLifecycle.ts
@@ -1,0 +1,121 @@
+export type SingleInstanceLifecycleMode =
+  | 'multiple-instance-owner'
+  | 'single-instance-primary'
+  | 'single-instance-secondary';
+
+export interface SingleInstanceLifecycleOwnership {
+  mode: SingleInstanceLifecycleMode;
+  ownsPrimaryLifecycle: boolean;
+}
+
+interface ResolveSingleInstanceLifecycleOwnershipOptions {
+  allowMultipleInstances: boolean;
+  acquiredSingleInstanceLock: boolean | null;
+}
+
+export function resolveSingleInstanceLifecycleOwnership({
+  allowMultipleInstances,
+  acquiredSingleInstanceLock,
+}: ResolveSingleInstanceLifecycleOwnershipOptions): SingleInstanceLifecycleOwnership {
+  if (allowMultipleInstances) {
+    return {
+      mode: 'multiple-instance-owner',
+      ownsPrimaryLifecycle: true,
+    };
+  }
+
+  if (acquiredSingleInstanceLock === null) {
+    throw new Error('Packaged single-instance lifecycle requires a lock result');
+  }
+
+  return acquiredSingleInstanceLock
+    ? {
+        mode: 'single-instance-primary',
+        ownsPrimaryLifecycle: true,
+      }
+    : {
+        mode: 'single-instance-secondary',
+        ownsPrimaryLifecycle: false,
+      };
+}
+
+export function runIfSingleInstanceLifecycleOwner(
+  ownership: SingleInstanceLifecycleOwnership,
+  effect: () => void,
+): boolean {
+  if (!ownership.ownsPrimaryLifecycle) {
+    return false;
+  }
+
+  effect();
+  return true;
+}
+
+export type LosingSecondaryControlPathResult =
+  | 'relayed-argv-file'
+  | 'deep-link-exit'
+  | 'waiting-for-open-file';
+
+interface StartLosingSecondaryControlPathOptions {
+  argv: readonly string[];
+  isAbsolutePath: (candidate: string) => boolean;
+  relayFile: (filePath: string) => void;
+  registerOpenFileHandler: (handler: (filePath: string) => void) => void;
+  scheduleExitTimeout: (handler: () => void, delayMs: number) => void;
+  quit: () => void;
+  onDeepLinkExit?: () => void;
+  onTimeoutExit?: () => void;
+}
+
+export function startLosingSecondaryControlPath({
+  argv,
+  isAbsolutePath,
+  relayFile,
+  registerOpenFileHandler,
+  scheduleExitTimeout,
+  quit,
+  onDeepLinkExit,
+  onTimeoutExit,
+}: StartLosingSecondaryControlPathOptions): LosingSecondaryControlPathResult {
+  let settled = false;
+
+  const relayAndExit = (filePath: string): void => {
+    if (settled) return;
+    settled = true;
+    relayFile(filePath);
+    quit();
+  };
+
+  const exitWithoutRelay = (): void => {
+    if (settled) return;
+    settled = true;
+    quit();
+  };
+
+  const fileArg = argv.find(
+    (arg) =>
+      !arg.startsWith('-') &&
+      arg !== argv[0] &&
+      isAbsolutePath(arg),
+  );
+
+  if (fileArg) {
+    relayAndExit(fileArg);
+    return 'relayed-argv-file';
+  }
+
+  if (argv.some((arg) => arg.startsWith('nimbalyst://'))) {
+    onDeepLinkExit?.();
+    exitWithoutRelay();
+    return 'deep-link-exit';
+  }
+
+  registerOpenFileHandler(relayAndExit);
+  scheduleExitTimeout(() => {
+    if (settled) return;
+    onTimeoutExit?.();
+    exitWithoutRelay();
+  }, 5000);
+
+  return 'waiting-for-open-file';
+}


### PR DESCRIPTION
Keeps primary initialization and cleanup owned by the lock-winning process. A losing secondary relays files or deep links and exits without stopping shared agent services. Verification: focused lifecycle suite 12/12; Electron typecheck has zero diagnostics in the four changed paths; diff check passes.

## Why this is worth merging

A second application instance must never clean up resources owned by the first. That race can terminate live sessions, remove active sockets, or corrupt the user's sense of which process owns the workspace. Binding cleanup to the instance that acquired ownership protects the running app while preserving normal shutdown behavior.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
