### PR TITLE
fix(hooks): run unlisted Windows tests before push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -58,10 +58,5 @@ npm run typecheck:prepush
 echo "[pre-push] Verifying platform test-gate behavior..."
 npm run test:prepush-gate
 
-if [ "$(node scripts/prepush-test-gate.mjs)" = "run" ]; then
-  echo "[pre-push] Running non-provider unit tests..."
-  npm run test:prepush
-else
-  echo "[pre-push] Skipping the full Vitest suite on local Windows; CI and non-Windows pushes still require it."
-  echo "[pre-push] See docs/WINDOWS_PREPUSH_GATE.md for the tracked nonportable failures."
-fi
+echo "[pre-push] Running non-provider unit tests (local Windows: only tracked nonportable suites are excluded)..."
+node scripts/prepush-test-gate.mjs

--- a/docs/WINDOWS_PREPUSH_GATE.md
+++ b/docs/WINDOWS_PREPUSH_GATE.md
@@ -1,9 +1,11 @@
 # Windows pre-push gate
 
 Local Windows pushes build the extension SDK, runtime, and memory-engine
-artifacts before running the full workspace typecheck. The complete Vitest
-suite remains mandatory in CI and on non-Windows machines, but is skipped for
-local Windows pushes until its platform failures are repaired.
+artifacts before running the full workspace typecheck. Vitest then runs with
+at most four workers and excludes only the explicit paths in
+`scripts/windows-known-failing-suites.mjs`. Every unlisted suite—including a
+new suite added later—still runs and can block the push. CI and non-Windows
+runs use the complete suite without exclusions or the worker cap.
 
 The 2026-07-13 baseline command, `npm run test:prepush`, failed in these
 unrelated suites: `claudeCodeEnvironment` (runtime and provider variants),
@@ -15,7 +17,19 @@ unrelated suites: `claudeCodeEnvironment` (runtime and provider variants),
 `aiSettingsMerge`, `MigrationOrchestrator`, `spawnCrashDiagnostics`,
 `claudeCliJsonlPath`, and `BrowserSessionHandlers`.
 
-The fallback is intentionally limited to `process.platform === 'win32'` with
-no CI flag. It does not bypass the manifest check, dependency override check,
-prerequisite builds, full workspace typecheck, or this repository's focused
-test requirements.
+The list was rechecked against current source on 2026-08-04. Seventeen suites
+still failed on Windows; `aiSettingsMerge.test.ts` passed and is no longer
+excluded. The manifest remains source-controlled and must shrink when a suite
+becomes portable rather than silently accumulating stale exemptions.
+
+The exclusions are applied inside each project in `vitest.config.ts` only
+when `NIMBALYST_PREPUSH_GATE=1`. A CLI `--exclude` does not reliably reach
+project-level discovery. `scripts/prepush-test-gate.mjs` is the only caller
+that sets the variable, and only for local Windows with no truthy `CI` flag.
+
+The four-worker cap prevents the SQLite/PGlite file-handle contention seen at
+CPU-count concurrency. It is local-Windows-only and does not change CI.
+
+This gate does not bypass the toolchain, fixture-author, manifest/lockfile,
+dependency-override, raw-NUL, prerequisite-build, full typecheck, or focused
+test checks that precede it in `.githooks/pre-push`.

--- a/scripts/__tests__/prepush-test-gate.test.mjs
+++ b/scripts/__tests__/prepush-test-gate.test.mjs
@@ -1,15 +1,79 @@
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
 import test from 'node:test';
-import { shouldRunFullPrePushSuite } from '../prepush-test-gate.mjs';
+import { fileURLToPath } from 'node:url';
+import {
+  buildVitestArgs,
+  buildVitestEnv,
+  shouldExcludeKnownFailingSuites,
+} from '../prepush-test-gate.mjs';
+import { WINDOWS_KNOWN_FAILING_SUITES } from '../windows-known-failing-suites.mjs';
 
 test('keeps the full suite enabled outside local Windows', () => {
-  assert.equal(shouldRunFullPrePushSuite({ platform: 'linux' }), true);
-  assert.equal(shouldRunFullPrePushSuite({ platform: 'darwin' }), true);
-  assert.equal(shouldRunFullPrePushSuite({ platform: 'win32', ci: 'true' }), true);
-  assert.equal(shouldRunFullPrePushSuite({ platform: 'win32', ci: '1' }), true);
+  assert.equal(shouldExcludeKnownFailingSuites({ platform: 'linux' }), false);
+  assert.equal(shouldExcludeKnownFailingSuites({ platform: 'darwin' }), false);
+  assert.equal(shouldExcludeKnownFailingSuites({ platform: 'win32', ci: 'true' }), false);
+  assert.equal(shouldExcludeKnownFailingSuites({ platform: 'win32', ci: '1' }), false);
 });
 
-test('skips only the known nonportable suite on local Windows', () => {
-  assert.equal(shouldRunFullPrePushSuite({ platform: 'win32' }), false);
-  assert.equal(shouldRunFullPrePushSuite({ platform: 'win32', ci: 'false' }), false);
+test('excludes only the tracked nonportable suites on local Windows', () => {
+  assert.equal(shouldExcludeKnownFailingSuites({ platform: 'win32' }), true);
+  assert.equal(shouldExcludeKnownFailingSuites({ platform: 'win32', ci: 'false' }), true);
+});
+
+test('uses the ordinary full-suite invocation outside local Windows', () => {
+  assert.deepEqual(buildVitestArgs({ platform: 'linux' }), ['vitest', '--run']);
+  assert.deepEqual(
+    buildVitestEnv(
+      { platform: 'linux' },
+      { KEEP_ME: 'yes', NIMBALYST_PREPUSH_GATE: '1' },
+    ),
+    { KEEP_ME: 'yes' },
+  );
+  assert.deepEqual(
+    buildVitestEnv(
+      { platform: 'win32', ci: 'true' },
+      { KEEP_ME: 'yes', NIMBALYST_PREPUSH_GATE: '1' },
+    ),
+    { KEEP_ME: 'yes' },
+  );
+});
+
+test('caps workers and activates config exclusions only on local Windows', () => {
+  assert.deepEqual(buildVitestArgs({ platform: 'win32' }), [
+    'vitest',
+    '--run',
+    '--maxWorkers',
+    '4',
+  ]);
+  assert.deepEqual(
+    buildVitestEnv({ platform: 'win32' }, { KEEP_ME: 'yes' }),
+    { KEEP_ME: 'yes', NIMBALYST_PREPUSH_GATE: '1' },
+  );
+});
+
+test('never relies on a top-level --exclude flag with project-based config', () => {
+  assert.equal(buildVitestArgs({ platform: 'win32' }).includes('--exclude'), false);
+  assert.equal(buildVitestArgs({ platform: 'linux' }).includes('--exclude'), false);
+});
+
+test('keeps the exclusion manifest explicit, unique, and current', () => {
+  const repositoryRoot = fileURLToPath(new URL('../../', import.meta.url));
+  assert.equal(WINDOWS_KNOWN_FAILING_SUITES.length, 17);
+  assert.equal(new Set(WINDOWS_KNOWN_FAILING_SUITES).size, 17);
+  assert.equal(
+    WINDOWS_KNOWN_FAILING_SUITES.includes(
+      'packages/electron/src/main/utils/__tests__/aiSettingsMerge.test.ts',
+    ),
+    false,
+  );
+  for (const suitePath of WINDOWS_KNOWN_FAILING_SUITES) {
+    assert.match(suitePath, /^packages\/.+\.test\.(?:ts|tsx)$/);
+    assert.equal(
+      existsSync(path.join(repositoryRoot, suitePath)),
+      true,
+      `missing exclusion path: ${suitePath}`,
+    );
+  }
 });

--- a/scripts/prepush-test-gate.mjs
+++ b/scripts/prepush-test-gate.mjs
@@ -1,13 +1,61 @@
+import { spawn } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+import { WINDOWS_KNOWN_FAILING_SUITES } from './windows-known-failing-suites.mjs';
+
 /**
- * The full Vitest suite currently has Windows-nonportable failures. Keep it
- * mandatory everywhere else, including Windows CI, while local Windows pushes
- * retain the typecheck and focused-test gates.
+ * Keep the complete suite mandatory everywhere except an interactive Windows
+ * push, where only the explicitly tracked nonportable files are excluded.
  */
-export function shouldRunFullPrePushSuite({ platform = process.platform, ci = process.env.CI } = {}) {
-  return platform !== 'win32' || /^(1|true|yes)$/i.test(ci ?? '');
+export function shouldExcludeKnownFailingSuites({
+  platform = process.platform,
+  ci = process.env.CI,
+} = {}) {
+  return platform === 'win32' && !/^(1|true|yes)$/i.test(ci ?? '');
+}
+
+export function buildVitestArgs(options = {}) {
+  const args = ['vitest', '--run'];
+  if (shouldExcludeKnownFailingSuites(options)) {
+    args.push('--maxWorkers', '4');
+  }
+  return args;
+}
+
+export function buildVitestEnv(options = {}, baseEnv = process.env) {
+  const env = { ...baseEnv };
+  if (shouldExcludeKnownFailingSuites(options)) {
+    env.NIMBALYST_PREPUSH_GATE = '1';
+  } else {
+    delete env.NIMBALYST_PREPUSH_GATE;
+  }
+  return env;
+}
+
+function main() {
+  const options = {};
+  const excludesKnownFailures = shouldExcludeKnownFailingSuites(options);
+  const args = buildVitestArgs(options);
+  const env = buildVitestEnv(options);
+
+  if (excludesKnownFailures) {
+    process.stderr.write(
+      `[prepush] Local Windows push: excluding ${WINDOWS_KNOWN_FAILING_SUITES.length} ` +
+        'tracked nonportable suite(s); all other suites remain mandatory. ' +
+        'See docs/WINDOWS_PREPUSH_GATE.md.\n',
+    );
+  }
+
+  const child = spawn('npx', args, { stdio: 'inherit', shell: true, env });
+  child.on('error', (error) => {
+    process.stderr.write(`[prepush] ERROR: unable to start Vitest: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+  child.on('exit', (code, signal) => {
+    process.exitCode = code ?? (signal ? 1 : 0);
+  });
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  process.stdout.write(shouldRunFullPrePushSuite() ? 'run\n' : 'skip\n');
+  main();
 }
-import { pathToFileURL } from 'node:url';

--- a/scripts/windows-known-failing-suites.d.mts
+++ b/scripts/windows-known-failing-suites.d.mts
@@ -1,0 +1,1 @@
+export const WINDOWS_KNOWN_FAILING_SUITES: readonly string[];

--- a/scripts/windows-known-failing-suites.mjs
+++ b/scripts/windows-known-failing-suites.mjs
@@ -1,0 +1,26 @@
+/**
+ * Suites that remain nonportable on local Windows as of 2026-08-04.
+ *
+ * The list is consumed only when NIMBALYST_PREPUSH_GATE=1, which is set by
+ * scripts/prepush-test-gate.mjs for a non-CI Windows push. New or unlisted
+ * suites remain mandatory. CI and non-Windows runs exclude none of these.
+ */
+export const WINDOWS_KNOWN_FAILING_SUITES = [
+  'packages/runtime/src/ai/server/providers/__tests__/claudeCodeEnvironment.test.ts',
+  'packages/runtime/src/electron/__tests__/claudeCodeEnvironment.test.ts',
+  'packages/electron/src/main/services/ai/__tests__/ClaudeCliSessionLauncher.test.ts',
+  'packages/electron/src/main/file/__tests__/FileSnapshotCache.test.ts',
+  'packages/electron/src/main/file/__tests__/WorkspaceEventBus-gitignore-bypass.test.ts',
+  'packages/electron/src/main/utils/__tests__/workspaceDetection.test.ts',
+  'packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.bashParser.test.ts',
+  'packages/electron/src/main/security/__tests__/SafePathValidator.test.ts',
+  'packages/electron/src/main/file/__tests__/WorkspaceEventBus-nested-gitignore.test.ts',
+  'packages/electron/src/main/ipc/__tests__/BrowserSessionHandlers.test.ts',
+  'packages/electron/src/main/protocols/__tests__/nimAssetProtocol.test.ts',
+  'packages/electron/src/main/protocols/__tests__/nimPreviewProtocol.test.ts',
+  'packages/electron/src/main/services/__tests__/ElectronDocumentService.frontmatterCompatibility.test.ts',
+  'packages/electron/src/main/services/__tests__/ElectronFileSystemService.test.ts',
+  'packages/electron/src/main/services/__tests__/SlashCommandService.test.ts',
+  'packages/electron/src/main/services/ai/__tests__/claudeCliJsonlPath.test.ts',
+  'packages/runtime/src/ai/server/providers/__tests__/spawnCrashDiagnostics.test.ts',
+];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import {createRequire} from 'module';
+import { WINDOWS_KNOWN_FAILING_SUITES } from './scripts/windows-known-failing-suites.mjs';
 
 const runtimeRequire = createRequire(
   path.resolve(__dirname, './packages/runtime/package.json'),
@@ -78,6 +79,12 @@ const include = [
 
 const baseExclude = ['node_modules', 'dist', 'build', '.idea', '.git', '.cache'];
 
+// Set only by scripts/prepush-test-gate.mjs for an interactive Windows push.
+// Each Vitest project owns its discovery rules, so the narrow exclusions must
+// be added to both project configs rather than passed as a top-level CLI flag.
+const prepushGateExcludes =
+  process.env.NIMBALYST_PREPUSH_GATE === '1' ? WINDOWS_KNOWN_FAILING_SUITES : [];
+
 // Paths that must run under the node environment (vitest 4 removed
 // `environmentMatchGlobs`; expressed with `test.projects` instead).
 const nodeOnly = ['packages/electron/src/main/**', 'packages/runtime/src/ai/**'];
@@ -118,7 +125,7 @@ export default defineConfig({
           environment: 'jsdom',
           setupFiles,
           include,
-          exclude: [...baseExclude, ...nodeOnly],
+          exclude: [...baseExclude, ...nodeOnly, ...prepushGateExcludes],
           // Inline so vite transforms it and our monaco-editor stub alias
           // applies to its transitive `monaco-editor/esm/.../editor.api.js`.
           server: { deps: { inline: [/y-monaco/] } },
@@ -139,7 +146,7 @@ export default defineConfig({
             'packages/electron/src/main/**/__tests__/**/*.{test,spec}.{ts,tsx}',
             'packages/runtime/src/ai/**/__tests__/**/*.{test,spec}.{ts,tsx}',
           ],
-          exclude: baseExclude,
+          exclude: [...baseExclude, ...prepushGateExcludes],
           server: { deps: { inline: [/y-monaco/] } },
         },
       },


### PR DESCRIPTION
## Summary

- run the full pre-push Vitest gate on Linux, macOS, and CI
- on local Windows, exclude only 17 explicitly documented nonportable suites and run every other suite with a bounded worker count
- prevent inherited environment state from activating the Windows-only exclusion path outside its intended boundary

This is the fixture-free, author-clean current-upstream successor to legacy PR #879. The contaminated
legacy branch remains unchanged; `a.txt`, `seed.txt`, and its fixture-author commits are excluded.

## Verification

- focused runner contract: 6/6 passed
- real routing control: unlisted `aiSettingsMerge.test.ts` ran (8/8) while a listed suite was excluded
- hook and Node syntax checks passed
- Semgrep security audit: zero findings
- exact seven-path independent review: ACCEPT, no findings
- local full gate stayed fail-closed on unrelated current-checkout dependency/baseline failures; no new exemptions or dependency changes were introduced

Exact-head GitHub CI is required before acceptance.

## Why this is worth merging

A pre-push gate should discover and run the tests that protect changed behavior, including on Windows. This closes the gap where unlisted suites could be absent from the local gate and where platform-specific path handling could turn protection into false failures. Contributors get a stricter gate with fewer incentives to bypass it.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
