### PR TITLE
fix: keep session-list relative time updating on idle sessions (#1200)

### DIFF
--- a/packages/electron/src/renderer/components/AgenticCoding/SessionListItem.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/SessionListItem.tsx
@@ -401,6 +401,17 @@ export const SessionListItem = memo<SessionListItemProps>(function SessionListIt
   const timestamp = sortBy === 'updated' ? (effectiveUpdatedAt || createdAt) : createdAt;
   const timestampLabel = sortBy === 'updated' ? 'updated' : 'created';
 
+  // A quiet session still ages: relativeTime is derived from a fixed timestamp,
+  // so without a periodic re-render the "X ago" label sits frozen until the
+  // session next has activity (#1200). One coarse tick a minute matches the
+  // finest granularity getRelativeTimeString renders — same approach as the
+  // Inbox section's relative labels.
+  const [relativeTimeTick, setRelativeTimeTick] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => setRelativeTimeTick((t) => t + 1), 60_000);
+    return () => clearInterval(timer);
+  }, []);
+
   const { relativeTime, fullDateTime } = useMemo(() => ({
     relativeTime: getRelativeTimeString(timestamp),
     fullDateTime: new Date(timestamp).toLocaleString(undefined, {
@@ -412,7 +423,7 @@ export const SessionListItem = memo<SessionListItemProps>(function SessionListIt
       hour12: true,
       timeZoneName: 'short'
     }),
-  }), [timestamp]);
+  }), [timestamp, relativeTimeTick]);
 
   // Extract model ID from provider:model format
   const displayModel = model?.includes(':') ? model.split(':')[1] : model;

--- a/packages/electron/src/renderer/components/AgenticCoding/__tests__/SessionListItem.relativeTimeTick.test.tsx
+++ b/packages/electron/src/renderer/components/AgenticCoding/__tests__/SessionListItem.relativeTimeTick.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+
+// Keep the component isolated, same setup as the sibling SessionListItem tests:
+// jotai atom reads return defaults, the store atom families are callable stubs,
+// and heavy children are stubbed so importing them has no side effects.
+vi.mock('jotai', () => ({
+  useAtomValue: () => undefined,
+  useSetAtom: () => () => {},
+}));
+vi.mock('@nimbalyst/runtime', () => ({ MaterialSymbol: () => null, ProviderIcon: () => null }));
+vi.mock('../../../store', () => ({
+  sessionOrChildProcessingAtom: () => ({}),
+  sessionUnreadAtom: () => ({}),
+  sessionPendingPromptAtom: () => ({}),
+  sessionHasPendingInteractivePromptAtom: () => ({}),
+  reparentSessionAtom: () => ({}),
+  refreshSessionListAtom: () => ({}),
+  sessionShareAtom: () => ({}),
+  sessionWakeupAtom: () => ({}),
+  sessionLastActivityAtom: () => ({}),
+}));
+vi.mock('../../../store/atoms/sessions', () => ({ convertToWorkstreamAtom: () => ({}) }));
+vi.mock('../SessionContextMenu', () => ({ SessionContextMenu: () => null }));
+
+import { SessionListItem } from '../SessionListItem';
+
+const baseProps = {
+  id: 's1',
+  isActive: false,
+  onClick: () => {},
+};
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('SessionListItem - relative time keeps ticking on an idle session (#1200)', () => {
+  it('advances the "X ago" label as time passes without new activity', () => {
+    vi.useFakeTimers();
+    const base = 1_700_000_000_000;
+    vi.setSystemTime(base);
+
+    // Session last touched 30s ago -> "Just now" at first paint.
+    const { container } = render(
+      <SessionListItem {...baseProps} title="Idle session" createdAt={base - 30_000} />,
+    );
+    const label = () => container.querySelector('.session-list-item-datetime')?.textContent;
+    expect(label()).toBe('Just now');
+
+    // One minute passes with no new activity. The per-minute tick must re-render
+    // so the label reflects real elapsed time (now 90s old -> "1 min ago").
+    // Before the fix there is no interval, so the label stays frozen at "Just now".
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(label()).toBe('1 min ago');
+  });
+});


### PR DESCRIPTION
Fixes #1200.

## Problem
The relative-time label in the session list (e.g. "32 mins ago") is computed in a `useMemo` keyed only on the session's timestamp. That timestamp changes only when the session gets new activity, so once a session goes idle the label freezes and never advances — a session that's actually 15 hours old keeps showing "32 mins ago".

## Fix
Add a once-a-minute tick that re-runs the memo, so the label reflects real elapsed time on idle sessions. This mirrors the existing approach in `TeamMode/Inbox/InboxSection.tsx`, which already solved the identical "a quiet label still ages" problem with a 60s interval.

## Test
Adds `SessionListItem.relativeTimeTick.test.tsx` (jsdom + fake timers): renders an idle row showing "Just now", advances the clock one minute, asserts it becomes "1 min ago". Confirmed it fails on the pre-fix code and passes with the fix.

Scoped to `SessionListItem.tsx` (the primary session list the issue names). `SessionRelativeTime.tsx` has the same pattern and could get the same treatment in a follow-up.
