### PR TITLE
docs: fix broken IPC listener link in JOTAI.md

### DIFF
--- a/docs/JOTAI.md
+++ b/docs/JOTAI.md
@@ -368,7 +368,7 @@ export const updateSessionStoreAtom = atom(
 
 ## Integration with Centralized IPC Listeners
 
-See [centralized-ipc-listener-architecture.md](../plans/centralized-ipc-listener-architecture.md) for the full pattern.
+See [IPC_LISTENERS.md](./IPC_LISTENERS.md) for the full pattern.
 
 ### The Flow
 


### PR DESCRIPTION
The "Integration with Centralized IPC Listeners" section in `docs/JOTAI.md` linked to `../plans/centralized-ipc-listener-architecture.md`, which doesn't exist in the repo (there's no `plans/` directory at the root).

That content now lives in `docs/IPC_LISTENERS.md` (its H1 is "Centralized IPC Listener Architecture"), so this repoints the link there.

- Before: `[...](../plans/centralized-ipc-listener-architecture.md)`
- After: `[...](./IPC_LISTENERS.md)`

Docs-only, one line.
