### PR TITLE
fix: keep text selection from breaking during transcript auto-scroll

### DIFF
--- a/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
@@ -564,9 +564,28 @@ export function isTranscriptAtBottom(distanceFromBottom: number): boolean {
 
 export function shouldAutoScrollTranscript(
   wasAtBottom: boolean,
-  distanceFromBottom: number
+  distanceFromBottom: number,
+  hasActiveSelection = false
 ): boolean {
+  // Never yank the viewport while the user is dragging a text selection in the
+  // transcript — the jump collapses the highlight they are making, which is the
+  // single most common "I can't copy from the chat" complaint during streaming.
+  if (hasActiveSelection) return false;
   return wasAtBottom || isTranscriptAtBottom(distanceFromBottom);
+}
+
+/**
+ * True only when there is a live, non-collapsed text selection whose anchor sits
+ * inside the transcript root. Scopes the auto-scroll suppression to selections
+ * made in the transcript, so selecting text elsewhere (the composer, a sidebar)
+ * never blocks the chat from following new messages.
+ */
+export function hasActiveTranscriptSelection(root: HTMLElement | null): boolean {
+  if (!root || typeof window === 'undefined') return false;
+  const selection = window.getSelection?.();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return false;
+  const anchor = selection.anchorNode;
+  return anchor != null && root.contains(anchor);
 }
 
 const isEditToolName = (name?: string): boolean => {
@@ -1482,7 +1501,8 @@ export const RichTranscriptView = React.forwardRef<
       const scrollOffset = vlistRef.current.scrollOffset;
       const distanceFromBottom = scrollSize - scrollOffset - viewportSize;
 
-      if (shouldAutoScrollTranscript(wasAtBottom, distanceFromBottom)) {
+      const hasActiveSelection = hasActiveTranscriptSelection(viewRootRef.current);
+      if (shouldAutoScrollTranscript(wasAtBottom, distanceFromBottom, hasActiveSelection)) {
         // Account for the "Thinking..." indicator which is an extra item after messages
         const lastIndex = isWaitingForResponse ? messages.length : messages.length - 1;
         vlistRef.current.scrollToIndex(lastIndex, { align: 'end' });

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.selectionGuard.test.ts
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.selectionGuard.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { hasActiveTranscriptSelection } from '../RichTranscriptView';
+
+// jsdom's Selection implementation is a stub, so we drive window.getSelection
+// directly: the unit under test is "given a selection, is it a non-collapsed
+// range anchored inside the transcript root?" — pure DOM containment logic.
+function stubSelection(value: Partial<Selection> | null) {
+  const original = window.getSelection;
+  window.getSelection = () => value as Selection | null;
+  return () => {
+    window.getSelection = original;
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('hasActiveTranscriptSelection (#1162 selection-drag fix)', () => {
+  it('is true for a non-collapsed selection anchored inside the transcript root', () => {
+    const root = document.createElement('div');
+    const inner = document.createElement('span');
+    inner.textContent = 'copy me';
+    root.appendChild(inner);
+    document.body.appendChild(root);
+    const restore = stubSelection({
+      isCollapsed: false,
+      rangeCount: 1,
+      anchorNode: inner.firstChild,
+    });
+    expect(hasActiveTranscriptSelection(root)).toBe(true);
+    restore();
+  });
+
+  it('is false for a collapsed selection (just a caret, no highlight)', () => {
+    const root = document.createElement('div');
+    root.textContent = 'text';
+    document.body.appendChild(root);
+    const restore = stubSelection({
+      isCollapsed: true,
+      rangeCount: 1,
+      anchorNode: root.firstChild,
+    });
+    expect(hasActiveTranscriptSelection(root)).toBe(false);
+    restore();
+  });
+
+  it('is false when the selection lives outside the transcript (e.g. the composer)', () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const outside = document.createElement('div');
+    outside.textContent = 'elsewhere';
+    document.body.appendChild(outside);
+    const restore = stubSelection({
+      isCollapsed: false,
+      rangeCount: 1,
+      anchorNode: outside.firstChild,
+    });
+    expect(hasActiveTranscriptSelection(root)).toBe(false);
+    restore();
+  });
+
+  it('is false when there is no selection or no root', () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const restore = stubSelection(null);
+    expect(hasActiveTranscriptSelection(root)).toBe(false);
+    expect(hasActiveTranscriptSelection(null)).toBe(false);
+    restore();
+  });
+});

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.test.ts
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.test.ts
@@ -415,6 +415,16 @@ describe('transcript auto-scroll thresholds', () => {
   it('still auto-scrolls when the transcript was sticky before the new content arrived', () => {
     expect(shouldAutoScrollTranscript(true, 200)).toBe(true);
   });
+
+  it('suppresses auto-scroll while a transcript selection is active, even when sticky at the bottom', () => {
+    // The user is dragging a highlight in the transcript; a jump to the bottom
+    // would collapse it. Selection wins over the sticky-bottom pull.
+    expect(shouldAutoScrollTranscript(true, 0, true)).toBe(false);
+  });
+
+  it('resumes auto-scroll once the selection is released', () => {
+    expect(shouldAutoScrollTranscript(true, 0, false)).toBe(true);
+  });
 });
 
 // Regression coverage for the user-reported bug on 2026-06-01: the


### PR DESCRIPTION
Problem
Selecting text in the chat transcript is unreliable while a session is streaming. If you start dragging a highlight and a new token arrives, the transcript auto-scrolls to follow it and your selection collapses. In practice this makes it very hard to copy text out of the chat, which is what #1162 reports.

Cause
The auto-scroll effect in RichTranscriptView.tsx runs on every messages change (including each streaming token) and, when the user was near the bottom, calls scrollToIndex(..., { align: 'end' }). That viewport jump lands mid-drag and clears the active selection.

Fix
Suppress auto-scroll while the user has an active text selection anchored inside the transcript, then resume normally once it is released:

shouldAutoScrollTranscript() takes a new optional hasActiveSelection argument (defaults to false, so all existing call sites are unchanged) and returns false when a selection is active.
New exported helper hasActiveTranscriptSelection(root) returns true only for a non-collapsed selection whose anchor is inside the transcript root, so selecting text in the composer or a sidebar still lets the chat follow new messages.
The auto-scroll effect passes the live selection state through.
No visual changes, no new dependencies. The per-message "Copy as Markdown" button referenced in #1162 already exists in this version; this PR addresses the harder-to-spot selection-drag half of the same complaint.

Tests
packages/runtime/src/ui/AgentTranscript/components/__tests__/:

Two added cases in RichTranscriptView.test.ts: auto-scroll is suppressed when a selection is active even while sticky at the bottom, and resumes when released.
New RichTranscriptView.selectionGuard.test.ts (jsdom): covers selection inside the transcript, a collapsed caret, a selection outside the transcript, and the no-selection / no-root cases.
Verified the tests fail against the unpatched code and pass with the fix. typecheck is clean.

Refs #1162

