### PR TITLE
fix(scripts): run workspace pre-push checks on Windows

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,7 +5,7 @@ set -eu
 # when the outgoing commits touch any manifest. This is exactly the check
 # CI's `npm ci` performs; without it, lockfile drift is only discovered
 # after pushing (2026-07-07 incident: npm 10/11 override-shape mismatch).
-base=$(git merge-base HEAD origin/main 2>/dev/null || echo HEAD~1)
+base=$(node scripts/resolve-prepush-base.mjs)
 
 # Fail fast, and accurately, when the hook is running under the wrong Node.
 # Every check below shells out to node/npm, and with engine-strict=true the

--- a/packages/electron/src/renderer/services/BodyDocCache.ts
+++ b/packages/electron/src/renderer/services/BodyDocCache.ts
@@ -439,6 +439,14 @@ export class BodyDocCache {
     // cache is the sole owner of the provider's lifecycle signals.
     const cacheConfig: DocumentSyncConfig = {
       ...config,
+      // Explicit even though the spread above already carries it: the
+      // renderer-sync-sockets checker (scripts/check-renderer-sync-sockets.mjs)
+      // only resolves one level of `{ ...other }` spread within the same file,
+      // and `config` arrives as a parameter from a factory defined elsewhere --
+      // so it can't see this field through the spread. Behavior-neutral
+      // (config.createWebSocket is always the same value at runtime); this
+      // just makes the invariant visible to the checker and to readers.
+      createWebSocket: config.createWebSocket,
       onStatusChange: (status) => {
         entry.lastStatus = status;
         for (const l of entry.listeners) {

--- a/scripts/__tests__/check-collab-client-boundaries.test.mjs
+++ b/scripts/__tests__/check-collab-client-boundaries.test.mjs
@@ -44,9 +44,18 @@ test('derives future headless domains from package exports and excludes UI entri
     './trackers-ui': { default: './src/trackers-ui/index.ts' },
   }, '/repo/packages/collab-client');
 
-  assert.deepEqual(entries, {
-    core: '/repo/packages/collab-client/src/core/index.ts',
-    docs: '/repo/packages/collab-client/src/docs/index.ts',
-    trackers: '/repo/packages/collab-client/src/trackers/index.ts',
+  // Compare relative to the synthetic root, normalized to POSIX separators,
+  // rather than the absolute paths directly -- path.* resolves a leading
+  // '/' as drive-relative on Windows (e.g. D:\repo\...), so a hardcoded
+  // POSIX-absolute expected value only ever matched on POSIX CI. This keeps
+  // the real assertions (which domains are derived, -ui entries excluded)
+  // platform-agnostic without touching the implementation under test.
+  const rel = Object.fromEntries(
+    Object.entries(entries).map(([key, value]) => [key, path.relative('/repo/packages/collab-client', value).split(path.sep).join('/')]),
+  );
+  assert.deepEqual(rel, {
+    core: 'src/core/index.ts',
+    docs: 'src/docs/index.ts',
+    trackers: 'src/trackers/index.ts',
   });
 });

--- a/scripts/__tests__/run-workspace-script.test.mjs
+++ b/scripts/__tests__/run-workspace-script.test.mjs
@@ -10,6 +10,27 @@ import {
   runScriptIn,
   selectWorkspaces,
 } from '../run-workspace-script.mjs';
+import { resolvePrepushBase } from '../resolve-prepush-base.mjs';
+
+test('checks fork pushes against canonical upstream main', () => {
+  const calls = [];
+  const base = resolvePrepushBase((...args) => {
+    calls.push(args);
+    if (args.at(-1) === 'upstream/main') return 'stable-base\n';
+    throw new Error('unexpected fallback');
+  });
+  assert.equal(base, 'stable-base');
+  assert.deepEqual(calls, [['merge-base', 'HEAD', 'upstream/main']]);
+});
+
+test('falls back to origin main when upstream is not configured', () => {
+  const base = resolvePrepushBase((...args) => {
+    if (args.at(-1) === 'upstream/main') throw new Error('unknown revision');
+    if (args.at(-1) === 'origin/main') return 'fork-base\n';
+    throw new Error('unexpected fallback');
+  });
+  assert.equal(base, 'fork-base');
+});
 
 test('launches the Windows npm shim through cmd.exe', () => {
   assert.deepEqual(npmSpawnConfig('win32', { ComSpec: 'C:\\Windows\\cmd.exe' }), {

--- a/scripts/__tests__/run-workspace-script.test.mjs
+++ b/scripts/__tests__/run-workspace-script.test.mjs
@@ -1,6 +1,38 @@
 import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
-import { expandWorkspacePatterns, runPool, selectWorkspaces } from '../run-workspace-script.mjs';
+import {
+  expandWorkspacePatterns,
+  npmSpawnConfig,
+  runPool,
+  runScriptIn,
+  selectWorkspaces,
+} from '../run-workspace-script.mjs';
+
+test('launches the Windows npm shim through cmd.exe', () => {
+  assert.deepEqual(npmSpawnConfig('win32', { ComSpec: 'C:\\Windows\\cmd.exe' }), {
+    command: 'C:\\Windows\\cmd.exe',
+    argsPrefix: ['/d', '/s', '/c', 'npm.cmd'],
+  });
+  assert.deepEqual(npmSpawnConfig('linux'), { command: 'npm', argsPrefix: [] });
+});
+
+test('runs an npm script in a workspace', async t => {
+  const rootDir = await mkdtemp(path.join(tmpdir(), 'run-workspace-script-'));
+  t.after(() => rm(rootDir, { recursive: true, force: true }));
+  await mkdir(path.join(rootDir, 'fixture'));
+  await writeFile(
+    path.join(rootDir, 'fixture', 'package.json'),
+    JSON.stringify({ scripts: { probe: 'node -e "process.stdout.write(\'launched\')"' } }),
+  );
+
+  const result = await runScriptIn('fixture', 'probe', rootDir);
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /launched/);
+});
 
 test('expands the trailing-star pattern and rejects shapes it cannot match', () => {
   const readDir = parent => (parent === 'packages/extensions' ? ['git', 'math'] : []);

--- a/scripts/resolve-prepush-base.mjs
+++ b/scripts/resolve-prepush-base.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+function runGit(...args) {
+  return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+}
+
+/** Prefer canonical upstream so a fork branch is checked against its real source base. */
+export function resolvePrepushBase(git = runGit) {
+  for (const mainRef of ['upstream/main', 'origin/main']) {
+    try {
+      return git('merge-base', 'HEAD', mainRef).trim();
+    } catch {
+      // Try the next configured remote.
+    }
+  }
+  return git('rev-parse', 'HEAD~1').trim();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  console.log(resolvePrepushBase());
+}

--- a/scripts/run-workspace-script.mjs
+++ b/scripts/run-workspace-script.mjs
@@ -19,7 +19,12 @@ import { availableParallelism } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+/** npm's Windows shim is a .cmd file, which Node must launch through cmd.exe. */
+export function npmSpawnConfig(platform = process.platform, env = process.env) {
+  return platform === 'win32'
+    ? { command: env.ComSpec || 'cmd.exe', argsPrefix: ['/d', '/s', '/c', 'npm.cmd'] }
+    : { command: 'npm', argsPrefix: [] };
+}
 
 /**
  * Expand the `workspaces` patterns from a root package.json into directories.
@@ -59,9 +64,10 @@ export async function runPool(items, limit, run) {
   return results;
 }
 
-function runScriptIn(dir, script, rootDir) {
+export function runScriptIn(dir, script, rootDir) {
   return new Promise(resolve => {
-    const child = spawn(NPM, ['run', script], {
+    const { command, argsPrefix } = npmSpawnConfig();
+    const child = spawn(command, [...argsPrefix, 'run', script], {
       cwd: path.join(rootDir, dir),
       env: process.env,
     });
@@ -69,7 +75,7 @@ function runScriptIn(dir, script, rootDir) {
     child.stdout.on('data', chunk => chunks.push(chunk));
     child.stderr.on('data', chunk => chunks.push(chunk));
     child.on('error', error => {
-      resolve({ dir, code: 1, output: `failed to spawn ${NPM}: ${error.message}\n` });
+      resolve({ dir, code: 1, output: `failed to spawn ${command}: ${error.message}\n` });
     });
     child.on('close', code => {
       resolve({ dir, code: code ?? 1, output: Buffer.concat(chunks).toString('utf8') });


### PR DESCRIPTION
## User outcome

Fork branches based on stable `v0.73.2` can run the normal Windows pre-push gate and publish a Carry Request instead of failing at `spawn EINVAL` or on unrelated gate portability defects.

## Base and head

- Stable source base: `v0.73.2` / `c0f6b6cdd138dc707ec4688ae9013a4ea76f9534`
- Head: `66bd6b696c4a672418d99cc14cd53f20ce3c7e79`
- Upstream PR base: `main`; merge-base with the head is the stable base SHA above.

## Source and reuse sweep

- Stable `v0.73.2`: `NO MATCH` for the Windows npm-shim launch behavior.
- Upstream `main`: same buggy launcher blob; no later launcher fix.
- Open upstream PRs and advertised development branches: no duplicate launcher fix.
- Original launcher/hook work: `d63eeb749` and `3b8d85b03`.
- Reused, compatibility-tested gate repairs from open PR #1180: `f805bac49` (sync-socket checker visibility) and `dd5638f14` (platform-neutral path assertion). Only those focused commits were replayed; none of PR #1180's unrelated branch history was imported.

## Changed paths

- `.githooks/pre-push`
- `scripts/resolve-prepush-base.mjs`
- `scripts/run-workspace-script.mjs`
- `scripts/__tests__/run-workspace-script.test.mjs`
- `scripts/__tests__/check-collab-client-boundaries.test.mjs`
- `packages/electron/src/renderer/services/BodyDocCache.ts`

## Checks

- Clean Windows reproduction before fix: `spawn('npm.cmd', ...)` throws `EINVAL` on Node `26.3.0`.
- `node --test scripts/__tests__/run-workspace-script.test.mjs`: 7/7 passed.
- `npm run test:prepush-gate`: 42/42 passed.
- Normal `git push` pre-push hook, without bypass:
  - toolchain and fixture-author guards passed;
  - override and tracked-NUL checks passed;
  - prerequisite builds passed;
  - workspace typecheck passed in 23/23 workspaces;
  - focused pre-push gate passed 42/42.
- Full Vitest remains intentionally skipped for local Windows pushes per `docs/WINDOWS_PREPUSH_GATE.md`; CI and non-Windows pushes still require it.

## Dependencies

This Carry Request has no dependency on unmerged draft PR #1155 and does not import it. No merge or release is requested.