### PR TITLE
feat(rail): differentiate awaiting/running/unread on multi-project badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Multi-project rail badges now distinguish sessions waiting on your response, still running, and finished-unread, using the same indicators as the session list.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/renderer/components/ProjectRail.css
+++ b/packages/electron/src/renderer/components/ProjectRail.css
@@ -95,6 +95,52 @@
   pointer-events: none;
 }
 
+/* Each badge state borrows the symbol and colour the session list already
+   uses for it, so the rail and the sidebar read as one language. Shape
+   carries the meaning, not just the number: a count alone can't say whether
+   it means "still working" or "done, go read it". */
+
+/* Awaiting a question — blocked on you. Warning colour + pulse, matching
+   SessionStatusIndicator's `waiting-for-input`. */
+.project-rail-item-badge.is-awaiting {
+  background-color: var(--nim-warning, #f59e0b);
+  color: var(--nim-on-warning, #ffffff);
+  animation: project-rail-badge-pulse 2s ease-in-out infinite;
+}
+
+/* Still running — nothing to do yet. The spinner replaces the count
+   deliberately: how many are mid-flight isn't actionable, and a spinning
+   number is unreadable at 16px. */
+.project-rail-item-badge.is-running {
+  background-color: var(--nim-primary, #3b82f6);
+  opacity: 0.8;
+}
+
+.project-rail-item-badge.is-running .material-symbols-outlined {
+  animation: project-rail-badge-spin 1s linear infinite;
+}
+
+/* Finished and unread — the count is the point: N threads to go read. */
+.project-rail-item-badge.is-unread {
+  background-color: var(--nim-primary, #3b82f6);
+}
+
+@keyframes project-rail-badge-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@keyframes project-rail-badge-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .project-rail-item-badge.is-awaiting,
+  .project-rail-item-badge.is-running .material-symbols-outlined {
+    animation: none;
+  }
+}
+
 .project-rail-item-close {
   position: absolute;
   top: -4px;

--- a/packages/electron/src/renderer/components/ProjectRail.tsx
+++ b/packages/electron/src/renderer/components/ProjectRail.tsx
@@ -25,6 +25,7 @@ import {
   type VirtualElement,
 } from '@floating-ui/react';
 import { windowControlsClearance } from '@nimbalyst/runtime/ui/floating/windowControlsClearance';
+import { MaterialSymbol } from '@nimbalyst/runtime/ui/icons/MaterialSymbol';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { OrgSwitcher } from './OrgSwitcher';
 import {
@@ -60,6 +61,7 @@ interface ProjectRailIconProps {
   isActive: boolean;
   processingCount: number;
   unreadCount: number;
+  awaitingCount: number;
   onActivate: (path: string) => void;
   onClose: (project: OpenProject) => void;
   onContextMenu: (project: OpenProject, x: number, y: number) => void;
@@ -70,6 +72,7 @@ function ProjectRailIcon({
   isActive,
   processingCount,
   unreadCount,
+  awaitingCount,
   onActivate,
   onClose,
   onContextMenu,
@@ -120,8 +123,33 @@ function ProjectRailIcon({
   // Inactive projects show a badge when something needs attention. Active
   // projects already have the user's eyes on them so we suppress the
   // badge to keep the rail quiet.
-  const showBadge = !isActive && (processingCount > 0 || unreadCount > 0);
-  const badgeLabel = processingCount > 0 ? `${processingCount}` : unreadCount > 0 ? `${unreadCount}` : '';
+  //
+  // Priority: awaiting a question > still running > finished-unread. The three
+  // are visually distinct rather than three flavours of the same number,
+  // because a bare count can't say whether it means "2 still working" or
+  // "2 done, go read them" — opposite calls to action. Each state borrows the
+  // symbol the session list already uses for it (SessionListItem's
+  // SessionStatusIndicator) so the rail and the sidebar read as one language:
+  //
+  //   awaiting  → contact_support, warning colour, pulsing (blocked on you)
+  //   running   → spinner, no count (nothing to do yet; count is noise)
+  //   unread    → plain count, primary colour (N finished threads to read)
+  const badgeState = !isActive
+    ? awaitingCount > 0
+      ? 'awaiting'
+      : processingCount > 0
+        ? 'running'
+        : unreadCount > 0
+          ? 'unread'
+          : 'none'
+    : 'none';
+  const showBadge = badgeState !== 'none';
+  const badgeTitle =
+    badgeState === 'awaiting'
+      ? `${awaitingCount} session${awaitingCount === 1 ? '' : 's'} waiting for your response`
+      : badgeState === 'running'
+        ? `${processingCount} session${processingCount === 1 ? '' : 's'} running`
+        : `${unreadCount} finished session${unreadCount === 1 ? '' : 's'} to read`;
 
   // Wrapper is a non-interactive container so the activate button and the
   // close button can sit as siblings. Nesting a button inside a button is
@@ -146,10 +174,14 @@ function ProjectRailIcon({
         {projectInitials(project.name)}
         {showBadge && (
           <span
-            className="project-rail-item-badge"
-            aria-label={processingCount > 0 ? `${processingCount} streaming session(s)` : `${unreadCount} unread`}
+            className={`project-rail-item-badge is-${badgeState}`}
+            aria-label={badgeTitle}
+            title={badgeTitle}
+            data-badge-state={badgeState}
           >
-            {badgeLabel}
+            {badgeState === 'awaiting' && <MaterialSymbol icon="contact_support" size={11} />}
+            {badgeState === 'running' && <MaterialSymbol icon="progress_activity" size={11} />}
+            {badgeState === 'unread' && unreadCount}
           </span>
         )}
       </button>
@@ -431,6 +463,7 @@ export function ProjectRail() {
             isActive={project.path === activePath}
             processingCount={activity?.processing ?? 0}
             unreadCount={activity?.unread ?? 0}
+            awaitingCount={activity?.awaiting ?? 0}
             onActivate={handleActivate}
             onClose={handleClose}
             onContextMenu={handleContextMenu}

--- a/packages/electron/src/renderer/store/atoms/__tests__/sessionActivity.test.ts
+++ b/packages/electron/src/renderer/store/atoms/__tests__/sessionActivity.test.ts
@@ -10,6 +10,8 @@ import {
   clearSessionStreamingAtom,
   markSessionUnreadAtom,
   clearSessionUnreadAtom,
+  markSessionAwaitingAtom,
+  clearSessionAwaitingAtom,
   clearWorkspaceActivityAtom,
   projectActivitySummaryAtom,
 } from '../sessionActivity';
@@ -128,6 +130,37 @@ describe('sessionActivity atoms', () => {
     });
   });
 
+  describe('awaiting', () => {
+    it('clears via the session index when no workspacePath is supplied', () => {
+      // Terminal lifecycle events often arrive without a workspacePath; the
+      // rail badge must still clear or it sticks forever.
+      jotaiStore.set(markSessionAwaitingAtom, { sessionId: 's1', workspacePath: PATH_A });
+      jotaiStore.set(clearSessionAwaitingAtom, { sessionId: 's1' });
+
+      expect(jotaiStore.get(globalSessionActivityAtom).has(PATH_A)).toBe(false);
+    });
+
+    it('keeps the workspace entry while other activity remains', () => {
+      jotaiStore.set(markSessionAwaitingAtom, { sessionId: 's1', workspacePath: PATH_A });
+      jotaiStore.set(markSessionUnreadAtom, { sessionId: 's2', workspacePath: PATH_A });
+      jotaiStore.set(clearSessionAwaitingAtom, { sessionId: 's1' });
+
+      expect(jotaiStore.get(globalSessionActivityAtom).get(PATH_A)?.unread.has('s2')).toBe(true);
+    });
+
+    it('does not drop a workspace whose only activity is an awaiting session', () => {
+      // Regression: the streaming/unread clear paths prune an entry when they
+      // see both those sets empty. Ignoring `awaiting` there silently deleted
+      // the question badge the moment an unrelated session went quiet.
+      jotaiStore.set(markSessionStreamingAtom, { sessionId: 's1', workspacePath: PATH_A });
+      jotaiStore.set(markSessionAwaitingAtom, { sessionId: 's2', workspacePath: PATH_A });
+      jotaiStore.set(clearSessionStreamingAtom, { sessionId: 's1' });
+
+      expect(jotaiStore.get(globalSessionActivityAtom).get(PATH_A)?.awaiting.has('s2')).toBe(true);
+      expect(jotaiStore.get(projectActivitySummaryAtom).get(PATH_A)?.awaiting).toBe(1);
+    });
+  });
+
   describe('projectActivitySummaryAtom', () => {
     it('summarizes streaming + unread counts per workspace', () => {
       jotaiStore.set(markSessionStreamingAtom, { sessionId: 's1', workspacePath: PATH_A });
@@ -136,8 +169,15 @@ describe('sessionActivity atoms', () => {
       jotaiStore.set(markSessionUnreadAtom, { sessionId: 's4', workspacePath: PATH_B });
 
       const summary = jotaiStore.get(projectActivitySummaryAtom);
-      expect(summary.get(PATH_A)).toEqual({ processing: 2, unread: 1 });
-      expect(summary.get(PATH_B)).toEqual({ processing: 0, unread: 1 });
+      expect(summary.get(PATH_A)).toEqual({ processing: 2, unread: 1, awaiting: 0 });
+      expect(summary.get(PATH_B)).toEqual({ processing: 0, unread: 1, awaiting: 0 });
+    });
+
+    it('reports awaiting counts for a workspace with no other activity', () => {
+      jotaiStore.set(markSessionAwaitingAtom, { sessionId: 's1', workspacePath: PATH_A });
+
+      const summary = jotaiStore.get(projectActivitySummaryAtom);
+      expect(summary.get(PATH_A)).toEqual({ processing: 0, unread: 0, awaiting: 1 });
     });
 
     it('omits workspaces with no activity', () => {

--- a/packages/electron/src/renderer/store/atoms/sessionActivity.ts
+++ b/packages/electron/src/renderer/store/atoms/sessionActivity.ts
@@ -25,6 +25,13 @@ export interface WorkspaceActivity {
   streaming: Set<string>;
   /** Session IDs with unread output (last message after lastReadAt). */
   unread: Set<string>;
+  /**
+   * Session IDs blocked on a durable interactive prompt (AskUserQuestion,
+   * ExitPlanMode, ToolPermission, …). Cross-workspace mirror of
+   * `sessionHasPendingInteractivePromptAtom`, which only ever holds the
+   * active workspace's sessions.
+   */
+  awaiting: Set<string>;
 }
 
 /**
@@ -60,7 +67,12 @@ export const workspaceSessionTurnActivityAtom = atomFamily((workspacePath: strin
 );
 
 function emptyActivity(): WorkspaceActivity {
-  return { streaming: new Set(), unread: new Set() };
+  return { streaming: new Set(), unread: new Set(), awaiting: new Set() };
+}
+
+/** True when no session in this workspace needs anything from the rail. */
+function isIdle(entry: WorkspaceActivity): boolean {
+  return entry.streaming.size === 0 && entry.unread.size === 0 && entry.awaiting.size === 0;
 }
 
 /**
@@ -165,7 +177,7 @@ export const clearSessionStreamingAtom = atom(
     const nextStreaming = new Set(existing.streaming);
     nextStreaming.delete(sessionId);
     const next = { ...existing, streaming: nextStreaming };
-    if (next.streaming.size === 0 && next.unread.size === 0) {
+    if (isIdle(next)) {
       map.delete(path);
     } else {
       map.set(path, next);
@@ -211,7 +223,55 @@ export const clearSessionUnreadAtom = atom(
     const nextUnread = new Set(existing.unread);
     nextUnread.delete(sessionId);
     const next = { ...existing, unread: nextUnread };
-    if (next.streaming.size === 0 && next.unread.size === 0) {
+    if (isIdle(next)) {
+      map.delete(path);
+    } else {
+      map.set(path, next);
+    }
+    set(globalSessionActivityAtom, map);
+  }
+);
+
+/**
+ * Mark a session as blocked on a durable interactive prompt.
+ */
+export const markSessionAwaitingAtom = atom(
+  null,
+  (get, set, payload: { sessionId: string; workspacePath: string }) => {
+    const { sessionId, workspacePath } = payload;
+    const map = new Map(get(globalSessionActivityAtom));
+    const entry = { ...(map.get(workspacePath) ?? emptyActivity()) };
+    if (entry.awaiting.has(sessionId)) return;
+    entry.awaiting = new Set(entry.awaiting).add(sessionId);
+    map.set(workspacePath, entry);
+    set(globalSessionActivityAtom, map);
+
+    const index = new Map(get(sessionActivityIndexAtom));
+    index.set(sessionId, workspacePath);
+    set(sessionActivityIndexAtom, index);
+  }
+);
+
+/**
+ * Clear the awaiting flag for a session. Like `clearSessionStreamingAtom`,
+ * `workspacePath` is optional so terminal events that lack it still resolve
+ * via `sessionActivityIndexAtom`.
+ */
+export const clearSessionAwaitingAtom = atom(
+  null,
+  (get, set, payload: { sessionId: string; workspacePath?: string }) => {
+    const { sessionId } = payload;
+    const path = payload.workspacePath ?? get(sessionActivityIndexAtom).get(sessionId);
+    if (!path) return;
+
+    const map = new Map(get(globalSessionActivityAtom));
+    const existing = map.get(path);
+    if (!existing || !existing.awaiting.has(sessionId)) return;
+
+    const nextAwaiting = new Set(existing.awaiting);
+    nextAwaiting.delete(sessionId);
+    const next = { ...existing, awaiting: nextAwaiting };
+    if (isIdle(next)) {
       map.delete(path);
     } else {
       map.set(path, next);
@@ -256,6 +316,8 @@ export const clearWorkspaceActivityAtom = atom(
 export interface ProjectActivitySummary {
   processing: number;
   unread: number;
+  /** Sessions blocked on a question. Outranks the other two in the rail badge. */
+  awaiting: number;
 }
 
 /**
@@ -268,8 +330,12 @@ export const projectActivitySummaryAtom = atom<Map<string, ProjectActivitySummar
   const activity = get(globalSessionActivityAtom);
   const out = new Map<string, ProjectActivitySummary>();
   for (const [path, entry] of activity) {
-    if (entry.streaming.size === 0 && entry.unread.size === 0) continue;
-    out.set(path, { processing: entry.streaming.size, unread: entry.unread.size });
+    if (isIdle(entry)) continue;
+    out.set(path, {
+      processing: entry.streaming.size,
+      unread: entry.unread.size,
+      awaiting: entry.awaiting.size,
+    });
   }
   return out;
 });

--- a/packages/electron/src/renderer/store/sessionStateListeners.ts
+++ b/packages/electron/src/renderer/store/sessionStateListeners.ts
@@ -48,6 +48,8 @@ import { activeWorkspacePathAtom, multiProjectModeAtom, openProjectsAtom } from 
 import {
   markSessionStreamingAtom,
   clearSessionStreamingAtom,
+  markSessionAwaitingAtom,
+  clearSessionAwaitingAtom,
   markSessionUnreadAtom,
   clearSessionUnreadAtom,
   markSessionTurnActivityAtom,
@@ -295,6 +297,10 @@ export function initSessionStateListeners(): () => void {
       // after the session ended in the no-workspacePath race documented
       // above. Per @ghinkle's review on the closed #293.
       store.set(clearSessionStreamingAtom, { sessionId });
+      // Same workspace-agnostic reasoning as the streaming clear above: the
+      // rail's "awaiting a question" badge must not survive the session
+      // ending, and the terminal event may not carry a workspacePath.
+      store.set(clearSessionAwaitingAtom, { sessionId });
       // A session reached a terminal state, so it left the backend's active set.
       // Re-derive the processing atoms against that authoritative set now (debounced
       // ~600ms) instead of waiting up to 15s for the interval. A meta-agent header
@@ -358,6 +364,12 @@ export function initSessionStateListeners(): () => void {
         // sessionProcessingAtom true above means the indicator keeps showing.
         if (sessionMeta?.provider !== 'claude-code-cli') {
           store.set(sessionHasPendingInteractivePromptAtom(sessionId), true);
+          // Mirror the flag into cross-workspace activity so the rail can show
+          // the question badge for projects that aren't currently mounted.
+          // Gated on the same non-CLI check: the CLI's coarse `waiting` status
+          // fires mid-turn without a real user prompt (NIM-850), and a false
+          // question badge on the rail is worse than none.
+          store.set(markSessionAwaitingAtom, { sessionId, workspacePath: resolvedWorkspacePath });
         }
         // Treat "waiting on user" as still processing for rail badge purposes —
         // the user typically hasn't switched away because of the prompt.
@@ -713,6 +725,27 @@ export function initSessionStateListeners(): () => void {
   };
 
   /**
+   * Mirror a durable interactive prompt into cross-workspace rail activity.
+   *
+   * The prompt IPC payloads carry only `sessionId`, so the workspace is
+   * resolved from the session registry (active workspace) and otherwise from
+   * `sessionActivityIndexAtom`, which the atom itself consults on clear.
+   * When neither knows the session we skip rather than guess — a question
+   * badge on the wrong project is worse than a missing one, and the session
+   * being unknown to both means nothing has ever streamed for it here.
+   */
+  const setSessionAwaiting = (sessionId: string, awaiting: boolean) => {
+    if (!awaiting) {
+      store.set(clearSessionAwaitingAtom, { sessionId });
+      return;
+    }
+    const workspacePath = store.get(sessionRegistryAtom).get(sessionId)?.workspaceId;
+    if (workspacePath) {
+      store.set(markSessionAwaitingAtom, { sessionId, workspacePath });
+    }
+  };
+
+  /**
    * Handle AskUserQuestion events globally.
    * Sets the pending interactive prompt indicator for the sidebar.
    * Also pushes the prompt data directly into sessionPendingPromptsAtom
@@ -723,6 +756,7 @@ export function initSessionStateListeners(): () => void {
     const { sessionId, questionId } = data;
     if (!sessionId) return;
     store.set(sessionHasPendingInteractivePromptAtom(sessionId), true);
+    setSessionAwaiting(sessionId, true);
 
     // Push prompt data directly into the prompts atom so voice mode
     // can read it immediately. The DB may not have persisted it yet.
@@ -746,6 +780,7 @@ export function initSessionStateListeners(): () => void {
     const { sessionId } = data;
     if (!sessionId) return;
     store.set(sessionHasPendingInteractivePromptAtom(sessionId), false);
+    setSessionAwaiting(sessionId, false);
     // Remove the resolved prompt from the array
     if (data.questionId) {
       const current = store.get(sessionPendingPromptsAtom(sessionId));
@@ -763,6 +798,7 @@ export function initSessionStateListeners(): () => void {
     const { sessionId, requestId } = data;
     if (!sessionId) return;
     store.set(sessionHasPendingInteractivePromptAtom(sessionId), true);
+    setSessionAwaiting(sessionId, true);
     const prompt: PendingPrompt = {
       id: requestId,
       sessionId,
@@ -783,6 +819,7 @@ export function initSessionStateListeners(): () => void {
     const { sessionId, approved } = data;
     if (!sessionId) return;
     store.set(sessionHasPendingInteractivePromptAtom(sessionId), false);
+    setSessionAwaiting(sessionId, false);
     if (data.requestId) {
       const current = store.get(sessionPendingPromptsAtom(sessionId));
       store.set(sessionPendingPromptsAtom(sessionId), current.filter(p => p.promptId !== data.requestId));
@@ -807,6 +844,7 @@ export function initSessionStateListeners(): () => void {
     const { sessionId, requestId } = data;
     if (!sessionId) return;
     store.set(sessionHasPendingInteractivePromptAtom(sessionId), true);
+    setSessionAwaiting(sessionId, true);
     const prompt: PendingPrompt = {
       id: requestId,
       sessionId,
@@ -827,6 +865,7 @@ export function initSessionStateListeners(): () => void {
     const { sessionId, requestId } = data;
     if (!sessionId) return;
     store.set(sessionHasPendingInteractivePromptAtom(sessionId), false);
+    setSessionAwaiting(sessionId, false);
     const current = store.get(sessionPendingPromptsAtom(sessionId));
     store.set(sessionPendingPromptsAtom(sessionId), current.filter(p => p.promptId !== requestId));
   };
@@ -845,6 +884,7 @@ export function initSessionStateListeners(): () => void {
     const { sessionId, proposalId } = data;
     if (!sessionId) return;
     store.set(sessionHasPendingInteractivePromptAtom(sessionId), true);
+    setSessionAwaiting(sessionId, true);
     const prompt: PendingPrompt = {
       id: proposalId,
       sessionId,
@@ -871,6 +911,7 @@ export function initSessionStateListeners(): () => void {
     const { sessionId, proposalId } = data;
     if (!sessionId) return;
     store.set(sessionHasPendingInteractivePromptAtom(sessionId), false);
+    setSessionAwaiting(sessionId, false);
     const current = store.get(sessionPendingPromptsAtom(sessionId));
     store.set(sessionPendingPromptsAtom(sessionId), current.filter(p => p.promptId !== proposalId));
   };
@@ -885,6 +926,7 @@ export function initSessionStateListeners(): () => void {
     const { sessionId, promptId, args } = data;
     if (!sessionId || !promptId) return;
     store.set(sessionHasPendingInteractivePromptAtom(sessionId), true);
+    setSessionAwaiting(sessionId, true);
     const prompt: PendingPrompt = {
       id: promptId,
       sessionId,
@@ -905,6 +947,7 @@ export function initSessionStateListeners(): () => void {
     const { sessionId, promptId } = data;
     if (!sessionId) return;
     store.set(sessionHasPendingInteractivePromptAtom(sessionId), false);
+    setSessionAwaiting(sessionId, false);
     const current = store.get(sessionPendingPromptsAtom(sessionId));
     store.set(sessionPendingPromptsAtom(sessionId), current.filter(p => p.promptId !== promptId));
   };


### PR DESCRIPTION
## What

Multi-project rail badges now distinguish three session states instead of collapsing them into one number:

| State | Badge | Meaning |
| --- | --- | --- |
| Awaiting your response | `contact_support` icon, warning colour, pulsing | Blocked on you |
| Still running | spinner, primary colour, no count | Working; nothing to do yet |
| Finished, unread | plain count, primary colour | N finished threads to read |

Priority is awaiting > running > unread. Active projects still show no badge.

## Why

Two problems with the badge as it stood.

**1. "Waiting for your response" was invisible at the rail level.** The per-session flag exists and the session list already renders it (`SessionStatusIndicator`), but it was never aggregated per workspace. `session:waiting` filed the session into the `streaming` set, so a project blocked on a question looked identical to one happily churning. In multi-project mode the whole point of the rail is deciding which project to switch to — and "needs an answer from me" is the one state that cannot make progress without you.

**2. A bare count couldn't say what it meant.** `processingCount` and `unreadCount` both rendered as a number in the same circle, with streaming winning:

```ts
const badgeLabel = processingCount > 0 ? `${processingCount}` : unreadCount > 0 ? `${unreadCount}` : '';
```

So "2" meant either *two still running* (do nothing) or *two finished, unread* (go read them) — opposite calls to action, same pixels. Worse, unread was suppressed entirely whenever anything was streaming.

Shape now carries the meaning, so the count is unambiguous: a number on the rail always means "finished, go read". The running state deliberately drops its count — how many are mid-flight isn't actionable, and a spinning digit at 16px is unreadable.

## How

**`sessionActivity.ts`** — added a third `awaiting: Set<string>` to `WorkspaceActivity`, alongside `streaming` and `unread`, with `markSessionAwaitingAtom` / `clearSessionAwaitingAtom` mirroring the existing unread pair. The two prune sites that delete an idle workspace entry now share an `isIdle()` helper, so a workspace whose only activity is an awaiting session isn't silently dropped when an unrelated session goes quiet.

**`sessionStateListeners.ts`** — three wiring points:
- Terminal events (`session:completed` / `error` / `interrupted`) clear it, using the same workspace-agnostic index lookup as the streaming clear, since those events may not carry a `workspacePath`.
- `session:waiting` mirrors it, gated on the existing non-CLI provider check.
- All five durable-prompt set/clear pairs (AskUserQuestion, ExitPlanMode, ToolPermission, GitCommitProposal, PromptForUserInput) route through a small `setSessionAwaiting` helper. Their IPC payloads carry only `sessionId`, so the workspace is resolved from the session registry; when neither the registry nor the activity index knows the session we skip rather than guess, since a question badge on the wrong project is worse than a missing one.

**`ProjectRail.tsx` / `.css`** — one `badgeState` discriminant driving an `is-{state}` class. Each state borrows the symbol and colour the session list already uses, so the rail and sidebar read as one language. Reduced-motion is honoured for both the pulse and the spinner.

### Note on CLI sessions

`session:waiting` only mirrors for non-CLI providers. The genuine Claude CLI drives that event off a coarse pid-file status that fires transiently mid-turn without a real user prompt — the same reason the existing code guards `sessionHasPendingInteractivePromptAtom` there. CLI sessions still badge correctly via the durable-prompt events, which are authoritative for them.

## Testing

Extended `sessionActivity.test.ts` (16 passing). The one non-obvious case is covered deliberately: clearing streaming must not evict a workspace that still has an awaiting session. I verified that test genuinely catches the regression by reverting the `isIdle` guard and watching it fail, then restoring it.

No test was added for the badge's three-way render branch — it would have meant extracting a subcomponent purely to make it testable, and it's a state a reviewer sees instantly on screen.

## Not covered

- **Visually unverified.** The logic and types are checked, but I have not observed this render in a running app. Worth an eyeball on the amber pulse and the spinner.
- **Cold-start under-reporting** (pre-existing, unchanged): activity is event-driven, so inactive projects show no badge until something happens in them, and a restart clears every badge until the next event. Fixing it needs a cross-workspace session query at rail init — separate change.
- States are mutually exclusive by priority, so a project with one blocked session and three finished ones shows only the question badge. Deliberate, but it does hide the unread count until the block is resolved.
