### PR TITLE
feat: add Kimi Code (alpha) agent provider via ACP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Kimi Code (alpha) agent provider: use Moonshot AI's Kimi Code CLI (K3 models) as a coding agent, with its own settings panel and CLI-based login.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -186,7 +186,7 @@ import { installExtensionAgentBridge } from './extensions/extensionAgentBridge';
 import { getAgentWorkflowService } from './services/AgentWorkflowService';
 import { queueMarketplaceInstallRequest, registerExtensionMarketplaceHandlers, runExtensionAutoUpdate } from './ipc/ExtensionMarketplaceHandlers';
 import { getRegisteredExtensions } from './extensions/RegisteredFileTypes';
-import { ClaudeCodeProvider, OpenAICodexProvider, OpenAICodexACPProvider, OpenCodeProvider, CopilotCLIProvider } from '@nimbalyst/runtime/ai/server';
+import { ClaudeCodeProvider, OpenAICodexProvider, OpenAICodexACPProvider, OpenCodeProvider, CopilotCLIProvider, KimiCodeProvider } from '@nimbalyst/runtime/ai/server';
 import { configureMcpServers } from '@nimbalyst/runtime/ai/server';
 import { matchesAllowPattern } from '@nimbalyst/runtime/ai/server/permissions/toolPermissionHelpers';
 import { resolveCodexPreEditHookScriptPath } from './services/ai/codexPreEditHookPath';
@@ -1893,6 +1893,28 @@ app.whenReady().then(async () => {
         }
         return enabledServers;
     });
+    KimiCodeProvider.setMCPConfigLoader(async (workspacePath?: string) => {
+        if (!mcpConfigService) {
+            throw new Error('MCP config service not initialized');
+        }
+        const mergedConfig = await mcpConfigService.getMergedConfig(workspacePath);
+        const allServers = mergedConfig.mcpServers || {};
+
+        const enabledServers: Record<string, any> = {};
+        for (const [name, config] of Object.entries(allServers)) {
+            if (isMCPServerEnabledForProvider(config as MCPServerConfig, MCP_PROVIDER_IDS.KIMI)) {
+                const isAuthorized = await mcpConfigService.isOAuthAuthorized(config as MCPServerConfig, {
+                    useMcpRemoteForNativeOAuth: true,
+                });
+                if (!isAuthorized) {
+                    logger.mcp.info(`[MCP] Skipping unauthorized OAuth server for Kimi: ${name}`);
+                    continue;
+                }
+                enabledServers[name] = mcpConfigService.processServerConfigForRuntime(config as any);
+            }
+        }
+        return enabledServers;
+    });
 
     // Claude CLI (subscription) launcher shares the Claude Agent MCP filter —
     // the genuine CLI hits the identical MCP handlers as the SDK path (NIM-806).
@@ -1991,6 +2013,7 @@ app.whenReady().then(async () => {
     OpenAICodexACPProvider.setShellEnvironmentLoader(() => getShellEnvironment());
     OpenCodeProvider.setShellEnvironmentLoader(() => getShellEnvironment());
     CopilotCLIProvider.setShellEnvironmentLoader(() => getShellEnvironment());
+    KimiCodeProvider.setShellEnvironmentLoader(() => getShellEnvironment());
 
     // Inject enhanced PATH loader so agents can access system tools
     // (docker, homebrew, nvm, etc.) that are missing from Electron's GUI PATH.
@@ -2002,6 +2025,7 @@ app.whenReady().then(async () => {
     OpenAICodexACPProvider.setEnhancedPathLoader(() => getEnhancedPath());
     OpenCodeProvider.setEnhancedPathLoader(() => getEnhancedPath());
     CopilotCLIProvider.setEnhancedPathLoader(() => getEnhancedPath());
+    KimiCodeProvider.setEnhancedPathLoader(() => getEnhancedPath());
 
     // Inject opencode.json loader so OpenCodeProvider.getModels() can surface
     // user-configured providers (e.g. an LM Studio bridge) in the model picker.

--- a/packages/electron/src/main/services/CLIManager.ts
+++ b/packages/electron/src/main/services/CLIManager.ts
@@ -195,7 +195,7 @@ interface InstallOptions {
   localInstall?: boolean;
 }
 
-type CLITool = 'claude-code' | 'openai-codex' | 'opencode' | 'copilot-cli';
+type CLITool = 'claude-code' | 'openai-codex' | 'opencode' | 'copilot-cli' | 'kimi-code';
 
 // CLI commands and their npm packages
 const CLI_PACKAGES: Record<CLITool, string> = {
@@ -203,6 +203,7 @@ const CLI_PACKAGES: Record<CLITool, string> = {
   'openai-codex': '@openai/codex',                   // OpenAI Codex package (actual on npm!)
   'opencode': 'opencode-ai',                           // OpenCode open source agent (npm: opencode-ai, binary: opencode)
   'copilot-cli': '@github/copilot',                       // GitHub Copilot CLI (npm: @github/copilot, binary: copilot)
+  'kimi-code': '@moonshot-ai/kimi-code',                 // Kimi Code CLI (npm: @moonshot-ai/kimi-code, binary: kimi)
 };
 
 const CLI_COMMANDS: Record<CLITool, string> = {
@@ -210,6 +211,7 @@ const CLI_COMMANDS: Record<CLITool, string> = {
   'openai-codex': 'codex',     // The actual command once installed
   'opencode': 'opencode',      // The actual command once installed
   'copilot-cli': 'copilot',    // The actual command once installed
+  'kimi-code': 'kimi',         // The actual command once installed
 };
 
 export class CLIManager {

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -1994,6 +1994,9 @@ export class AIService {
           case 'copilot-cli':
             // Copilot uses its own CLI auth (copilot auth login), no API key needed
             break;
+          case 'kimi-code':
+            // Kimi Code uses its own CLI auth (kimi login), no API key needed
+            break;
           case 'lmstudio':
             // LMStudio doesn't need an API key, just the base URL
             break;
@@ -3400,6 +3403,10 @@ export class AIService {
             // Copilot uses its own CLI auth, no API key needed
             apiKey = 'not-required';
             break;
+          case 'kimi-code':
+            // Kimi Code uses its own CLI auth, no API key needed
+            apiKey = 'not-required';
+            break;
           case 'lmstudio':
             // LMStudio doesn't need an API key, just test the connection
             apiKey = 'not-required';
@@ -3601,6 +3608,7 @@ export class AIService {
       if (providerSettings['openai']?.enabled === true && !!apiKeys['openai']) enabledSet.add('openai');
       if (providerSettings['openai-codex']?.enabled === true) enabledSet.add('openai-codex');
       if (providerSettings['opencode']?.enabled === true) enabledSet.add('opencode');
+      if (providerSettings['kimi-code']?.enabled === true) enabledSet.add('kimi-code');
       if (providerSettings['lmstudio']?.enabled === true) enabledSet.add('lmstudio');
 
       const modelsConfig = {
@@ -3761,6 +3769,10 @@ export class AIService {
         'copilot-cli': {
           // Copilot uses its own CLI auth (copilot auth login), no API key needed
           enabled: providerSettings['copilot-cli']?.enabled === true,
+        },
+        'kimi-code': {
+          // Kimi Code uses its own CLI auth (kimi login), no API key needed
+          enabled: providerSettings['kimi-code']?.enabled === true,
         },
         'lmstudio': {
           enabled: providerSettings['lmstudio']?.enabled === true,

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -534,6 +534,10 @@ export class MessageStreamingHandler {
             // Copilot uses its own CLI auth, no API key needed
             requiresApiKey = false;
             break;
+          case 'kimi-code':
+            // Kimi Code uses its own CLI auth, no API key needed
+            requiresApiKey = false;
+            break;
           case 'lmstudio':
             // LMStudio doesn't need an API key, just the base URL
             apiKey = 'not-required'; // Dummy value since LMStudio doesn't need a key

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -522,7 +522,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // AI operations (new unified interface)
   aiHasApiKey: () => ipcRenderer.invoke('ai:hasApiKey'),
   aiInitialize: (provider?: string, apiKey?: string) => ipcRenderer.invoke('ai:initialize', provider, apiKey),
-  aiCreateSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'opencode' | 'copilot-cli' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) => {
+  aiCreateSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'opencode' | 'copilot-cli' | 'kimi-code' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) => {
     // console.log('[Preload] aiCreateSession called:', { provider, workspacePath, sessionType, worktreeId });
     return ipcRenderer.invoke('ai:createSession', provider, documentContext, workspacePath, modelId, sessionType, worktreeId);
   },

--- a/packages/electron/src/renderer/components/GlobalSettings/panels/KimiCodePanel.tsx
+++ b/packages/electron/src/renderer/components/GlobalSettings/panels/KimiCodePanel.tsx
@@ -1,0 +1,158 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { ProviderConfig } from '../../Settings/SettingsView';
+import { SettingsToggle } from '../SettingsToggle';
+import { AlphaBadge, SETTINGS_ALPHA_TOOLTIP } from '../../common/AlphaBadge';
+
+interface KimiCodePanelProps {
+  config: ProviderConfig;
+  apiKeys: Record<string, string>;
+  availableModels: any[];
+  loading: boolean;
+  onToggle: (enabled: boolean) => void;
+  onApiKeyChange: (key: string, value: string) => void;
+  onModelToggle: (modelId: string, enabled: boolean) => void;
+  onSelectAllModels: (selectAll: boolean) => void;
+  onTestConnection: () => Promise<void>;
+  onConfigChange: (updates: Partial<ProviderConfig>) => void;
+}
+
+type CLIStatus = 'checking' | 'installed' | 'not-installed' | 'installing' | 'install-error';
+
+export function KimiCodePanel({
+  config,
+  onToggle,
+}: KimiCodePanelProps) {
+  const [cliStatus, setCLIStatus] = useState<CLIStatus>('checking');
+  const [cliVersion, setCLIVersion] = useState<string | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
+
+  const checkCLI = useCallback(async () => {
+    setCLIStatus('checking');
+    try {
+      const result = await window.electronAPI.invoke('cli:checkInstallation', 'kimi-code');
+      if (result?.installed) {
+        setCLIVersion(result.version || null);
+        setCLIStatus('installed');
+      } else {
+        setCLIStatus('not-installed');
+      }
+    } catch {
+      setCLIStatus('not-installed');
+    }
+  }, []);
+
+  useEffect(() => {
+    checkCLI();
+  }, [checkCLI]);
+
+  const handleInstall = async () => {
+    setCLIStatus('installing');
+    setInstallError(null);
+    try {
+      await window.electronAPI.invoke('cli:install', 'kimi-code', {});
+      await checkCLI();
+    } catch (err) {
+      setInstallError(err instanceof Error ? err.message : String(err));
+      setCLIStatus('install-error');
+    }
+  };
+
+  return (
+    <div className="provider-panel flex flex-col">
+      <div className="provider-panel-header mb-6 pb-4 border-b border-[var(--nim-border)]">
+        <h3 className="provider-panel-title text-xl font-semibold leading-tight mb-2 text-[var(--nim-text)] flex items-center gap-2">
+          Kimi Code
+          <AlphaBadge size="sm" tooltip={SETTINGS_ALPHA_TOOLTIP} />
+        </h3>
+        <p className="provider-panel-description text-sm leading-relaxed text-[var(--nim-text-muted)]">
+          Moonshot AI's Kimi Code coding agent (K3 models) via the ACP (Agent Client
+          Protocol) server mode. Uses your existing Kimi CLI login for authentication.
+        </p>
+      </div>
+
+      <div className="provider-panel-section py-4 mb-4 border-b border-[var(--nim-border)]">
+        <h4 className="provider-panel-section-title text-base font-semibold mb-3 text-[var(--nim-text)]">Kimi CLI</h4>
+
+        {cliStatus === 'checking' && (
+          <p className="text-[13px] text-[var(--nim-text-muted)]">Checking for Kimi CLI...</p>
+        )}
+
+        {cliStatus === 'installed' && (
+          <div className="flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-[var(--nim-success)] shrink-0" />
+            <span className="text-[13px] text-[var(--nim-text)]">
+              Installed{cliVersion ? ` (${cliVersion})` : ''}
+            </span>
+          </div>
+        )}
+
+        {(cliStatus === 'not-installed' || cliStatus === 'install-error') && (
+          <div>
+            <p className="text-[13px] text-[var(--nim-text-muted)] mb-3 leading-relaxed">
+              The Kimi Code CLI is required to run the agent. Install it with:
+            </p>
+            <code className="block text-[13px] text-[var(--nim-code-text)] bg-[var(--nim-code-bg)] px-3 py-2 rounded mb-3 select-text">
+              npm install -g @moonshot-ai/kimi-code
+            </code>
+            <button
+              className="inline-flex items-center justify-center py-2 px-4 rounded-md text-sm font-medium cursor-pointer transition-all bg-[var(--nim-primary)] text-white border border-[var(--nim-primary)] hover:opacity-90"
+              onClick={handleInstall}
+            >
+              Install Kimi CLI
+            </button>
+            {installError && (
+              <div className="text-xs mt-2 text-[var(--nim-error)]">
+                {installError}
+                <p className="mt-1 text-[var(--nim-text-muted)]">
+                  Try running manually: <code className="text-[var(--nim-code-text)] bg-[var(--nim-code-bg)] px-1 rounded">npm install -g @moonshot-ai/kimi-code</code>
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {cliStatus === 'installing' && (
+          <div className="flex items-center gap-2">
+            <span className="text-[13px] text-[var(--nim-text-muted)]">Installing Kimi CLI...</span>
+          </div>
+        )}
+
+        <p className="text-[13px] text-[var(--nim-text-muted)] mt-3 leading-relaxed">
+          See the{' '}
+          <a
+            href="https://www.kimi.com/code/docs/en/kimi-code-cli/quickstart.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--nim-primary)] hover:underline"
+          >
+            Kimi Code CLI documentation
+          </a>
+          {' '}for installation and authentication details.
+        </p>
+      </div>
+
+      <SettingsToggle
+        variant="enable"
+        name="Enable Kimi Code"
+        checked={config.enabled || false}
+        onChange={onToggle}
+      />
+
+      {config.enabled && (
+        <div className="provider-panel-section py-4 mb-4 border-b border-[var(--nim-border)] last:border-b-0 last:mb-0 last:pb-0">
+          <h4 className="provider-panel-section-title text-base font-semibold mb-3 text-[var(--nim-text)]">Authentication</h4>
+          <div className="cli-config-section">
+            <p className="text-[13px] text-[var(--nim-text-muted)] mb-3">
+              Kimi Code uses your existing login for authentication. Run{' '}
+              <code className="text-[var(--nim-code-text)] bg-[var(--nim-code-bg)] px-1 rounded">kimi login</code>{' '}
+              in your terminal to authenticate with your Kimi account.
+            </p>
+            <p className="text-[13px] text-[var(--nim-text-muted)]">
+              Model selection is managed by Kimi Code. No additional API key is required.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/components/Settings/SettingsSidebar.tsx
+++ b/packages/electron/src/renderer/components/Settings/SettingsSidebar.tsx
@@ -39,7 +39,7 @@ const GROUP_DESCRIPTIONS: Record<string, string> = {
 };
 
 function routeIcon(route: SettingsRoute): React.ReactNode {
-  if (['claude-code', 'claude', 'openai', 'openai-codex', 'opencode', 'copilot-cli', 'lmstudio'].includes(route.id)) {
+  if (['claude-code', 'claude', 'openai', 'openai-codex', 'opencode', 'copilot-cli', 'kimi-code', 'lmstudio'].includes(route.id)) {
     const providerId = route.id === 'openai-codex' ? 'openai' : route.id;
     return getProviderIcon(providerId, { size: 16 });
   }

--- a/packages/electron/src/renderer/components/Settings/SettingsView.tsx
+++ b/packages/electron/src/renderer/components/Settings/SettingsView.tsx
@@ -27,6 +27,7 @@ import { OpenAIPanel } from '../GlobalSettings/panels/OpenAIPanel';
 import { OpenAICodexPanel } from '../GlobalSettings/panels/OpenAICodexPanel';
 import { OpenCodePanel } from '../GlobalSettings/panels/OpenCodePanel';
 import { CopilotCLIPanel } from '../GlobalSettings/panels/CopilotCLIPanel';
+import { KimiCodePanel } from '../GlobalSettings/panels/KimiCodePanel';
 import { LMStudioPanel } from '../GlobalSettings/panels/LMStudioPanel';
 import { AdvancedPanel } from '../GlobalSettings/panels/AdvancedPanel';
 import { DatabasePanel } from '../GlobalSettings/panels/DatabasePanel';
@@ -504,7 +505,7 @@ export function SettingsView({
   };
 
   const handleProviderToggle = async (provider: string, enabled: boolean) => {
-    if (enabled && (provider === 'claude-code' || provider === 'openai-codex' || provider === 'opencode' || provider === 'copilot-cli')) {
+    if (enabled && (provider === 'claude-code' || provider === 'openai-codex' || provider === 'opencode' || provider === 'copilot-cli' || provider === 'kimi-code')) {
       await fetchModels(provider);
     }
 
@@ -520,12 +521,12 @@ export function SettingsView({
 
       posthog?.capture('ai_provider_configured', {
         provider,
-        modelCount: (provider === 'openai-codex' || provider === 'opencode' || provider === 'copilot-cli') ? 0 : models.length,
+        modelCount: (provider === 'openai-codex' || provider === 'opencode' || provider === 'copilot-cli' || provider === 'kimi-code') ? 0 : models.length,
         action: enabled ? 'enabled' : 'disabled'
       });
 
       // OpenAI Codex and OpenCode use dynamic model discovery, not user selection
-      if (provider === 'openai-codex' || provider === 'opencode' || provider === 'copilot-cli') {
+      if (provider === 'openai-codex' || provider === 'opencode' || provider === 'copilot-cli' || provider === 'kimi-code') {
         const currentProvider = prev[provider] || { enabled: false };
         return {
           ...prev,
@@ -547,7 +548,7 @@ export function SettingsView({
     });
     debouncedSave();
 
-    if (enabled && provider !== 'claude-code' && provider !== 'openai-codex' && provider !== 'opencode' && provider !== 'copilot-cli') {
+    if (enabled && provider !== 'claude-code' && provider !== 'openai-codex' && provider !== 'opencode' && provider !== 'copilot-cli' && provider !== 'kimi-code') {
       fetchModels(provider);
     }
   };
@@ -671,7 +672,7 @@ export function SettingsView({
       onApiKeyChange: handleApiKeyChange,
       onModelToggle: (modelId: string, enabled: boolean) => {
         // OpenAI Codex, OpenCode, and Copilot don't support user model selection - models are discovered dynamically
-        if (selectedCategory === 'openai-codex' || selectedCategory === 'opencode' || selectedCategory === 'copilot-cli') {
+        if (selectedCategory === 'openai-codex' || selectedCategory === 'opencode' || selectedCategory === 'copilot-cli' || selectedCategory === 'kimi-code') {
           return;
         }
 
@@ -698,7 +699,7 @@ export function SettingsView({
       },
       onSelectAllModels: (selectAll: boolean) => {
         // OpenAI Codex, OpenCode, and Copilot don't support user model selection - models are discovered dynamically
-        if (selectedCategory === 'openai-codex' || selectedCategory === 'opencode' || selectedCategory === 'copilot-cli') {
+        if (selectedCategory === 'openai-codex' || selectedCategory === 'opencode' || selectedCategory === 'copilot-cli' || selectedCategory === 'kimi-code') {
           return;
         }
 
@@ -871,6 +872,8 @@ export function SettingsView({
         return wrapWithOverride('opencode', 'OpenCode', <OpenCodePanel {...commonProps} />);
       case 'copilot-cli':
         return wrapWithOverride('copilot-cli', 'GitHub Copilot', <CopilotCLIPanel {...commonProps} />);
+      case 'kimi-code':
+        return wrapWithOverride('kimi-code', 'Kimi Code', <KimiCodePanel {...commonProps} />);
       case 'lmstudio':
         return wrapWithOverride('lmstudio', 'LM Studio', <LMStudioPanel {...commonProps} />);
       case 'advanced':

--- a/packages/electron/src/renderer/components/Settings/settingsRoutes.ts
+++ b/packages/electron/src/renderer/components/Settings/settingsRoutes.ts
@@ -14,6 +14,7 @@ export type ApplicationSettingsCategory =
   | 'openai-codex'
   | 'opencode'
   | 'copilot-cli'
+  | 'kimi-code'
   | 'lmstudio'
   | 'marketplace'
   | 'installed-extensions'
@@ -143,6 +144,7 @@ const builtinSettingsRouteDefinitions: readonly Omit<BuiltinSettingsRoute, 'sour
   { id: 'openai-codex', scope: 'application', group: 'Agent Providers', label: 'OpenAI Codex', icon: 'smart_toy' },
   { id: 'opencode', scope: 'application', group: 'Agent Providers', label: 'OpenCode', icon: 'terminal', isAlpha: true },
   { id: 'copilot-cli', scope: 'application', group: 'Agent Providers', label: 'GitHub Copilot', icon: 'terminal', isAlpha: true },
+  { id: 'kimi-code', scope: 'application', group: 'Agent Providers', label: 'Kimi Code', icon: 'terminal', isAlpha: true },
   { id: 'claude', scope: 'application', group: 'Chat Providers', label: 'Claude Chat', icon: 'chat', isAvailable: directChatProvidersVisible },
   { id: 'openai', scope: 'application', group: 'Chat Providers', label: 'OpenAI', icon: 'chat', isAvailable: directChatProvidersVisible },
   { id: 'lmstudio', scope: 'application', group: 'Chat Providers', label: 'LM Studio', icon: 'memory', isAvailable: directChatProvidersVisible },

--- a/packages/electron/src/renderer/components/UnifiedAI/ModelSelector.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/ModelSelector.tsx
@@ -24,7 +24,7 @@ import { AlphaBadge } from '../common/AlphaBadge';
 import { HelpTooltip } from '../../help';
 import { isDirectChatProvider, isProviderVisible } from '../../utils/chatProviderVisibility';
 
-const ALPHA_PROVIDERS = new Set(['opencode', 'copilot-cli']);
+const ALPHA_PROVIDERS = new Set(['opencode', 'copilot-cli', 'kimi-code']);
 const TYPEAHEAD_RESET_MS = 700;
 
 interface Model {
@@ -261,6 +261,7 @@ export function ModelSelector({
       case 'openai-codex':
       case 'opencode':
       case 'copilot-cli':
+      case 'kimi-code':
       case 'lmstudio':
         return provider;
       case 'openai-codex-acp':
@@ -315,6 +316,7 @@ export function ModelSelector({
       case 'openai-codex-acp': return 'OpenAI Codex (ACP)';
       case 'opencode': return 'OpenCode';
       case 'copilot-cli': return 'GitHub Copilot';
+      case 'kimi-code': return 'Kimi Code';
       case 'lmstudio': return 'LMStudio';
       default: {
         // Extension-contributed providers carry their contribution id here

--- a/packages/electron/src/renderer/electron.d.ts
+++ b/packages/electron/src/renderer/electron.d.ts
@@ -427,7 +427,7 @@ interface ElectronAPI {
   // AI operations (flat methods)
   aiHasApiKey: () => Promise<boolean>;
   aiInitialize: (provider?: string, apiKey?: string) => Promise<any>;
-  aiCreateSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'opencode' | 'copilot-cli' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) => Promise<any>;
+  aiCreateSession: (provider: 'claude' | 'claude-code' | 'claude-code-cli' | 'openai' | 'openai-codex' | 'opencode' | 'copilot-cli' | 'kimi-code' | 'lmstudio', documentContext?: any, workspacePath?: string, modelId?: string, sessionType?: string, worktreeId?: string) => Promise<any>;
   aiSendMessage: (message: string, documentContext?: any, sessionId?: string, workspacePath?: string) => Promise<any>;
   aiGetSessions: (workspacePath?: string) => Promise<any>;
   aiLoadSession: (sessionId: string, workspacePath?: string, trackAsResume?: boolean) => Promise<any>;

--- a/packages/electron/src/renderer/store/atoms/appSettings.ts
+++ b/packages/electron/src/renderer/store/atoms/appSettings.ts
@@ -1200,6 +1200,7 @@ const defaultProviders: Record<string, ProviderConfig> = {
   'openai-codex-acp': { enabled: false, testStatus: 'idle', installStatus: 'not-installed' },
   opencode: { enabled: false, testStatus: 'idle', installStatus: 'not-installed' },
   'copilot-cli': { enabled: false, testStatus: 'idle', installStatus: 'not-installed' },
+  'kimi-code': { enabled: false, testStatus: 'idle', installStatus: 'not-installed' },
   lmstudio: { enabled: false, baseUrl: 'http://127.0.0.1:8234', testStatus: 'idle' },
 };
 

--- a/packages/electron/src/renderer/utils/modelUtils.ts
+++ b/packages/electron/src/renderer/utils/modelUtils.ts
@@ -172,6 +172,7 @@ export function getProviderDisplayName(provider: string): string {
     case 'openai': return 'OpenAI';
     case 'lmstudio': return 'LMStudio';
     case 'copilot-cli': return 'GitHub Copilot';
+    case 'kimi-code': return 'Kimi Code';
     default: return provider;
   }
 }

--- a/packages/electron/src/shared/settings/keys.ts
+++ b/packages/electron/src/shared/settings/keys.ts
@@ -127,6 +127,11 @@ export const SETTINGS_REGISTRY = {
     { store: 'ai-settings', path: 'providerSettings.copilot-cli' },
     { enabled: false, testStatus: 'idle', installStatus: 'not-installed' },
   ),
+  'ai.provider.kimi-code': setting(
+    ProviderConfigSchema,
+    { store: 'ai-settings', path: 'providerSettings.kimi-code' },
+    { enabled: false, testStatus: 'idle', installStatus: 'not-installed' },
+  ),
   'ai.provider.lmstudio': setting(
     ProviderConfigSchema,
     { store: 'ai-settings', path: 'providerSettings.lmstudio' },

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -491,6 +491,7 @@ export const DEFAULT_MODELS = {
   lmstudio: 'lmstudio:local-model',
   opencode: 'opencode:anthropic/claude-sonnet-4-5',
   'copilot-cli': 'copilot-cli:default',
+  'kimi-code': 'kimi-code:default',
 };
 
 /**
@@ -557,6 +558,44 @@ export const OPENCODE_PRESET_MODELS: OpenCodePresetModel[] = [
     name: 'GLM 5.2 (Z.AI Coding Plan)',
     providerID: 'zai-coding-plan',
     modelID: 'glm-5.2',
+  },
+];
+
+/**
+ * Preset models for the Kimi Code agent.
+ *
+ * Kimi Code's model catalog is served dynamically after `kimi login`, so this
+ * list only carries the models we want in the picker before the CLI is
+ * authenticated. The `acpModelId` is what the provider passes to
+ * `session/set_config_option` (configId `model`); `default` means "leave the
+ * CLI on its own default" and is never sent.
+ */
+export interface KimiCodePresetModel {
+  /** Full id with the `kimi-code:` registry prefix. */
+  id: string;
+  /** Human-readable label shown in pickers. */
+  name: string;
+  /** Model id on the ACP wire (`session/set_config_option`). */
+  acpModelId: string;
+  /** Context window in tokens. */
+  contextWindow: number;
+}
+
+export const KIMI_CODE_PRESET_MODELS: KimiCodePresetModel[] = [
+  {
+    id: 'kimi-code:default',
+    name: 'Kimi Code (default)',
+    acpModelId: 'default',
+    // The CLI default currently resolves to a K3-family model; 1M window
+    // per the K3 model card (github.com/MoonshotAI/Kimi-K3).
+    contextWindow: 1000000,
+  },
+  {
+    id: 'kimi-code:kimi-k3',
+    name: 'Kimi K3',
+    acpModelId: 'kimi-k3',
+    // K3 ships with a 1M-token context window (github.com/MoonshotAI/Kimi-K3).
+    contextWindow: 1000000,
   },
 ];
 

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -591,11 +591,19 @@ export const KIMI_CODE_PRESET_MODELS: KimiCodePresetModel[] = [
     contextWindow: 1000000,
   },
   {
-    id: 'kimi-code:kimi-k3',
+    id: 'kimi-code:k3',
     name: 'Kimi K3',
-    acpModelId: 'kimi-k3',
+    // Wire id verified against the authenticated catalog returned by
+    // session/new (configOptions.model): kimi-code/k3.
+    acpModelId: 'kimi-code/k3',
     // K3 ships with a 1M-token context window (github.com/MoonshotAI/Kimi-K3).
     contextWindow: 1000000,
+  },
+  {
+    id: 'kimi-code:k3-256k',
+    name: 'Kimi K3 256k',
+    acpModelId: 'kimi-code/k3-256k',
+    contextWindow: 262144,
   },
 ];
 

--- a/packages/runtime/src/ai/server/ModelRegistry.ts
+++ b/packages/runtime/src/ai/server/ModelRegistry.ts
@@ -86,6 +86,10 @@ export class ModelRegistry {
           const { CopilotCLIProvider } = await import('./providers/CopilotCLIProvider');
           models = await CopilotCLIProvider.getModels();
           break;
+        case 'kimi-code':
+          const { KimiCodeProvider } = await import('./providers/KimiCodeProvider');
+          models = await KimiCodeProvider.getModels();
+          break;
         default:
           assertExhaustiveProvider(provider);
       }
@@ -125,6 +129,7 @@ export class ModelRegistry {
     if (shouldFetch('opencode')) promises.push(this.getModelsForProvider('opencode'));
     if (shouldFetch('lmstudio')) promises.push(this.getModelsForProvider('lmstudio', undefined, apiKeys['lmstudio_url']));
     if (shouldFetch('copilot-cli')) promises.push(this.getModelsForProvider('copilot-cli'));
+    if (shouldFetch('kimi-code')) promises.push(this.getModelsForProvider('kimi-code'));
 
     const results = await Promise.allSettled(promises);
 
@@ -174,6 +179,9 @@ export class ModelRegistry {
       case 'copilot-cli':
         const { CopilotCLIProvider: CLP } = await import('./providers/CopilotCLIProvider');
         return CLP.getDefaultModel();
+      case 'kimi-code':
+        const { KimiCodeProvider: KCP } = await import('./providers/KimiCodeProvider');
+        return KCP.getDefaultModel();
       default:
         assertExhaustiveProvider(provider);
     }

--- a/packages/runtime/src/ai/server/ProviderFactory.ts
+++ b/packages/runtime/src/ai/server/ProviderFactory.ts
@@ -12,6 +12,7 @@ import { OpenAICodexACPProvider } from './providers/OpenAICodexACPProvider';
 import { LMStudioProvider } from './providers/LMStudioProvider';
 import { OpenCodeProvider } from './providers/OpenCodeProvider';
 import { CopilotCLIProvider } from './providers/CopilotCLIProvider';
+import { KimiCodeProvider } from './providers/KimiCodeProvider';
 import { ExtensionAgentProvider } from './providers/ExtensionAgentProvider';
 import { ProviderConfig, AIProviderType, assertExhaustiveProvider } from './types';
 
@@ -81,6 +82,9 @@ export class ProviderFactory {
         break;
       case 'copilot-cli':
         provider = new CopilotCLIProvider();
+        break;
+      case 'kimi-code':
+        provider = new KimiCodeProvider();
         break;
       default:
         assertExhaustiveProvider(type);

--- a/packages/runtime/src/ai/server/index.ts
+++ b/packages/runtime/src/ai/server/index.ts
@@ -12,6 +12,7 @@ export * from './providers/ProviderPermissionMixin';
 export * from './providers/LMStudioProvider';
 export * from './providers/OpenCodeProvider';
 export * from './providers/CopilotCLIProvider';
+export * from './providers/KimiCodeProvider';
 export * from './utils/errorDetection';
 export * from './preferredAgentLanguageConfig';
 export { McpConfigService } from './services/McpConfigService';

--- a/packages/runtime/src/ai/server/protocols/KimiACPProtocol.ts
+++ b/packages/runtime/src/ai/server/protocols/KimiACPProtocol.ts
@@ -1,0 +1,585 @@
+/**
+ * Kimi Code ACP Protocol Adapter
+ *
+ * Wraps `kimi acp` (Agent Client Protocol, JSON-RPC over stdio) to provide a
+ * normalized protocol interface for the KimiCodeProvider.
+ *
+ * This adapter isolates all ACP-specific details:
+ * - Process spawning and stdio transport
+ * - JSON-RPC message framing (newline-delimited)
+ * - Session create/load lifecycle
+ * - Model selection via `session/set_config_option`
+ * - Event parsing and conversion to ProtocolEvent
+ *
+ * Kimi Code CLI implements the standard ACP schema (@agentclientprotocol/sdk):
+ * `session/update` notifications carry `update.sessionUpdate` discriminators
+ * (`agent_message_chunk`, `agent_thought_chunk`, `tool_call`,
+ * `tool_call_update`, `usage_update`, ...).
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+import { createInterface, Interface as ReadlineInterface } from 'readline';
+import {
+  AgentProtocol,
+  ProtocolSession,
+  SessionOptions,
+  ProtocolMessage,
+  ProtocolEvent,
+  ToolResult,
+} from './ProtocolInterface';
+
+interface ACPRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface ACPNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface ACPResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+const AUTH_ERROR_MESSAGE =
+  'Kimi Code is not logged in. Run `kimi login` in your terminal to authenticate ' +
+  '(or `kimi` and use /login).';
+
+function isAuthError(message: string): boolean {
+  return /auth|login|token|unauthorized|forbidden/i.test(message);
+}
+
+/**
+ * Kimi Code ACP Protocol Adapter
+ *
+ * Spawns `kimi acp` and communicates via JSON-RPC over stdin/stdout.
+ * Normalizes ACP events into Nimbalyst ProtocolEvent objects.
+ */
+export class KimiACPProtocol implements AgentProtocol {
+  readonly platform = 'kimi-acp';
+
+  private process: ChildProcess | null = null;
+  private readline: ReadlineInterface | null = null;
+  private nextRequestId = 1;
+  private pendingRequests = new Map<number, PendingRequest>();
+  private notificationHandlers: Array<(notification: ACPNotification) => void> = [];
+  private command: string;
+  private baseArgs: string[];
+  private processEnv: Record<string, string> | undefined;
+  private initialized = false;
+
+  constructor(kimiPath?: string) {
+    this.command = kimiPath || 'kimi';
+    this.baseArgs = ['acp'];
+  }
+
+  setKimiPath(path: string): void {
+    this.command = path;
+    this.baseArgs = ['acp'];
+  }
+
+  setProcessEnv(env: Record<string, string> | undefined): void {
+    this.processEnv = env;
+  }
+
+  private ensureProcess(): ChildProcess {
+    if (this.process && !this.process.killed) {
+      return this.process;
+    }
+
+    const proc = spawn(this.command, this.baseArgs, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: this.processEnv ?? process.env,
+    });
+
+    this.process = proc;
+
+    const rl = createInterface({ input: proc.stdout! });
+    this.readline = rl;
+
+    rl.on('line', (line) => {
+      this.handleLine(line);
+    });
+
+    // `kimi acp` keeps the ACP channel clean on stdout; diagnostics go to stderr.
+    proc.stderr?.on('data', (data: Buffer) => {
+      console.warn('[KIMI-ACP] stderr:', data.toString());
+    });
+
+    proc.on('exit', (code, signal) => {
+      console.log(`[KIMI-ACP] Process exited: code=${code}, signal=${signal}`);
+      this.rejectAllPending(new Error(`Kimi process exited (code=${code})`));
+      this.process = null;
+      this.readline = null;
+      this.initialized = false;
+    });
+
+    return proc;
+  }
+
+  private handleLine(line: string): void {
+    if (!line.trim()) return;
+
+    let parsed: ACPResponse | ACPNotification;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      console.warn('[KIMI-ACP] Unparseable line:', line.slice(0, 200));
+      return;
+    }
+
+    if ('id' in parsed && typeof parsed.id === 'number') {
+      const pending = this.pendingRequests.get(parsed.id);
+      if (pending) {
+        this.pendingRequests.delete(parsed.id);
+        const response = parsed as ACPResponse;
+        if (response.error) {
+          const detail = response.error.data ? ` (${JSON.stringify(response.error.data)})` : '';
+          pending.reject(new Error(`${response.error.message}${detail}`));
+        } else {
+          pending.resolve(response.result);
+        }
+      }
+      // Requests FROM the agent (fs/*, session/request_permission) also carry
+      // an id; they fall through here. We do not advertise fs capabilities in
+      // initialize, so the agent should not send them.
+    } else if ('method' in parsed) {
+      for (const handler of this.notificationHandlers) {
+        handler(parsed as ACPNotification);
+      }
+    }
+  }
+
+  private sendRequest(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    const proc = this.ensureProcess();
+    const id = this.nextRequestId++;
+    const request: ACPRequest = { jsonrpc: '2.0', id, method, params };
+
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { resolve, reject });
+      proc.stdin!.write(JSON.stringify(request) + '\n');
+    });
+  }
+
+  private sendNotification(method: string, params?: Record<string, unknown>): void {
+    const proc = this.ensureProcess();
+    const notification: ACPNotification = { jsonrpc: '2.0', method, params };
+    proc.stdin!.write(JSON.stringify(notification) + '\n');
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const [, pending] of this.pendingRequests) {
+      pending.reject(error);
+    }
+    this.pendingRequests.clear();
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return;
+    this.ensureProcess();
+
+    try {
+      await this.sendRequest('initialize', {
+        protocolVersion: 1,
+        clientInfo: { name: 'nimbalyst', version: '1.0.0' },
+        clientCapabilities: {
+          fs: { readTextFile: false, writeTextFile: false },
+        },
+      });
+      this.initialized = true;
+      console.log('[KIMI-ACP] Protocol initialized');
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (isAuthError(msg)) {
+        throw new Error(AUTH_ERROR_MESSAGE);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Select the model for a session via the ACP generic config picker.
+   * Best-effort: an unknown model id must not kill the session -- the CLI
+   * keeps its default model and we log the rejection.
+   */
+  private async trySetModel(sessionId: string, model: string | undefined): Promise<void> {
+    if (!model || model === 'default') return;
+    try {
+      await this.sendRequest('session/set_config_option', {
+        sessionId,
+        configId: 'model',
+        value: model,
+      });
+      console.log('[KIMI-ACP] Model set:', model);
+    } catch (error) {
+      console.warn('[KIMI-ACP] Could not set model, using CLI default:', error);
+    }
+  }
+
+  async createSession(options: SessionOptions): Promise<ProtocolSession> {
+    await this.ensureInitialized();
+
+    const params: Record<string, unknown> = {
+      cwd: options.workspacePath || process.cwd(),
+      mcpServers: options.mcpServers ? this.formatMcpServers(options.mcpServers) : [],
+    };
+
+    try {
+      const result = await this.sendRequest('session/new', params) as Record<string, unknown>;
+      const sessionId = (result?.sessionId as string) || `kimi-${Date.now()}`;
+      console.log('[KIMI-ACP] Session created:', sessionId);
+
+      await this.trySetModel(sessionId, options.model);
+
+      return {
+        id: sessionId,
+        platform: this.platform,
+        raw: { result },
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (isAuthError(msg)) {
+        throw new Error(AUTH_ERROR_MESSAGE);
+      }
+      throw error;
+    }
+  }
+
+  async resumeSession(sessionId: string, options: SessionOptions): Promise<ProtocolSession> {
+    await this.ensureInitialized();
+
+    try {
+      const result = await this.sendRequest('session/load', {
+        sessionId,
+        cwd: options.workspacePath || process.cwd(),
+        mcpServers: options.mcpServers ? this.formatMcpServers(options.mcpServers) : [],
+      }) as Record<string, unknown>;
+      console.log('[KIMI-ACP] Session resumed:', sessionId);
+
+      await this.trySetModel(sessionId, options.model);
+
+      return {
+        id: sessionId,
+        platform: this.platform,
+        raw: { result },
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+
+      if (isAuthError(msg)) {
+        throw new Error(AUTH_ERROR_MESSAGE);
+      }
+
+      // The session may already be live in this process from an earlier turn.
+      // Reuse it rather than discarding the conversation context.
+      if (/already loaded|already exists/i.test(msg)) {
+        console.log('[KIMI-ACP] Session already loaded, reusing:', sessionId);
+        return {
+          id: sessionId,
+          platform: this.platform,
+          raw: { alreadyLoaded: true },
+        };
+      }
+
+      console.warn('[KIMI-ACP] Resume failed, creating new session:', error);
+      return this.createSession(options);
+    }
+  }
+
+  async forkSession(sessionId: string, options: SessionOptions): Promise<ProtocolSession> {
+    await this.ensureInitialized();
+
+    // Kimi Code advertises `session/fork` in its session capabilities.
+    try {
+      const result = await this.sendRequest('session/fork', {
+        sessionId,
+        cwd: options.workspacePath || process.cwd(),
+      }) as Record<string, unknown>;
+      const newSessionId = result?.sessionId as string | undefined;
+      if (newSessionId) {
+        console.log('[KIMI-ACP] Session forked:', sessionId, '->', newSessionId);
+        return {
+          id: newSessionId,
+          platform: this.platform,
+          raw: { result },
+        };
+      }
+    } catch (error) {
+      console.warn('[KIMI-ACP] Fork failed, creating new session:', error);
+    }
+    return this.createSession(options);
+  }
+
+  async *sendMessage(
+    session: ProtocolSession,
+    message: ProtocolMessage
+  ): AsyncIterable<ProtocolEvent> {
+    this.ensureProcess();
+
+    let fullText = '';
+    let usage: { input_tokens: number; output_tokens: number; total_tokens: number } | undefined;
+    let contextFillTokens: number | undefined;
+    let contextWindow: number | undefined;
+
+    const notificationQueue: ACPNotification[] = [];
+    let notificationResolve: (() => void) | null = null;
+    let streamComplete = false;
+
+    const onNotification = (notification: ACPNotification) => {
+      // Only queue updates for this session; a shared process can host
+      // several ACP sessions.
+      const params = notification.params as Record<string, unknown> | undefined;
+      if (params?.sessionId && params.sessionId !== session.id) return;
+      notificationQueue.push(notification);
+      if (notificationResolve) {
+        notificationResolve();
+        notificationResolve = null;
+      }
+    };
+
+    this.notificationHandlers.push(onNotification);
+
+    try {
+      let sendError: Error | null = null;
+
+      const sendPromise = this.sendRequest('session/prompt', {
+        sessionId: session.id,
+        prompt: [
+          { type: 'text', text: message.content },
+        ],
+      });
+
+      sendPromise.then(() => {
+        streamComplete = true;
+        if (notificationResolve) {
+          notificationResolve();
+          notificationResolve = null;
+        }
+      }).catch((err) => {
+        sendError = err instanceof Error ? err : new Error(String(err));
+        streamComplete = true;
+        if (notificationResolve) {
+          notificationResolve();
+          notificationResolve = null;
+        }
+      });
+
+      while (true) {
+        while (notificationQueue.length > 0) {
+          const notification = notificationQueue.shift()!;
+
+          yield {
+            type: 'raw_event',
+            metadata: { rawEvent: notification },
+          };
+
+          const events = this.parseNotification(notification);
+          for (const event of events) {
+            if (event.type === 'text' && event.content) {
+              fullText += event.content;
+            }
+            if (event.usage) {
+              usage = event.usage;
+            }
+            if (event.contextFillTokens !== undefined) {
+              contextFillTokens = event.contextFillTokens;
+              contextWindow = event.contextWindow;
+              continue; // usage_update snapshot; folded into `complete`
+            }
+            yield event;
+          }
+        }
+
+        if (streamComplete && notificationQueue.length === 0) {
+          break;
+        }
+
+        await new Promise<void>((resolve) => {
+          notificationResolve = resolve;
+        });
+      }
+
+      if (sendError && !fullText) {
+        const msg = (sendError as Error).message;
+        yield { type: 'error', error: isAuthError(msg) ? AUTH_ERROR_MESSAGE : msg };
+      } else {
+        yield {
+          type: 'complete',
+          content: fullText,
+          usage: usage ?? { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+          contextFillTokens,
+          contextWindow,
+        };
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      yield {
+        type: 'error',
+        error: errorMessage,
+      };
+    } finally {
+      const idx = this.notificationHandlers.indexOf(onNotification);
+      if (idx >= 0) {
+        this.notificationHandlers.splice(idx, 1);
+      }
+    }
+  }
+
+  abortSession(session: ProtocolSession): void {
+    this.sendNotification('session/cancel', { sessionId: session.id });
+  }
+
+  cleanupSession(_session: ProtocolSession): void {
+    // No-op; the ACP process stays alive for reuse across sessions
+  }
+
+  destroy(): void {
+    if (this.process && !this.process.killed) {
+      this.process.kill();
+    }
+    this.process = null;
+    this.readline = null;
+    this.initialized = false;
+    this.rejectAllPending(new Error('Protocol destroyed'));
+    this.notificationHandlers = [];
+  }
+
+  private formatMcpServers(mcpServers: Record<string, unknown>): unknown[] {
+    const servers: unknown[] = [];
+    for (const [name, config] of Object.entries(mcpServers)) {
+      if (!config || typeof config !== 'object') continue;
+      const sc = config as Record<string, unknown>;
+      const converted = this.convertToACPMcpServer(name, sc);
+      if (converted) servers.push(converted);
+    }
+    return servers;
+  }
+
+  private convertToACPMcpServer(name: string, sc: Record<string, unknown>): Record<string, unknown> | null {
+    const type = typeof sc.type === 'string' ? sc.type : (typeof sc.url === 'string' ? 'sse' : 'stdio');
+
+    if (type === 'http' || type === 'sse') {
+      if (typeof sc.url !== 'string') return null;
+      return {
+        name,
+        type,
+        url: sc.url,
+        headers: this.toKeyValueArray(sc.headers ?? sc.http_headers),
+      };
+    }
+
+    if (typeof sc.command !== 'string') return null;
+    return {
+      name,
+      type: 'stdio',
+      command: sc.command,
+      args: Array.isArray(sc.args) ? sc.args : [],
+      env: this.toKeyValueArray(sc.env),
+    };
+  }
+
+  private toKeyValueArray(obj: unknown): Array<{ name: string; value: string }> {
+    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return [];
+    return Object.entries(obj as Record<string, unknown>)
+      .filter(([, v]) => typeof v === 'string')
+      .map(([k, v]) => ({ name: k, value: v as string }));
+  }
+
+  private parseNotification(notification: ACPNotification): ProtocolEvent[] {
+    const events: ProtocolEvent[] = [];
+    if (notification.method !== 'session/update') return events;
+
+    const params = notification.params || {};
+    const update = params.update as Record<string, unknown> | undefined;
+    if (!update) return events;
+
+    const updateType = update.sessionUpdate as string | undefined;
+    const content = update.content as Record<string, unknown> | undefined;
+
+    switch (updateType) {
+      case 'agent_message_chunk': {
+        const text = typeof content?.text === 'string' ? content.text : '';
+        if (text) events.push({ type: 'text', content: text });
+        break;
+      }
+
+      case 'agent_thought_chunk': {
+        const text = typeof content?.text === 'string' ? content.text : '';
+        if (text) events.push({ type: 'reasoning', content: text });
+        break;
+      }
+
+      case 'tool_call': {
+        events.push({
+          type: 'tool_call',
+          toolCall: {
+            id: typeof update.toolCallId === 'string' ? update.toolCallId : undefined,
+            name: typeof update.title === 'string' ? update.title : 'unknown',
+            arguments: (update.rawInput ?? undefined) as Record<string, unknown> | undefined,
+          },
+        });
+        break;
+      }
+
+      case 'tool_call_update': {
+        const status = update.status as string | undefined;
+        if (status !== 'completed' && status !== 'failed') break;
+        events.push({
+          type: 'tool_result',
+          toolResult: {
+            id: typeof update.toolCallId === 'string' ? update.toolCallId : undefined,
+            name: typeof update.title === 'string' ? update.title : 'unknown',
+            result: (update.rawOutput ?? this.extractToolContentText(update.content)) as ToolResult | string | undefined,
+          },
+        });
+        break;
+      }
+
+      // Context-window snapshot: `used` is the current fill, `size` the
+      // model's window. Folded into the `complete` event by sendMessage.
+      case 'usage_update': {
+        const used = typeof update.used === 'number' ? update.used : undefined;
+        const size = typeof update.size === 'number' ? update.size : undefined;
+        if (used !== undefined) {
+          events.push({
+            type: 'usage',
+            contextFillTokens: used,
+            contextWindow: size,
+          });
+        }
+        break;
+      }
+
+      default:
+        break;
+    }
+
+    return events;
+  }
+
+  private extractToolContentText(content: unknown): string | undefined {
+    if (!Array.isArray(content)) return undefined;
+    const parts: string[] = [];
+    for (const item of content) {
+      if (item && typeof item === 'object') {
+        const c = (item as Record<string, unknown>).content as Record<string, unknown> | undefined;
+        if (c && c.type === 'text' && typeof c.text === 'string') {
+          parts.push(c.text);
+        }
+      }
+    }
+    return parts.length > 0 ? parts.join('\n') : undefined;
+  }
+}

--- a/packages/runtime/src/ai/server/providers/KimiCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/KimiCodeProvider.ts
@@ -1,0 +1,632 @@
+/**
+ * Kimi Code Agent Provider
+ *
+ * Integrates the Kimi Code CLI's ACP (Agent Client Protocol) server mode
+ * into Nimbalyst. Kimi runs as `kimi acp` and communicates via JSON-RPC
+ * over stdin/stdout.
+ *
+ * Key features:
+ * - ACP protocol transport (standard @agentclientprotocol schema)
+ * - Session create/resume via protocol session IDs
+ * - Model selection via `session/set_config_option` (K3 and siblings)
+ * - MCP server passthrough to Kimi's ACP session
+ * - Canonical transcript storage via raw event logging
+ */
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { BaseAgentProvider } from './BaseAgentProvider';
+import { buildUserMessageAddition } from './documentContextUtils';
+import { buildClaudeCodeSystemPrompt } from '../../prompt';
+import { DEFAULT_MODELS, KIMI_CODE_PRESET_MODELS } from '../../modelConstants';
+import {
+  ProviderConfig,
+  DocumentContext,
+  StreamChunk,
+  AIModel,
+  AIProviderType,
+  ChatAttachment,
+} from '../types';
+import { KimiACPProtocol } from '../protocols/KimiACPProtocol';
+import { ProtocolEvent } from '../protocols/ProtocolInterface';
+import { McpConfigService } from '../services/McpConfigService';
+import { getMcpConfigService, isInternalMcpServerEnabled, areTrackerToolsEnabled, resolveTrackersWorkspacePath } from '../services/mcpServerConfig';
+import { MCPServerConfig } from '../../../types/MCPServerConfig';
+import { safeJSONSerialize } from '../../../utils/serialization';
+import { AgentProtocolTranscriptAdapter } from './agentProtocol/AgentProtocolTranscriptAdapter';
+import { PermissionMode } from './ProviderPermissionMixin';
+import { TranscriptMigrationRepository } from '../../../storage/repositories/TranscriptMigrationRepository';
+
+interface KimiCodeProviderDeps {
+  protocol?: KimiACPProtocol;
+}
+
+function splitPathEntries(pathValue: string | undefined): string[] {
+  if (!pathValue) return [];
+  return pathValue
+    .split(path.delimiter)
+    .map((entry) => entry.trim().replace(/^"(.*)"$/, '$1'))
+    .filter(Boolean);
+}
+
+function findExecutableInPathEntries(
+  executableNames: string[],
+  pathValue: string | undefined
+): string | undefined {
+  for (const entry of splitPathEntries(pathValue)) {
+    for (const executableName of executableNames) {
+      const candidate = path.join(entry, executableName);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Candidate locations for the `kimi` executable, in priority order.
+ *
+ * A packaged macOS app launched from Finder/Dock has only
+ * /usr/bin:/bin:/usr/sbin:/sbin in PATH, which misses every place kimi is
+ * typically installed -- so absolute candidates come first and the PATH
+ * lookup is a fallback. KIMI_BIN (checked by the caller) overrides all.
+ */
+function getSystemKimiExecutableCandidates(pathValue?: string): string[] {
+  const platform = process.platform;
+  const homeDir = os.homedir();
+  const pathModule = platform === 'win32' ? path.win32 : path;
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+  const addCandidate = (candidate: string | undefined) => {
+    if (!candidate) return;
+    const normalized = pathModule.normalize(candidate);
+    if (seen.has(normalized)) return;
+    seen.add(normalized);
+    candidates.push(candidate);
+  };
+
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA || path.win32.join(homeDir, 'AppData', 'Roaming');
+    addCandidate(path.win32.join(appData, 'npm', 'kimi.cmd'));
+    addCandidate(path.win32.join(homeDir, 'AppData', 'Roaming', 'npm', 'kimi.cmd'));
+    addCandidate(findExecutableInPathEntries(['kimi.cmd', 'kimi.exe'], pathValue ?? process.env.PATH));
+    addCandidate('kimi');
+    return candidates;
+  }
+
+  addCandidate(path.join(homeDir, '.local', 'bin', 'kimi'));
+  addCandidate(path.join(homeDir, '.npm-global', 'bin', 'kimi'));
+  addCandidate('/usr/local/bin/kimi');
+  addCandidate('/opt/homebrew/bin/kimi');
+  addCandidate(findExecutableInPathEntries(['kimi'], pathValue ?? process.env.PATH));
+  addCandidate('kimi');
+  return candidates;
+}
+
+export class KimiCodeProvider extends BaseAgentProvider {
+  static readonly DEFAULT_MODEL = DEFAULT_MODELS['kimi-code'];
+
+  private readonly protocol: KimiACPProtocol;
+  private readonly mcpConfigService: McpConfigService;
+
+  private _initData: {
+    model: string;
+    mcpServerCount: number;
+    isResumedSession: boolean;
+  } | null = null;
+
+  private static mcpConfigLoader: ((workspacePath?: string) => Promise<Record<string, MCPServerConfig>>) | null = null;
+  private static shellEnvironmentLoader: (() => Record<string, string> | null) | null = null;
+  private static enhancedPathLoader: (() => string) | null = null;
+  private static kimiPathLoader: (() => string | null) | null = null;
+
+  constructor(deps?: KimiCodeProviderDeps) {
+    super();
+
+    this.protocol = deps?.protocol || new KimiACPProtocol();
+
+    this.mcpConfigService = getMcpConfigService({
+      mcpConfigLoader: KimiCodeProvider.mcpConfigLoader,
+      claudeSettingsEnvLoader: null,
+      shellEnvironmentLoader: KimiCodeProvider.shellEnvironmentLoader,
+    });
+  }
+
+  async initialize(config: ProviderConfig): Promise<void> {
+    this.config = config;
+  }
+
+  getProviderName(): string {
+    return 'kimi-code';
+  }
+
+  // --- Static injection setters (called from electron main process at startup) ---
+
+  public static setMCPConfigLoader(loader: ((workspacePath?: string) => Promise<Record<string, MCPServerConfig>>) | null): void {
+    KimiCodeProvider.mcpConfigLoader = loader;
+  }
+
+  public static setShellEnvironmentLoader(loader: (() => Record<string, string> | null) | null): void {
+    KimiCodeProvider.shellEnvironmentLoader = loader;
+  }
+
+  public static setEnhancedPathLoader(loader: (() => string) | null): void {
+    KimiCodeProvider.enhancedPathLoader = loader;
+  }
+
+  public static setKimiPathLoader(loader: (() => string | null) | null): void {
+    KimiCodeProvider.kimiPathLoader = loader;
+  }
+
+  private static resolveKimiExecutableForRuntime(pathValue?: string): string | undefined {
+    // Explicit override wins: settings-injected path loader, then KIMI_BIN.
+    if (KimiCodeProvider.kimiPathLoader) {
+      const customPath = KimiCodeProvider.kimiPathLoader();
+      if (customPath) {
+        return customPath;
+      }
+    }
+
+    const envOverride = process.env.KIMI_BIN?.trim();
+    if (envOverride && fs.existsSync(envOverride)) {
+      return envOverride;
+    }
+
+    for (const candidate of getSystemKimiExecutableCandidates(pathValue)) {
+      if (candidate === 'kimi' || fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    return undefined;
+  }
+
+  // --- Model discovery ---
+
+  static async getModels(): Promise<AIModel[]> {
+    return KIMI_CODE_PRESET_MODELS.map((preset) => ({
+      id: preset.id,
+      name: preset.name,
+      provider: 'kimi-code' as AIProviderType,
+      contextWindow: preset.contextWindow,
+    }));
+  }
+
+  static getDefaultModel(): string {
+    return DEFAULT_MODELS['kimi-code'];
+  }
+
+  getName(): string {
+    return 'kimi-code';
+  }
+
+  getDisplayName(): string {
+    return 'Kimi Code';
+  }
+
+  getDescription(): string {
+    return 'Kimi Code CLI agent provider via ACP protocol';
+  }
+
+  getProviderSessionData(sessionId: string): any {
+    const { providerSessionId } = this.sessions.getProviderSessionData(sessionId);
+    return { providerSessionId };
+  }
+
+  getInitData(): {
+    model: string;
+    mcpServerCount: number;
+    isResumedSession: boolean;
+  } | null {
+    return this._initData;
+  }
+
+  async cancelStream(_sessionId?: string): Promise<void> {
+    this.abort();
+  }
+
+  async *sendMessage(
+    message: string,
+    documentContext?: DocumentContext,
+    sessionId?: string,
+    messages?: any[],
+    workspacePath?: string,
+    attachments?: ChatAttachment[]
+  ): AsyncIterableIterator<StreamChunk> {
+    if (!workspacePath) {
+      yield { type: 'error', error: '[KimiCodeProvider] workspacePath is required but was not provided' };
+      return;
+    }
+
+    const systemPrompt = this.buildSystemPrompt(documentContext);
+    const { userMessageAddition, messageWithContext } = buildUserMessageAddition(message, documentContext);
+
+    if (sessionId && (systemPrompt || userMessageAddition)) {
+      this.emit('promptAdditions', {
+        sessionId,
+        systemPromptAddition: systemPrompt || null,
+        userMessageAddition,
+        attachments: [],
+        timestamp: Date.now(),
+      });
+    }
+
+    const prompt = messageWithContext;
+
+    if (sessionId) {
+      const metadataToLog: Record<string, unknown> = this.withPromptProvenanceMetadata(documentContext);
+      if (documentContext?.mode) {
+        metadataToLog.mode = documentContext.mode;
+      }
+      await this.logAgentMessageBestEffort(
+        sessionId,
+        'input',
+        prompt,
+        Object.keys(metadataToLog).length > 0 ? { metadata: metadataToLog } : undefined
+      );
+    }
+
+    const mcpConfigWorkspacePath = documentContext?.mcpConfigWorkspacePath || workspacePath;
+    const abortController = new AbortController();
+    this.abortController = abortController;
+
+    let fullText = '';
+
+    try {
+      const permissionResult = await this.requestKimiTurnPermission(workspacePath, documentContext?.permissionsPath);
+      if (permissionResult.decision !== 'allow') {
+        yield { type: 'error', error: permissionResult.reason || 'Kimi Code turn denied' };
+        return;
+      }
+
+      const existingSessionId = this.sessions.getSessionId(sessionId || '');
+
+      const mcpServers = await this.mcpConfigService.getMcpServersConfig({
+        sessionId,
+        workspacePath: mcpConfigWorkspacePath,
+        profile: 'standard',
+      });
+
+      this.configureProtocol();
+
+      const kimiAvailable = KimiCodeProvider.isKimiInstalled();
+      if (!kimiAvailable) {
+        yield {
+          type: 'error',
+          error: 'Kimi Code CLI is not installed. Install it with:\n\n' +
+            '  npm install -g @moonshot-ai/kimi-code\n\n' +
+            'Then run `kimi login` to authenticate.',
+        };
+        return;
+      }
+
+      const configuredModel = this.config?.model || KimiCodeProvider.DEFAULT_MODEL;
+      // Strip the registry prefix: `kimi-code:kimi-k3` -> `kimi-k3` for ACP.
+      const resolvedModel = configuredModel.replace(/^kimi-code:/, '');
+      const isResumedSession = !!existingSessionId;
+
+      const sessionOptions = {
+        workspacePath,
+        model: resolvedModel,
+        systemPrompt,
+        mcpServers,
+      };
+
+      const session = isResumedSession
+        ? await this.protocol.resumeSession(existingSessionId, sessionOptions)
+        : await this.protocol.createSession(sessionOptions);
+
+      this._initData = {
+        model: configuredModel,
+        mcpServerCount: Object.keys(mcpServers).length,
+        isResumedSession,
+      };
+
+      const transcriptAdapter = new AgentProtocolTranscriptAdapter(null, sessionId ?? '');
+      transcriptAdapter.userMessage(
+        prompt,
+        documentContext?.mode === 'planning' ? 'planning' : 'agent',
+        attachments as any,
+      );
+
+      for await (const event of this.protocol.sendMessage(session, {
+        content: prompt,
+        attachments,
+        sessionId,
+        mode: documentContext?.mode || 'agent',
+      })) {
+        if (abortController.signal.aborted) {
+          throw new Error('Operation cancelled');
+        }
+
+        if (sessionId) {
+          try {
+            await this.storeRawEventIfPresent(event, sessionId);
+          } catch {
+            // DB not available -- non-critical
+          }
+        }
+
+        for (const item of transcriptAdapter.processEvent(event)) {
+          switch (item.kind) {
+            case 'text':
+              fullText += item.text;
+              yield { type: 'text', content: item.text };
+              break;
+            case 'tool_call':
+              yield { type: 'tool_call', toolCall: item.toolCall };
+              break;
+            case 'complete':
+              // Store the complete assistant response so the raw parser can
+              // create a canonical assistant_message event from it.
+              if (sessionId && fullText) {
+                await this.storeAssistantResponse(sessionId, fullText);
+                await this.processTranscriptMessages(sessionId);
+              }
+              yield {
+                type: 'complete',
+                content: item.event.content,
+                isComplete: true,
+                usage: item.event.usage,
+              };
+              break;
+            case 'error':
+              yield { type: 'error', error: item.message };
+              break;
+            case 'raw_event':
+            case 'reasoning':
+            case 'unknown':
+              break;
+          }
+        }
+      }
+
+      if (sessionId && session.id && session.id !== existingSessionId) {
+        this.sessions.captureSessionId(sessionId, session.id);
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const isAbort = abortController.signal.aborted || /abort|cancel/i.test(errorMessage);
+      if (!isAbort) {
+        if (/process exited|ENOENT|spawn.*kimi/i.test(errorMessage)) {
+          yield {
+            type: 'error',
+            error: 'Kimi Code CLI is not installed or failed to start. Install it with:\n\n' +
+              '  npm install -g @moonshot-ai/kimi-code\n\n' +
+              'Then run `kimi login` to authenticate.',
+          };
+        } else if (/auth|login|token|unauthorized|forbidden/i.test(errorMessage)) {
+          yield {
+            type: 'error',
+            error: 'Kimi Code is not logged in. Run `kimi login` in your terminal to authenticate.',
+            isAuthError: true,
+          };
+        } else {
+          yield { type: 'error', error: errorMessage };
+        }
+      }
+    } finally {
+      if (this.abortController === abortController) {
+        this.abortController = null;
+      }
+    }
+  }
+
+  cleanupSession(sessionId: string): void {
+    this.sessions.deleteSession(sessionId);
+  }
+
+  destroy(): void {
+    this.protocol.destroy();
+    super.destroy();
+  }
+
+  protected buildSystemPrompt(documentContext?: DocumentContext): string {
+    const hasSessionNaming = isInternalMcpServerEnabled();
+    const worktreePath = documentContext?.worktreePath;
+
+    return buildClaudeCodeSystemPrompt({
+      hasSessionNaming,
+      toolReferenceStyle: 'codex',
+      worktreePath,
+      isVoiceMode: false,
+      enableAgentTeams: false,
+      trackersEnabled: areTrackerToolsEnabled(resolveTrackersWorkspacePath(documentContext)),
+    });
+  }
+
+  private static isKimiInstalled(): boolean {
+    const command = KimiCodeProvider.resolveKimiExecutableForRuntime(
+      KimiCodeProvider.enhancedPathLoader?.() || process.env.PATH
+    ) || 'kimi';
+    // Use the enhanced PATH (Homebrew, npm-global, etc.) so the runtime check
+    // matches what the settings panel sees -- a packaged macOS app launched
+    // from Finder/Dock has only /usr/bin:/bin:/usr/sbin:/sbin in PATH.
+    let env: NodeJS.ProcessEnv | undefined;
+    if (KimiCodeProvider.enhancedPathLoader) {
+      try {
+        env = { ...process.env, PATH: KimiCodeProvider.enhancedPathLoader() };
+      } catch {
+        // fall through to default env
+      }
+    }
+    try {
+      execFileSync(command, ['--version'], { stdio: 'pipe', timeout: 5000, env });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private configureProtocol(): void {
+    const resolvedPath = KimiCodeProvider.resolveKimiExecutableForRuntime(
+      KimiCodeProvider.enhancedPathLoader?.() || process.env.PATH
+    );
+    if (resolvedPath) {
+      this.protocol.setKimiPath(resolvedPath);
+    }
+
+    const env = KimiCodeProvider.buildKimiEnvironment();
+    if (env) {
+      this.protocol.setProcessEnv(env);
+    }
+  }
+
+  private static buildKimiEnvironment(): Record<string, string> | null {
+    let shellEnv: Record<string, string> | null = null;
+    let enhancedPath: string | null = null;
+
+    if (KimiCodeProvider.shellEnvironmentLoader) {
+      try {
+        shellEnv = KimiCodeProvider.shellEnvironmentLoader();
+      } catch {
+        // continue without shell env
+      }
+    }
+
+    if (KimiCodeProvider.enhancedPathLoader) {
+      try {
+        enhancedPath = KimiCodeProvider.enhancedPathLoader();
+      } catch {
+        // continue without enhanced PATH
+      }
+    }
+
+    if (!shellEnv && !enhancedPath) {
+      return null;
+    }
+
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value !== undefined) {
+        env[key] = value;
+      }
+    }
+    if (shellEnv) {
+      Object.assign(env, shellEnv);
+    }
+    if (enhancedPath) {
+      env.PATH = enhancedPath;
+    }
+
+    // Scrub API keys per CLAUDE.md policy. Kimi Code manages its own auth
+    // (device-code OAuth via `kimi login`, stored in its own config).
+    delete env.ANTHROPIC_API_KEY;
+    delete env.OPENAI_API_KEY;
+
+    return env;
+  }
+
+  private async requestKimiTurnPermission(
+    workspacePath: string,
+    permissionsPath?: string
+  ): Promise<{ decision: 'allow' | 'deny'; reason?: string; permissionMode?: PermissionMode }> {
+    const pathForTrust = permissionsPath || workspacePath;
+
+    if (pathForTrust && BaseAgentProvider.trustChecker) {
+      const trustStatus = BaseAgentProvider.trustChecker(pathForTrust);
+
+      if (!trustStatus.trusted) {
+        return {
+          decision: 'deny',
+          reason: 'Workspace is not trusted. Please trust this workspace to use Kimi Code.',
+        };
+      }
+
+      // Like Codex and Copilot, Kimi requires allow-all or bypass-all since
+      // the initial integration does not surface ACP per-tool permission
+      // callbacks (`session/request_permission`) as Nimbalyst prompts yet.
+      if (trustStatus.mode === 'bypass-all' || trustStatus.mode === 'allow-all') {
+        return { decision: 'allow', permissionMode: trustStatus.mode };
+      }
+
+      return {
+        decision: 'deny',
+        reason: 'Kimi Code requires "Allow Edits" permission mode. Please change the permission mode in workspace settings.',
+      };
+    }
+
+    return { decision: 'allow' };
+  }
+
+  private async processTranscriptMessages(sessionId: string): Promise<void> {
+    try {
+      if (TranscriptMigrationRepository.hasService()) {
+        await TranscriptMigrationRepository.getService().processNewMessages(
+          sessionId,
+          this.getProviderName(),
+        );
+      }
+    } catch {
+      // Best effort -- the session reload will catch up via ensureUpToDate
+    }
+  }
+
+  private async storeAssistantResponse(sessionId: string, text: string): Promise<void> {
+    const codexCompatibleEvent = {
+      type: 'item.completed',
+      item: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text }],
+      },
+    };
+    try {
+      await this.logAgentMessage(
+        sessionId,
+        this.getProviderName(),
+        'output',
+        JSON.stringify(codexCompatibleEvent),
+        { eventType: 'item.completed', kimiProvider: true },
+        false,
+        undefined,
+        true
+      );
+    } catch {
+      // Best effort
+    }
+  }
+
+  private async storeRawEventIfPresent(event: ProtocolEvent, sessionId: string): Promise<void> {
+    if (event.type !== 'raw_event' || !event.metadata?.rawEvent) {
+      return;
+    }
+
+    const { content, usedFallback } = safeJSONSerialize(event.metadata.rawEvent);
+    const rawEventType = this.getRawEventType(event.metadata.rawEvent);
+
+    await this.logAgentMessage(
+      sessionId,
+      this.getProviderName(),
+      'output',
+      usedFallback
+        ? JSON.stringify({ type: rawEventType, valueType: typeof event.metadata.rawEvent, fallback: true })
+        : content,
+      {
+        eventType: rawEventType,
+        kimiProvider: true,
+        rawEventSerializationFallback: usedFallback,
+      },
+      false,
+      undefined,
+      false
+    );
+  }
+
+  private getRawEventType(rawEvent: unknown): string {
+    if (rawEvent && typeof rawEvent === 'object') {
+      const method = (rawEvent as Record<string, unknown>).method;
+      if (typeof method === 'string' && method.trim().length > 0) {
+        return method;
+      }
+      const type = (rawEvent as Record<string, unknown>).type;
+      if (typeof type === 'string' && type.trim().length > 0) {
+        return type;
+      }
+    }
+    return 'unknown';
+  }
+}

--- a/packages/runtime/src/ai/server/providers/KimiCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/KimiCodeProvider.ts
@@ -304,8 +304,10 @@ export class KimiCodeProvider extends BaseAgentProvider {
       }
 
       const configuredModel = this.config?.model || KimiCodeProvider.DEFAULT_MODEL;
-      // Strip the registry prefix: `kimi-code:kimi-k3` -> `kimi-k3` for ACP.
-      const resolvedModel = configuredModel.replace(/^kimi-code:/, '');
+      // Map the registry id to the ACP wire id (`kimi-code:k3` -> `kimi-code/k3`);
+      // unknown ids fall back to the bare variant so user-typed wire ids pass through.
+      const preset = KIMI_CODE_PRESET_MODELS.find((p) => p.id === configuredModel);
+      const resolvedModel = preset ? preset.acpModelId : configuredModel.replace(/^kimi-code:/, '');
       const isResumedSession = !!existingSessionId;
 
       const sessionOptions = {

--- a/packages/runtime/src/ai/server/transcript/TranscriptTransformer.ts
+++ b/packages/runtime/src/ai/server/transcript/TranscriptTransformer.ts
@@ -23,6 +23,7 @@ import { CodexRawParser } from './parsers/CodexRawParser';
 import { CodexRawParserDispatcher } from './parsers/CodexRawParserDispatcher';
 import { CodexACPRawParser } from './parsers/CodexACPRawParser';
 import { CopilotRawParser } from './parsers/CopilotRawParser';
+import { KimiCodeRawParser } from './parsers/KimiCodeRawParser';
 import { OpenCodeRawParser } from './parsers/OpenCodeRawParser';
 import { VoiceRawParser } from './parsers/VoiceRawParser';
 import type {
@@ -466,6 +467,9 @@ export class TranscriptTransformer {
   private createParser(provider: string): IRawMessageParser {
     if (provider === 'copilot-cli') {
       return new CopilotRawParser();
+    }
+    if (provider === 'kimi-code') {
+      return new KimiCodeRawParser();
     }
     if (provider === 'openai-codex') {
       // Dispatches per-message between the SDK parser (legacy default) and

--- a/packages/runtime/src/ai/server/transcript/parsers/KimiCodeRawParser.ts
+++ b/packages/runtime/src/ai/server/transcript/parsers/KimiCodeRawParser.ts
@@ -1,0 +1,204 @@
+/**
+ * KimiCodeRawParser -- parses Kimi Code ACP raw messages into canonical
+ * event descriptors.
+ *
+ * Kimi Code implements the standard ACP schema (@agentclientprotocol/sdk),
+ * so session/update notifications carry the spec field names:
+ *   {"jsonrpc":"2.0","method":"session/update","params":{
+ *     "sessionId":"...","update":{"sessionUpdate":"agent_message_chunk",
+ *       "content":{"type":"text","text":"Hello"}}}}
+ *   tool calls: {"sessionUpdate":"tool_call","toolCallId":"...","title":"...",
+ *     "kind":"read","status":"pending","rawInput":{...}}
+ *   updates:    {"sessionUpdate":"tool_call_update","toolCallId":"...",
+ *     "status":"completed","rawOutput":...}
+ *
+ * This parser handles:
+ * - Input messages (user prompts, same format as other providers)
+ * - agent_message_chunk / agent_thought_chunk updates
+ * - tool_call / tool_call_update updates
+ * - Kimi assistant response messages (stored as item.completed, same
+ *   Codex-compatible envelope the Copilot provider uses)
+ */
+
+import type { RawMessage } from '../TranscriptTransformer';
+import type {
+  IRawMessageParser,
+  ParseContext,
+  CanonicalEventDescriptor,
+} from './IRawMessageParser';
+
+export class KimiCodeRawParser implements IRawMessageParser {
+  async parseMessage(
+    msg: RawMessage,
+    _context: ParseContext,
+  ): Promise<CanonicalEventDescriptor[]> {
+    if (msg.hidden) return [];
+
+    if (msg.direction === 'input') {
+      return this.parseInputMessage(msg);
+    }
+
+    return this.parseOutputMessage(msg);
+  }
+
+  private parseInputMessage(msg: RawMessage): CanonicalEventDescriptor[] {
+    const content = String(msg.content ?? '').trim();
+    if (!content) return [];
+
+    if (this.isSystemReminder(content, msg.metadata)) {
+      return [{
+        type: 'system_message',
+        text: content,
+        systemType: 'status',
+        createdAt: msg.createdAt,
+      }];
+    }
+
+    return [{
+      type: 'user_message',
+      text: content,
+      mode: (msg.metadata?.mode as 'agent' | 'planning') ?? 'agent',
+      createdAt: msg.createdAt,
+    }];
+  }
+
+  private parseOutputMessage(msg: RawMessage): CanonicalEventDescriptor[] {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(msg.content);
+    } catch {
+      // Plain text output = assistant response
+      const text = String(msg.content ?? '').trim();
+      if (text) {
+        return [{ type: 'assistant_message', text, createdAt: msg.createdAt }];
+      }
+      return [];
+    }
+
+    // Codex-compatible item.completed envelope stored by the provider after a
+    // turn completes (reliable transcript rendering without chunk reassembly)
+    if (parsed.type === 'item.completed' && parsed.item) {
+      return this.parseItemCompleted(parsed.item as Record<string, unknown>, msg);
+    }
+
+    // ACP session/update notifications
+    if (parsed.method === 'session/update' && parsed.params) {
+      const params = parsed.params as Record<string, unknown>;
+      const update = params.update as Record<string, unknown> | undefined;
+      if (update) {
+        return this.parseSessionUpdate(update, msg);
+      }
+    }
+
+    return [];
+  }
+
+  private parseItemCompleted(
+    item: Record<string, unknown>,
+    msg: RawMessage,
+  ): CanonicalEventDescriptor[] {
+    if (item.type !== 'message' || item.role !== 'assistant') return [];
+
+    const content = item.content;
+    if (!Array.isArray(content)) return [];
+
+    const textParts: string[] = [];
+    for (const part of content) {
+      if (part && typeof part === 'object' && !Array.isArray(part)) {
+        const p = part as Record<string, unknown>;
+        if (p.type === 'output_text' && typeof p.text === 'string') {
+          textParts.push(p.text);
+        }
+      }
+    }
+
+    const text = textParts.join('');
+    if (!text) return [];
+
+    return [{ type: 'assistant_message', text, createdAt: msg.createdAt }];
+  }
+
+  private parseSessionUpdate(
+    update: Record<string, unknown>,
+    msg: RawMessage,
+  ): CanonicalEventDescriptor[] {
+    const updateType = update.sessionUpdate as string | undefined;
+    const content = update.content as Record<string, unknown> | undefined;
+
+    switch (updateType) {
+      case 'agent_message_chunk':
+        // Don't emit per-chunk -- the item.completed message has the full text
+        return [];
+
+      case 'agent_thought_chunk':
+        // Reasoning is not rendered in transcript
+        return [];
+
+      case 'tool_call': {
+        const name = typeof update.title === 'string' ? update.title : 'unknown';
+        const id = typeof update.toolCallId === 'string' ? update.toolCallId : undefined;
+        const args = (update.rawInput ?? undefined) as Record<string, unknown> | undefined;
+
+        return [{
+          type: 'tool_call_started',
+          toolName: name,
+          toolDisplayName: name,
+          arguments: args ?? {},
+          providerToolCallId: id ?? null,
+          createdAt: msg.createdAt,
+        }];
+      }
+
+      case 'tool_call_update': {
+        const id = typeof update.toolCallId === 'string' ? update.toolCallId : undefined;
+        const status = update.status as string | undefined;
+        if (!id || (status !== 'completed' && status !== 'failed')) return [];
+
+        const output = update.rawOutput ?? this.extractToolContentText(update.content);
+        const resultStr = typeof output === 'string' ? output : JSON.stringify(output ?? '');
+
+        return [{
+          type: 'tool_call_completed',
+          providerToolCallId: id,
+          status: status === 'failed' ? 'error' : 'completed',
+          result: resultStr,
+        }];
+      }
+
+      case 'error': {
+        const errorMsg = typeof update.message === 'string' ? update.message :
+                         typeof content?.message === 'string' ? content.message : 'Unknown error';
+        return [{
+          type: 'system_message',
+          text: errorMsg,
+          systemType: 'error',
+          createdAt: msg.createdAt,
+        }];
+      }
+
+      default:
+        return [];
+    }
+  }
+
+  private extractToolContentText(content: unknown): string | undefined {
+    if (!Array.isArray(content)) return undefined;
+    const parts: string[] = [];
+    for (const item of content) {
+      if (item && typeof item === 'object') {
+        const c = (item as Record<string, unknown>).content as Record<string, unknown> | undefined;
+        if (c && c.type === 'text' && typeof c.text === 'string') {
+          parts.push(c.text);
+        }
+      }
+    }
+    return parts.length > 0 ? parts.join('\n') : undefined;
+  }
+
+  private isSystemReminder(content: string, metadata?: Record<string, unknown>): boolean {
+    return (
+      metadata?.promptType === 'system_reminder' ||
+      /<SYSTEM_REMINDER>[\s\S]*<\/SYSTEM_REMINDER>/.test(content)
+    );
+  }
+}

--- a/packages/runtime/src/ai/server/transcript/parsers/__tests__/KimiCodeRawParser.test.ts
+++ b/packages/runtime/src/ai/server/transcript/parsers/__tests__/KimiCodeRawParser.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { KimiCodeRawParser } from '../KimiCodeRawParser';
+import type { RawMessage } from '../../TranscriptTransformer';
+import type { ParseContext } from '../IRawMessageParser';
+
+const ctx = {} as ParseContext;
+
+function raw(direction: 'input' | 'output', content: string, metadata?: Record<string, unknown>): RawMessage {
+  return {
+    id: 1,
+    sessionId: 's1',
+    direction,
+    content,
+    metadata,
+    hidden: false,
+    createdAt: new Date('2026-08-05T12:00:00Z'),
+  } as unknown as RawMessage;
+}
+
+function sessionUpdate(update: Record<string, unknown>): string {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'session/update',
+    params: { sessionId: 'acp-1', update },
+  });
+}
+
+describe('KimiCodeRawParser', () => {
+  it('parses the item.completed envelope into an assistant message', async () => {
+    const parser = new KimiCodeRawParser();
+    const content = JSON.stringify({
+      type: 'item.completed',
+      item: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'Ciao' }] },
+    });
+    const events = await parser.parseMessage(raw('output', content), ctx);
+    expect(events).toEqual([expect.objectContaining({ type: 'assistant_message', text: 'Ciao' })]);
+  });
+
+  it('maps ACP tool_call (toolCallId/title/rawInput) to tool_call_started', async () => {
+    const parser = new KimiCodeRawParser();
+    const content = sessionUpdate({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'tc-1',
+      title: 'Read file',
+      kind: 'read',
+      status: 'pending',
+      rawInput: { path: '/tmp/x' },
+    });
+    const events = await parser.parseMessage(raw('output', content), ctx);
+    expect(events).toEqual([expect.objectContaining({
+      type: 'tool_call_started',
+      toolName: 'Read file',
+      providerToolCallId: 'tc-1',
+      arguments: { path: '/tmp/x' },
+    })]);
+  });
+
+  it('maps completed and failed tool_call_update to tool_call_completed, ignoring in_progress', async () => {
+    const parser = new KimiCodeRawParser();
+    const completed = await parser.parseMessage(raw('output', sessionUpdate({
+      sessionUpdate: 'tool_call_update', toolCallId: 'tc-1', status: 'completed', rawOutput: 'ok',
+    })), ctx);
+    expect(completed).toEqual([expect.objectContaining({
+      type: 'tool_call_completed', providerToolCallId: 'tc-1', status: 'completed', result: 'ok',
+    })]);
+
+    const failed = await parser.parseMessage(raw('output', sessionUpdate({
+      sessionUpdate: 'tool_call_update', toolCallId: 'tc-2', status: 'failed',
+    })), ctx);
+    expect(failed).toEqual([expect.objectContaining({ status: 'error', providerToolCallId: 'tc-2' })]);
+
+    const inProgress = await parser.parseMessage(raw('output', sessionUpdate({
+      sessionUpdate: 'tool_call_update', toolCallId: 'tc-3', status: 'in_progress',
+    })), ctx);
+    expect(inProgress).toEqual([]);
+  });
+
+  it('suppresses per-chunk text and thought updates (full text arrives via item.completed)', async () => {
+    const parser = new KimiCodeRawParser();
+    for (const updateType of ['agent_message_chunk', 'agent_thought_chunk']) {
+      const events = await parser.parseMessage(raw('output', sessionUpdate({
+        sessionUpdate: updateType, content: { type: 'text', text: 'chunk' },
+      })), ctx);
+      expect(events).toEqual([]);
+    }
+  });
+
+  it('parses user input as a user_message', async () => {
+    const parser = new KimiCodeRawParser();
+    const events = await parser.parseMessage(raw('input', 'fai una cosa', { mode: 'agent' }), ctx);
+    expect(events).toEqual([expect.objectContaining({ type: 'user_message', text: 'fai una cosa' })]);
+  });
+});

--- a/packages/runtime/src/ai/server/transcript/processDescriptor.ts
+++ b/packages/runtime/src/ai/server/transcript/processDescriptor.ts
@@ -230,9 +230,12 @@ export async function processDescriptor(
 
 export function selectRawParser(
   provider: string,
-): 'codex' | 'codex-acp' | 'copilot' | 'claude-code' | 'opencode' | 'voice' {
+): 'codex' | 'codex-acp' | 'copilot' | 'claude-code' | 'opencode' | 'voice' | 'kimi-code' {
   if (provider === 'copilot-cli') {
     return 'copilot';
+  }
+  if (provider === 'kimi-code') {
+    return 'kimi-code';
   }
   if (provider === 'openai-codex') {
     return 'codex';

--- a/packages/runtime/src/ai/server/transcript/projectRawMessages.ts
+++ b/packages/runtime/src/ai/server/transcript/projectRawMessages.ts
@@ -19,6 +19,7 @@ import { ClaudeCodeRawParser } from './parsers/ClaudeCodeRawParser';
 import { CodexRawParserDispatcher } from './parsers/CodexRawParserDispatcher';
 import { CodexACPRawParser } from './parsers/CodexACPRawParser';
 import { CopilotRawParser } from './parsers/CopilotRawParser';
+import { KimiCodeRawParser } from './parsers/KimiCodeRawParser';
 import { OpenCodeRawParser } from './parsers/OpenCodeRawParser';
 import { VoiceRawParser } from './parsers/VoiceRawParser';
 import type { IRawMessageParser, ParseContext } from './parsers/IRawMessageParser';
@@ -36,6 +37,7 @@ function createParser(provider: string): IRawMessageParser {
   if (kind === 'codex') return new CodexRawParserDispatcher();
   if (kind === 'codex-acp') return new CodexACPRawParser();
   if (kind === 'copilot') return new CopilotRawParser();
+  if (kind === 'kimi-code') return new KimiCodeRawParser();
   if (kind === 'opencode') return new OpenCodeRawParser();
   if (kind === 'voice') return new VoiceRawParser();
   return new ClaudeCodeRawParser();

--- a/packages/runtime/src/ai/server/transcript/searchableTextExtractor.ts
+++ b/packages/runtime/src/ai/server/transcript/searchableTextExtractor.ts
@@ -332,7 +332,7 @@ export function extractSearchable(input: ExtractorInput): ExtractedSearchable {
   // Treat all "agent provider" output payloads through their SDK-shaped extractors;
   // chat providers write plainer rows and use the generic extractor.
   if (direction === 'input') {
-    if (source === 'claude-code' || source === 'openai-codex' || source === 'openai-codex-acp' || source === 'opencode' || source === 'copilot-cli') {
+    if (source === 'claude-code' || source === 'openai-codex' || source === 'openai-codex-acp' || source === 'opencode' || source === 'copilot-cli' || source === 'kimi-code') {
       const parsed = safeJsonParse(content);
       const result = extractClaudeCodeInput(parsed, content, metadata);
       return { searchableText: capLen(result.searchableText), messageKind: result.messageKind };
@@ -347,7 +347,7 @@ export function extractSearchable(input: ExtractorInput): ExtractedSearchable {
     const result = extractClaudeCodeOutput(parsed, content);
     return { searchableText: capLen(result.searchableText), messageKind: result.messageKind };
   }
-  if (source === 'openai-codex' || source === 'openai-codex-acp' || source === 'opencode' || source === 'copilot-cli') {
+  if (source === 'openai-codex' || source === 'openai-codex-acp' || source === 'opencode' || source === 'copilot-cli' || source === 'kimi-code') {
     const parsed = safeJsonParse(content);
     const result = extractCodexOutput(parsed, content);
     return { searchableText: capLen(result.searchableText), messageKind: result.messageKind };

--- a/packages/runtime/src/ai/server/types.ts
+++ b/packages/runtime/src/ai/server/types.ts
@@ -176,7 +176,7 @@ export interface Message {
  * Add new providers here -- the type, runtime array, and exhaustiveness
  * checks all derive from this one definition.
  */
-export const AI_PROVIDER_TYPES = ['claude', 'claude-code', 'claude-code-cli', 'openai', 'openai-codex', 'openai-codex-acp', 'lmstudio', 'opencode', 'copilot-cli'] as const;
+export const AI_PROVIDER_TYPES = ['claude', 'claude-code', 'claude-code-cli', 'openai', 'openai-codex', 'openai-codex-acp', 'lmstudio', 'opencode', 'copilot-cli', 'kimi-code'] as const;
 
 export type AIProviderType = typeof AI_PROVIDER_TYPES[number];
 
@@ -195,8 +195,8 @@ export function assertExhaustiveProvider(provider: never): never {
   throw new Error(`Unhandled provider: ${provider}`);
 }
 
-export function isAgentProvider(provider: string | null | undefined): provider is 'claude-code' | 'claude-code-cli' | 'openai-codex' | 'openai-codex-acp' | 'opencode' | 'copilot-cli' {
-  return provider === 'claude-code' || provider === 'claude-code-cli' || provider === 'openai-codex' || provider === 'openai-codex-acp' || provider === 'opencode' || provider === 'copilot-cli';
+export function isAgentProvider(provider: string | null | undefined): provider is 'claude-code' | 'claude-code-cli' | 'openai-codex' | 'openai-codex-acp' | 'opencode' | 'copilot-cli' | 'kimi-code' {
+  return provider === 'claude-code' || provider === 'claude-code-cli' || provider === 'openai-codex' || provider === 'openai-codex-acp' || provider === 'opencode' || provider === 'copilot-cli' || provider === 'kimi-code';
 }
 
 /**

--- a/packages/runtime/src/sync/syncContentTruncator.ts
+++ b/packages/runtime/src/sync/syncContentTruncator.ts
@@ -225,6 +225,25 @@ export function shouldSyncMessageForSessionRoom(
     return true;
   }
 
+  // Kimi Code streams the same ACP shape as Copilot: text arrives
+  // self-contained on the item.completed row, thought chunks are dropped by
+  // design, and usage_update snapshots are only cached locally.
+  if (source.startsWith('kimi-code')) {
+    if (
+      content
+      && (content.includes('"agent_message_chunk"') || content.includes('"agent_thought_chunk"') || content.includes('"usage_update"'))
+    ) {
+      try {
+        const parsed = JSON.parse(content) as { params?: { update?: { sessionUpdate?: string } } };
+        const updateType = parsed?.params?.update?.sessionUpdate;
+        if (updateType === 'agent_message_chunk' || updateType === 'agent_thought_chunk' || updateType === 'usage_update') return false;
+      } catch {
+        // Unparseable -- let it through.
+      }
+    }
+    return true;
+  }
+
   if (source.startsWith('opencode')) {
     const eventType = typeof metadata?.eventType === 'string' ? metadata.eventType : '';
     // Rows without an eventType are not SSE events (e.g. user input) -- sync.

--- a/packages/runtime/src/types/MCPServerConfig.ts
+++ b/packages/runtime/src/types/MCPServerConfig.ts
@@ -135,6 +135,7 @@ export const MCP_PROVIDER_IDS = {
   CLAUDE_AGENT: 'claude-agent',
   CODEX: 'codex',
   COPILOT: 'copilot',
+  KIMI: 'kimi',
 } as const;
 
 export type MCPProviderId = typeof MCP_PROVIDER_IDS[keyof typeof MCP_PROVIDER_IDS];
@@ -143,6 +144,7 @@ export const ALL_MCP_PROVIDER_IDS: MCPProviderId[] = [
   MCP_PROVIDER_IDS.CLAUDE_AGENT,
   MCP_PROVIDER_IDS.CODEX,
   MCP_PROVIDER_IDS.COPILOT,
+  MCP_PROVIDER_IDS.KIMI,
 ];
 
 /**

--- a/packages/runtime/src/ui/icons/ProviderIcons.tsx
+++ b/packages/runtime/src/ui/icons/ProviderIcons.tsx
@@ -8,6 +8,7 @@ interface IconProps {
 
 const PROVIDER_ICON_MAP: Record<string, string> = {
   'copilot-cli': 'terminal',
+  'kimi-code': 'terminal',
   // ACP transport reuses the OpenAI Codex icon (same underlying agent).
   'openai-codex-acp': 'openai-codex',
   'claude-code-cli': 'claude-code',


### PR DESCRIPTION
Adds Moonshot AI's Kimi Code CLI as an alpha agent provider, following the same ACP (Agent Client Protocol) integration path as GitHub Copilot.

## How it works

- `KimiACPProtocol` spawns `kimi acp` (JSON-RPC over stdio, standard `@agentclientprotocol` schema: `agent_message_chunk`, `agent_thought_chunk`, `tool_call`/`tool_call_update`, `usage_update`).
- Model selection via `session/set_config_option` (`configId: 'model'`); best-effort, falls back to the CLI default on rejection. Preset wire ids (`kimi-code/k3`, `kimi-code/k3-256k`) verified against the authenticated catalog returned by `session/new`.
- `usage_update` `{used, size}` is folded into the `complete` event as context fill / context window.
- Auth stays in the CLI (`kimi login`); no API key touches Nimbalyst settings, and `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` are scrubbed from the child env per repo policy.
- Binary resolution mirrors Copilot's (absolute candidates first because of the Finder-minimal PATH, then enhanced PATH), plus a `KIMI_BIN` override.
- Settings panel modeled on `CopilotCLIPanel`: alpha badge, CLI install/check via `CLIManager`, login instructions.
- Transcript: dedicated `KimiCodeRawParser` (standard ACP field names: `toolCallId`/`title`/`rawInput`, unlike the Copilot parser), same `item.completed` envelope for the final assistant text; the sync truncator drops chunk/thought/usage rows.

## Testing

- Unit tests for the raw parser (tool_call mapping, chunk suppression, item.completed).
- `tsc --noEmit` clean on `packages/runtime` and `packages/electron`.
- Protocol shapes verified against kimi-cli 0.33.0 (`initialize` handshake, authenticated `session/new` catalog, `session/set_config_option` model switch).

## Notes for reviewers

- Like Copilot, per-tool ACP permission callbacks (`session/request_permission`) are not surfaced yet: the provider requires allow-all/bypass-all mode (same gate as Copilot/Codex).
- The K3 preset advertises a 1M-token context window per the model card; at runtime the authoritative value arrives via `usage_update.size`.
- `ModelLabel.swift` (iOS mirror of modelUtils) was not updated: the provider is desktop-only alpha. Happy to add it if preferred.
