### PR TITLE
fix: verify worktree identity without duplicate agent catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -462,6 +462,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tracker workstream tabs are now safe and durable and no longer resurrect closed tabs.
 - Filtered tracker empty states now offer an actionable next step instead of a dead end.
 - The mobile transcript resolves the SDK file-tree subpath correctly.
+- Claude Agent worktree sessions no longer list project skills and commands twice.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -125,7 +125,12 @@ import { registerDatabaseBrowserSqliteHandlers } from './ipc/DatabaseBrowserSqli
 import { registerMigrationHandlers } from './ipc/MigrationHandlers';
 import { registerTerminalHandlers, shutdownTerminalHandlers } from './ipc/TerminalHandlers';
 import { AIService } from './services/ai/AIService';
-import { detectFileWorkspace, suggestWorkspaceForFile, getAdditionalDirectoriesForWorkspace } from './utils/workspaceDetection';
+import {
+  detectFileWorkspace,
+  suggestWorkspaceForFile,
+  getAdditionalDirectoriesForWorkspace,
+  getClaudeAdditionalDirectoriesForWorkspace,
+} from './utils/workspaceDetection';
 import {
   getExternalAttachmentStagingDirectory,
   resolveWorkspaceAttachmentStagingDirectory,
@@ -2052,16 +2057,10 @@ app.whenReady().then(async () => {
       });
     }
 
-    // Inject additional directories loader. Adds the parent project root and
-    // sibling worktrees so agents can read shared configs, traverse the .git
-    // common dir from a worktree, and (for Codex) escape its workspace-write
-    // sandbox when an orchestrator session needs to edit sibling worktrees.
-    // Issue #37 problem 1.
-    // Claude opts out of sibling worktrees: the Claude CLI loads .claude/commands
-    // skills from every additional directory, so N worktrees = N duplicate
-    // copies of every project skill in the system prompt (~7K tokens wasted per
-    // session). Claude has no Codex-style sandbox; cross-worktree file access
-    // still works through the normal permission flow.
+    // Codex keeps parent/sibling roots for its workspace-write sandbox. Claude
+    // filters every checkout of the current project because its binary discovers
+    // the same commands and skills from each additional root. Both providers
+    // retain the external attachment-staging directory added by current upstream.
     const withAttachmentStagingDirectory = (workspacePath: string, directories: string[]) => {
       const attachmentDirectory = getExternalAttachmentStagingDirectory(workspacePath);
       return attachmentDirectory
@@ -2071,7 +2070,7 @@ app.whenReady().then(async () => {
     ClaudeCodeProvider.setAdditionalDirectoriesLoader((workspacePath: string) =>
       withAttachmentStagingDirectory(
         workspacePath,
-        getAdditionalDirectoriesForWorkspace(workspacePath, { includeSiblingWorktrees: false }),
+        getClaudeAdditionalDirectoriesForWorkspace(workspacePath),
       ));
     OpenAICodexProvider.setAdditionalDirectoriesLoader((workspacePath: string) =>
       withAttachmentStagingDirectory(workspacePath, getAdditionalDirectoriesForWorkspace(workspacePath)));

--- a/packages/electron/src/main/mcp/__tests__/mcpWorkspaceResolver.worktree.test.ts
+++ b/packages/electron/src/main/mcp/__tests__/mcpWorkspaceResolver.worktree.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const mocks = vi.hoisted(() => ({
+  findWindowByWorkspace: vi.fn(),
+  getByPath: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromId: vi.fn() },
+}));
+
+vi.mock('../../window/WindowManager', () => ({
+  findWindowByWorkspace: mocks.findWindowByWorkspace,
+}));
+
+vi.mock('../../database/initialize', () => ({
+  getDatabase: vi.fn(() => ({})),
+}));
+
+vi.mock('../../services/WorktreeStore', () => ({
+  createWorktreeStore: vi.fn(() => ({ getByPath: mocks.getByPath })),
+}));
+
+vi.mock('../backendToolRegistry', () => ({
+  getBackendTools: vi.fn(() => []),
+  getVoiceEnabledBackendTools: vi.fn(() => []),
+}));
+
+import {
+  findWindowIdForWorkspacePath,
+  workspaceToWindowMap,
+} from '../mcpWorkspaceResolver';
+
+function createLinkedWorktree(mainRepoPath: string, worktreePath: string, worktreeName: string): void {
+  fs.mkdirSync(path.join(mainRepoPath, '.git'), { recursive: true });
+  const registrationDir = path.join(mainRepoPath, '.git', 'worktrees', worktreeName);
+  fs.mkdirSync(registrationDir, { recursive: true });
+  fs.mkdirSync(worktreePath, { recursive: true });
+  fs.writeFileSync(path.join(worktreePath, '.git'), `gitdir: ${registrationDir}\n`);
+  fs.writeFileSync(path.join(registrationDir, 'gitdir'), `${path.join(worktreePath, '.git')}\n`);
+}
+
+describe('findWindowIdForWorkspacePath linked-worktree fallback', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nim-mcp-worktree-route-'));
+    workspaceToWindowMap.clear();
+    mocks.findWindowByWorkspace.mockReset();
+    mocks.getByPath.mockReset();
+    mocks.getByPath.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    workspaceToWindowMap.clear();
+  });
+
+  it('routes a valid out-of-tree linked worktree to its already-open parent project window without WorktreeStore', async () => {
+    const projectPath = path.join(tmpRoot, 'project');
+    const worktreePath = path.join(tmpRoot, 'dedicated-volume', 'external-worktree');
+    createLinkedWorktree(projectPath, worktreePath, 'external-worktree');
+    const canonicalProjectPath = fs.realpathSync.native(projectPath);
+    const parentWindow = { id: 47, isDestroyed: () => false };
+    mocks.findWindowByWorkspace.mockImplementation((workspacePath: string) =>
+      workspacePath === canonicalProjectPath ? parentWindow : null,
+    );
+
+    await expect(findWindowIdForWorkspacePath(worktreePath)).resolves.toBe(47);
+
+    expect(mocks.findWindowByWorkspace).toHaveBeenCalledWith(worktreePath);
+    expect(mocks.findWindowByWorkspace).toHaveBeenCalledWith(canonicalProjectPath);
+    expect(workspaceToWindowMap.get(canonicalProjectPath)).toBe(47);
+    expect(mocks.getByPath).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for a forged worktree pointer and never routes it to the victim project window', async () => {
+    const victimProjectPath = path.join(tmpRoot, 'victim');
+    const legitimateWorktreePath = path.join(tmpRoot, 'legitimate-worktree');
+    createLinkedWorktree(victimProjectPath, legitimateWorktreePath, 'legitimate');
+    const forgedPath = path.join(tmpRoot, 'attacker');
+    fs.mkdirSync(forgedPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(forgedPath, '.git'),
+      `gitdir: ${path.join(victimProjectPath, '.git', 'worktrees', 'legitimate')}\n`,
+    );
+    const canonicalVictimPath = fs.realpathSync.native(victimProjectPath);
+    mocks.findWindowByWorkspace.mockImplementation((workspacePath: string) =>
+      workspacePath === canonicalVictimPath ? { id: 91, isDestroyed: () => false } : null,
+    );
+
+    await expect(findWindowIdForWorkspacePath(forgedPath)).resolves.toBeNull();
+
+    expect(mocks.findWindowByWorkspace).not.toHaveBeenCalledWith(canonicalVictimPath);
+    expect(workspaceToWindowMap.has(canonicalVictimPath)).toBe(false);
+  });
+
+  it('fails closed for a stale registration without a back-pointer', async () => {
+    const projectPath = path.join(tmpRoot, 'project');
+    const registrationDir = path.join(projectPath, '.git', 'worktrees', 'stale');
+    const stalePath = path.join(tmpRoot, 'stale-worktree');
+    fs.mkdirSync(registrationDir, { recursive: true });
+    fs.mkdirSync(stalePath, { recursive: true });
+    fs.writeFileSync(path.join(stalePath, '.git'), `gitdir: ${registrationDir}\n`);
+    const canonicalProjectPath = fs.realpathSync.native(projectPath);
+    mocks.findWindowByWorkspace.mockImplementation((workspacePath: string) =>
+      workspacePath === canonicalProjectPath ? { id: 99, isDestroyed: () => false } : null,
+    );
+
+    await expect(findWindowIdForWorkspacePath(stalePath)).resolves.toBeNull();
+
+    expect(mocks.findWindowByWorkspace).not.toHaveBeenCalledWith(canonicalProjectPath);
+    expect(workspaceToWindowMap.has(canonicalProjectPath)).toBe(false);
+  });
+});

--- a/packages/electron/src/main/mcp/mcpWorkspaceResolver.ts
+++ b/packages/electron/src/main/mcp/mcpWorkspaceResolver.ts
@@ -6,6 +6,7 @@ import {
   getVoiceEnabledBackendTools as registryGetVoiceBackendTools,
   type BackendToolDefinition,
 } from "./backendToolRegistry";
+import { isWorktreePath, resolveProjectPath } from "../utils/workspaceDetection";
 
 // Store document state PER SESSION to avoid cross-window contamination
 export const documentStateBySession = new Map<string, any>();
@@ -60,6 +61,25 @@ export async function findWindowIdForWorkspacePath(
     // Cache the mapping for future lookups
     workspaceToWindowMap.set(workspacePath, targetWindow.id);
     return targetWindow.id;
+  }
+
+  // A valid linked worktree may have been created outside Nimbalyst (and thus
+  // be absent from WorktreeStore). Git metadata is still a stronger identity
+  // source than a missing UI record. Resolve only verified linked worktrees
+  // and route them to an already-open parent project; never fall back to a
+  // lexical path convention or a different project window.
+  if (isWorktreePath(workspacePath)) {
+    const projectPath = resolveProjectPath(workspacePath);
+    worktreeToProjectPathCache.set(workspacePath, projectPath);
+    windowId = workspaceToWindowMap.get(projectPath);
+    if (windowId !== undefined) {
+      return windowId;
+    }
+    targetWindow = findWindowByWorkspace(projectPath);
+    if (targetWindow && !targetWindow.isDestroyed()) {
+      workspaceToWindowMap.set(projectPath, targetWindow.id);
+      return targetWindow.id;
+    }
   }
 
   // Check if this might be a worktree path

--- a/packages/electron/src/main/services/GitWorktreeService.ts
+++ b/packages/electron/src/main/services/GitWorktreeService.ts
@@ -252,10 +252,17 @@ export class GitWorktreeService {
   private async createWorktreeImpl(workspacePath: string, options: CreateWorktreeOptions): Promise<Worktree> {
     logger.info('Creating worktree', { workspacePath, options });
 
-    // Ensure this is a git repository
+    // A canonical workspace can intentionally keep a bare repository in
+    // <workspace>/.git while using the workspace as its explicit work tree.
+    // simple-git's checkIsRepo() rejects that arrangement because its cwd is
+    // not itself a Git work tree, so identify it narrowly and pass the Git
+    // directory/work-tree pair to every creation command.
     const git: SimpleGit = simpleGit(workspacePath);
-    const isRepo = await git.checkIsRepo();
-    if (!isRepo) {
+    const gitDir = path.join(workspacePath, '.git');
+    const isStandardRepo = await git.checkIsRepo();
+    const usesBareGitDir = !isStandardRepo && await this.isBareGitDir(gitDir);
+
+    if (!isStandardRepo && !usesBareGitDir) {
       throw new Error(`Not a git repository: ${workspacePath}`);
     }
 
@@ -267,9 +274,21 @@ export class GitWorktreeService {
     let baseBranch: string;
     if (options.baseBranch) {
       baseBranch = options.baseBranch;
+    } else if (usesBareGitDir) {
+      // A bare Git directory has no safe implicit checked-out branch for the
+      // workspace. Requiring an explicit ref prevents accidentally basing a
+      // new worktree on an arbitrary symbolic HEAD.
+      throw new Error(`baseBranch is required for bare Git workspace: ${workspacePath}`);
     } else {
       // Get the current branch of the repo root
       baseBranch = await this.getCurrentBranch(git);
+    }
+
+    const gitPrefix = usesBareGitDir ? [`--git-dir=${gitDir}`, `--work-tree=${workspacePath}`] : [];
+    try {
+      await git.raw([...gitPrefix, 'rev-parse', '--verify', `${baseBranch}^{commit}`]);
+    } catch (error) {
+      throw new Error(`Invalid baseBranch '${baseBranch}' for ${workspacePath}: ${error instanceof Error ? error.message : String(error)}`);
     }
     logger.info('Using base branch', { baseBranch });
 
@@ -307,7 +326,7 @@ export class GitWorktreeService {
     try {
       // Create the worktree with a new branch
       logger.info('Creating git worktree', { worktreePath, branchName, baseBranch });
-      await git.raw(['worktree', 'add', '-b', branchName, worktreePath, baseBranch]);
+      await git.raw([...gitPrefix, 'worktree', 'add', '-b', branchName, worktreePath, baseBranch]);
 
       logger.info('Worktree created successfully', { worktreePath });
 
@@ -337,6 +356,24 @@ export class GitWorktreeService {
       }
 
       throw new Error(`Failed to create worktree: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * Returns true only for the intentional <workspace>/.git bare-directory
+   * layout. A missing .git path, .git file, or non-bare repository remains
+   * fail-closed and is handled by the normal repository path.
+   */
+  private async isBareGitDir(gitDir: string): Promise<boolean> {
+    try {
+      if (!fs.statSync(gitDir).isDirectory()) {
+        return false;
+      }
+
+      const gitDirClient = simpleGit(gitDir);
+      return (await gitDirClient.raw(['rev-parse', '--is-bare-repository'])).trim() === 'true';
+    } catch {
+      return false;
     }
   }
 

--- a/packages/electron/src/main/services/__tests__/GitWorktreeService.bareWorkspace.test.ts
+++ b/packages/electron/src/main/services/__tests__/GitWorktreeService.bareWorkspace.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { GitWorktreeService } from '../GitWorktreeService';
+
+const temporaryRoots: string[] = [];
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function createBareWorkspace(): { root: string; workspace: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nimbalyst-bare-worktree-'));
+  temporaryRoots.push(root);
+  const seed = path.join(root, 'seed');
+  const workspace = path.join(root, 'workspace');
+
+  fs.mkdirSync(seed, { recursive: true });
+  git(['init', '--initial-branch=main'], seed);
+  git(['config', 'user.email', 'test@nimbalyst.local'], seed);
+  git(['config', 'user.name', 'Nimbalyst Test'], seed);
+  fs.writeFileSync(path.join(seed, 'README.md'), 'seed\n');
+  git(['add', 'README.md'], seed);
+  git(['commit', '-m', 'seed'], seed);
+
+  fs.mkdirSync(workspace, { recursive: true });
+  git(['init', '--bare', path.join(workspace, '.git')], root);
+  git(['remote', 'add', 'origin', seed], path.join(workspace, '.git'));
+  git(['fetch', 'origin', 'main:main'], path.join(workspace, '.git'));
+  git(['symbolic-ref', 'HEAD', 'refs/heads/main'], path.join(workspace, '.git'));
+
+  return { root, workspace };
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('GitWorktreeService bare workspace support', () => {
+  it('creates a worktree from an explicit base ref when .git is intentionally bare', async () => {
+    const { workspace } = createBareWorkspace();
+    const service = new GitWorktreeService();
+
+    const worktree = await service.createWorktree(workspace, {
+      name: 'explicit-base',
+      baseBranch: 'main',
+    });
+
+    expect(worktree.baseBranch).toBe('main');
+    expect(worktree.branch).toBe('worktree/explicit-base');
+    expect(fs.existsSync(path.join(worktree.path, '.git'))).toBe(true);
+    expect(git(['rev-parse', '--abbrev-ref', 'HEAD'], worktree.path).trim()).toBe('worktree/explicit-base');
+  });
+
+  it('fails closed without an explicit base ref for a bare workspace', async () => {
+    const { workspace } = createBareWorkspace();
+    const service = new GitWorktreeService();
+
+    await expect(service.createWorktree(workspace, { name: 'missing-base' }))
+      .rejects.toThrow(`baseBranch is required for bare Git workspace: ${workspace}`);
+  });
+});

--- a/packages/electron/src/main/utils/__tests__/workspaceDetection.test.ts
+++ b/packages/electron/src/main/utils/__tests__/workspaceDetection.test.ts
@@ -8,7 +8,9 @@ import {
   clearWorktreeIdentityCache,
   findNearestAncestor,
   findProjectRoot,
+  filterClaudeCatalogDuplicateDirectories,
   getAdditionalDirectoriesForWorkspace,
+  getClaudeAdditionalDirectoriesForWorkspace,
 } from '../workspaceDetection';
 
 /**
@@ -205,9 +207,8 @@ describe('getAdditionalDirectoriesForWorkspace', () => {
   let worktreesDir: string;
 
   beforeEach(() => {
-    // Real filesystem fixture so the sync fs.readdirSync path is exercised
-    // end-to-end. The function is called from a synchronous loader and must
-    // tolerate a missing _worktrees dir without blowing up.
+    // Real filesystem fixture so the synchronous Git-registration scan is
+    // exercised end-to-end without needing a Git executable on PATH.
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nim-add-dirs-'));
     projectPath = path.join(tmpRoot, 'project');
     fs.mkdirSync(projectPath);
@@ -223,35 +224,42 @@ describe('getAdditionalDirectoriesForWorkspace', () => {
   });
 
   it('returns sibling worktree paths when called from the parent project root', () => {
-    fs.mkdirSync(worktreesDir);
-    fs.mkdirSync(path.join(worktreesDir, 'proud-gorge'));
-    fs.mkdirSync(path.join(worktreesDir, 'swift-falcon'));
+    const externalWorktreesDir = path.join(tmpRoot, 'dedicated-worktree-volume');
+    const proudGorge = path.join(worktreesDir, 'proud-gorge');
+    const swiftFalcon = path.join(externalWorktreesDir, 'swift-falcon');
+    createLinkedWorktree(projectPath, proudGorge, 'proud-gorge');
+    createLinkedWorktree(projectPath, swiftFalcon, 'swift-falcon');
 
     const dirs = getAdditionalDirectoriesForWorkspace(projectPath);
     expect(dirs.sort()).toEqual([
-      path.join(worktreesDir, 'proud-gorge'),
-      path.join(worktreesDir, 'swift-falcon'),
+      fs.realpathSync.native(proudGorge),
+      fs.realpathSync.native(swiftFalcon),
     ].sort());
   });
 
   it('returns the parent project plus other sibling worktrees when called from a worktree', () => {
-    fs.mkdirSync(worktreesDir);
     const cwd = path.join(worktreesDir, 'proud-gorge');
     createLinkedWorktree(projectPath, cwd, 'proud-gorge');
-    fs.mkdirSync(path.join(worktreesDir, 'swift-falcon'));
+    const externalSibling = path.join(tmpRoot, 'other-volume', 'swift-falcon');
+    createLinkedWorktree(projectPath, externalSibling, 'swift-falcon');
 
     const dirs = getAdditionalDirectoriesForWorkspace(cwd);
     expect(dirs.sort()).toEqual([
       fs.realpathSync.native(projectPath),
-      path.join(fs.realpathSync.native(worktreesDir), 'swift-falcon'),
+      fs.realpathSync.native(externalSibling),
     ].sort());
     // The current worktree itself must not appear -- it is already the
     // workingDirectory, and re-listing it would just add noise.
     expect(dirs).not.toContain(cwd);
   });
 
-  it('survives a missing _worktrees directory', () => {
-    // No worktrees dir created. Should not throw, just return empty.
+  it('survives a project with no registered worktrees', () => {
+    // No .git/worktrees directory created. Should not throw, just return empty.
+    expect(getAdditionalDirectoriesForWorkspace(projectPath)).toEqual([]);
+  });
+
+  it('does not grant access to an arbitrary directory in a conventional worktrees folder', () => {
+    fs.mkdirSync(path.join(worktreesDir, 'unverified-directory'), { recursive: true });
     expect(getAdditionalDirectoriesForWorkspace(projectPath)).toEqual([]);
   });
 
@@ -259,9 +267,8 @@ describe('getAdditionalDirectoriesForWorkspace', () => {
     // The Claude Code loader opts out: the CLI discovers .claude/commands
     // skills in every additional directory, so N sibling worktrees inflate the
     // system prompt with N duplicate copies of every project skill.
-    fs.mkdirSync(worktreesDir);
-    fs.mkdirSync(path.join(worktreesDir, 'proud-gorge'));
-    fs.mkdirSync(path.join(worktreesDir, 'swift-falcon'));
+    createLinkedWorktree(projectPath, path.join(worktreesDir, 'proud-gorge'), 'proud-gorge');
+    createLinkedWorktree(projectPath, path.join(tmpRoot, 'other-volume', 'swift-falcon'), 'swift-falcon');
 
     const dirs = getAdditionalDirectoriesForWorkspace(projectPath, {
       includeSiblingWorktrees: false,
@@ -270,10 +277,9 @@ describe('getAdditionalDirectoriesForWorkspace', () => {
   });
 
   it('keeps the parent project but drops siblings when includeSiblingWorktrees is false (worktree)', () => {
-    fs.mkdirSync(worktreesDir);
     const cwd = path.join(worktreesDir, 'proud-gorge');
     createLinkedWorktree(projectPath, cwd, 'proud-gorge');
-    fs.mkdirSync(path.join(worktreesDir, 'swift-falcon'));
+    createLinkedWorktree(projectPath, path.join(tmpRoot, 'other-volume', 'swift-falcon'), 'swift-falcon');
 
     const dirs = getAdditionalDirectoriesForWorkspace(cwd, {
       includeSiblingWorktrees: false,
@@ -283,18 +289,181 @@ describe('getAdditionalDirectoriesForWorkspace', () => {
   });
 });
 
+describe('Claude workflow catalog directory scopes', () => {
+  let tmpRoot: string;
+  let projectPath: string;
+  let worktreePath: string;
+
+  const writeCommand = (root: string, name: string) => {
+    const commandDir = path.join(root, '.claude', 'commands');
+    fs.mkdirSync(commandDir, { recursive: true });
+    fs.writeFileSync(path.join(commandDir, `${name}.md`), `---\ndescription: ${name}\n---\n`);
+  };
+
+  const writeSkill = (root: string, name: string) => {
+    const skillDir = path.join(root, '.claude', 'skills', name);
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `---\nname: ${name}\ndescription: ${name}\n---\n`);
+  };
+
+  const collectCatalog = (roots: string[]) => roots.flatMap((root) => {
+    const entries: Array<{ kind: 'command' | 'skill'; name: string; sourceRoot: string }> = [];
+    const commandsDir = path.join(root, '.claude', 'commands');
+    if (fs.existsSync(commandsDir)) {
+      for (const entry of fs.readdirSync(commandsDir, { withFileTypes: true })) {
+        if (entry.isFile() && entry.name.endsWith('.md')) {
+          entries.push({ kind: 'command', name: path.basename(entry.name, '.md'), sourceRoot: root });
+        }
+      }
+    }
+    const skillsDir = path.join(root, '.claude', 'skills');
+    if (fs.existsSync(skillsDir)) {
+      for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+        if (entry.isDirectory() && fs.existsSync(path.join(skillsDir, entry.name, 'SKILL.md'))) {
+          entries.push({ kind: 'skill', name: entry.name, sourceRoot: root });
+        }
+      }
+    }
+    return entries;
+  });
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nim-claude-catalog-scopes-'));
+    projectPath = path.join(tmpRoot, 'project');
+    worktreePath = path.join(tmpRoot, 'project_worktrees', 'fresh-worktree');
+    // Worktree identity is git-metadata-based (see createLinkedWorktree above), not the
+    // lexical `<project>_worktrees/<name>` naming convention alone -- a bare directory at
+    // that path is no longer recognized as a worktree.
+    createLinkedWorktree(projectPath, worktreePath, 'fresh-worktree');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    clearWorktreeIdentityCache();
+  });
+
+  it('keeps one project catalog for both main-checkout and worktree Claude sessions', () => {
+    for (const root of [projectPath, worktreePath]) {
+      writeCommand(root, 'repair');
+      writeSkill(root, 'review');
+    }
+
+    const previousWorktreeRoots = [
+      worktreePath,
+      ...getAdditionalDirectoriesForWorkspace(worktreePath, { includeSiblingWorktrees: false }),
+    ];
+    const previousWorktreeCatalog = collectCatalog(previousWorktreeRoots);
+    expect(previousWorktreeCatalog).toHaveLength(4);
+    expect(previousWorktreeCatalog.map(({ kind, name }) => `${kind}:${name}`)).toEqual([
+      'command:repair',
+      'skill:review',
+      'command:repair',
+      'skill:review',
+    ]);
+
+    const mainCatalog = collectCatalog([
+      projectPath,
+      ...getClaudeAdditionalDirectoriesForWorkspace(projectPath),
+    ]);
+    const worktreeCatalog = collectCatalog([
+      worktreePath,
+      ...getClaudeAdditionalDirectoriesForWorkspace(worktreePath),
+    ]);
+
+    expect(mainCatalog.map(({ kind, name }) => `${kind}:${name}`)).toEqual([
+      'command:repair',
+      'skill:review',
+    ]);
+    expect(worktreeCatalog.map(({ kind, name }) => `${kind}:${name}`)).toEqual([
+      'command:repair',
+      'skill:review',
+    ]);
+  });
+
+  it('dedups a registered worktree at a NON-convention path, in both directions', () => {
+    // Real registered worktree, but NOT under `<project>_worktrees/<name>` -- this
+    // machine's actual worktree volumes (D:/nimbalyst-worktrees, D:/claude-worktrees)
+    // use a hyphen and live outside the project directory entirely. F (PR #13)
+    // deliberately made worktree discovery git-metadata-based, not path-lexical, so
+    // dedup must recognize this via registration, not the `_worktrees` naming guess.
+    const offConventionWorktree = path.join(tmpRoot, 'external-worktree-volume', 'unrelated-dir-name');
+    createLinkedWorktree(projectPath, offConventionWorktree, 'unrelated-dir-name');
+
+    for (const root of [projectPath, offConventionWorktree]) {
+      writeCommand(root, 'repair');
+      writeSkill(root, 'review');
+    }
+
+    const mainCatalog = collectCatalog([
+      projectPath,
+      ...getClaudeAdditionalDirectoriesForWorkspace(projectPath),
+    ]);
+    const worktreeCatalog = collectCatalog([
+      offConventionWorktree,
+      ...getClaudeAdditionalDirectoriesForWorkspace(offConventionWorktree),
+    ]);
+
+    expect(mainCatalog.map(({ kind, name }) => `${kind}:${name}`)).toEqual([
+      'command:repair',
+      'skill:review',
+    ]);
+    expect(worktreeCatalog.map(({ kind, name }) => `${kind}:${name}`)).toEqual([
+      'command:repair',
+      'skill:review',
+    ]);
+  });
+
+  it('preserves same-looking entries from a distinct source while removing same-project scopes', () => {
+    const siblingPath = path.join(tmpRoot, 'project_worktrees', 'sibling');
+    const externalRoot = path.join(tmpRoot, 'external-workflows');
+    // Real registered sibling worktree of the same parent project (not just a
+    // lexically-named bare directory -- see the off-convention test above for why).
+    createLinkedWorktree(projectPath, siblingPath, 'sibling');
+    fs.mkdirSync(externalRoot, { recursive: true });
+
+    writeCommand(worktreePath, 'review');
+    writeCommand(projectPath, 'review');
+    writeCommand(siblingPath, 'review');
+    writeSkill(externalRoot, 'review');
+
+    const filtered = filterClaudeCatalogDuplicateDirectories(worktreePath, [
+      projectPath,
+      siblingPath,
+      externalRoot,
+    ]);
+    expect(filtered).toEqual([externalRoot]);
+
+    const catalog = collectCatalog([worktreePath, ...filtered]);
+    expect(catalog.map(({ kind, name }) => `${kind}:${name}`)).toEqual([
+      'command:review',
+      'skill:review',
+    ]);
+  });
+
+  it('normalizes Windows case and separators when comparing catalog provenance', () => {
+    expect(filterClaudeCatalogDuplicateDirectories(
+      'C:\\Repos\\Project_worktrees\\Fresh',
+      [
+        'c:/repos/project',
+        'C:\\REPOS\\PROJECT_WORKTREES\\Sibling',
+        'D:\\Repos\\Project',
+      ],
+    )).toEqual(['D:\\Repos\\Project']);
+  });
+});
+
 describe('findNearestAncestor', () => {
-  const trusted = new Set(['/path/to/project']);
+  const project = path.join(path.sep, 'path', 'to', 'project');
+  const trusted = new Set([project]);
   const pred = (dir: string) => trusted.has(dir);
 
   it('returns the start path itself when it matches', () => {
-    expect(findNearestAncestor('/path/to/project', pred)).toBe('/path/to/project');
+    expect(findNearestAncestor(project, pred)).toBe(project);
   });
 
   it('walks up to the nearest matching ancestor (subfolder cascade)', () => {
-    expect(findNearestAncestor('/path/to/project/packages/electron', pred))
-      .toBe('/path/to/project');
-    expect(findNearestAncestor('/path/to/project/src', pred)).toBe('/path/to/project');
+    expect(findNearestAncestor(path.join(project, 'packages', 'electron'), pred)).toBe(project);
+    expect(findNearestAncestor(path.join(project, 'src'), pred)).toBe(project);
   });
 
   it('returns null when no ancestor matches', () => {
@@ -302,34 +471,39 @@ describe('findNearestAncestor', () => {
   });
 
   it('returns the most specific matching ancestor when several match', () => {
-    const t2 = new Set(['/a', '/a/b/c']);
-    expect(findNearestAncestor('/a/b/c/d', (d) => t2.has(d))).toBe('/a/b/c');
+    const root = path.join(path.sep, 'a');
+    const nested = path.join(root, 'b', 'c');
+    const t2 = new Set([root, nested]);
+    expect(findNearestAncestor(path.join(nested, 'd'), (d) => t2.has(d))).toBe(nested);
   });
 
   it('handles empty input and trailing slashes', () => {
     expect(findNearestAncestor('', pred)).toBe(null);
-    expect(findNearestAncestor('/path/to/project/packages/', pred)).toBe('/path/to/project');
+    expect(findNearestAncestor(`${path.join(project, 'packages')}${path.sep}`, pred)).toBe(project);
   });
 
   describe('stopAt boundary', () => {
     it('still returns a match found at or below the boundary', () => {
       // boundary === the matching ancestor: it is tested, then the walk stops.
-      expect(findNearestAncestor('/path/to/project/src', pred, '/path/to/project'))
-        .toBe('/path/to/project');
+      expect(findNearestAncestor(path.join(project, 'src'), pred, project)).toBe(project);
     });
 
     it('does NOT climb past the boundary to a higher match', () => {
       // A trusted grandparent must not be inherited when a nearer boundary caps
       // the walk - this is the trust-boundary guard for nested projects.
-      const t = new Set(['/root']);
+      const root = path.join(path.sep, 'root');
+      const child = path.join(root, 'child');
+      const t = new Set([root]);
       const p = (d: string) => t.has(d);
-      expect(findNearestAncestor('/root/child/leaf', p, '/root/child')).toBe(null);
+      expect(findNearestAncestor(path.join(child, 'leaf'), p, child)).toBe(null);
     });
 
     it('returns the nearer match even when a farther one also matches', () => {
-      const t = new Set(['/root', '/root/child']);
+      const root = path.join(path.sep, 'root');
+      const child = path.join(root, 'child');
+      const t = new Set([root, child]);
       const p = (d: string) => t.has(d);
-      expect(findNearestAncestor('/root/child/leaf', p, '/root/child')).toBe('/root/child');
+      expect(findNearestAncestor(path.join(child, 'leaf'), p, child)).toBe(child);
     });
   });
 });

--- a/packages/electron/src/main/utils/workspaceDetection.ts
+++ b/packages/electron/src/main/utils/workspaceDetection.ts
@@ -534,13 +534,8 @@ export function ensureExtensionSDKDocsTrusted(docsPath: string): void {
  * - Sibling worktrees (unless opted out — see includeSiblingWorktrees)
  *
  * @param workspacePath - The current workspace path
- * @param options.includeSiblingWorktrees - default true. The Claude Code
- *   loader passes false: the Claude CLI discovers `.claude/commands` skills in
- *   every additional directory, so with N sibling worktrees every project
- *   skill appears N+1 times in the system prompt (~7K tokens of duplicates per
- *   session in a many-worktree repo). Codex keeps true — its workspace-write
- *   sandbox blocks sibling-worktree edits without `--add-dir`, and it loads no
- *   skills from those directories.
+ * @param options.includeSiblingWorktrees - default true. Providers with no
+ *   cross-worktree sandbox requirement may opt out.
  * @returns Array of additional directory paths the agent should have access to
  */
 export function getAdditionalDirectoriesForWorkspace(
@@ -584,27 +579,140 @@ export function getAdditionalDirectoriesForWorkspace(
   return Array.from(additionalDirs);
 }
 
+function canonicalCatalogPathIdentity(targetPath: string): string {
+  const isWindowsPath = /^[A-Za-z]:[\\/]/.test(targetPath) || /^[\\/]{2}/.test(targetPath);
+  const pathApi = isWindowsPath ? path.win32 : path;
+  const resolved = pathApi.resolve(targetPath);
+  const root = pathApi.parse(resolved).root;
+  const withoutTrailingSeparators = resolved.length > root.length
+    ? resolved.replace(/[\\/]+$/, '')
+    : resolved;
+  const separatorNormalized = withoutTrailingSeparators.replace(/\\/g, '/');
+
+  // Windows path identity is case-insensitive even when a fixture is executed
+  // on a non-Windows host. POSIX paths retain case sensitivity.
+  return isWindowsPath ? separatorNormalized.toLowerCase() : separatorNormalized;
+}
+
+function resolveCatalogProjectPath(targetPath: string): string {
+  // Real git-metadata-based resolution (resolveProjectPath -> resolveWorktreeIdentity)
+  // is authoritative whenever the path actually exists on this filesystem -- it
+  // recognizes a registered worktree at ANY location, not just the lexical
+  // `<project>_worktrees/<name>` convention (e.g. this machine's real worktrees at
+  // D:/nimbalyst-worktrees, D:/claude-worktrees). The lexical regex below is a
+  // fallback ONLY for a synthetic Windows-style path string that cannot be checked
+  // on this host (a POSIX-hosted unit test simulating a Windows path).
+  if (fs.existsSync(targetPath)) {
+    return resolveProjectPath(targetPath);
+  }
+
+  const isWindowsPath = /^[A-Za-z]:[\\/]/.test(targetPath) || /^[\\/]{2}/.test(targetPath);
+  if (!isWindowsPath) {
+    return resolveProjectPath(targetPath);
+  }
+
+  const normalized = path.win32.normalize(targetPath).replace(/[\\/]+$/, '');
+  const worktreeMatch = normalized.match(/^(.+)_worktrees[\\/].+$/i);
+  return worktreeMatch ? worktreeMatch[1] : normalized;
+}
+
 /**
- * List full filesystem paths of every sibling worktree directory for a
- * project, following Nimbalyst's `<project>_worktrees/<name>` convention.
- * Returns an empty list if the worktrees directory does not exist or cannot
- * be read. Sync so it can be used from the synchronous additionalDirectories
- * loader contract.
+ * Remove Claude additional-directory scopes that point at another checkout of
+ * the current project. The Claude binary discovers project commands
+ * and skills from every additional directory, so a worktree cwd plus its parent
+ * checkout contributes the identical catalog twice. Compare canonical project
+ * provenance rather than command display names: unrelated directories (and
+ * plugin/provider-native catalogs, which use separate SDK options) remain.
+ */
+export function filterClaudeCatalogDuplicateDirectories(
+  workspacePath: string,
+  additionalDirectories: string[],
+): string[] {
+  const workspaceProjectIdentity = canonicalCatalogPathIdentity(resolveCatalogProjectPath(workspacePath));
+  const seenDirectoryIdentities = new Set<string>();
+
+  return additionalDirectories.filter((directory) => {
+    if (!directory) {
+      return false;
+    }
+
+    const directoryIdentity = canonicalCatalogPathIdentity(directory);
+    if (seenDirectoryIdentities.has(directoryIdentity)) {
+      return false;
+    }
+    seenDirectoryIdentities.add(directoryIdentity);
+
+    const directoryProjectIdentity = canonicalCatalogPathIdentity(resolveCatalogProjectPath(directory));
+    return directoryProjectIdentity !== workspaceProjectIdentity;
+  });
+}
+
+/**
+ * Additional directories safe to pass to Claude without re-importing the
+ * current project's workflow catalog. Codex keeps the broader writable-root
+ * list because its sandbox needs parent/sibling checkout access and does not
+ * use this Claude-specific discovery boundary.
+ */
+export function getClaudeAdditionalDirectoriesForWorkspace(workspacePath: string): string[] {
+  return filterClaudeCatalogDuplicateDirectories(
+    workspacePath,
+    getAdditionalDirectoriesForWorkspace(workspacePath, { includeSiblingWorktrees: false }),
+  );
+}
+
+/**
+ * List every verified linked worktree registered by this project, regardless
+ * of where its checkout lives on disk. Git records each linked worktree under
+ * `<project>/.git/worktrees/<name>/gitdir`; each registration is then checked
+ * again through resolveWorktreeIdentity so malformed, stale, forged, or
+ * submodule-like metadata fails closed.
+ *
+ * This deliberately replaces the old `<project>_worktrees/<name>` directory
+ * convention. A valid worktree may live elsewhere (for example on a dedicated
+ * D: worktree volume), while an arbitrary directory inside a conventionally
+ * named folder must never receive sibling-worktree access just from its name.
+ * The function remains synchronous because the provider loader is synchronous.
  */
 function listSiblingWorktreePaths(projectPath: string): string[] {
   if (!projectPath) {
     return [];
   }
-  const projectName = path.basename(projectPath);
-  const worktreesDir = path.resolve(projectPath, '..', `${projectName}_worktrees`);
-  if (!fs.existsSync(worktreesDir)) {
+  let canonicalProjectPath: string;
+  try {
+    canonicalProjectPath = fs.realpathSync.native(projectPath);
+  } catch {
     return [];
   }
+
+  const registrationsDir = path.join(canonicalProjectPath, '.git', 'worktrees');
+  if (!fs.existsSync(registrationsDir)) return [];
+
   try {
-    const entries = fs.readdirSync(worktreesDir, { withFileTypes: true });
-    return entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => path.join(worktreesDir, entry.name));
+    const siblingPaths = new Set<string>();
+    const registrations = fs.readdirSync(registrationsDir, { withFileTypes: true });
+    for (const registration of registrations) {
+      if (!registration.isDirectory()) continue;
+
+      try {
+        const gitdirPointer = fs.readFileSync(
+          path.join(registrationsDir, registration.name, 'gitdir'),
+          'utf8',
+        ).trim();
+        if (!gitdirPointer) continue;
+
+        const gitFilePath = path.isAbsolute(gitdirPointer)
+          ? gitdirPointer
+          : path.resolve(path.join(registrationsDir, registration.name), gitdirPointer);
+        const candidatePath = fs.realpathSync.native(path.dirname(gitFilePath));
+        const candidateIdentity = resolveWorktreeIdentity(candidatePath);
+        if (candidateIdentity.isWorktree && candidateIdentity.parentRoot === canonicalProjectPath) {
+          siblingPaths.add(candidateIdentity.canonical);
+        }
+      } catch {
+        // One stale registration must not hide the rest or expand access.
+      }
+    }
+    return Array.from(siblingPaths);
   } catch {
     return [];
   }

--- a/packages/runtime/src/ai/server/providers/__tests__/sdkOptionsBuilder.path.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/sdkOptionsBuilder.path.test.ts
@@ -12,6 +12,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 vi.mock('electron', () => ({
   app: {
@@ -30,6 +33,7 @@ vi.mock('../../../../electron/claudeCodeEnvironment', () => ({
 
 import { buildSdkOptions } from '../claudeCode/sdkOptionsBuilder';
 import { ClaudeCodeDeps } from '../claudeCode/dependencyInjection';
+import { getClaudeAdditionalDirectoriesForWorkspace } from '../../../../../../electron/src/main/utils/workspaceDetection';
 
 function makeDeps(overrides: Partial<Parameters<typeof buildSdkOptions>[0]> = {}) {
   return {
@@ -112,5 +116,50 @@ describe('buildSdkOptions PATH overlay (NIM-376)', () => {
     const { options } = await buildSdkOptions(makeDeps(), makeParams());
 
     expect(options.env.PATH).toBe('/usr/bin:/bin');
+  });
+});
+
+describe('buildSdkOptions Claude workflow catalog scopes (NIM-254)', () => {
+  let tmpRoot: string;
+  let projectPath: string;
+  let worktreePath: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nim-sdk-catalog-scopes-'));
+    projectPath = path.join(tmpRoot, 'project');
+    worktreePath = path.join(tmpRoot, 'project_worktrees', 'fresh-worktree');
+    fs.mkdirSync(projectPath, { recursive: true });
+    fs.mkdirSync(worktreePath, { recursive: true });
+    ClaudeCodeDeps.setAdditionalDirectoriesLoader(getClaudeAdditionalDirectoriesForWorkspace);
+    ClaudeCodeDeps.setExtensionPluginsLoader(async () => [
+      { type: 'local', path: path.join(tmpRoot, 'plugin-a') },
+      { type: 'local', path: path.join(tmpRoot, 'plugin-b') },
+    ]);
+    ClaudeCodeDeps.setClaudeCodeSettingsLoader(async () => ({
+      projectCommandsEnabled: true,
+      userCommandsEnabled: true,
+    }));
+  });
+
+  afterEach(() => {
+    ClaudeCodeDeps.setAdditionalDirectoriesLoader(null);
+    ClaudeCodeDeps.setExtensionPluginsLoader(null);
+    ClaudeCodeDeps.setClaudeCodeSettingsLoader(null);
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('passes one project discovery scope for both main and worktree sessions without hiding plugins', async () => {
+    const main = await buildSdkOptions(makeDeps(), makeParams({ workspacePath: projectPath }));
+    const worktree = await buildSdkOptions(makeDeps(), makeParams({ workspacePath: worktreePath }));
+
+    expect(main.options.cwd).toBe(projectPath);
+    expect(main.options.additionalDirectories).toBeUndefined();
+    expect(worktree.options.cwd).toBe(worktreePath);
+    expect(worktree.options.additionalDirectories).toBeUndefined();
+    expect(worktree.options.settingSources).toEqual(['local', 'user', 'project']);
+    expect(worktree.options.plugins).toEqual([
+      { type: 'local', path: path.join(tmpRoot, 'plugin-a') },
+      { type: 'local', path: path.join(tmpRoot, 'plugin-b') },
+    ]);
   });
 });


### PR DESCRIPTION
Replays verified linked-worktree routing, explicit bare-workspace refs, and Claude catalog deduplication onto current upstream as one collision-complete nine-path successor. The historical fixture-authored discovery patch is replaced by this Yogev-authored commit. Current upstream attachment staging and deny-rule wiring are preserved. Verification: four focused suites 48/48; attachment-staging suite 10/10; zero owned-path Electron or Runtime typecheck diagnostics; Semgrep security-audit zero findings/errors; diff check passes.

## Why this is worth merging

Worktree identity should come from Git's own metadata, not directory naming or duplicated agent catalogs. Resolving the registered worktree once prevents the same checkout from appearing as multiple execution targets, keeps session routing attached to the real repository, and avoids destructive operations being aimed through an inferred path.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
