### PR TITLE
fix: publish queue state to mobile when a phone-queued prompt is inserted

### DIFF
--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -1181,6 +1181,19 @@ export class AIService {
 
                 logger.main.info(`[AIService] Inserted ${newPromptsCount} new prompts into queued_prompts table`);
 
+                // Mirror the freshly-inserted rows back to mobile. Every other
+                // creation/mutation path (createQueuedPrompt, claim, complete,
+                // fail, delete, cancel/interrupt sweeps) publishes after its
+                // change; this mobile-receive path never did, so a prompt sent
+                // from a phone never got its own confirming "you're now
+                // authoritatively queued" push -- it only left the queue (via
+                // the claim-time publish) but never entered it. The sending
+                // device's own optimistic local row is not enough by itself:
+                // the mobile queue pane is driven by synced state, not local
+                // composition, so without this push a phone-originated prompt
+                // never displays as queued at all while pending.
+                await this.publishQueueStateToSync(sessionId);
+
                 // Load session to get its workspacePath for window routing
                 // Use repository directly since we just need metadata, not full session load
                 const { AISessionsRepository } = await import('@nimbalyst/runtime/storage/repositories/AISessionsRepository');


### PR DESCRIPTION
Forwarded: pending
Applied-Upstream: no
Last-Checked: 2026-08-10

Fixes #1193.

## Bug

A prompt sent from the iOS app while the target session is busy is correctly accepted and tracked
as `pending` server-side, but never appears in the queue pane while it's actually pending -- it
only ever stops being empty once the prompt is claimed, at which point it's removed (it was never
shown at all). Reproduced live twice against production (v0.72.8), including a ~52s pending window
with no display at any point during it.

## Root cause

`AIService.ts`'s `onIndexChange` handler -- the receive path for a mobile-originated queued prompt
-- inserts the new row (`queueStore.create(...)`) but never calls `publishQueueStateToSync(sessionId)`
afterward. Every other queue-mutation path in this file (`createQueuedPrompt`, `claim`, `complete`,
`fail`, `delete`, cancel/interrupt sweeps) already publishes after its change; this receive path was
the one gap. `PGLiteQueuedPromptsStore`'s own state tracking is correct throughout -- this is purely
a missing mobile-sync push on one insertion path.

## Fix

One call added, matching the existing pattern at the other 8 call sites in this file. No wire
protocol or iOS changes needed -- iOS's existing sync-consumption logic already handles this
correctly once the push actually happens.

## Verification

- Rebased on current `upstream/main` (`2e6237c8e`), single commit, no other file changes.
- Re-checked 2026-08-10 (3 days after the fix was written) with
  `tools/upstream_sync/upstream_check.py` scoped to this exact file: no new upstream commits since
  `2e6237c8e` touch this file; direct read of `onIndexChange` on current `upstream/main` confirms
  the `publishQueueStateToSync` call is still absent there -- this fix has not been applied
  upstream by anyone else in the interim.

## Why this is worth merging

When a phone inserts a prompt, every connected surface should immediately agree that the work exists. Publishing the queue update at insertion removes the window where mobile shows success but desktop reports an empty queue, reducing duplicate submissions and making pending-work state trustworthy across devices.
