### PR TITLE
fix(worktrees): preserve session lifecycle on deletion (NIM-257)

### DIFF
--- a/packages/electron/src/main/ipc/WorktreeHandlers.ts
+++ b/packages/electron/src/main/ipc/WorktreeHandlers.ts
@@ -583,35 +583,10 @@ export function registerWorktreeHandlers(): void {
         throw new Error('workspacePath is required');
       }
 
-      logger.info('Deleting worktree', { worktreeId, workspacePath });
-
-      // Get worktree from database to find its path
-      const db = getDatabase();
-      if (!db) {
-        throw new Error('Database not initialized');
-      }
-
-      const worktreeStore = createWorktreeStore(db);
-      const worktree = await worktreeStore.get(worktreeId);
-
-      if (!worktree) {
-        throw new Error(`Worktree not found: ${worktreeId}`);
-      }
-
-      // Stop the git ref watcher for this worktree
-      await gitRefWatcher.stop(worktree.path);
-
-      // Delete the git worktree
-      await gitWorktreeService.deleteWorktree(worktree.path, workspacePath);
-
-      // Delete the database record
-      await worktreeStore.delete(worktreeId);
-
-      logger.info('Worktree deleted successfully', { worktreeId });
-
-      return {
-        success: true,
-      };
+      // Deletion is lifecycle-sensitive: the archive path owns session/provider
+      // retirement and its recovery path. Never remove a worktree directly and
+      // leave a resumable session pointing at a deleted working directory.
+      return archiveWorktree(worktreeId, workspacePath);
     } catch (error) {
       logger.error('Failed to delete worktree:', error);
       return {

--- a/packages/electron/src/main/ipc/__tests__/worktreeDeletionLifecycle.test.ts
+++ b/packages/electron/src/main/ipc/__tests__/worktreeDeletionLifecycle.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  resolve(process.cwd(), 'packages/electron/src/main/ipc/WorktreeHandlers.ts'),
+  'utf8',
+);
+const start = source.indexOf("ipcMain.handle('worktree:delete'");
+const end = source.indexOf("ipcMain.handle('worktree:archive'", start);
+const deleteHandler = source.slice(start, end);
+
+describe('worktree:delete lifecycle boundary', () => {
+  it('delegates deletion to archiveWorktree instead of bypassing session retirement', () => {
+    expect(deleteHandler).toContain('return archiveWorktree(worktreeId, workspacePath);');
+    expect(deleteHandler).not.toContain('await worktreeStore.delete(worktreeId);');
+  });
+});


### PR DESCRIPTION
## NIM-257 — lifecycle-safe worktree deletion

### User outcome

Deleting a worktree preserves its session lifecycle: the archive path retires sessions and providers before deferred disk cleanup, rather than leaving resumable sessions pointed at a removed directory.

### Carry receipt

- Stable source / merge-base: `v0.73.2` / `c0f6b6cdd138dc707ec4688ae9013a4ea76f9534`
- Fork head: `a6d360cbc0e3f2269860e2054f99b36e49e415d5`
- GitHub PR base: `nimbalyst/nimbalyst:main` / `4a42e0ad5cca7973251e3513db3ecd036171bd7d`
- Recovered provenance: `97ee0d255550a538a50f56cb75e5f1d19a0576e3`
- Source/reuse: stable and upstream main do not route `worktree:delete` through `archiveWorktree`; the recovered local implementation reapplies cleanly to the stable base.
- Changed paths:
  - `packages/electron/src/main/ipc/WorktreeHandlers.ts`
  - `packages/electron/src/main/ipc/__tests__/worktreeDeletionLifecycle.test.ts`
- Focused test: `vitest run packages/electron/src/main/ipc/__tests__/worktreeDeletionLifecycle.test.ts` — **1 passed**.
- Normal Windows pre-push hook passed without bypass: fixture-author, dependency-override, tracked-NUL, prerequisite-build, 23-workspace typecheck, and focused pre-push tests all passed. The full Vitest suite remains intentionally skipped on local Windows per `docs/WINDOWS_PREPUSH_GATE.md`; CI runs it.

This CReq does not depend on unmerged upstream draft PR #1155. No merge or release is requested.

## Why this is worth merging

Deleting a worktree is also a session-lifecycle event. Routing deletion through the existing archive path preserves source identity, recovery history, and session retirement instead of leaving live records pointing at vanished files. The result is a recoverable cleanup operation rather than silent lifecycle damage.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
