### PR TITLE
fix(electron): bound safe ToolCallMatcher history scans

### DIFF
--- a/packages/electron/src/main/services/ToolCallMatcher.ts
+++ b/packages/electron/src/main/services/ToolCallMatcher.ts
@@ -942,10 +942,39 @@ class ToolCallMatcherImpl {
       }
       const sessionFiles = [...sessionFilesByKey.values()];
 
-      // 3. Load tool call windows from raw ai_agent_messages
-      const windows = await getRawToolCallWindows(sessionId, workspacePath);
+      // A session with no edited files cannot produce a match, so avoid the
+      // raw-message scan entirely.
+      if (sessionFiles.length === 0) return 0;
 
-      if (windows.length === 0 || sessionFiles.length === 0) return 0;
+      // Bound raw history for providers whose file rows have no definitive
+      // tool IDs (notably Codex). Exact metadata toolUseId matches deliberately
+      // bypass scoreMatch's time cutoff, so sessions carrying any such ID must
+      // retain the unbounded lookup to preserve those matches.
+      const hasDefinitiveToolUseIds = sessionFiles.some(file =>
+        typeof file.metadata?.toolUseId === 'string' && file.metadata.toolUseId.length > 0
+      );
+      let rawWindowOptions: { afterDate: Date; beforeDate: Date } | undefined;
+      if (!hasDefinitiveToolUseIds) {
+        const fileTimestamps = sessionFiles.map(file => ensureNumber(file.timestamp_ms));
+        const hasInvalidTimestamp = fileTimestamps.some(timestamp => !Number.isFinite(timestamp));
+        let minFileTs = Infinity;
+        let maxFileTs = -Infinity;
+        for (const timestamp of fileTimestamps) {
+          if (timestamp < minFileTs) minFileTs = timestamp;
+          if (timestamp > maxFileTs) maxFileTs = timestamp;
+        }
+        if (!hasInvalidTimestamp) {
+          rawWindowOptions = {
+            afterDate: new Date(minFileTs - TIME_CUTOFF_MS),
+            beforeDate: new Date(maxFileTs + TIME_CUTOFF_MS),
+          };
+        }
+      }
+
+      // 3. Load tool call windows from raw ai_agent_messages.
+      const windows = await getRawToolCallWindows(sessionId, workspacePath, rawWindowOptions);
+
+      if (windows.length === 0) return 0;
 
       // 4. Deduplicate windows by toolCallItemId.
       // When both item.started and item.completed exist for the same tool call,

--- a/packages/electron/src/main/services/__tests__/ToolCallMatcher.test.ts
+++ b/packages/electron/src/main/services/__tests__/ToolCallMatcher.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+vi.mock('jotai-family', () => ({ atomFamily: vi.fn() }));
+
 vi.mock('../../database/PGLiteDatabaseWorker', () => ({
   database: {
     isInitialized: () => true,
@@ -903,6 +905,122 @@ describe('ToolCallMatcher', () => {
 
       const diffs = await toolCallMatcher.getDiffsForToolCall(SESSION_ID, RAW);
       expect(diffs).toEqual([]);
+    });
+  });
+
+  describe('matchSession raw-message bounds', () => {
+    const queryMock = database.query as ReturnType<typeof vi.fn>;
+
+    it('bounds sessions without definitive tool IDs to the editable file window', async () => {
+      const sessionId = 'bounded-session';
+      const earliestTimestamp = 1_700_000_000_000;
+      const latestTimestamp = earliestTimestamp + 45_000;
+
+      queryMock
+        .mockImplementationOnce(async (sql: string, params: unknown[]) => {
+          expect(sql).toContain('FROM ai_sessions');
+          expect(params).toEqual([sessionId]);
+          return { rows: [{ workspace_id: '/workspace' }] };
+        })
+        .mockImplementationOnce(async (sql: string, params: unknown[]) => {
+          expect(sql).toContain('FROM session_files');
+          expect(params).toEqual([sessionId]);
+          return {
+            rows: [
+              { id: 'early-file', file_path: '/workspace/src/early.ts', timestamp_ms: earliestTimestamp, metadata: {} },
+              { id: 'late-file', file_path: '/workspace/src/late.ts', timestamp_ms: latestTimestamp, metadata: {} },
+            ],
+          };
+        })
+        .mockImplementationOnce(async (sql: string, params: unknown[]) => {
+          expect(sql).toContain('FROM ai_agent_messages');
+          expect(sql).toContain('(EXTRACT(EPOCH FROM created_at) * 1000) >= $2');
+          expect(sql).toContain('(EXTRACT(EPOCH FROM created_at) * 1000) <= $3');
+          expect(params).toEqual([sessionId, earliestTimestamp - 10_000, latestTimestamp + 10_000]);
+          return { rows: [] };
+        });
+
+      await expect(toolCallMatcher.matchSession(sessionId)).resolves.toBe(0);
+      expect(queryMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('preserves out-of-window exact toolUseId matches with an unbounded lookup', async () => {
+      const sessionId = 'definitive-id-session';
+      const fileTimestamp = 1_700_000_000_000;
+      const toolTimestamp = fileTimestamp - 60_000;
+      let insertedParams: unknown[] | undefined;
+
+      queryMock
+        .mockImplementationOnce(async () => ({ rows: [{ workspace_id: '/workspace' }] }))
+        .mockImplementationOnce(async () => ({
+          rows: [{
+            id: 'file-1',
+            file_path: '/workspace/src/kept.ts',
+            timestamp_ms: fileTimestamp,
+            metadata: { toolUseId: 'tool-definitive' },
+          }],
+        }))
+        .mockImplementationOnce(async (sql: string, params: unknown[]) => {
+          expect(sql).toContain('FROM ai_agent_messages');
+          expect(sql).not.toContain('(EXTRACT(EPOCH FROM created_at) * 1000) >= $2');
+          expect(sql).not.toContain('(EXTRACT(EPOCH FROM created_at) * 1000) <= $3');
+          expect(params).toEqual([sessionId]);
+          return {
+            rows: [{
+              id: 42,
+              created_at_ms: toolTimestamp,
+              metadata: {},
+              content: JSON.stringify({
+                type: 'assistant',
+                message: {
+                  content: [{
+                    type: 'tool_use',
+                    id: 'tool-definitive',
+                    name: 'Edit',
+                    input: { file_path: '/workspace/src/kept.ts' },
+                  }],
+                },
+              }),
+            }],
+          };
+        })
+        .mockImplementationOnce(async () => ({ rows: [] }))
+        .mockImplementationOnce(async (_sql: string, params: unknown[]) => {
+          insertedParams = params;
+          return { rows: [] };
+        });
+
+      await expect(toolCallMatcher.matchSession(sessionId)).resolves.toBe(1);
+      expect(insertedParams).toEqual(expect.arrayContaining([
+        sessionId,
+        'file-1',
+        42,
+        'tool-definitive',
+      ]));
+    });
+
+    it('falls back to an unbounded lookup when a stored file timestamp is invalid', async () => {
+      const sessionId = 'invalid-timestamp-session';
+      queryMock
+        .mockImplementationOnce(async () => ({ rows: [{ workspace_id: '/workspace' }] }))
+        .mockImplementationOnce(async () => ({
+          rows: [{
+            id: 'file-invalid',
+            file_path: '/workspace/src/invalid.ts',
+            timestamp_ms: 'not-a-number',
+            metadata: {},
+          }],
+        }))
+        .mockImplementationOnce(async (sql: string, params: unknown[]) => {
+          expect(sql).toContain('FROM ai_agent_messages');
+          expect(sql).not.toContain('(EXTRACT(EPOCH FROM created_at) * 1000) >= $2');
+          expect(sql).not.toContain('(EXTRACT(EPOCH FROM created_at) * 1000) <= $3');
+          expect(params).toEqual([sessionId]);
+          return { rows: [] };
+        });
+
+      await expect(toolCallMatcher.matchSession(sessionId)).resolves.toBe(0);
+      expect(queryMock).toHaveBeenCalledTimes(3);
     });
   });
 });


### PR DESCRIPTION
## Summary
- bound raw-message history to the editable file window for ID-less matcher sessions
- preserve unbounded lookup where exact tool IDs bypass the timestamp cutoff
- fall back safely for invalid timestamps and skip empty sessions

This is the current-upstream, output-equivalent successor to stale PR #1085; that branch is unchanged.

## Verification
- focused ToolCallMatcher: 46 tests passed
- changed-path TypeScript diagnostics: 0
- Semgrep security audit: 0 findings