### PR TITLE
fix(storage): bound session metadata growth

### DIFF
--- a/packages/electron/src/main/ipc/MigrationHandlers.ts
+++ b/packages/electron/src/main/ipc/MigrationHandlers.ts
@@ -25,8 +25,10 @@ import {
   getMigrationProxy,
   stopPeriodicBackupTimer,
 } from '../database/initialize';
+import { legacyPgliteDatabase } from '../database/PGLiteDatabaseWorker';
 import { resolveBackend, readBackendState, commitRollbackToPglite } from '../database/sqlite/BackendSelector';
 import { AnalyticsService } from '../services/analytics/AnalyticsService';
+import type { BackupPhysicalGrowthAssessment } from '../services/database/DatabaseBackupService';
 import * as fs from 'fs';
 
 let runningMigration = false;
@@ -59,6 +61,17 @@ export function registerMigrationHandlers(): void {
       const migratedDirs = fs
         .readdirSync(userDataPath)
         .filter((d) => d.startsWith('pglite-db.migrated-'));
+      let storageHealth: BackupPhysicalGrowthAssessment | null = null;
+      if (resolved.backend === 'pglite') {
+        const backupService = legacyPgliteDatabase.getBackupService();
+        if (backupService) {
+          try {
+            storageHealth = await backupService.assessPhysicalGrowth();
+          } catch (err) {
+            logger.main.warn('[Migration] Failed to read PGlite storage health:', err);
+          }
+        }
+      }
       return {
         success: true,
         activeBackend: resolved.backend,
@@ -68,6 +81,7 @@ export function registerMigrationHandlers(): void {
         migratedDirs,
         running: runningMigration,
         runningDryRun,
+        storageHealth,
       };
     } catch (err) {
       return { success: false, error: (err as Error).message };

--- a/packages/electron/src/main/services/PGLiteSessionStore.ts
+++ b/packages/electron/src/main/services/PGLiteSessionStore.ts
@@ -2,6 +2,7 @@
  * PGLite implementation of SessionStore interface from runtime package
  */
 
+import { isDeepStrictEqual } from 'node:util';
 import { toMillis } from '../utils/timestampUtils';
 import { parseJsonObjectColumn } from '../utils/jsonColumn';
 import {
@@ -494,8 +495,14 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
             );
             if (transition.changed) merged.activity = transition.metadata.activity;
           }
-          updates.push(`metadata = $${values.length + 1}`);
-          values.push(JSON.stringify(merged));
+          // JSONB object order is not meaningful and JSON serialization drops
+          // undefined object properties. Compare the canonical persisted value
+          // so repeated token/context snapshots do not create another dead tuple.
+          const persistedMerged = JSON.parse(JSON.stringify(merged)) as Record<string, any>;
+          if (!isDeepStrictEqual(existingMetadata, persistedMerged)) {
+            updates.push(`metadata = $${values.length + 1}`);
+            values.push(JSON.stringify(persistedMerged));
+          }
         }
       }
       if ((metadata as any).hasBeenNamed !== undefined) pushUpdate('has_been_named =', (metadata as any).hasBeenNamed);

--- a/packages/electron/src/main/services/__tests__/PGLiteSessionStore.test.ts
+++ b/packages/electron/src/main/services/__tests__/PGLiteSessionStore.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
+import { PGlite } from '@electric-sql/pglite';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
   createPGLiteSessionStore,
   getAllSessionsForSync,
@@ -302,6 +306,43 @@ describe('PGLiteSessionStore JSON-column read normalization', () => {
 });
 
 describe('PGLiteSessionStore.updateMetadata defense-in-depth', () => {
+  it('skips the durable metadata UPDATE when the canonical merged value is unchanged', async () => {
+    const persistedMetadata = {
+      tokenUsage: {
+        currentContext: { contextWindow: 200_000, tokens: 8 },
+        totalTokens: 16,
+        outputTokens: 4,
+        inputTokens: 12,
+      },
+    };
+    const incomingMetadata = {
+      tokenUsage: {
+        inputTokens: 12,
+        outputTokens: 4,
+        totalTokens: 16,
+        currentContext: { tokens: 8, contextWindow: 200_000 },
+      },
+    };
+    const calls: string[] = [];
+    const db = {
+      query: vi.fn(async (sql: string) => {
+        calls.push(sql);
+        if (/^SELECT metadata FROM ai_sessions/i.test(sql.trim())) {
+          return { rows: [{ metadata: persistedMetadata }] };
+        }
+        if (/^UPDATE ai_sessions/i.test(sql.trim())) {
+          return { rows: [{ metadata: incomingMetadata }] };
+        }
+        throw new Error(`Unexpected no-op metadata query: ${sql}`);
+      }),
+    };
+    const store = createPGLiteSessionStore(db as any);
+
+    await store.updateMetadata('s1', { metadata: incomingMetadata });
+
+    expect(calls.filter((sql) => /^UPDATE ai_sessions/i.test(sql.trim()))).toHaveLength(0);
+  });
+
   it('refuses to merge when metadata.metadata is a string and warns', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const db = {
@@ -331,6 +372,63 @@ describe('PGLiteSessionStore.updateMetadata defense-in-depth', () => {
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
+
+  it('keeps the physical session relation stable across 10,000 identical metadata updates', async () => {
+    const isolatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nim-session-growth-'));
+    const db = new PGlite({ dataDir: path.join(isolatedRoot, 'pglite-db') });
+    try {
+      const persistedMetadata = {
+        tokenUsage: {
+          currentContext: { contextWindow: 200_000, tokens: 8 },
+          totalTokens: 16,
+          outputTokens: 4,
+          inputTokens: 12,
+        },
+      };
+      const equivalentUpdate = {
+        tokenUsage: {
+          inputTokens: 12,
+          outputTokens: 4,
+          totalTokens: 16,
+          currentContext: { tokens: 8, contextWindow: 200_000 },
+        },
+      };
+      await db.exec(`
+        CREATE TABLE ai_sessions (
+          id TEXT PRIMARY KEY,
+          metadata JSONB DEFAULT '{}'
+        );
+      `);
+      await db.query(
+        'INSERT INTO ai_sessions (id, metadata) VALUES ($1, $2::jsonb)',
+        ['growth-session', JSON.stringify(persistedMetadata)],
+      );
+      const relationBytes = async (): Promise<number> => {
+        const { rows } = await db.query<{ bytes: string | number }>(
+          "SELECT pg_total_relation_size('ai_sessions') AS bytes",
+        );
+        return Number(rows[0]?.bytes) || 0;
+      };
+      const beforeBytes = await relationBytes();
+      const store = createPGLiteSessionStore(db as any);
+
+      for (let update = 0; update < 10_000; update += 1) {
+        await store.updateMetadata('growth-session', { metadata: equivalentUpdate });
+      }
+
+      const afterBytes = await relationBytes();
+      expect(beforeBytes).toBeGreaterThan(0);
+      expect(afterBytes).toBe(beforeBytes);
+      const { rows } = await db.query<{ metadata: Record<string, unknown> }>(
+        'SELECT metadata FROM ai_sessions WHERE id = $1',
+        ['growth-session'],
+      );
+      expect(rows[0]?.metadata).toEqual(persistedMetadata);
+    } finally {
+      await db.close();
+      fs.rmSync(isolatedRoot, { recursive: true, force: true });
+    }
+  }, 120_000);
 });
 
 describe('PGLiteSessionStore.updateMetadata nullable column clears', () => {

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -27,7 +27,10 @@ import { CLAUDE_CODE_SAFE_FALLBACK_MODEL } from '@nimbalyst/runtime/ai/modelCons
 import { reconcileClaudeCodeModels } from './claudeCodeModelReconcile';
 import { isModelEnabled } from './modelEnablementFilter';
 import { getSessionStateManager } from '@nimbalyst/runtime/ai/server/SessionStateManager';
-import { parseContextUsageMessage } from '@nimbalyst/runtime/ai/server/utils/contextUsage';
+import {
+  parseContextUsageMessage,
+  type ParsedContextUsage,
+} from '@nimbalyst/runtime/ai/server/utils/contextUsage';
 import { isBedrockToolSearchError } from '@nimbalyst/runtime/ai/server/utils/errorDetection';
 import { resolveEffortLevel, resolveThinkingMode } from '@nimbalyst/runtime/ai/server/effortLevels';
 import type { SessionStore } from '@nimbalyst/runtime';
@@ -146,6 +149,36 @@ import { ensureClaudeCliSession, claudeCliSessionSupportsPlugins } from './claud
 import { supportsWorkspaceSlashWorkflowProvider } from '../../../shared/agentWorkflowProviders';
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Build the durable /context snapshot without retaining provider markdown.
+ * Parsed counters/categories are sufficient to rehydrate the context meter;
+ * raw command output is transient and can otherwise amplify every metadata
+ * rewrite and backup.
+ */
+export function buildPersistedContextTokenUsage(
+  currentUsage: SessionData['tokenUsage'],
+  parsedUsage: ParsedContextUsage,
+): NonNullable<SessionData['tokenUsage']> {
+  const usage = currentUsage ?? {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
+  return {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    totalTokens: usage.totalTokens,
+    costUSD: usage.costUSD,
+    contextWindow: parsedUsage.contextWindow,
+    categories: parsedUsage.categories,
+    currentContext: {
+      tokens: parsedUsage.totalTokens,
+      contextWindow: parsedUsage.contextWindow,
+      categories: parsedUsage.categories,
+    },
+  };
+}
 
 // Debounced re-sync of the available-models list to mobile. The renderer can
 // send rapid providerSettings slices when toggling providers, so coalesce them
@@ -1788,30 +1821,10 @@ export class AIService {
           if (parsedUsage) {
             // Get current session to preserve cumulative tokens
             const currentSession = await this.sessionManager.loadSession(session.id, workspacePath);
-            const currentUsage = currentSession?.tokenUsage ?? {
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0
-            };
-
-            // Store /context data in currentContext (snapshot of context window)
-            // Preserve cumulative input/output tokens from modelUsage
-            const tokenUsage = {
-              inputTokens: currentUsage.inputTokens,
-              outputTokens: currentUsage.outputTokens,
-              totalTokens: currentUsage.totalTokens,
-              costUSD: currentUsage.costUSD,
-              // Legacy fields for backward compatibility
-              contextWindow: parsedUsage.contextWindow,
-              categories: parsedUsage.categories,
-              // New field for context window snapshot
-              currentContext: {
-                tokens: parsedUsage.totalTokens,
-                contextWindow: parsedUsage.contextWindow,
-                categories: parsedUsage.categories,
-                rawResponse: contextResponse  // Store raw markdown for display on session reload
-              }
-            };
+            const tokenUsage = buildPersistedContextTokenUsage(
+              currentSession?.tokenUsage,
+              parsedUsage,
+            );
 
             // Persist token usage to session metadata
             await this.sessionManager.updateSessionTokenUsage(session.id, tokenUsage);

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -121,6 +121,50 @@ import type { AIService } from './AIService';
 import type { HooklessAgentFileWatcher } from './HooklessAgentFileWatcher';
 import type { WorkspaceFileAttributionMode } from '../WorkspaceFileAttributionPolicy';
 
+type SessionTokenUsage = NonNullable<SessionData['tokenUsage']>;
+
+type MidTurnContextUsageSession = {
+  id: string;
+  tokenUsage?: SessionData['tokenUsage'];
+};
+
+/**
+ * Project a provider's mid-turn context snapshot without persisting it.
+ * Completion remains the durable token-usage boundary; per-chunk observations
+ * update only the live renderer and in-memory session.
+ */
+export function applyMidTurnContextUsage(params: {
+  session: MidTurnContextUsageSession;
+  contextFillTokens: number | undefined;
+  contextWindow: number | undefined;
+  send: (payload: { sessionId: string; tokenUsage: SessionTokenUsage }) => void;
+}): SessionTokenUsage | undefined {
+  const { session, contextFillTokens, contextWindow } = params;
+  if (contextFillTokens === undefined || !contextWindow) return undefined;
+
+  const updatedUsage: SessionTokenUsage = {
+    ...(session.tokenUsage ?? { inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+    contextWindow,
+    currentContext: { tokens: contextFillTokens, contextWindow },
+  };
+  params.send({ sessionId: session.id, tokenUsage: updatedUsage });
+  session.tokenUsage = updatedUsage;
+  return updatedUsage;
+}
+
+/**
+ * Legacy sessions may still carry raw `/context` markdown in currentContext.
+ * Completion is a durable boundary, so every fallback snapshot must discard
+ * that provider response before it is persisted again.
+ */
+export function sanitizePersistedCurrentContext(
+  currentContext: SessionTokenUsage['currentContext'],
+): SessionTokenUsage['currentContext'] {
+  if (!currentContext) return undefined;
+  const { rawResponse: _rawResponse, ...persistedContext } = currentContext;
+  return persistedContext;
+}
+
 function resolveWorkspaceFileAttributionMode(
   providerName: string,
   provider: AIProvider | null | undefined,
@@ -1527,40 +1571,12 @@ export class MessageStreamingHandler {
             // input/output counters -- those settle on the 'complete' chunk.
             const partialContextFill: number | undefined = chunk.contextFillTokens;
             const partialContextWindow = selectedModelContextWindow || session.tokenUsage?.contextWindow;
-            if (partialContextFill !== undefined && partialContextWindow) {
-              const currentUsage = session.tokenUsage ?? {
-                inputTokens: 0,
-                outputTokens: 0,
-                totalTokens: 0,
-              };
-              const updatedUsage: NonNullable<SessionData['tokenUsage']> = {
-                ...currentUsage,
-                contextWindow: partialContextWindow,
-                currentContext: { tokens: partialContextFill, contextWindow: partialContextWindow },
-              };
-
-              await this.svc.sessionManager.updateSessionTokenUsage(session.id, updatedUsage);
-              safeSend(event, 'ai:tokenUsageUpdated', {
-                sessionId: session.id,
-                tokenUsage: updatedUsage,
-              });
-
-              // Push live context usage to mobile sync
-              const syncProvider = getSyncProvider();
-              if (syncProvider) {
-                syncProvider.pushChange(session.id, {
-                  type: 'metadata_updated',
-                  metadata: {
-                    currentContext: {
-                      tokens: partialContextFill,
-                      contextWindow: partialContextWindow,
-                    },
-                  } as any,
-                });
-              }
-
-              session.tokenUsage = updatedUsage;
-            }
+            applyMidTurnContextUsage({
+              session,
+              contextFillTokens: partialContextFill,
+              contextWindow: partialContextWindow,
+              send: (payload) => safeSend(event, 'ai:tokenUsageUpdated', payload),
+            });
             break;
           }
 
@@ -2367,7 +2383,7 @@ export class MessageStreamingHandler {
                   ? undefined
                   : (contextFillTokens !== undefined && contextWindowForDisplay)
                     ? { tokens: contextFillTokens, contextWindow: contextWindowForDisplay }
-                    : currentUsage.currentContext,
+                    : sanitizePersistedCurrentContext(currentUsage.currentContext),
               };
 
               await this.svc.sessionManager.updateSessionTokenUsage(session.id, updatedUsage);
@@ -2475,8 +2491,8 @@ export class MessageStreamingHandler {
                   isCodexProvider && !contextCompacted
                     ? (contextFillTokens !== undefined && codexContextWindow
                       ? { tokens: contextFillTokens, contextWindow: codexContextWindow }
-                      : currentUsage.currentContext)
-                    : currentUsage.currentContext,
+                      : sanitizePersistedCurrentContext(currentUsage.currentContext))
+                    : sanitizePersistedCurrentContext(currentUsage.currentContext),
               };
 
               await this.svc.sessionManager.updateSessionTokenUsage(session.id, updatedUsage);

--- a/packages/electron/src/main/services/ai/__tests__/MessageStreamingHandler.contextMeter.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/MessageStreamingHandler.contextMeter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('jotai-family', () => ({ atomFamily: vi.fn() }));
+
+import { buildPersistedContextTokenUsage } from '../AIService';
+import {
+  applyMidTurnContextUsage,
+  sanitizePersistedCurrentContext,
+} from '../MessageStreamingHandler';
+
+const cumulative = {
+  inputTokens: 90_000,
+  outputTokens: 10_000,
+  totalTokens: 100_000,
+};
+
+describe('MessageStreamingHandler context persistence boundary', () => {
+  it('excludes raw /context markdown from the durable token snapshot', () => {
+    const rawResponse = 'provider-markdown-sentinel'.repeat(16_384);
+    const next = buildPersistedContextTokenUsage(
+      {
+        ...cumulative,
+        costUSD: 1.25,
+        currentContext: {
+          tokens: 1,
+          contextWindow: 200_000,
+          rawResponse,
+        },
+      },
+      {
+        totalTokens: 32_000,
+        contextWindow: 200_000,
+        categories: [{ name: 'System prompt', tokens: 8_000, percentage: 25 }],
+      },
+    );
+
+    expect(next).toMatchObject({
+      ...cumulative,
+      costUSD: 1.25,
+      contextWindow: 200_000,
+      currentContext: {
+        tokens: 32_000,
+        contextWindow: 200_000,
+        categories: [{ name: 'System prompt', tokens: 8_000, percentage: 25 }],
+      },
+    });
+    expect(next.currentContext).not.toHaveProperty('rawResponse');
+    expect(JSON.stringify(next)).not.toContain('provider-markdown-sentinel');
+  });
+
+  it('keeps mid-turn context usage transient without durable metadata or sync writes', () => {
+    const session = {
+      id: 'session-1',
+      tokenUsage: { ...cumulative },
+    };
+    const send = vi.fn();
+    const next = applyMidTurnContextUsage({
+      session,
+      contextFillTokens: 32_000,
+      contextWindow: 200_000,
+      send,
+    });
+
+    expect(next).toMatchObject({
+      ...cumulative,
+      contextWindow: 200_000,
+      currentContext: { tokens: 32_000, contextWindow: 200_000 },
+    });
+    expect(session.tokenUsage).toBe(next);
+    expect(send).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      tokenUsage: next,
+    });
+  });
+
+  it('removes legacy raw provider markdown from completion fallback snapshots', () => {
+    const legacyContext = {
+      tokens: 32_000,
+      contextWindow: 200_000,
+      categories: [{ name: 'System prompt', tokens: 8_000, percentage: 25 }],
+      rawResponse: 'legacy-provider-markdown'.repeat(16_384),
+    };
+
+    const persisted = sanitizePersistedCurrentContext(legacyContext);
+
+    expect(persisted).toEqual({
+      tokens: 32_000,
+      contextWindow: 200_000,
+      categories: [{ name: 'System prompt', tokens: 8_000, percentage: 25 }],
+    });
+    expect(persisted).not.toHaveProperty('rawResponse');
+    expect(JSON.stringify(persisted)).not.toContain('legacy-provider-markdown');
+  });
+});

--- a/packages/electron/src/main/services/database/DatabaseBackupService.ts
+++ b/packages/electron/src/main/services/database/DatabaseBackupService.ts
@@ -30,6 +30,20 @@ interface BackupMetadata {
   lastSuccessfulBackup: string | null;
 }
 
+export interface BackupPhysicalGrowthAssessment {
+  databaseSizeBytes: number;
+  aiSessionsRelationSizeBytes: number;
+  aiSessionsLiveRowBytes: number;
+  retainedBackupBytes: number;
+  projectedPeakBytes: number;
+  sessionPhysicalToLiveRatio: number;
+  maintenanceRecommended: boolean;
+  operatorGuidance: string | null;
+}
+
+const MIN_BLOATED_SESSION_RELATION_BYTES = 128 * 1024 * 1024;
+const SESSION_PHYSICAL_TO_LIVE_WARNING_RATIO = 10;
+
 export class DatabaseBackupService {
   private backupDir: string;
   private metadataPath: string;
@@ -159,6 +173,65 @@ export class DatabaseBackupService {
   }
 
   /**
+   * Read-only storage assessment used before a rolling backup copies the
+   * physical PGlite directory. Comparing the relation size with the live
+   * metadata payload distinguishes retained heap/TOAST history from genuine
+   * session data, while projectedPeakBytes makes the temporary fourth copy
+   * visible to operators.
+   */
+  async assessPhysicalGrowth(): Promise<BackupPhysicalGrowthAssessment> {
+    const result = await this.dbWorker.query<{
+      database_size_bytes: string | number;
+      ai_sessions_relation_size_bytes: string | number;
+      ai_sessions_live_row_bytes: string | number;
+    }>(`
+      SELECT
+        pg_database_size(current_database()) AS database_size_bytes,
+        pg_table_size('ai_sessions') AS ai_sessions_relation_size_bytes,
+        COALESCE((SELECT SUM(pg_column_size(s)) FROM ai_sessions AS s), 0) AS ai_sessions_live_row_bytes
+    `);
+    const row = result.rows[0];
+    const databaseSizeBytes = Number(row?.database_size_bytes) || 0;
+    const aiSessionsRelationSizeBytes = Number(row?.ai_sessions_relation_size_bytes) || 0;
+    const aiSessionsLiveRowBytes = Number(row?.ai_sessions_live_row_bytes) || 0;
+    const retainedBackupPaths = [
+      'pglite-db.backup-current',
+      'pglite-db.backup-previous',
+      'pglite-db.backup-oldest',
+    ].map((slot) => path.join(this.backupDir, slot));
+    const retainedBackupSizes = await Promise.all(
+      retainedBackupPaths.map((backupPath) => this.getDirectorySize(backupPath)),
+    );
+    const retainedBackupBytes = retainedBackupSizes.reduce(
+      (total, backupSize) => total + backupSize,
+      0,
+    );
+    const sessionPhysicalToLiveRatio = aiSessionsLiveRowBytes > 0
+      ? aiSessionsRelationSizeBytes / aiSessionsLiveRowBytes
+      : aiSessionsRelationSizeBytes > 0
+        ? Number.POSITIVE_INFINITY
+        : 0;
+    const maintenanceRecommended =
+      aiSessionsRelationSizeBytes >= MIN_BLOATED_SESSION_RELATION_BYTES
+      && sessionPhysicalToLiveRatio >= SESSION_PHYSICAL_TO_LIVE_WARNING_RATIO;
+
+    return {
+      databaseSizeBytes,
+      aiSessionsRelationSizeBytes,
+      aiSessionsLiveRowBytes,
+      retainedBackupBytes,
+      // Peak disk use includes the live database, all retained backups, and
+      // the in-progress temporary copy before rotation promotes it.
+      projectedPeakBytes: retainedBackupBytes + (2 * databaseSizeBytes),
+      sessionPhysicalToLiveRatio,
+      maintenanceRecommended,
+      operatorGuidance: maintenanceRecommended
+        ? 'Open Settings > Database and run the SQLite migration dry-run before the next backup.'
+        : null,
+    };
+  }
+
+  /**
    * Copy directory recursively
    */
   private async copyDirectory(src: string, dest: string): Promise<void> {
@@ -236,6 +309,17 @@ export class DatabaseBackupService {
       if (!fsSync.existsSync(this.dbPath)) {
         logger.main.warn('[Backup Service] Database path does not exist:', this.dbPath);
         return { success: false, error: 'Database path does not exist' };
+      }
+
+      try {
+        const growth = await this.assessPhysicalGrowth();
+        if (growth.maintenanceRecommended) {
+          logger.main.warn('[Backup Service] Physical session growth needs operator review', growth);
+        }
+      } catch (error) {
+        // Telemetry must not make a verified backup unavailable. The warning
+        // keeps a failed assessment visible while preserving recovery safety.
+        logger.main.warn('[Backup Service] Failed to assess physical growth:', error);
       }
 
       // Check disk space

--- a/packages/electron/src/main/services/database/__tests__/DatabaseBackupService.test.ts
+++ b/packages/electron/src/main/services/database/__tests__/DatabaseBackupService.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
+import { PGlite } from '@electric-sql/pglite';
 
 // PGLite backup service is `app.getPath('userData')`-backed for the legacy
 // cleanup scan; stub it before the import.
@@ -96,5 +97,88 @@ describe('DatabaseBackupService temp-dir cleanup', () => {
     // Sanity: the synthetic tempPath was never created (real code uses a
     // timestamped name), but no temp-backup-* should remain anywhere.
     expect(fs.existsSync(tempPath)).toBe(false);
+  });
+
+  it('reports physical session bloat and dry-run guidance before another rolling copy', async () => {
+    const gib = 1024 ** 3;
+    const mib = 1024 ** 2;
+    const query = vi.fn(async (_sql: string) => ({
+      rows: [{
+        database_size_bytes: String(5 * gib),
+        ai_sessions_relation_size_bytes: String(1800 * mib),
+        ai_sessions_live_row_bytes: String(2 * mib),
+      }],
+    }));
+
+    const service = new DatabaseBackupService(
+      path.join(tmp, 'pglite-db'),
+      { query } as never,
+    );
+    const serviceWithGrowthProbe = service as unknown as {
+      assessPhysicalGrowth: () => Promise<{
+        databaseSizeBytes: number;
+        aiSessionsRelationSizeBytes: number;
+        aiSessionsLiveRowBytes: number;
+        retainedBackupBytes: number;
+        projectedPeakBytes: number;
+        sessionPhysicalToLiveRatio: number;
+        maintenanceRecommended: boolean;
+        operatorGuidance: string | null;
+      }>;
+    };
+    const retainedSizes = [11, 13, 17];
+    for (const [index, slot] of [
+      'pglite-db.backup-current',
+      'pglite-db.backup-previous',
+      'pglite-db.backup-oldest',
+    ].entries()) {
+      const slotPath = path.join(backupDir, slot);
+      await fsp.mkdir(slotPath, { recursive: true });
+      await fsp.writeFile(path.join(slotPath, 'page'), Buffer.alloc(retainedSizes[index]));
+    }
+
+    const assessment = await serviceWithGrowthProbe.assessPhysicalGrowth();
+
+    expect(query).toHaveBeenCalledOnce();
+    expect(query.mock.calls[0]?.[0]).toContain('pg_database_size(current_database())');
+    expect(query.mock.calls[0]?.[0]).toContain("pg_table_size('ai_sessions')");
+    expect(query.mock.calls[0]?.[0]).toContain('pg_column_size(s)');
+    expect(assessment).toMatchObject({
+      databaseSizeBytes: 5 * gib,
+      aiSessionsRelationSizeBytes: 1800 * mib,
+      aiSessionsLiveRowBytes: 2 * mib,
+      retainedBackupBytes: 41,
+      projectedPeakBytes: (10 * gib) + 41,
+      sessionPhysicalToLiveRatio: 900,
+      maintenanceRecommended: true,
+    });
+    expect(assessment.operatorGuidance).toMatch(/Settings.*dry-run.*before the next backup/i);
+  });
+
+  it('compares physical table storage with live complete-row bytes in PGlite', async () => {
+    const db = new PGlite({ dataDir: path.join(tmp, 'growth-query-db') });
+    try {
+      await db.exec(`
+        CREATE TABLE ai_sessions (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL,
+          metadata JSONB NOT NULL DEFAULT '{}'
+        );
+        INSERT INTO ai_sessions (id, title, metadata)
+        VALUES ('s1', 'Session', '{"tokenUsage":{"totalTokens":16}}');
+      `);
+      const service = new DatabaseBackupService(
+        path.join(tmp, 'growth-query-db'),
+        { query: (sql: string) => db.query(sql) } as never,
+      );
+
+      const assessment = await service.assessPhysicalGrowth();
+
+      expect(assessment.aiSessionsRelationSizeBytes).toBeGreaterThan(0);
+      expect(assessment.aiSessionsLiveRowBytes).toBeGreaterThan(0);
+      expect(assessment.sessionPhysicalToLiveRatio).toBeGreaterThan(0);
+    } finally {
+      await db.close();
+    }
   });
 });

--- a/packages/electron/src/renderer/components/GlobalSettings/panels/DatabasePanel.tsx
+++ b/packages/electron/src/renderer/components/GlobalSettings/panels/DatabasePanel.tsx
@@ -30,6 +30,17 @@ import {
 
 type Backend = 'pglite' | 'sqlite';
 
+interface StorageHealth {
+  databaseSizeBytes: number;
+  aiSessionsRelationSizeBytes: number;
+  aiSessionsLiveRowBytes: number;
+  retainedBackupBytes: number;
+  projectedPeakBytes: number;
+  sessionPhysicalToLiveRatio: number;
+  maintenanceRecommended: boolean;
+  operatorGuidance: string | null;
+}
+
 interface MigrationStatus {
   activeBackend: Backend;
   pgliteDirExists: boolean;
@@ -37,6 +48,7 @@ interface MigrationStatus {
   migratedDirs: string[];
   running: boolean;
   runningDryRun: boolean;
+  storageHealth: StorageHealth | null;
 }
 
 interface DryRunResult {
@@ -121,6 +133,7 @@ export function DatabasePanel(): React.ReactElement {
         migratedDirs: resp.migratedDirs,
         running: resp.running,
         runningDryRun: resp.runningDryRun,
+        storageHealth: resp.storageHealth,
       });
     } catch (err) {
       setStatusError(String((err as Error).message ?? err));
@@ -339,6 +352,41 @@ export function DatabasePanel(): React.ReactElement {
           </div>
         )}
       </div>
+
+      {/* Read-only storage assessment ----------------------------------- */}
+      {status?.activeBackend === 'pglite' && status.storageHealth && (
+        <div className="provider-panel-section mb-6 nim-database-storage-health">
+          <h4 className="provider-panel-section-title text-base font-semibold mb-2 text-[var(--nim-text)]">
+            Physical storage
+          </h4>
+          <div className="grid grid-cols-2 gap-3 rounded-md border border-[var(--nim-border)] bg-[var(--nim-bg-secondary)] p-3">
+            <Stat label="Database" value={formatBytes(status.storageHealth.databaseSizeBytes)} />
+            <Stat label="Sessions relation" value={formatBytes(status.storageHealth.aiSessionsRelationSizeBytes)} />
+            <Stat label="Live session rows" value={formatBytes(status.storageHealth.aiSessionsLiveRowBytes)} />
+            <Stat label="Retained backups" value={formatBytes(status.storageHealth.retainedBackupBytes)} />
+            <Stat label="Projected backup peak" value={formatBytes(status.storageHealth.projectedPeakBytes)} />
+            <Stat
+              label="Physical / live ratio"
+              value={Number.isFinite(status.storageHealth.sessionPhysicalToLiveRatio)
+                ? `${status.storageHealth.sessionPhysicalToLiveRatio.toFixed(1)}×`
+                : '∞'}
+              ok={!status.storageHealth.maintenanceRecommended}
+            />
+          </div>
+          {status.storageHealth.maintenanceRecommended && status.storageHealth.operatorGuidance ? (
+            <div className="mt-3 rounded-md border border-[rgba(245,158,11,0.35)] bg-[rgba(245,158,11,0.1)] p-3 text-sm text-[var(--nim-text)]">
+              <div className="font-medium">Maintenance recommended</div>
+              <div className="mt-1 text-xs leading-relaxed text-[var(--nim-text-muted)]">
+                {status.storageHealth.operatorGuidance}
+              </div>
+            </div>
+          ) : (
+            <p className="mt-2 text-xs text-[var(--nim-text-muted)]">
+              No abnormal session-metadata amplification detected.
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Dry run section ------------------------------------------------- */}
       {status?.activeBackend === 'pglite' && (

--- a/packages/electron/src/renderer/components/GlobalSettings/panels/__tests__/DatabasePanel.test.tsx
+++ b/packages/electron/src/renderer/components/GlobalSettings/panels/__tests__/DatabasePanel.test.tsx
@@ -11,7 +11,18 @@ import { DatabasePanel } from '../DatabasePanel';
 
 type Backend = 'pglite' | 'sqlite';
 
-function installMigrationApi(activeBackend: Backend) {
+interface StorageHealth {
+  databaseSizeBytes: number;
+  aiSessionsRelationSizeBytes: number;
+  aiSessionsLiveRowBytes: number;
+  retainedBackupBytes: number;
+  projectedPeakBytes: number;
+  sessionPhysicalToLiveRatio: number;
+  maintenanceRecommended: boolean;
+  operatorGuidance: string | null;
+}
+
+function installMigrationApi(activeBackend: Backend, storageHealth: StorageHealth | null = null) {
   const invoke = vi.fn(async (channel: string) => {
     if (channel === 'db:migration:get-status') {
       return {
@@ -22,6 +33,7 @@ function installMigrationApi(activeBackend: Backend) {
         migratedDirs: [],
         running: false,
         runningDryRun: false,
+        storageHealth: activeBackend === 'pglite' ? storageHealth : null,
       };
     }
     if (channel === 'db:migration:dry-run-status') {
@@ -77,5 +89,52 @@ describe('DatabasePanel dry-run eligibility', () => {
     await screen.findByText('SQLite (new)');
     screen.getByText(/No further\s+migration is needed/i);
     expect(screen.queryByRole('button', { name: 'Migrate to SQLite' })).toBeNull();
+  });
+
+  it('projects abnormal physical growth and keeps the existing dry-run action available', async () => {
+    const invoke = installMigrationApi('pglite', {
+      databaseSizeBytes: 5 * 1024 ** 3,
+      aiSessionsRelationSizeBytes: 1800 * 1024 ** 2,
+      aiSessionsLiveRowBytes: 2 * 1024 ** 2,
+      retainedBackupBytes: 15 * 1024 ** 3,
+      projectedPeakBytes: 25 * 1024 ** 3,
+      sessionPhysicalToLiveRatio: 900,
+      maintenanceRecommended: true,
+      operatorGuidance: 'Open Settings > Database and run the SQLite migration dry-run before the next backup.',
+    });
+    render(<DatabasePanel />);
+
+    await screen.findByRole('heading', { name: 'Physical storage' });
+    expect(screen.getByText('5.00 GB')).toBeTruthy();
+    expect(screen.getByText('1.76 GB')).toBeTruthy();
+    expect(screen.getByText('2.0 MB')).toBeTruthy();
+    expect(screen.getByText('15.00 GB')).toBeTruthy();
+    expect(screen.getByText('25.00 GB')).toBeTruthy();
+    expect(screen.getByText('Maintenance recommended')).toBeTruthy();
+    expect(screen.getByText(/run the SQLite migration dry-run before the next backup/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run dry-run migration' }));
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('db:migration:dry-run');
+    });
+  });
+
+  it('projects healthy physical storage without a maintenance warning', async () => {
+    installMigrationApi('pglite', {
+      databaseSizeBytes: 100 * 1024 ** 2,
+      aiSessionsRelationSizeBytes: 2 * 1024 ** 2,
+      aiSessionsLiveRowBytes: 1 * 1024 ** 2,
+      retainedBackupBytes: 200 * 1024 ** 2,
+      projectedPeakBytes: 400 * 1024 ** 2,
+      sessionPhysicalToLiveRatio: 2,
+      maintenanceRecommended: false,
+      operatorGuidance: null,
+    });
+    render(<DatabasePanel />);
+
+    await screen.findByRole('heading', { name: 'Physical storage' });
+    expect(screen.getByText('100.0 MB')).toBeTruthy();
+    expect(screen.getByText('No abnormal session-metadata amplification detected.')).toBeTruthy();
+    expect(screen.queryByText('Maintenance recommended')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- skip canonical no-op session metadata writes and keep mid-turn context snapshots transient
- exclude raw provider context output from durable session metadata
- expose physical database growth, retained-backup, and projected-peak evidence in Settings

## Verification
- focused storage/context/Settings: 30 tests passed
- migration and fresh-schema: 20 tests passed
- changed-path TypeScript diagnostics: 0
- Semgrep security audit: 0 findings

## Why this is worth merging

High-frequency session metadata can grow the physical database and every retained backup even when the logical value has not changed. This patch skips canonical no-op writes, keeps unsettled observations transient, and exposes physical growth and projected peak evidence. It reduces storage amplification without weakening compare-and-swap behavior or pretending to replace the separate retention and compaction lifecycle.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
