### PR TITLE
Protocol extension: optional force/reason on requestMobilePush (proposal, #704)

### DIFF
--- a/packages/collab-protocol/src/__tests__/personalMobilePush.test.ts
+++ b/packages/collab-protocol/src/__tests__/personalMobilePush.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import type { ClientMessage, RequestMobilePushMessage } from "../personal.js";
+
+// Client-side protocol extension for upstream issue #704: optional `force`/
+// `reason` fields on `RequestMobilePushMessage`. These are primarily
+// type-level regression tests -- the file fails to compile (not just fails
+// at runtime) if the fields are ever made required or removed, protecting
+// the backwards-compatibility contract this change is built around. This is
+// a protocol-only change: the sync server does not yet honor `force`/
+// `reason`, so this has no effect on delivered behavior until a companion
+// server-side change lands.
+
+describe("RequestMobilePushMessage force/reason fields (#704 protocol extension)", () => {
+  it("accepts a message with force/reason omitted (pre-existing shape, still valid)", () => {
+    const message: RequestMobilePushMessage = {
+      type: "requestMobilePush",
+      sessionId: "session-1",
+      title: "Title",
+      body: "Body",
+    };
+    expect(message.force).toBeUndefined();
+    expect(message.reason).toBeUndefined();
+  });
+
+  it("accepts a message with requestingDeviceId but no force/reason", () => {
+    const message: RequestMobilePushMessage = {
+      type: "requestMobilePush",
+      sessionId: "session-1",
+      title: "Title",
+      body: "Body",
+      requestingDeviceId: "device-1",
+    };
+    expect(message.force).toBeUndefined();
+    expect(message.reason).toBeUndefined();
+  });
+
+  it("accepts a message with force/reason set for explicit agent-attention flows", () => {
+    const message: RequestMobilePushMessage = {
+      type: "requestMobilePush",
+      sessionId: "session-1",
+      title: "Title",
+      body: "Body",
+      force: true,
+      reason: "agent_attention",
+    };
+    expect(message.force).toBe(true);
+    expect(message.reason).toBe("agent_attention");
+  });
+
+  it("is assignable to the ClientMessage union with force/reason present", () => {
+    const message: ClientMessage = {
+      type: "requestMobilePush",
+      sessionId: "session-1",
+      title: "Title",
+      body: "Body",
+      force: true,
+      reason: "agent_completion",
+    };
+    expect(message.type).toBe("requestMobilePush");
+  });
+});

--- a/packages/collab-protocol/src/personal.ts
+++ b/packages/collab-protocol/src/personal.ts
@@ -278,6 +278,20 @@ export interface RequestMobilePushMessage {
   body: string;
   /** Device ID of the requesting device, used for active-device routing */
   requestingDeviceId?: string;
+  /**
+   * When true, requests that the server bypass its default active-desktop
+   * suppression and deliver to mobile regardless of desktop presence.
+   * Optional and backwards-compatible: omit for the existing default
+   * (desktop-active suppression) behavior. Protocol-only for now -- the
+   * sync server must also be updated to honor this field before it has any
+   * effect.
+   */
+  force?: boolean;
+  /**
+   * Why this push is being requested. Intended to inform server-side
+   * rate-limiting and routing once the server honors `force`. Optional.
+   */
+  reason?: 'agent_attention' | 'agent_completion' | 'interactive_prompt';
 }
 
 /** Update project config (encrypted blob with commands, etc.) */

--- a/packages/runtime/src/sync/CollabV3Sync.ts
+++ b/packages/runtime/src/sync/CollabV3Sync.ts
@@ -299,7 +299,7 @@ type ClientMessage =
   | { type: 'voiceToolRequest'; request: EncryptedVoiceToolRequest }
   | { type: 'voiceToolResponse'; response: EncryptedVoiceToolResponse }
   | { type: 'sessionControl'; message: { sessionId: string; messageType: string; payload?: Record<string, unknown>; timestamp: number; sentBy: 'desktop' | 'mobile' } }
-  | { type: 'requestMobilePush'; sessionId: string; title: string; body: string; requestingDeviceId?: string }
+  | { type: 'requestMobilePush'; sessionId: string; title: string; body: string; requestingDeviceId?: string; force?: boolean; reason?: 'agent_attention' | 'agent_completion' | 'interactive_prompt' }
   | { type: 'settingsSync'; settings: EncryptedSettingsPayload }
   | { type: 'readReceipt'; receipt: EncryptedReadReceiptPayload }
   | { type: 'trackerPersonalState'; state: EncryptedTrackerPersonalStatePayload }
@@ -4134,7 +4134,12 @@ export function createCollabV3Sync(config: SyncConfig): SyncProvider {
     },
 
     /** Request the sync server to send a push notification to mobile devices */
-    async requestMobilePush(sessionId: string, title: string, body: string): Promise<void> {
+    async requestMobilePush(
+      sessionId: string,
+      title: string,
+      body: string,
+      options?: { force?: boolean; reason?: 'agent_attention' | 'agent_completion' | 'interactive_prompt' },
+    ): Promise<void> {
       // Ensure we're connected before sending the request
       if (!indexWs || !indexConnected) {
         console.log('[CollabV3] Not connected to index, attempting to reconnect before requesting mobile push...');
@@ -4165,6 +4170,8 @@ export function createCollabV3Sync(config: SyncConfig): SyncProvider {
         title,
         body,
         requestingDeviceId: deviceId,
+        force: options?.force,
+        reason: options?.reason,
       };
       // console.log('[CollabV3] Requesting mobile push for session:', sessionId, 'deviceId:', deviceId, 'readyState:', indexWs.readyState);
       try {

--- a/packages/runtime/src/sync/__tests__/CollabV3Sync.requestMobilePush.test.ts
+++ b/packages/runtime/src/sync/__tests__/CollabV3Sync.requestMobilePush.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createCollabV3Sync } from '../CollabV3Sync';
+
+// Covers the client-side protocol extension proposed in upstream issue #704:
+// optional `force`/`reason` fields on `requestMobilePush`. This is a
+// protocol-only, backwards-compatible change -- these tests confirm the
+// client threads the fields through the wire message when given, and that
+// omitting `options` produces byte-identical output to before this change
+// (no `force`/`reason` keys at all, since JSON.stringify drops `undefined`
+// values). The sync server does not yet honor these fields; see #704.
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = 0;
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = 3;
+    this.onclose?.({ code: 1000, reason: '', wasClean: true } as CloseEvent);
+  });
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  receive(message: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(message) } as MessageEvent);
+  }
+}
+
+function jwtFor(subject: string): string {
+  const payload = btoa(JSON.stringify({ sub: subject }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `header.${payload}.signature`;
+}
+
+describe('CollabV3Sync.requestMobilePush force/reason options', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('omits force/reason when options is not provided (backwards compatible)', async () => {
+    const provider = createCollabV3Sync({
+      serverUrl: 'wss://sync.example.test',
+      orgId: 'org-1',
+      userId: 'user-1',
+      getJwt: async () => jwtFor('user-1'),
+    });
+
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    const indexSocket = FakeWebSocket.instances[0];
+    indexSocket.open();
+
+    await provider.requestMobilePush?.('session-1', 'Title', 'Body');
+
+    expect(indexSocket.send).toHaveBeenCalledOnce();
+    const sent = JSON.parse(indexSocket.send.mock.calls[0][0] as string);
+    expect(sent).toEqual({
+      type: 'requestMobilePush',
+      sessionId: 'session-1',
+      title: 'Title',
+      body: 'Body',
+    });
+    expect(sent).not.toHaveProperty('force');
+    expect(sent).not.toHaveProperty('reason');
+
+    provider.disconnectAll();
+  });
+
+  it('forwards force/reason on the wire when explicitly requested', async () => {
+    const provider = createCollabV3Sync({
+      serverUrl: 'wss://sync.example.test',
+      orgId: 'org-1',
+      userId: 'user-1',
+      getJwt: async () => jwtFor('user-1'),
+    });
+
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    const indexSocket = FakeWebSocket.instances[0];
+    indexSocket.open();
+
+    await provider.requestMobilePush?.('session-1', 'Title', 'Body', {
+      force: true,
+      reason: 'agent_attention',
+    });
+
+    expect(indexSocket.send).toHaveBeenCalledOnce();
+    const sent = JSON.parse(indexSocket.send.mock.calls[0][0] as string);
+    expect(sent).toMatchObject({
+      type: 'requestMobilePush',
+      sessionId: 'session-1',
+      title: 'Title',
+      body: 'Body',
+      force: true,
+      reason: 'agent_attention',
+    });
+
+    provider.disconnectAll();
+  });
+});

--- a/packages/runtime/src/sync/types.ts
+++ b/packages/runtime/src/sync/types.ts
@@ -285,8 +285,27 @@ export interface SyncProvider {
    * Request the sync server to send a push notification to mobile devices.
    * Used when agent completes execution and user should be notified on mobile.
    * The server will check device presence before sending (suppresses if mobile is active).
+   *
+   * `options` is optional and backwards-compatible: omit it for the existing
+   * default behavior. `options.force`/`options.reason` are protocol-only
+   * today -- the sync server must also be updated to honor them before they
+   * have any effect (see `RequestMobilePushMessage` in `@nimbalyst/collab-protocol`).
    */
-  requestMobilePush?(sessionId: string, title: string, body: string): Promise<void>;
+  requestMobilePush?(
+    sessionId: string,
+    title: string,
+    body: string,
+    options?: {
+      /**
+       * When true, requests the server bypass its default active-desktop
+       * suppression and deliver to mobile regardless of desktop presence.
+       * Reserved for explicit user-authorized agent attention flows.
+       */
+      force?: boolean;
+      /** Why this push is being requested. */
+      reason?: 'agent_attention' | 'agent_completion' | 'interactive_prompt';
+    },
+  ): Promise<void>;
 
   /** Get list of currently connected devices */
   getConnectedDevices?(): DeviceInfo[];


### PR DESCRIPTION
## Summary

**Protocol-extension proposal only. This PR is inert alone: it introduces no user-visible
behavior change by itself.** It adds optional `force`/`reason` fields to the client-side
`requestMobilePush` wire protocol and threads them through the client sync provider's
`requestMobilePush` signature, matching the proposal in #704. All new fields/params are
optional, so this is fully backwards-compatible: any existing caller (and the current sync
server, which does not read these fields) behaves exactly as before.

- `packages/collab-protocol/src/personal.ts`: `RequestMobilePushMessage` gains optional
  `force?: boolean` and `reason?: 'agent_attention' | 'agent_completion' | 'interactive_prompt'`.
- `packages/runtime/src/sync/types.ts`: `SyncProvider.requestMobilePush` gains an optional
  4th `options?: { force?, reason? }` parameter.
- `packages/runtime/src/sync/CollabV3Sync.ts`: the implementation forwards `options.force` /
  `options.reason` into the outgoing wire message (and its local `ClientMessage` mirror type is
  updated to match). Omitting `options` produces byte-identical wire output to before this
  change (`JSON.stringify` drops the resulting `undefined` values).

**Explicitly out of scope for this PR** (see #704 for the full proposal):
- Any sync-server change to actually honor `force`/`reason` (not in this repo).
- Wiring the existing `notify_user` MCP tool's `mobilePush: "always"` option to
  `force: true, reason: "agent_attention"` -- that's separate follow-up work once a
  server-side companion change exists.

This is opened as a **draft** since there's no maintainer signal yet on #704 -- posting this
now to make the concrete shape of the proposed client-side change reviewable, not asking for a
merge decision yet.

## Related issue

Relates to #704 (does not close it -- the issue also requires a server-side change that is
outside this client repo's scope).

## Testing

- Added two targeted vitest files (only for the two changed packages) and ran them directly
  (not the full suite, per the known upstream test-fixture-pollution issue #812):
  - `packages/collab-protocol/src/__tests__/personalMobilePush.test.ts`: type-level regression
    coverage confirming `RequestMobilePushMessage` still accepts the pre-existing shape
    (`force`/`reason` omitted) and accepts the new optional fields when present.
  - `packages/runtime/src/sync/__tests__/CollabV3Sync.requestMobilePush.test.ts`: confirms
    `requestMobilePush(...)` without `options` sends a wire message with no `force`/`reason`
    keys at all (backwards compatible), and that
    `requestMobilePush(..., { force: true, reason: 'agent_attention' })` forwards both fields
    on the wire.
  - Both files pass: `npx vitest run packages/collab-protocol/src/__tests__/personalMobilePush.test.ts packages/runtime/src/sync/__tests__/CollabV3Sync.requestMobilePush.test.ts` -> 2 files, 6 tests, all passed.
- `tsc --noEmit` is clean for both `packages/collab-protocol` and `packages/runtime`.
- Confirmed via `grep` that the only two existing call sites of `requestMobilePush`
  (`packages/electron/src/main/services/ai/claudeCliObservationSingleton.ts` and
  `MessageStreamingHandler.ts`) call it with 3 positional args through optional chaining
  (`?.()`), so they are unaffected by the new optional 4th parameter.

## Notes for reviewers

- No changes to `packages/electron/src/main/mcp/metaAgentServer.ts` or any other `notify_user`
  call site -- that carry work is intentionally out of scope here.
- No server-side/sync-service changes (not in this repo).
- Please treat this as a shape-review of the protocol extension, not a request to merge a
  behavior change -- draft status reflects that.

## Why this is worth merging

Mobile delivery needs a principled distinction between routine updates and explicit human-attention requests. Adding optional `force` and `reason` fields at the protocol boundary lets callers request that distinction without inventing a second transport, while old clients remain compatible because both fields are optional. The reason also makes exceptional delivery auditable instead of turning `force` into an unexplained bypass.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
