### PR TITLE
fix: report archive state and comments from tracker_get

### DIFF
--- a/packages/cli/src/gateway/LiveGateway.ts
+++ b/packages/cli/src/gateway/LiveGateway.ts
@@ -298,6 +298,12 @@ function mcpItemToRecord(item: any): TrackerRecord {
       if (v !== undefined) fields[k] = v;
     }
   }
+  // `tracker_get` returns comments as a top-level key rather than inside the
+  // customFields bag, so they reach no field without this. Empty stays unset:
+  // an item with no comments should read the same as it always has.
+  if (Array.isArray(item.comments) && item.comments.length > 0) {
+    fields.comments = item.comments;
+  }
   return {
     id: item.id,
     primaryType: item.type,

--- a/packages/cli/src/gateway/__tests__/LiveGateway.test.ts
+++ b/packages/cli/src/gateway/__tests__/LiveGateway.test.ts
@@ -123,3 +123,58 @@ describe('LiveGateway tracker list adaptation', () => {
     expect(callTool).toHaveBeenCalledWith('/ws', 'tracker_list', { inbox: true, full: true });
   });
 });
+
+// MUL-26: `tracker_get` used to omit `archived` entirely, and the `?? false`
+// below turned the absent key into a confident `false` -- so an archived item
+// read back as active through `nim tracker get --json` permanently. Comments
+// arrive as a top-level key (not in the customFields bag), so they need their
+// own mapping or they land nowhere.
+describe('LiveGateway tracker get adaptation', () => {
+  function makeGetGateway(item: Record<string, unknown>) {
+    return makeGateway(async () => ({
+      isError: false,
+      summary: 'retrieved',
+      structured: { action: 'retrieved', item },
+      raw: {},
+    }));
+  }
+
+  it('carries archive and sync state through to the record', async () => {
+    const gateway = makeGetGateway({
+      id: 'bug-1',
+      type: 'bug',
+      title: 'Probe',
+      archived: true,
+      archivedAt: '2026-08-10T16:38:19.899Z',
+      syncStatus: 'synced',
+    });
+
+    const record = await gateway.getTracker('/ws', 'bug-1');
+
+    expect(record?.archived).toBe(true);
+    expect(record?.syncStatus).toBe('synced');
+  });
+
+  it('maps top-level comments into the record fields', async () => {
+    const gateway = makeGetGateway({
+      id: 'bug-1',
+      type: 'bug',
+      title: 'Probe',
+      comments: [{ id: 'comment_1', body: 'PROBE-XYZZY', deleted: false }],
+    });
+
+    const record = await gateway.getTracker('/ws', 'bug-1');
+
+    expect(record?.fields.comments).toEqual([
+      { id: 'comment_1', body: 'PROBE-XYZZY', deleted: false },
+    ]);
+  });
+
+  it('leaves comments unset when the item carries none', async () => {
+    const gateway = makeGetGateway({ id: 'bug-1', type: 'bug', title: 'Probe', comments: [] });
+
+    const record = await gateway.getTracker('/ws', 'bug-1');
+
+    expect(record?.fields.comments).toBeUndefined();
+  });
+});

--- a/packages/electron/src/main/mcp/tools/__tests__/trackerToolHandlers.test.ts
+++ b/packages/electron/src/main/mcp/tools/__tests__/trackerToolHandlers.test.ts
@@ -647,6 +647,135 @@ describe('handleTrackerGet', () => {
     expect(payload.structured.item.issueKeyStatus).toBe('unassigned');
     expect(payload.summary).toContain('This item has no key until it is published.');
   });
+
+  // MUL-26: `structured.item` was built from a 12-key whitelist that omitted
+  // `archived`, so an archived item read back as active through `tracker_get`
+  // forever -- while `tracker_list` and the markdown summary both said archived.
+  // `nim`'s LiveGateway then turned the absent key into a confident `false`.
+  it('reports archive state in the structured payload, not just the summary', async () => {
+    mockDocumentServices.set('/tmp/ws', mockDocService);
+    mockDocService.getTrackerItemById.mockResolvedValueOnce(
+      makeItem({ archived: true, archivedAt: '2026-08-10T16:38:19.899Z' }),
+    );
+
+    const payload = JSON.parse(
+      (await handleTrackerGet({ id: 'NIM-1' }, '/tmp/ws')).content[0].text!,
+    );
+
+    expect(payload.summary).toContain('**Archived**: yes');
+    expect(payload.structured.item.archived).toBe(true);
+    expect(payload.structured.item.archivedAt).toBe('2026-08-10T16:38:19.899Z');
+  });
+
+  it('defaults archive state to false rather than dropping the key', async () => {
+    mockDocumentServices.set('/tmp/ws', mockDocService);
+    mockDocService.getTrackerItemById.mockResolvedValueOnce(makeItem());
+
+    const payload = JSON.parse(
+      (await handleTrackerGet({ id: 'NIM-1' }, '/tmp/ws')).content[0].text!,
+    );
+
+    expect(payload.structured.item.archived).toBe(false);
+    expect(payload.structured.item.archivedAt).toBeUndefined();
+  });
+
+  it('agrees with tracker_list on archive state for the same item', async () => {
+    const item = makeItem({ id: 'gone', archived: true, syncStatus: 'synced' });
+    mockDocumentServices.set('/tmp/ws', mockDocService);
+    mockDocService.getTrackerItemById.mockResolvedValueOnce(item);
+    mockDocService.listTrackerItems.mockResolvedValue([item]);
+
+    const got = JSON.parse(
+      (await handleTrackerGet({ id: 'gone' }, '/tmp/ws')).content[0].text!,
+    ).structured.item;
+    const listed = JSON.parse(
+      (await handleTrackerList({ archived: true }, '/tmp/ws')).content[0].text!,
+    ).structured.items[0];
+
+    expect(got.archived).toBe(listed.archived);
+    expect(got.syncStatus).toBe(listed.syncStatus);
+  });
+
+  // The comment write path canonicalizes to `data.comments`, which
+  // `rowToTrackerItem` lifts into the customFields bag -- and
+  // `internalCustomFieldKeys` then stripped it back out, so a posted comment
+  // was readable through no MCP surface at all.
+  it('surfaces comments that reach the item through the customFields bag', async () => {
+    mockDocumentServices.set('/tmp/ws', mockDocService);
+    mockDocService.getTrackerItemById.mockResolvedValueOnce(
+      makeItem({
+        customFields: {
+          prUrl: 'https://example.test/pr/1',
+          comments: [
+            {
+              id: 'comment_1',
+              authorIdentity: { displayName: 'Test User' },
+              body: 'PROBE-XYZZY',
+              createdAt: 1785790418549,
+              deleted: false,
+            },
+          ],
+        },
+      }),
+    );
+
+    const payload = JSON.parse(
+      (await handleTrackerGet({ id: 'NIM-1' }, '/tmp/ws')).content[0].text!,
+    );
+
+    expect(payload.structured.item.comments).toHaveLength(1);
+    expect(payload.structured.item.comments[0].body).toBe('PROBE-XYZZY');
+    // Genuine schema fields keep their place in the bag, and `comments` is not
+    // duplicated into it (the summary would render it as a stray field line).
+    expect(payload.structured.item.customFields).toEqual({
+      prUrl: 'https://example.test/pr/1',
+    });
+  });
+
+  it('reports an empty comment list rather than dropping the key', async () => {
+    mockDocumentServices.set('/tmp/ws', mockDocService);
+    mockDocService.getTrackerItemById.mockResolvedValueOnce(makeItem());
+
+    const payload = JSON.parse(
+      (await handleTrackerGet({ id: 'NIM-1' }, '/tmp/ws')).content[0].text!,
+    );
+
+    expect(payload.structured.item.comments).toEqual([]);
+  });
+});
+
+// The fix above reads comments out of `item.customFields`. That only holds
+// because neither row mapper lists `comments` in its "known" first-class key
+// set, so `extractItemCustomFields` leaves it in the bag. Guard that here: if a
+// mapper ever promotes `comments` to a top-level field, tracker_get goes quiet
+// again rather than failing loudly.
+describe('rowToTrackerItem archive and comment mapping', () => {
+  it('carries data.comments into the customFields bag', () => {
+    const item = rowToTrackerItem(
+      makeRow({
+        data: JSON.stringify({
+          title: 'Scoped bug',
+          comments: [{ id: 'comment_1', body: 'PROBE-XYZZY', deleted: false }],
+        }),
+      }),
+    );
+
+    expect(item.comments).toBeUndefined();
+    expect(item.customFields?.comments).toEqual([
+      { id: 'comment_1', body: 'PROBE-XYZZY', deleted: false },
+    ]);
+  });
+
+  it('maps the archive columns onto first-class fields', () => {
+    const archived = rowToTrackerItem(
+      makeRow({ archived: 1, archived_at: '2026-08-10T16:38:19.899Z' }),
+    );
+    expect(archived.archived).toBe(1);
+    expect(archived.archivedAt).toBe('2026-08-10T16:38:19.899Z');
+
+    const active = rowToTrackerItem(makeRow({ archived: 0, archived_at: null }));
+    expect(active.archivedAt).toBeUndefined();
+  });
 });
 
 describe('tracker schema tools', () => {

--- a/packages/electron/src/main/mcp/tools/trackerToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/trackerToolHandlers.ts
@@ -1355,6 +1355,19 @@ export async function handleTrackerGet(
         tags: item.tags || [],
         owner: item.owner || undefined,
         dueDate: item.dueDate || undefined,
+        // Archive and sync state, matching tracker_list's payload. Omitting
+        // them made the same item read archived through `list` and active
+        // through `get` forever: `nim`'s LiveGateway defaults the absent key
+        // (`item.archived ?? false`), so a missing key became a confident
+        // `false` rather than "unknown".
+        archived: item.archived ?? false,
+        archivedAt: item.archivedAt || undefined,
+        syncStatus: item.syncStatus || 'local',
+        // Comments are stored at `data.comments` and land in the customFields
+        // bag (no row mapper claims `comments` as a first-class field). Read
+        // them before the internal-key filtering below, which strips them --
+        // otherwise a posted comment is readable through no MCP surface at all.
+        comments: (item.customFields?.comments as any[] | undefined) ?? [],
         // Surface schema-defined custom fields (e.g. github-pr's prNumber) that
         // are otherwise dropped by the known-field whitelist above. Uses the
         // same internal-key filtering as the summary so the bag is clean.


### PR DESCRIPTION
## Summary

`tracker_get` built `structured.item` from a 12-key whitelist that omitted `archived`, while `tracker_list` included it — so the same item read archived through `list` and active through `get`, permanently. `internalCustomFieldKeys` stripped `archived` and `comments` from the custom-fields bag too, so no client could recover them, and `LiveGateway`'s `item.archived ?? false` turned the absent key into a confident `false`.

The app's state was correct throughout: `rowToTrackerItem` maps both fields and the summary already printed `**Archived**: yes`. Only the JSON was wrong — the surface agents parse.

- `structured.item` now carries `archived`, `archivedAt` and `syncStatus`, matching `tracker_list`.
- `comments` are read from the custom-fields bag before `internalCustomFieldKeys` strips them. That set is unchanged, so the summary still renders archive state as its own line.
- `LiveGateway.mcpItemToRecord` maps top-level `comments` into the record fields; an item with no comments leaves it unset.

`tracker_get_by_urn` delegates to `handleTrackerGet`, so it is fixed by the same change. The summary is untouched — rendering comments in `nim tracker show` is a separate design call.

## Related issue

Closes #1224

## Testing

Verified red before the fix, green after. Five new tests failed against the existing payload:

```
Tests  5 failed | 56 passed (61)
  ✕ reports archive state in the structured payload, not just the summary
  ✕ defaults archive state to false rather than dropping the key
  ✕ agrees with tracker_list on archive state for the same item
  ✕ surfaces comments that reach the item through the customFields bag
  ✕ reports an empty comment list rather than dropping the key
```

After the fix, both touched suites pass at 70/70.

Two further tests pin why the fix works: comments survive in `customFields` only because neither row mapper claims `comments` as a first-class field. If one ever does, the suite fails loudly instead of `tracker_get` going quiet again.

## Notes for reviewers

- `archived` is passed through as `item.archived ?? false`, matching `tracker_list` exactly rather than coercing to a boolean. On SQLite the flag can arrive as `0`/`1` (NIM-2072/NIM-2280); normalising it here alone would make `get` and `list` disagree in a new way.
- Comments pass through as stored, including any `deleted: true`. There is no delete verb today, so filtering would invent a semantic that hasn't been decided.
- No `CHANGELOG.md` entry, in line with most merged PRs here — happy to add one.
- Nothing validates this payload's key set (no output schema under `mcp/`). Of the `structured.item` consumers, `httpServer.ts` is a passthrough, `mcpTopology.ts` lists only tool names, and `TrackerToolWidget.tsx` ignores unknown fields.
