### PR TITLE
fix: preserve empty workstream hierarchy

### DIFF
--- a/packages/electron/src/main/ipc/SessionHandlers.ts
+++ b/packages/electron/src/main/ipc/SessionHandlers.ts
@@ -28,6 +28,10 @@ import { setSessionPendingPrompt } from '../services/ai/pendingPromptPersistence
 import { normalizeSessionPhaseMetadataUpdate } from '../services/session/sessionPhaseTransition';
 import { destroyProviderForArchivedSession } from '../services/ai/archiveSessionProviderLifecycle';
 import { resolveSessionModelSelection } from '../services/ai/sessionModelSelection';
+import {
+    serializeSessionReparentMutation,
+    validateSessionReparent,
+} from './sessionReparentValidation';
 
 // Initialize session manager
 const sessionManager = new SessionManager();
@@ -691,7 +695,7 @@ export async function registerSessionHandlers() {
         sessionId: string;
         newParentId: string | null;
         workspacePath: string;
-    }) => {
+    }) => serializeSessionReparentMutation(async () => {
         try {
             const { sessionId, newParentId, workspacePath } = payload;
 
@@ -701,36 +705,53 @@ export async function registerSessionHandlers() {
                 return { success: false, error: 'Session not found' };
             }
 
-            // Validate session belongs to the workspace
-            if (session.workspacePath !== workspacePath) {
-                return { success: false, error: 'Session does not belong to this workspace' };
-            }
+            const [workspaceSessions, parent] = await Promise.all([
+                AISessionsRepository.list(workspacePath, { includeArchived: true }),
+                newParentId ? AISessionsRepository.get(newParentId) : Promise.resolve(null),
+            ]);
+            const sourceMeta = workspaceSessions.find(candidate => candidate.id === sessionId);
 
-            // If setting a parent, validate the parent exists and is in same workspace
-            if (newParentId) {
-                const parent = await AISessionsRepository.get(newParentId);
-                if (!parent) {
-                    return { success: false, error: 'Parent session not found' };
-                }
-                if (parent.workspacePath !== workspacePath) {
-                    return { success: false, error: 'Parent session is in a different workspace' };
-                }
-
-                // Parent must not itself be a child session (no nested workstreams)
-                if (parent.parentSessionId) {
-                    return { success: false, error: 'Cannot nest workstreams: parent is already a child session' };
-                }
+            const validationError = validateSessionReparent({
+                source: {
+                    id: session.id,
+                    workspacePath: session.workspacePath ?? '',
+                    sessionType: session.sessionType,
+                    parentSessionId: session.parentSessionId,
+                    worktreeId: session.worktreeId,
+                    childCount: sourceMeta?.childCount ?? 0,
+                    metadata: session.metadata,
+                },
+                destination: parent ? {
+                    id: parent.id,
+                    workspacePath: parent.workspacePath ?? '',
+                    sessionType: parent.sessionType,
+                    parentSessionId: parent.parentSessionId,
+                    worktreeId: parent.worktreeId,
+                    metadata: parent.metadata,
+                } : null,
+                newParentId,
+                workspacePath,
+            });
+            if (validationError) {
+                return { success: false, error: validationError };
             }
 
             // Update parent_session_id
             await AISessionsRepository.updateMetadata(sessionId, { parentSessionId: newParentId });
+
+            for (const window of BrowserWindow.getAllWindows()) {
+                if (!window.isDestroyed()) {
+                    window.webContents.send('sessions:session-updated', sessionId, { parentSessionId: newParentId });
+                    window.webContents.send('sessions:refresh-list', { workspacePath, sessionId });
+                }
+            }
 
             return { success: true };
         } catch (error) {
             console.error('[SessionHandlers] Failed to set session parent:', error);
             return { success: false, error: String(error) };
         }
-    });
+    }));
 
     // Search sessions for workspace (full content search)
     safeHandle('sessions:search', async (event, workspacePath: string, query: string, options?: {

--- a/packages/electron/src/main/ipc/__tests__/sessionReparentValidation.test.ts
+++ b/packages/electron/src/main/ipc/__tests__/sessionReparentValidation.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+  serializeSessionReparentMutation,
+  validateSessionReparent,
+  type ReparentValidationNode,
+} from '../sessionReparentValidation';
+
+function node(
+  id: string,
+  overrides: Partial<ReparentValidationNode> = {},
+): ReparentValidationNode {
+  return {
+    id,
+    workspacePath: '/workspace',
+    sessionType: 'session',
+    parentSessionId: null,
+    worktreeId: null,
+    childCount: 0,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('sessions:set-parent hierarchy validation', () => {
+  const destination = node('destination', { sessionType: 'workstream' });
+
+  it('rejects typed and legacy structural sources', () => {
+    expect(validateSessionReparent({
+      source: node('typed', { sessionType: 'workstream' }),
+      destination,
+      newParentId: destination.id,
+      workspacePath: '/workspace',
+    })).toMatch(/container/i);
+    expect(validateSessionReparent({
+      source: node('legacy', { metadata: { isWorkstreamRoot: true } }),
+      destination,
+      newParentId: destination.id,
+      workspacePath: '/workspace',
+    })).toMatch(/container/i);
+    expect(validateSessionReparent({
+      source: node('child-bearing', { childCount: 1 }),
+      destination,
+      newParentId: destination.id,
+      workspacePath: '/workspace',
+    })).toMatch(/container/i);
+  });
+
+  it('rejects self-parent, destination-child, and cross-workspace moves', () => {
+    expect(validateSessionReparent({
+      source: node('source'),
+      destination: node('source'),
+      newParentId: 'source',
+      workspacePath: '/workspace',
+    })).toMatch(/own parent/i);
+    expect(validateSessionReparent({
+      source: node('source'),
+      destination: node('nested', { parentSessionId: 'root' }),
+      newParentId: 'nested',
+      workspacePath: '/workspace',
+    })).toMatch(/already a child/i);
+    expect(validateSessionReparent({
+      source: node('source'),
+      destination: node('other', { workspacePath: '/other' }),
+      newParentId: 'other',
+      workspacePath: '/workspace',
+    })).toMatch(/different workspace/i);
+  });
+
+  it('rejects worktree-depth violations and preserves valid moves', () => {
+    expect(validateSessionReparent({
+      source: node('worktree-source', { worktreeId: 'wt-1' }),
+      destination,
+      newParentId: destination.id,
+      workspacePath: '/workspace',
+    })).toMatch(/worktree-resident/i);
+    expect(validateSessionReparent({
+      source: node('source'),
+      destination: node('worktree-destination', { worktreeId: 'wt-1' }),
+      newParentId: 'worktree-destination',
+      workspacePath: '/workspace',
+    })).toMatch(/worktree-resident/i);
+    expect(validateSessionReparent({
+      source: node('source', { parentSessionId: 'old-parent' }),
+      destination,
+      newParentId: destination.id,
+      workspacePath: '/workspace',
+    })).toBeNull();
+    expect(validateSessionReparent({
+      source: node('source', { parentSessionId: 'old-parent' }),
+      destination: null,
+      newParentId: null,
+      workspacePath: '/workspace',
+    })).toBeNull();
+  });
+
+  it('serializes validation and writes so concurrent moves cannot create a third level', async () => {
+    const parents = new Map<string, string | null>([
+      ['root', null],
+      ['destination', null],
+      ['source', null],
+    ]);
+    let releaseFirstWrite!: () => void;
+    const firstWriteGate = new Promise<void>(resolve => {
+      releaseFirstWrite = resolve;
+    });
+    let firstValidated!: () => void;
+    const firstValidatedGate = new Promise<void>(resolve => {
+      firstValidated = resolve;
+    });
+    let secondEntered = false;
+
+    const hierarchyNode = (id: string): ReparentValidationNode => node(id, {
+      parentSessionId: parents.get(id) ?? null,
+      childCount: Array.from(parents.values()).filter(parentId => parentId === id).length,
+    });
+    const move = async (
+      sourceId: string,
+      destinationId: string,
+      pauseBeforeWrite = false,
+    ): Promise<string | null> => {
+      const error = validateSessionReparent({
+        source: hierarchyNode(sourceId),
+        destination: hierarchyNode(destinationId),
+        newParentId: destinationId,
+        workspacePath: '/workspace',
+      });
+      if (error) return error;
+      if (pauseBeforeWrite) {
+        firstValidated();
+        await firstWriteGate;
+      }
+      parents.set(sourceId, destinationId);
+      return null;
+    };
+
+    const first = serializeSessionReparentMutation(
+      () => move('source', 'destination', true),
+    );
+    await firstValidatedGate;
+    const second = serializeSessionReparentMutation(async () => {
+      secondEntered = true;
+      return move('destination', 'root');
+    });
+
+    await Promise.resolve();
+    expect(secondEntered).toBe(false);
+    releaseFirstWrite();
+
+    await expect(first).resolves.toBeNull();
+    await expect(second).resolves.toMatch(/container/i);
+    expect(parents.get('source')).toBe('destination');
+    expect(parents.get('destination')).toBeNull();
+  });
+});

--- a/packages/electron/src/main/ipc/sessionReparentValidation.ts
+++ b/packages/electron/src/main/ipc/sessionReparentValidation.ts
@@ -1,0 +1,68 @@
+import {
+  isStructuralWorkstreamContainer,
+  type SessionHierarchyNode,
+} from '../../shared/sessionHierarchy';
+
+export interface ReparentValidationNode extends SessionHierarchyNode {
+  workspacePath: string;
+}
+
+let sessionReparentMutationTail: Promise<void> = Promise.resolve();
+
+/**
+ * Keep hierarchy validation and its subsequent write in one critical section.
+ * Without this fence, two IPC calls can both validate an old snapshot and
+ * interleave their writes into a third hierarchy level.
+ */
+export function serializeSessionReparentMutation<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  const run = sessionReparentMutationTail.then(operation, operation);
+  sessionReparentMutationTail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+export function validateSessionReparent({
+  source,
+  destination,
+  newParentId,
+  workspacePath,
+}: {
+  source: ReparentValidationNode;
+  destination: ReparentValidationNode | null;
+  newParentId: string | null;
+  workspacePath: string;
+}): string | null {
+  if (source.workspacePath !== workspacePath) {
+    return 'Session does not belong to this workspace';
+  }
+  if (isStructuralWorkstreamContainer(source)) {
+    return 'Cannot move a workstream container';
+  }
+  if (source.worktreeId) {
+    return 'Cannot move a worktree-resident session into a workstream';
+  }
+  if (!newParentId) {
+    return null;
+  }
+  if (source.id === newParentId) {
+    return 'A session cannot be its own parent';
+  }
+  if (!destination) {
+    return 'Parent session not found';
+  }
+  if (destination.workspacePath !== workspacePath) {
+    return 'Parent session is in a different workspace';
+  }
+  if (destination.parentSessionId) {
+    return 'Cannot nest workstreams: parent is already a child session';
+  }
+  if (destination.worktreeId) {
+    return 'Cannot parent a session beneath a worktree-resident session';
+  }
+
+  return null;
+}

--- a/packages/electron/src/main/services/RepositoryManager.ts
+++ b/packages/electron/src/main/services/RepositoryManager.ts
@@ -23,6 +23,7 @@ import { createPGLiteQueuedPromptsStore, type QueuedPromptsStore } from './PGLit
 import { createPGLiteSessionWakeupsStore, type SessionWakeupsStore } from './PGLiteSessionWakeupsStore';
 import { runAgentMessagesBackfill } from './AgentMessagesBackfill';
 import { healArchivedWorkstreamChildren } from './healArchivedWorkstreamChildren';
+import { repairNestedWorkstreamContainers } from './repairNestedWorkstreamContainers';
 import { runWhenFirstUsable } from './startupMaintenanceGate';
 import { database } from '../database/PGLiteDatabaseWorker';
 import { createSQLiteStoreAdapter } from '../database/sqlite/SQLiteStoreAdapter';
@@ -182,6 +183,23 @@ class RepositoryManager {
         const { healed } = await healArchivedWorkstreamChildren(dbAdapter);
         if (healed > 0) {
           logger.main.info(`[RepositoryManager] Archived ${healed} orphaned workstream child session(s) whose parent was archived (NIM-1831)`);
+        }
+      });
+
+      // NIM-421: typed workstream containers are always roots. Repair only
+      // the invalid parent edge and route the write through the registered
+      // session store so ordinary sync metadata propagation still applies.
+      const hierarchyRepairSessionStore = this.sessionStore;
+      if (!hierarchyRepairSessionStore) {
+        throw new Error('Session store unavailable for NIM-421 hierarchy repair');
+      }
+      runWhenFirstUsable('nested-workstream-container-repair', async () => {
+        const { repaired } = await repairNestedWorkstreamContainers(
+          dbAdapter,
+          (sessionId, metadata) => hierarchyRepairSessionStore.updateMetadata(sessionId, metadata),
+        );
+        if (repaired > 0) {
+          logger.main.info(`[RepositoryManager] Unparented ${repaired} nested workstream container(s) (NIM-421)`);
         }
       });
 

--- a/packages/electron/src/main/services/__tests__/repairNestedWorkstreamContainers.test.ts
+++ b/packages/electron/src/main/services/__tests__/repairNestedWorkstreamContainers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { repairNestedWorkstreamContainers } from '../repairNestedWorkstreamContainers';
+
+describe('repairNestedWorkstreamContainers', () => {
+  it('unparents only invalid typed containers through the normal metadata writer', async () => {
+    const sql: string[] = [];
+    const db = {
+      query: vi.fn(async (query: string) => {
+        sql.push(query);
+        return { rows: [{ id: 'nested-a' }, { id: 'nested-b' }] };
+      }),
+    };
+    const updateMetadata = vi.fn(async () => undefined);
+
+    const result = await repairNestedWorkstreamContainers(db as any, updateMetadata);
+
+    expect(result).toEqual({ repaired: 2 });
+    expect(updateMetadata.mock.calls).toEqual([
+      ['nested-a', { parentSessionId: null }],
+      ['nested-b', { parentSessionId: null }],
+    ]);
+    expect(sql.join('\n')).toMatch(/session_type = 'workstream'/i);
+    expect(sql.join('\n')).toMatch(/parent_session_id IS NOT NULL/i);
+    expect(sql.join('\n')).not.toMatch(/ai_agent_messages/i);
+    expect(sql.join('\n')).not.toMatch(/\bDELETE\b/i);
+  });
+
+  it('is idempotent once no invalid edges remain', async () => {
+    const db = {
+      query: vi.fn()
+        .mockResolvedValueOnce({ rows: [{ id: 'nested' }] })
+        .mockResolvedValueOnce({ rows: [] }),
+    };
+    const updateMetadata = vi.fn(async () => undefined);
+
+    expect(await repairNestedWorkstreamContainers(db as any, updateMetadata)).toEqual({ repaired: 1 });
+    expect(await repairNestedWorkstreamContainers(db as any, updateMetadata)).toEqual({ repaired: 0 });
+    expect(updateMetadata).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/electron/src/main/services/repairNestedWorkstreamContainers.ts
+++ b/packages/electron/src/main/services/repairNestedWorkstreamContainers.ts
@@ -1,0 +1,33 @@
+import type { UpdateSessionMetadataPayload } from '@nimbalyst/runtime/ai/adapters/sessionStore';
+
+type PGliteLike = {
+  query: <T = any>(sql: string, params?: any[]) => Promise<{ rows: T[] }>;
+};
+
+type UpdateSessionMetadata = (
+  sessionId: string,
+  metadata: UpdateSessionMetadataPayload,
+) => Promise<void>;
+
+/**
+ * Repair the one forbidden edge only. Updates flow through the registered
+ * session store so connected sync sessions receive the same metadata update as
+ * an ordinary reparent; transcript rows are never queried or mutated.
+ */
+export async function repairNestedWorkstreamContainers(
+  db: PGliteLike,
+  updateSessionMetadata: UpdateSessionMetadata,
+): Promise<{ repaired: number }> {
+  const result = await db.query<{ id: string }>(
+    `SELECT id
+     FROM ai_sessions
+     WHERE session_type = 'workstream'
+       AND parent_session_id IS NOT NULL`,
+  );
+
+  for (const { id } of result.rows) {
+    await updateSessionMetadata(id, { parentSessionId: null });
+  }
+
+  return { repaired: result.rows.length };
+}

--- a/packages/electron/src/renderer/components/AgentMode/AgentMode.tsx
+++ b/packages/electron/src/renderer/components/AgentMode/AgentMode.tsx
@@ -37,6 +37,7 @@ import {
   viewModeAtom,
   setViewModeAtom,
   registerWorkstreamSelectedHook,
+  workstreamSessionsAtom,
 } from '../../store';
 import {
   initWorkstreamState,
@@ -77,6 +78,7 @@ import {
   addSessionToWorktreeActionAtom,
 } from '../../store/actions/sessionHistoryActions';
 import { defaultAgentModelAtom } from '../../store/atoms/appSettings';
+import { reconcileActiveSessionId } from '../../../shared/sessionHierarchy';
 export interface AgentModeRef {
   createNewSession: (initialDraft?: string) => Promise<string | undefined>;
   createNewWorktreeSession: (options?: { baseBranch?: string; name?: string }) => Promise<void>;
@@ -209,9 +211,22 @@ export const AgentMode = forwardRef<AgentModeRef, AgentModeProps>(function Agent
     [selectedWorkstream?.id]
   );
   const activeChildId = useAtomValue(activeChildAtom);
+  const memberSessionIdsAtom = useMemo(
+    () => selectedWorkstream ? workstreamSessionsAtom(selectedWorkstream.id) : atom<string[]>([]),
+    [selectedWorkstream?.id],
+  );
+  const memberSessionIds = useAtomValue(memberSessionIdsAtom);
 
-  // The actual active session is either the active child OR the workstream parent
-  const actualActiveSessionId = activeChildId || selectedWorkstream?.id || null;
+  // Route only to a current member. Empty typed containers deliberately have
+  // no transcript-bearing active session.
+  const actualActiveSessionId = selectedWorkstream
+    ? reconcileActiveSessionId({
+        containerId: selectedWorkstream.id,
+        childSessionIds: memberSessionIds,
+        activeSessionId: activeChildId,
+        isStructuralContainer: selectedWorkstream.type === 'workstream',
+      })
+    : null;
 
   // Sync the active session to the global atom so nav gutter components
   // (VoiceModeButton) can read it without workstream context. The global
@@ -368,11 +383,13 @@ export const AgentMode = forwardRef<AgentModeRef, AgentModeProps>(function Agent
         mode: 'agent',
         agent: {
           workstreamId: selectedWorkstream?.id || actualActiveSessionId,
-          childSessionId: activeChildId || null,
+          childSessionId: actualActiveSessionId === selectedWorkstream?.id
+            ? null
+            : actualActiveSessionId,
         },
       });
     }
-  }, [isActive, actualActiveSessionId, selectedWorkstream?.id, activeChildId, pushNavigationEntry, isRestoringNavigation]);
+  }, [isActive, actualActiveSessionId, selectedWorkstream?.id, pushNavigationEntry, isRestoringNavigation]);
 
   // Handle "New Session" from tray menu (dispatchCreateNewSession is identity-stable)
   const trayNewSessionRequest = useAtomValue(trayNewSessionRequestAtom);

--- a/packages/electron/src/renderer/components/AgentMode/AgentWorkstreamPanel.tsx
+++ b/packages/electron/src/renderer/components/AgentMode/AgentWorkstreamPanel.tsx
@@ -107,6 +107,7 @@ import {
   setSessionTagsAtom,
 } from '../../store/atoms/sessionKanban';
 import { defaultAgentModelAtom } from '../../store/atoms/appSettings';
+import { reconcileActiveSessionId } from '../../../shared/sessionHierarchy';
 
 export interface AgentWorkstreamPanelRef {
   closeActiveTab: () => void;
@@ -825,7 +826,13 @@ export const AgentWorkstreamPanel = React.memo(React.forwardRef<AgentWorkstreamP
 
   // Get sessions in this workstream
   const sessions = useAtomValue(workstreamSessionsAtom(workstreamId));
-  const activeSessionId = useAtomValue(workstreamActiveChildAtom(workstreamId));
+  const persistedActiveSessionId = useAtomValue(workstreamActiveChildAtom(workstreamId));
+  const activeSessionId = reconcileActiveSessionId({
+    containerId: workstreamId,
+    childSessionIds: sessions,
+    activeSessionId: persistedActiveSessionId,
+    isStructuralContainer: workstreamType === 'workstream',
+  });
   const setActiveSession = useSetAtom(setActiveSessionInWorkstreamAtom);
 
   // Worktree state - read cached worktree path from atom (available synchronously on remount)
@@ -835,6 +842,12 @@ export const AgentWorkstreamPanel = React.memo(React.forwardRef<AgentWorkstreamP
   const sessionWorktreeId = useAtomValue(sessionWorktreeIdAtom(workstreamId));
   const worktreeRecord = useAtomValue(worktreeRecordAtom(sessionWorktreeId ?? NO_WORKTREE_KEY));
   const setWorktreeRecord = useSetAtom(setWorktreeRecordAtom);
+
+  useEffect(() => {
+    if (persistedActiveSessionId !== activeSessionId) {
+      setWorkstreamState({ activeChildId: activeSessionId });
+    }
+  }, [persistedActiveSessionId, activeSessionId, setWorkstreamState]);
 
   // Debug: log when activeSessionId changes
   // useEffect(() => {

--- a/packages/electron/src/renderer/components/AgentMode/EmptyWorkstreamState.tsx
+++ b/packages/electron/src/renderer/components/AgentMode/EmptyWorkstreamState.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export const EmptyWorkstreamState: React.FC<{ onNewSession: () => void }> = ({
+  onNewSession,
+}) => (
+  <div
+    className="workstream-session-tabs-empty flex flex-1 flex-col items-center justify-center gap-3 text-[var(--nim-text-muted)] text-sm"
+    data-testid="workstream-session-tabs-empty"
+  >
+    <p>This workstream has no sessions.</p>
+    <button className="nim-btn nim-btn-primary" onClick={onNewSession}>
+      New session
+    </button>
+  </div>
+);

--- a/packages/electron/src/renderer/components/AgentMode/WorkstreamSessionTabs.tsx
+++ b/packages/electron/src/renderer/components/AgentMode/WorkstreamSessionTabs.tsx
@@ -26,9 +26,14 @@ import {
 } from '../../store';
 import { defaultAgentModelAtom } from '../../store/atoms/appSettings';
 import { convertToWorkstreamAtom } from '../../store/atoms/sessions';
-import { workstreamHasChildrenAtom } from '../../store/atoms/workstreamState';
+import {
+  workstreamHasChildrenAtom,
+  workstreamTypeAtom,
+} from '../../store/atoms/workstreamState';
 import { SessionContextMenu } from '../AgenticCoding/SessionContextMenu';
 import type { SerializableDocumentContext } from '../../hooks/useDocumentContext';
+import { isStructuralWorkstreamContainer } from '../../../shared/sessionHierarchy';
+import { EmptyWorkstreamState } from './EmptyWorkstreamState';
 
 export interface WorkstreamSessionTabsProps {
   workspacePath: string;
@@ -232,6 +237,7 @@ export const WorkstreamSessionTabs: React.FC<WorkstreamSessionTabsProps> = React
   collapseTranscript = false,
 }) => {
   const hasChildren = useAtomValue(workstreamHasChildrenAtom(workstreamId));
+  const storedWorkstreamType = useAtomValue(workstreamTypeAtom(workstreamId));
   const createChildSession = useSetAtom(createChildSessionAtom);
   const convertToWorkstream = useSetAtom(convertToWorkstreamAtom);
   const defaultModel = useAtomValue(defaultAgentModelAtom);
@@ -248,9 +254,11 @@ export const WorkstreamSessionTabs: React.FC<WorkstreamSessionTabsProps> = React
     const registry = store.get(sessionRegistryAtom);
     const sessionMeta = registry.get(workstreamId);
     const resolvedParentId = sessionMeta?.parentSessionId || workstreamId;
+    const isStructuralContainer = isStructuralWorkstreamContainer(sessionMeta)
+      || storedWorkstreamType === 'workstream';
 
     // Regular workstream logic
-    if (hasChildren || resolvedParentId !== workstreamId) {
+    if (hasChildren || isStructuralContainer || resolvedParentId !== workstreamId) {
       // Already a workstream (has children, or we resolved to a parent) - create a child
       await createChildSession({
         parentSessionId: resolvedParentId,
@@ -265,21 +273,35 @@ export const WorkstreamSessionTabs: React.FC<WorkstreamSessionTabsProps> = React
         model: defaultModel,
       });
     }
-  }, [workstreamId, workspacePath, hasChildren, worktreeId, onAddSessionToWorktree, createChildSession, convertToWorkstream, defaultModel]);
+  }, [workstreamId, workspacePath, hasChildren, storedWorkstreamType, worktreeId, onAddSessionToWorktree, createChildSession, convertToWorkstream, defaultModel]);
 
-  if (!activeSessionId) {
+  const routableActiveSessionId = activeSessionId && sessions.includes(activeSessionId)
+    ? activeSessionId
+    : sessions[0] ?? null;
+
+  if (sessions.length === 0) {
     return (
-      <div className="workstream-session-tabs-empty flex items-center justify-center h-full text-[var(--nim-text-muted)] text-sm">
-        <p>Loading sessions...</p>
+      <div className="workstream-session-tabs flex flex-col overflow-hidden h-full">
+        <SessionTabBar
+          sessions={[]}
+          activeSessionId={null}
+          onSessionSelect={onSessionSelect}
+          onNewSession={handleNewSession}
+        />
+        <EmptyWorkstreamState onNewSession={handleNewSession} />
       </div>
     );
+  }
+
+  if (!routableActiveSessionId) {
+    return null;
   }
 
   return (
     <div className={`workstream-session-tabs flex flex-col overflow-hidden ${collapseTranscript ? '' : 'h-full'}`}>
       <SessionTabBar
         sessions={sessions}
-        activeSessionId={activeSessionId}
+        activeSessionId={routableActiveSessionId}
         onSessionSelect={onSessionSelect}
         onNewSession={handleNewSession}
         onSessionArchive={onSessionArchive}
@@ -289,8 +311,8 @@ export const WorkstreamSessionTabs: React.FC<WorkstreamSessionTabsProps> = React
 
       <div className={`workstream-session-tabs-content overflow-hidden ${collapseTranscript ? '' : 'flex-1 min-h-0'}`}>
         <AgentSessionPanel
-          key={activeSessionId}
-          sessionId={activeSessionId}
+          key={routableActiveSessionId}
+          sessionId={routableActiveSessionId}
           workspacePath={workspacePath}
           onFileClick={onFileClick}
           onClearAgentSession={handleNewSession}

--- a/packages/electron/src/renderer/components/AgentMode/__tests__/EmptyWorkstreamState.test.tsx
+++ b/packages/electron/src/renderer/components/AgentMode/__tests__/EmptyWorkstreamState.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EmptyWorkstreamState } from '../EmptyWorkstreamState';
+
+afterEach(cleanup);
+
+describe('EmptyWorkstreamState', () => {
+  it('shows a truthful empty state with a working creation affordance', () => {
+    const onNewSession = vi.fn();
+    render(<EmptyWorkstreamState onNewSession={onNewSession} />);
+
+    expect(screen.getByText('This workstream has no sessions.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'New session' }));
+    expect(onNewSession).toHaveBeenCalledOnce();
+    expect(screen.queryByText('Loading sessions...')).toBeNull();
+  });
+});

--- a/packages/electron/src/renderer/components/AgenticCoding/SessionHistory.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/SessionHistory.tsx
@@ -2226,8 +2226,8 @@ const SessionHistoryComponent: React.FC = () => {
       if (metaAgentSessionIds.has(session.id) || metaAgentChildSessionIds.has(session.id)) continue;
 
       if (!session.worktreeId) {
-        // Check if this is a workstream (has children)
-        const isWorkstream = (session.childCount ?? 0) > 0;
+        // Typed workstream containers remain structural even when empty.
+        const isWorkstream = isWorkstreamParentSession(session);
         if (isWorkstream) {
           // Create workstream item with cached children (or empty array if not loaded yet)
           const cachedChildren = workstreamChildrenCache.get(session.id) || [];

--- a/packages/electron/src/renderer/components/AgenticCoding/SessionListItem.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/SessionListItem.tsx
@@ -194,7 +194,9 @@ export const SessionListItem = memo<SessionListItemProps>(({
   // Determine if this session can be dragged
   // Can drag if: (1) Has a parent (is a child session), OR (2) Is an orphan (no parent, no children)
   // Worktree sessions cannot be dragged - they are tied to their git worktree
-  const isDraggable = !isWorktreeSession && (parentSessionId !== null || !isWorkstream);
+  const isDraggable = sessionType !== 'workstream'
+    && !isWorktreeSession
+    && (parentSessionId !== null || !isWorkstream);
 
   // Determine if this session can accept drops
   // Workstreams and standalone root sessions can be drop targets (dropping creates a workstream)
@@ -258,12 +260,14 @@ export const SessionListItem = memo<SessionListItemProps>(({
       parentId: parentSessionId,
       workspacePath: projectPath,
       isWorktreeSession,
+      isWorkstream,
+      sessionType,
     };
 
     e.dataTransfer.setData('application/x-nimbalyst-session', JSON.stringify(dragData));
     e.dataTransfer.effectAllowed = 'move';
     setIsDragging(true);
-  }, [isDraggable, id, parentSessionId, projectPath, isWorktreeSession]);
+  }, [isDraggable, id, parentSessionId, projectPath, isWorktreeSession, isWorkstream, sessionType]);
 
   const handleDragEnd = useCallback((e: React.DragEvent) => {
     setIsDragging(false);
@@ -299,11 +303,20 @@ export const SessionListItem = memo<SessionListItemProps>(({
     if (!dataStr || !projectPath) return;
 
     try {
-      const { sessionId, parentId, workspacePath, isWorktreeSession: draggedIsWorktree } = JSON.parse(dataStr);
+      const {
+        sessionId,
+        parentId,
+        workspacePath,
+        isWorktreeSession: draggedIsWorktree,
+        isWorkstream: draggedIsWorkstream,
+        sessionType: draggedSessionType,
+      } = JSON.parse(dataStr);
 
-      // Validate worktree sessions cannot be moved
-      if (draggedIsWorktree) {
-        console.error('[SessionListItem] Cannot move worktree sessions');
+      // Structural containers and worktree sessions cannot be moved. Check
+      // before converting a standalone drop target so a rejected source cannot
+      // leave behind an unnecessary workstream container.
+      if (draggedIsWorktree || draggedIsWorkstream || draggedSessionType === 'workstream') {
+        console.error('[SessionListItem] Cannot move structural or worktree sessions');
         return;
       }
 

--- a/packages/electron/src/renderer/components/AgenticCoding/WorkstreamGroup.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/WorkstreamGroup.tsx
@@ -10,11 +10,13 @@ import {
   groupSessionStatusAtom,
   reparentSessionAtom,
   refreshSessionListAtom,
+  sessionRegistryAtom,
   sessionShareAtom,
   removeSessionShareAtom,
   shareKeysAtom,
   buildShareUrl,
 } from '../../store';
+import { isStructuralWorkstreamContainer } from '../../../shared/sessionHierarchy';
 import { errorNotificationService } from '../../services/ErrorNotificationService';
 import { WorktreeIcon } from '../common/WorktreeIcon';
 import { dialogRef, DIALOG_IDS } from '../../dialogs';
@@ -194,6 +196,7 @@ export const WorkstreamGroup: React.FC<WorkstreamGroupProps> = ({
   const [isValidDropTarget, setIsValidDropTarget] = useState(false);
   const reparentSession = useSetAtom(reparentSessionAtom);
   const refreshSessionList = useSetAtom(refreshSessionListAtom);
+  const sessionRegistry = useAtomValue(sessionRegistryAtom);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     if (type !== 'workstream' || !projectPath) return;
@@ -223,10 +226,23 @@ export const WorkstreamGroup: React.FC<WorkstreamGroupProps> = ({
     if (!dataStr || !projectPath) return;
 
     try {
-      const { sessionId, parentId, workspacePath, isWorktreeSession: draggedIsWorktree } = JSON.parse(dataStr);
+      const {
+        sessionId,
+        parentId,
+        workspacePath,
+        isWorktreeSession: draggedIsWorktree,
+        isWorkstream: draggedIsWorkstream,
+        sessionType: draggedSessionType,
+      } = JSON.parse(dataStr);
+      const sourceSession = sessionRegistry.get(sessionId);
 
-      // Worktree sessions cannot be moved
-      if (draggedIsWorktree) return;
+      // Structural containers and worktree sessions cannot be moved.
+      if (
+        draggedIsWorktree
+        || draggedIsWorkstream
+        || draggedSessionType === 'workstream'
+        || isStructuralWorkstreamContainer(sourceSession)
+      ) return;
 
       if (workspacePath !== projectPath) return;
       if (sessionId === id) return;
@@ -254,7 +270,7 @@ export const WorkstreamGroup: React.FC<WorkstreamGroupProps> = ({
     } catch (error) {
       console.error('[WorkstreamGroup] Failed to handle drop:', error);
     }
-  }, [type, projectPath, id, reparentSession, refreshSessionList]);
+  }, [type, projectPath, id, reparentSession, refreshSessionList, sessionRegistry]);
 
   // Worktree rename state
   const [isRenamingWorktree, setIsRenamingWorktree] = useState(false);
@@ -733,6 +749,14 @@ export const WorkstreamGroup: React.FC<WorkstreamGroupProps> = ({
       {/* Sessions List */}
       {isExpanded && (
         <div className="workstream-group-sessions pt-1 pb-1 pl-10 animate-[workstreamSlideDown_0.2s_ease-out]">
+          {type === 'workstream' && sortedSessions.length === 0 && (
+            <div
+              className="workstream-group-empty py-2 pr-3 text-xs text-[var(--nim-text-faint)]"
+              data-testid="workstream-group-empty"
+            >
+              No sessions yet
+            </div>
+          )}
           {sortedSessions.map(session => (
             <WorkstreamSessionItem
               key={session.id}

--- a/packages/electron/src/renderer/components/AgenticCoding/__tests__/WorkstreamGroup.childPinReconciliation.test.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/__tests__/WorkstreamGroup.childPinReconciliation.test.tsx
@@ -40,6 +40,7 @@ vi.mock('../../../store', () => {
     }),
     reparentSessionAtom: setter(async () => true),
     refreshSessionListAtom: setter(async () => undefined),
+    sessionRegistryAtom: value(new Map()),
     sessionShareAtom: () => value(null),
     removeSessionShareAtom: setter(),
     shareKeysAtom: value(new Map()),

--- a/packages/electron/src/renderer/components/AgenticCoding/__tests__/WorkstreamGroup.titleTooltip.test.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/__tests__/WorkstreamGroup.titleTooltip.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../../../store', () => ({
   groupSessionStatusAtom: () => ({}),
   reparentSessionAtom: () => ({}),
   refreshSessionListAtom: () => ({}),
+  sessionRegistryAtom: () => ({}),
   sessionShareAtom: () => ({}),
   removeSessionShareAtom: () => ({}),
   shareKeysAtom: () => ({}),

--- a/packages/electron/src/renderer/store/atoms/__tests__/sessionListFilter.test.ts
+++ b/packages/electron/src/renderer/store/atoms/__tests__/sessionListFilter.test.ts
@@ -50,6 +50,11 @@ describe('session list virtual tags', () => {
   it('recognizes legacy child-bearing roots as workstreams without including blitzes', () => {
     expect(isWorkstreamParentSession(session({ id: 'legacy', childCount: 2 }))).toBe(true);
     expect(isWorkstreamParentSession(session({
+      id: 'empty-typed',
+      sessionType: 'workstream',
+      childCount: 0,
+    }))).toBe(true);
+    expect(isWorkstreamParentSession(session({
       id: 'blitz',
       sessionType: 'blitz',
       childCount: 2,

--- a/packages/electron/src/renderer/store/atoms/__tests__/sessions.workstreamIdentity.test.ts
+++ b/packages/electron/src/renderer/store/atoms/__tests__/sessions.workstreamIdentity.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createStore } from 'jotai';
+import type { SessionMeta } from '@nimbalyst/runtime';
+import {
+  loadSessionChildrenAtom,
+  reparentSessionAtom,
+  sessionChildrenAtom,
+  sessionRegistryAtom,
+  workstreamSessionsAtom,
+} from '../sessions';
+import {
+  initWorkstreamState,
+  setWorkstreamActiveChildAtom,
+  workstreamStateAtom,
+} from '../workstreamState';
+
+function session(overrides: Partial<SessionMeta> & Pick<SessionMeta, 'id'>): SessionMeta {
+  const { id, ...rest } = overrides;
+  return {
+    id,
+    title: id,
+    provider: 'test',
+    sessionType: 'session',
+    workspaceId: '/workspace',
+    worktreeId: null,
+    parentSessionId: null,
+    childCount: 0,
+    uncommittedCount: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    messageCount: 0,
+    isArchived: false,
+    isPinned: false,
+    ...rest,
+  };
+}
+
+describe('workstream active-child identity', () => {
+  const workspacePath = '/workspace';
+  const parentId = 'workstream';
+  let jotaiStore: ReturnType<typeof createStore>;
+  let invoke: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    jotaiStore = createStore();
+    initWorkstreamState(workspacePath);
+    invoke = vi.fn(async (channel: string) => {
+      if (channel === 'sessions:set-parent') return { success: true };
+      throw new Error(`Unexpected IPC channel: ${channel}`);
+    });
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: { invoke },
+    });
+  });
+
+  it('keeps a non-removed active child selected', async () => {
+    jotaiStore.set(sessionChildrenAtom(parentId), ['active', 'removed']);
+    jotaiStore.set(workstreamStateAtom(parentId), {
+      type: 'workstream',
+      childSessionIds: ['active', 'removed'],
+      activeChildId: 'active',
+    });
+
+    await jotaiStore.set(reparentSessionAtom, {
+      sessionId: 'removed',
+      oldParentId: parentId,
+      newParentId: null,
+      workspacePath,
+    });
+
+    expect(jotaiStore.get(workstreamStateAtom(parentId)).activeChildId).toBe('active');
+  });
+
+  it('selects the first remaining child when the active child is removed', async () => {
+    jotaiStore.set(sessionChildrenAtom(parentId), ['removed', 'remaining']);
+    jotaiStore.set(workstreamStateAtom(parentId), {
+      type: 'workstream',
+      childSessionIds: ['removed', 'remaining'],
+      activeChildId: 'removed',
+    });
+
+    await jotaiStore.set(reparentSessionAtom, {
+      sessionId: 'removed',
+      oldParentId: parentId,
+      newParentId: null,
+      workspacePath,
+    });
+
+    expect(jotaiStore.get(workstreamStateAtom(parentId)).activeChildId).toBe('remaining');
+  });
+
+  it('reconciles idempotently as both children leave a typed workstream', async () => {
+    jotaiStore.set(sessionChildrenAtom(parentId), ['first', 'last']);
+    jotaiStore.set(workstreamStateAtom(parentId), {
+      type: 'workstream',
+      childSessionIds: ['first', 'last'],
+      activeChildId: 'first',
+    });
+
+    await jotaiStore.set(reparentSessionAtom, {
+      sessionId: 'first',
+      oldParentId: parentId,
+      newParentId: null,
+      workspacePath,
+    });
+
+    expect(jotaiStore.get(workstreamStateAtom(parentId)).activeChildId).toBe('last');
+
+    await jotaiStore.set(reparentSessionAtom, {
+      sessionId: 'last',
+      oldParentId: parentId,
+      newParentId: null,
+      workspacePath,
+    });
+
+    const state = jotaiStore.get(workstreamStateAtom(parentId));
+    expect(state.activeChildId).toBeNull();
+    expect(state.type).toBe('workstream');
+  });
+
+  it('loads an empty typed workstream without routing to the container itself', async () => {
+    jotaiStore.set(
+      sessionRegistryAtom,
+      new Map([[parentId, session({ id: parentId, sessionType: 'workstream' })]]),
+    );
+    invoke.mockResolvedValueOnce({ success: true, children: [] });
+
+    await jotaiStore.set(loadSessionChildrenAtom, { parentSessionId: parentId, workspacePath });
+
+    const state = jotaiStore.get(workstreamStateAtom(parentId));
+    expect(state.childSessionIds).toEqual([]);
+    expect(state.activeChildId).toBeNull();
+    expect(state.type).toBe('workstream');
+    expect(jotaiStore.get(workstreamSessionsAtom(parentId))).toEqual([]);
+  });
+
+  it('allows an explicit null active child for an empty container', () => {
+    jotaiStore.set(workstreamStateAtom(parentId), {
+      type: 'workstream',
+      activeChildId: 'stale',
+    });
+
+    jotaiStore.set(setWorkstreamActiveChildAtom, {
+      workstreamId: parentId,
+      childId: null,
+    });
+
+    expect(jotaiStore.get(workstreamStateAtom(parentId)).activeChildId).toBeNull();
+  });
+});

--- a/packages/electron/src/renderer/store/atoms/sessions.ts
+++ b/packages/electron/src/renderer/store/atoms/sessions.ts
@@ -22,6 +22,10 @@ import type { SessionMeta } from '@nimbalyst/runtime';
 import deepEqual from 'fast-deep-equal';
 import { workstreamStateAtom, setWorkstreamActiveChildAtom } from './workstreamState';
 import { aiInputHistoryAtom } from './aiInputUndo';
+import {
+  isStructuralWorkstreamContainer,
+  reconcileActiveSessionId,
+} from '../../../shared/sessionHierarchy';
 
 // SessionMeta is imported from @nimbalyst/runtime (canonical type).
 // Re-export for consumers that import from the store.
@@ -1158,16 +1162,24 @@ export const loadSessionChildrenAtom = atom(
         // console.log('[loadSessionChildrenAtom] Current workstream state:', currentState);
         // console.log('[loadSessionChildrenAtom] Current active child:', currentActive, 'childIds:', childIds);
 
-        // Determine the active child:
-        // - If has children: use current active if valid, else first child
-        // - If no children (single session): use the parent session itself
-        const newActiveChild = childIds.length > 0
-          ? (currentActive && childIds.includes(currentActive) ? currentActive : childIds[0])
-          : parentSessionId;
+        const parentMeta = get(sessionRegistryAtom).get(parentSessionId);
+        const parentData = get(sessionStoreAtom(parentSessionId));
+        const isStructuralContainer = isStructuralWorkstreamContainer({
+          id: parentSessionId,
+          sessionType: parentMeta?.sessionType ?? parentData?.sessionType,
+          childCount: parentMeta?.childCount,
+          metadata: parentData?.metadata,
+        }) || currentState.type === 'workstream';
+        const newActiveChild = reconcileActiveSessionId({
+          containerId: parentSessionId,
+          childSessionIds: childIds,
+          activeSessionId: currentActive,
+          isStructuralContainer,
+        });
         // console.log('[loadSessionChildrenAtom] Setting activeChildId to:', newActiveChild);
 
         set(workstreamStateAtom(parentSessionId), {
-          type: childIds.length > 0 ? 'workstream' : 'single',
+          type: isStructuralContainer ? 'workstream' : 'single',
           childSessionIds: childIds,
           activeChildId: newActiveChild,
         });
@@ -1326,6 +1338,30 @@ export const reparentSessionAtom = atom(
     }
 
     try {
+      const registry = get(sessionRegistryAtom);
+      const source = registry.get(sessionId);
+      const destination = newParentId ? registry.get(newParentId) : null;
+      if (
+        source && (
+          isStructuralWorkstreamContainer(source)
+          || Boolean(source.worktreeId)
+          || source.workspaceId !== workspacePath
+        )
+      ) {
+        return false;
+      }
+      if (
+        newParentId && (
+          sessionId === newParentId
+          || !destination
+          || destination.workspaceId !== workspacePath
+          || Boolean(destination.parentSessionId)
+          || Boolean(destination.worktreeId)
+        )
+      ) {
+        return false;
+      }
+
       // Call IPC to update database
       const result = await window.electronAPI.invoke(
         'sessions:set-parent',
@@ -1352,8 +1388,16 @@ export const reparentSessionAtom = atom(
         set(sessionChildrenAtom(oldParentId), newOldChildren);
 
         // Update old parent's workstream state
+        const oldState = get(workstreamStateAtom(oldParentId));
         set(workstreamStateAtom(oldParentId), {
+          type: 'workstream',
           childSessionIds: newOldChildren,
+          activeChildId: reconcileActiveSessionId({
+            containerId: oldParentId,
+            childSessionIds: newOldChildren,
+            activeSessionId: oldState.activeChildId,
+            isStructuralContainer: true,
+          }),
         });
       }
 
@@ -2491,11 +2535,16 @@ export const workstreamSessionsAtom = atomFamily((workstreamId: string) =>
       return filterArchived(worktreeSessions);
     }
 
-    // Check if this is a workstream root that hasn't had children loaded yet
-    // Look up childCount from the registry (more reliable than metadata)
+    // Check if this is a workstream root that hasn't had children loaded yet.
+    // Typed empty containers remain structural and must never route to self.
     const sessionMeta = registry.get(workstreamId);
     // console.log('[workstreamSessionsAtom]', workstreamId, 'sessionMeta:', sessionMeta?.id, 'childCount:', sessionMeta?.childCount);
-    if (sessionMeta?.childCount && sessionMeta.childCount > 0) {
+    if (isStructuralWorkstreamContainer({
+      id: workstreamId,
+      sessionType: sessionMeta?.sessionType ?? sessionData?.sessionType,
+      childCount: sessionMeta?.childCount,
+      metadata: sessionData?.metadata,
+    })) {
       // This is a workstream parent - find non-archived children from registry by parentSessionId
       // This works even before the workstream is opened
       const childrenFromRegistry = Array.from(registry.values())

--- a/packages/electron/src/renderer/store/atoms/workstreamState.ts
+++ b/packages/electron/src/renderer/store/atoms/workstreamState.ts
@@ -655,7 +655,7 @@ export const setWorktreeActiveSessionAtom = atom(
  */
 export const setWorkstreamActiveChildAtom = atom(
   null,
-  (get, set, { workstreamId, childId }: { workstreamId: string; childId: string }) => {
+  (get, set, { workstreamId, childId }: { workstreamId: string; childId: string | null }) => {
     set(workstreamStateAtom(workstreamId), { activeChildId: childId });
   }
 );

--- a/packages/electron/src/shared/__tests__/sessionHierarchy.test.ts
+++ b/packages/electron/src/shared/__tests__/sessionHierarchy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isStructuralWorkstreamContainer,
+  reconcileActiveSessionId,
+} from '../sessionHierarchy';
+
+describe('session hierarchy identity', () => {
+  it('recognizes typed, metadata-backed, and child-bearing containers', () => {
+    expect(isStructuralWorkstreamContainer({ id: 'typed', sessionType: 'workstream' })).toBe(true);
+    expect(isStructuralWorkstreamContainer({
+      id: 'metadata',
+      metadata: { isWorkstreamRoot: true },
+    })).toBe(true);
+    expect(isStructuralWorkstreamContainer({ id: 'legacy', childCount: 1 })).toBe(true);
+    expect(isStructuralWorkstreamContainer({ id: 'session', sessionType: 'session' })).toBe(false);
+  });
+
+  it('never routes a stale active ID outside current membership', () => {
+    expect(reconcileActiveSessionId({
+      containerId: 'workstream',
+      childSessionIds: ['member'],
+      activeSessionId: 'stale',
+      isStructuralContainer: true,
+    })).toBe('member');
+  });
+
+  it('keeps empty containers unrouted while singleton sessions route to self', () => {
+    expect(reconcileActiveSessionId({
+      containerId: 'workstream',
+      childSessionIds: [],
+      activeSessionId: 'stale',
+      isStructuralContainer: true,
+    })).toBeNull();
+    expect(reconcileActiveSessionId({
+      containerId: 'session',
+      childSessionIds: [],
+      activeSessionId: null,
+      isStructuralContainer: false,
+    })).toBe('session');
+  });
+});

--- a/packages/electron/src/shared/sessionHierarchy.ts
+++ b/packages/electron/src/shared/sessionHierarchy.ts
@@ -1,0 +1,50 @@
+export interface SessionHierarchyNode {
+  id: string;
+  sessionType?: string | null;
+  parentSessionId?: string | null;
+  worktreeId?: string | null;
+  childCount?: number | null;
+  metadata?: Record<string, unknown> | null;
+}
+/**
+ * Structural workstream containers never own a transcript surface. Stored type
+ * is authoritative; metadata/children cover legacy rows created before typed
+ * workstream roots were consistently persisted.
+ */
+export function isStructuralWorkstreamContainer(
+  session: SessionHierarchyNode | null | undefined,
+): boolean {
+  return Boolean(
+    session
+      && (
+        session.sessionType === 'workstream'
+        || session.metadata?.isWorkstreamRoot === true
+        || (session.childCount ?? 0) > 0
+      )
+  );
+}
+
+/**
+ * Keep active-child state inside the current membership. Empty structural
+ * containers deliberately resolve to null; only transcript-bearing singleton
+ * sessions may route to their own ID.
+ */
+export function reconcileActiveSessionId({
+  containerId,
+  childSessionIds,
+  activeSessionId,
+  isStructuralContainer,
+}: {
+  containerId: string;
+  childSessionIds: readonly string[];
+  activeSessionId: string | null;
+  isStructuralContainer: boolean;
+}): string | null {
+  if (childSessionIds.length > 0) {
+    return activeSessionId && childSessionIds.includes(activeSessionId)
+      ? activeSessionId
+      : childSessionIds[0];
+  }
+
+  return isStructuralContainer ? null : containerId;
+}


### PR DESCRIPTION
## Summary

- preserve typed empty workstreams as structural containers without routing them to a transcript
- reject invalid and concurrent reparent operations that could create nested workstreams
- repair legacy nested containers and reconcile active child identity

## Successor scope

This is the independently accepted, author-clean current-upstream successor to legacy #974. It preserves #974 and integration-container #969 unchanged. CHANGELOG.md is intentionally excluded because its historical line is non-causal and is the only current-upstream merge conflict.

## Verification

- dependency-safe focused matrix: 6 files / 14 tests passed
- forced concurrent S -> D / D -> R interleaving regression passed
- Semgrep p/security-audit: zero findings/errors across 22 paths
- git diff --check passed
- independent rereview: ACCEPT, no actionable findings

The broader local Jotai-dependent window is unavailable because this checkout lacks its already-declared jotai-family package. Exact-head Unit Tests, TypeScript Check, and Transcript Bundle CI are therefore required before acceptance.

## Why this is worth merging

A workstream container still carries identity, ownership, ordering, and navigation value when its last child moves away. Deleting that container collapses the user's structure and makes later recovery ambiguous. Preserving the typed empty node keeps the hierarchy stable without treating it as a transcript-bearing session or runnable agent.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
