### PR TITLE
fix(ai): reattach persisted background work after recycle (NIM-253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Running Claude background agents now resume from their surviving transcript after a provider restart.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/services/PGLiteSessionStore.ts
+++ b/packages/electron/src/main/services/PGLiteSessionStore.ts
@@ -85,6 +85,41 @@ function parseJsonColumn(value: unknown): unknown {
 let moduleDb: PGliteLike | null = null;
 let moduleEnsureReady: EnsureReadyFn | null = null;
 
+// PGLite and SQLite expose different JSON merge operators, so metadata uses a
+// backend-neutral read/merge/write. Serialize that complete mutation per
+// session, including across multiple store wrappers sharing one DB adapter.
+const metadataMutationGates = new WeakMap<PGliteLike, Map<string, Promise<void>>>();
+
+async function withSessionMetadataMutationLock<T>(
+  db: PGliteLike,
+  sessionId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let sessionGates = metadataMutationGates.get(db);
+  if (!sessionGates) {
+    sessionGates = new Map();
+    metadataMutationGates.set(db, sessionGates);
+  }
+
+  const previous = sessionGates.get(sessionId) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  sessionGates.set(sessionId, gate);
+
+  await previous.catch(() => undefined);
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (sessionGates.get(sessionId) === gate) {
+      sessionGates.delete(sessionId);
+      if (sessionGates.size === 0) metadataMutationGates.delete(db);
+    }
+  }
+}
+
 /**
  * Get the database instance for direct queries (e.g., migrations)
  */
@@ -427,6 +462,7 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
       await ensureReady();
       const updates: string[] = [];
       const values: any[] = [sessionId];
+      let incomingMetadata: Record<string, any> | undefined;
 
       const pushUpdate = (clause: string, value: any) => {
         updates.push(`${clause} $${values.length + 1}`);
@@ -470,32 +506,7 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
             `[PGLiteSessionStore] updateMetadata refused non-object metadata for session ${sessionId}: type=${typeof incoming}, isArray=${Array.isArray(incoming)}`,
           );
         } else {
-          const normalizedIncoming = normalizeSessionPhaseMetadataUpdate(incoming);
-          const { rows } = await db.query<{ metadata: unknown }>(
-            `SELECT metadata FROM ai_sessions WHERE id = $1`,
-            [sessionId],
-          );
-          const existingMetadata = normalizeJsonObject(rows[0]?.metadata);
-          const merged: Record<string, any> = { ...existingMetadata, ...normalizedIncoming };
-          // Record workflow-phase transitions into metadata.activity[] so the
-          // session's lifecycle history is self-contained and renderable on the
-          // project-graph timeline (see session/sessionPhaseTransition.ts). This
-          // is the single chokepoint for every phase change -- the
-          // update_session_meta MCP tool and the kanban UI both land here. Only
-          // the workflow `phase` is tracked; operational status flips too often
-          // for the bounded log.
-          const incomingPhase = normalizedIncoming.phase;
-          if (typeof incomingPhase === 'string') {
-            const transition = computeSessionPhaseTransition(
-              existingMetadata as Record<string, any>,
-              incomingPhase,
-              null,
-              Date.now(),
-            );
-            if (transition.changed) merged.activity = transition.metadata.activity;
-          }
-          updates.push(`metadata = $${values.length + 1}`);
-          values.push(JSON.stringify(merged));
+          incomingMetadata = normalizeSessionPhaseMetadataUpdate(incoming);
         }
       }
       if ((metadata as any).hasBeenNamed !== undefined) pushUpdate('has_been_named =', (metadata as any).hasBeenNamed);
@@ -509,31 +520,60 @@ export function createPGLiteSessionStore(db: PGliteLike, ensureDbReady?: EnsureR
       if (metadata.canonicalLastTransformedAt !== undefined) pushUpdate('canonical_last_transformed_at =', metadata.canonicalLastTransformedAt);
       if (metadata.canonicalLastRawMessageId !== undefined) pushUpdate('canonical_last_raw_message_id =', metadata.canonicalLastRawMessageId);
 
-      // NOTE: We intentionally do NOT update updated_at here. The updated_at timestamp
-      // should only change when messages are added (via PGLiteAgentMessagesStore.create),
-      // so that session history sorting accurately reflects the last message time.
-      if (!updates.length) {
-        // Nothing to update - no-op
-        return;
-      }
+      const applyUpdates = async (metadataPatch?: Record<string, any>) => {
+        if (metadataPatch) {
+          const { rows } = await db.query<{ metadata: unknown }>(
+            `SELECT metadata FROM ai_sessions WHERE id = $1`,
+            [sessionId],
+          );
+          const existingMetadata = normalizeJsonObject(rows[0]?.metadata);
+          const merged: Record<string, any> = {
+            ...existingMetadata,
+            ...metadataPatch,
+          };
+          // Record workflow-phase transitions into metadata.activity[] so the
+          // session's lifecycle history is self-contained and renderable on the
+          // project-graph timeline (see session/sessionPhaseTransition.ts).
+          const incomingPhase = metadataPatch.phase;
+          if (typeof incomingPhase === 'string') {
+            const transition = computeSessionPhaseTransition(
+              existingMetadata as Record<string, any>,
+              incomingPhase,
+              null,
+              Date.now(),
+            );
+            if (transition.changed) merged.activity = transition.metadata.activity;
+          }
+          updates.push(`metadata = $${values.length + 1}`);
+          values.push(JSON.stringify(merged));
+        }
 
-      const setClause = updates.join(', ');
-      await db.query(
-        `UPDATE ai_sessions SET ${setClause} WHERE id=$1`,
-        values
-      );
-
-      // GitHub #925 / NIM-1831: a workstream is archived (or restored) as a unit.
-      // Cascade the is_archived flag to direct children (linked by
-      // parent_session_id) so archiving a workstream parent doesn't leave its
-      // child sessions active — invisible orphans that keep counting toward the
-      // active total. buildSessionArchiveFilter only checks a row's own
-      // is_archived, so the children must carry the flag themselves.
-      if (metadata.isArchived !== undefined) {
+        // NOTE: We intentionally do NOT update updated_at here. The updated_at timestamp
+        // should only change when messages are added (via PGLiteAgentMessagesStore.create),
+        // so that session history sorting accurately reflects the last message time.
+        if (!updates.length) return;
+        const setClause = updates.join(', ');
         await db.query(
-          `UPDATE ai_sessions SET is_archived=$2 WHERE parent_session_id=$1`,
-          [sessionId, metadata.isArchived]
+          `UPDATE ai_sessions SET ${setClause} WHERE id=$1`,
+          values
         );
+
+        // A workstream is archived (or restored) as a unit. Keep direct children
+        // aligned so they cannot become invisible active-session orphans.
+        if (metadata.isArchived !== undefined) {
+          await db.query(
+            `UPDATE ai_sessions SET is_archived=$2 WHERE parent_session_id=$1`,
+            [sessionId, metadata.isArchived]
+          );
+        }
+      };
+
+      if (incomingMetadata) {
+        await withSessionMetadataMutationLock(db, sessionId, () =>
+          applyUpdates(incomingMetadata)
+        );
+      } else {
+        await applyUpdates();
       }
     },
 

--- a/packages/electron/src/main/services/__tests__/PGLiteSessionStore.test.ts
+++ b/packages/electron/src/main/services/__tests__/PGLiteSessionStore.test.ts
@@ -331,6 +331,70 @@ describe('PGLiteSessionStore.updateMetadata defense-in-depth', () => {
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
+
+  it('serializes concurrent shallow metadata patches so recovery and unrelated fields both survive', async () => {
+    let storedMetadata = '{}';
+    let updateCount = 0;
+    let releaseFirstUpdate!: () => void;
+    const firstUpdateBlocked = new Promise<void>((resolve) => {
+      releaseFirstUpdate = resolve;
+    });
+    let firstUpdateEntered!: () => void;
+    const firstUpdateStarted = new Promise<void>((resolve) => {
+      firstUpdateEntered = resolve;
+    });
+
+    const db = {
+      query: vi.fn(async (sql: string, params: unknown[] = []) => {
+        if (/SELECT\s+metadata\s+FROM\s+ai_sessions/i.test(sql)) {
+          return { rows: [{ metadata: storedMetadata }] };
+        }
+        if (/UPDATE\s+ai_sessions\s+SET\s+metadata\s*=/i.test(sql)) {
+          updateCount += 1;
+          const nextMetadata = String(params[params.length - 1]);
+          if (updateCount === 1) {
+            firstUpdateEntered();
+            await firstUpdateBlocked;
+          }
+          storedMetadata = nextMetadata;
+          return { rows: [] };
+        }
+        return { rows: [] };
+      }),
+    };
+    const recoveryStore = createPGLiteSessionStore(db as any);
+    const unrelatedStore = createPGLiteSessionStore(db as any);
+
+    const recoveryPatch = recoveryStore.updateMetadata('s1', {
+      metadata: {
+        backgroundAgentRecovery: {
+          version: 1,
+          tasks: { generation1: { recoveryState: 'claimed' } },
+        },
+      },
+    });
+    await firstUpdateStarted;
+    const unrelatedPatch = unrelatedStore.updateMetadata('s1', {
+      metadata: { phase: 'validating', tags: ['recovery'] },
+    });
+
+    // Drain the promise queue while the first write remains blocked. Without
+    // per-session serialization, the second caller reads the same stale JSON,
+    // writes its patch, and is then overwritten when the first write resumes.
+    for (let index = 0; index < 8; index += 1) await Promise.resolve();
+    releaseFirstUpdate();
+    await Promise.all([recoveryPatch, unrelatedPatch]);
+
+    expect(JSON.parse(storedMetadata)).toEqual({
+      backgroundAgentRecovery: {
+        version: 1,
+        tasks: { generation1: { recoveryState: 'claimed' } },
+      },
+      phase: 'validating',
+      tags: ['recovery'],
+      activity: expect.any(Array),
+    });
+  });
 });
 
 describe('PGLiteSessionStore.updateMetadata nullable column clears', () => {

--- a/packages/runtime/src/ai/server/SessionManager.ts
+++ b/packages/runtime/src/ai/server/SessionManager.ts
@@ -1281,13 +1281,8 @@ export class SessionManager {
    * This persists cumulative token usage for the session
    */
   async updateSessionTokenUsage(sessionId: string, tokenUsage: SessionData['tokenUsage']): Promise<void> {
-    // Get current metadata and merge token usage into it
-    const session = await AISessionsRepository.get(sessionId);
-    const currentMetadata = (session?.metadata ?? {}) as Record<string, unknown>;
-
     await AISessionsRepository.updateMetadata(sessionId, {
       metadata: {
-        ...currentMetadata,
         tokenUsage
       }
     });

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -52,6 +52,7 @@ import {
 import type { InterruptTurnResult } from '../AIProvider';
 import { isBedrockToolSearchError } from '../utils/errorDetection';
 import { AgentMessagesRepository } from '../../../storage/repositories/AgentMessagesRepository';
+import { AISessionsRepository } from '../../../storage/repositories/AISessionsRepository';
 import { TranscriptMigrationRepository } from '../../../storage/repositories/TranscriptMigrationRepository';
 import { TeammateManager, type TeammateToLeadMessage } from './TeammateManager';
 import path from 'path';
@@ -141,6 +142,11 @@ import {
   readLatestSdkDebugLogTail,
 } from './claudeCode/spawnCrashDiagnostics';
 import { applyTaskListMutation, sortTaskList, type TaskListItem } from './claudeCode/taskListReconstruct';
+import {
+  BackgroundAgentRecoveryCoordinator,
+  buildBackgroundAgentRecoveryInstruction,
+  inspectClaudeBackgroundAgentTranscript,
+} from './claudeCode/backgroundTaskRecovery';
 
 
 /**
@@ -182,6 +188,8 @@ const SDK_NATIVE_TOOLS: readonly string[] = [
 const NIMBALYST_HANDLED_TOOLS: readonly string[] = [
   'ScheduleWakeup',
 ];
+
+let claudeProviderInstanceSequence = 0;
 
 /**
  * Track changes in the agent-sdk and claude-code itself here:
@@ -307,7 +315,15 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     // Set from task_updated patches (is_backgrounded): the task's tool call
     // returned a launch acknowledgement, not a completion. See NIM-1470.
     isBackgrounded?: boolean;
+    sourceTurnId?: string;
+    agentName?: string;
   }>();
+
+  private readonly backgroundAgentRecovery: BackgroundAgentRecoveryCoordinator;
+  private readonly recoveryInstanceId: string;
+  private recoveryTurnSequence = 0;
+  private recoverySessionId: string | undefined;
+  private destroying = false;
 
   // Terminal task_notification chunks received while draining background tasks
   // after the lead turn ended. Consumed by finalizeBackgroundDrain to wake the
@@ -376,6 +392,19 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
 
   constructor() {
     super();
+    this.recoveryInstanceId = `claude-provider-${process.pid}-${Date.now()}-${++claudeProviderInstanceSequence}`;
+    this.backgroundAgentRecovery = new BackgroundAgentRecoveryCoordinator({
+      instanceId: this.recoveryInstanceId,
+      getSession: async (sessionId) => AISessionsRepository.get(sessionId),
+      mergeSessionMetadata: async (sessionId, patch) => {
+        await AISessionsRepository.updateMetadata(sessionId, { metadata: patch });
+      },
+      inspectTranscript: (input) => inspectClaudeBackgroundAgentTranscript({
+        ...input,
+        projectsDir: process.env.NIMBALYST_CLAUDE_PROJECTS_DIR
+          || path.join(os.homedir(), '.claude', 'projects'),
+      }),
+    });
     this.teammateManager = new TeammateManager({
       logNonBlocking: (sessionId, source, direction, content, metadata) =>
         this.logAgentMessageNonBlocking(sessionId, source, direction, content, metadata),
@@ -467,7 +496,9 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     workspacePath: string,
     sessionId: string | undefined,
     permissionsPath: string | undefined,
-    isTeammateSession: boolean
+    isTeammateSession: boolean,
+    recoveryTurnId?: string,
+    plannedRecoveryGenerations?: readonly string[],
   ): AgentToolHooks {
     return new AgentToolHooks({
       workspacePath: workspacePath,
@@ -483,8 +514,45 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
       getPendingExitPlanModeConfirmations: () => this.pendingExitPlanModeConfirmations,
       getSessionApprovedPatterns: () => this.permissions.sessionApprovedPatterns,
       getPendingToolPermissions: () => this.permissions.pendingToolPermissions,
-      teammatePreToolHandler: async (toolName, toolInput, toolUseID, sessionId) =>
-        this.teammateManager.handlePreToolUse(toolName, toolInput, toolUseID, sessionId),
+      teammatePreToolHandler: async (toolName, toolInput, toolUseID, hookSessionId) => {
+        if (toolName === 'SendMessage' && hookSessionId && recoveryTurnId && toolUseID) {
+          try {
+            const recoveryDecision = await this.backgroundAgentRecovery.guardNativeSendMessage({
+              sessionId: hookSessionId,
+              turnId: recoveryTurnId,
+              toolUseId: toolUseID,
+              input: toolInput || {},
+            });
+            if (recoveryDecision.matched && !recoveryDecision.allow) {
+              return {
+                handled: true,
+                result: {
+                  hookSpecificOutput: {
+                    hookEventName: 'PreToolUse',
+                    permissionDecision: 'deny',
+                    permissionDecisionReason: recoveryDecision.reason,
+                  },
+                },
+              };
+            }
+          } catch (error) {
+            console.error('[CLAUDE-CODE] Failed to guard native background-agent recovery dispatch:', error);
+            if ((plannedRecoveryGenerations?.length ?? 0) > 0) {
+              return {
+                handled: true,
+                result: {
+                  hookSpecificOutput: {
+                    hookEventName: 'PreToolUse',
+                    permissionDecision: 'deny',
+                    permissionDecisionReason: 'Background-agent recovery state could not be verified.',
+                  },
+                },
+              };
+            }
+          }
+        }
+        return this.teammateManager.handlePreToolUse(toolName, toolInput, toolUseID, hookSessionId);
+      },
       isTeammateSession: !!isTeammateSession,
       permissionsPath,
       historyManager: this.createHistoryManagerAdapter(),
@@ -648,6 +716,9 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     attachments?: any[]
   ): AsyncIterableIterator<StreamChunk> {
     const startTime = Date.now();
+    const recoveryTurnId = `${this.recoveryInstanceId}:turn-${++this.recoveryTurnSequence}`;
+    const plannedRecoveryGenerations: string[] = [];
+    if (sessionId) this.recoverySessionId = sessionId;
 
     // CRITICAL: Capture hidden mode flag at START and reset immediately
     // This prevents race conditions when concurrent sendMessage calls overlap
@@ -729,7 +800,9 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
       workspacePath!,
       sessionId,
       permissionsPath,
-      false
+      false,
+      recoveryTurnId,
+      plannedRecoveryGenerations,
     );
 
     // Clear edited files tracker for new turn
@@ -788,6 +861,33 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
         }
       }
 
+      // Require workspace path before inspecting any persisted provider evidence.
+      if (!workspacePath) {
+        throw new Error('[CLAUDE-CODE] workspacePath is required but was not provided');
+      }
+
+      const providerSessionId = sessionId ? this.sessions.getSessionId(sessionId) ?? undefined : undefined;
+      const recovery = sessionId
+        ? await this.backgroundAgentRecovery.claimResumeDispatches({
+          sessionId,
+          workspacePath,
+          providerSessionId,
+          turnId: recoveryTurnId,
+          isResume: Boolean(providerSessionId),
+        }).catch((error) => {
+          console.error('[CLAUDE-CODE] Failed to inspect durable background-agent recovery state:', error);
+          return { dispatches: [], notices: [] };
+        })
+        : { dispatches: [], notices: [] };
+      plannedRecoveryGenerations.push(...recovery.dispatches.map((dispatch) => dispatch.generation));
+      const recoveryInstruction = buildBackgroundAgentRecoveryInstruction(
+        recovery.dispatches,
+        recovery.notices,
+      );
+      if (sessionId && providerSessionId) {
+        this.emit('message:logged', { sessionId, direction: 'output' });
+      }
+
       // Build system prompt (no longer contains document context)
       const promptBuildStart = Date.now();
       // console.log('[CLAUDE-CODE] sendMessage - documentContext keys:', documentContext ? Object.keys(documentContext) : 'undefined');
@@ -802,7 +902,10 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
       // workspacePath is the CLI's cwd (see buildSdkOptions), so it is also the
       // repo the suppressed CLI block would have described.
       await this.ensureGitContext(workspacePath);
-      const systemPrompt = this.buildSystemPrompt(documentContext, enableAgentTeams, isMetaAgent, workflowPreset);
+      let systemPrompt = this.buildSystemPrompt(documentContext, enableAgentTeams, isMetaAgent, workflowPreset);
+      if (recoveryInstruction) {
+        systemPrompt = `${systemPrompt}\n\n${recoveryInstruction}`;
+      }
 
       // Note: Attachments (images/documents) are NOT added to the message text.
       // They're sent as separate content blocks via the API's multimodal format.
@@ -828,11 +931,6 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
           attachments: attachmentSummaries,
           timestamp: Date.now()
         });
-      }
-
-      // Require workspace path
-      if (!workspacePath) {
-        throw new Error('[CLAUDE-CODE] workspacePath is required but was not provided');
       }
 
       // Build SDK options (settings, MCP config, env, session resumption, prompt input)
@@ -1430,6 +1528,20 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
                     }
                   }
 
+                  if (toolCall.name === 'SendMessage' && sessionId) {
+                    try {
+                      await this.backgroundAgentRecovery.observeNativeSendMessageResult({
+                        sessionId,
+                        turnId: recoveryTurnId,
+                        toolUseId: item.toolUseId,
+                        isError: item.isError === true,
+                        content: item.content,
+                      });
+                    } catch (error) {
+                      console.error('[CLAUDE-CODE] Failed to persist native background-agent recovery result:', error);
+                    }
+                  }
+
                   this.processTeammateToolResult(sessionId, toolCall.name, toolCall.arguments, item.content, toolCall.isError === true, toolCall.id);
 
                   // Mirror SDK-native task-list mutations into session metadata so
@@ -1437,6 +1549,23 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
                   // only available in the result, so capture happens here).
                   if (!toolCall.isError) {
                     this.captureTaskListMutation(sessionId, toolCall.name, toolCall.arguments, item.content);
+                  }
+
+                  if (toolCall.name === 'TaskStop' && !item.isError) {
+                    const stoppedTaskId = typeof toolCall.arguments?.task_id === 'string'
+                      ? toolCall.arguments.task_id
+                      : typeof toolCall.arguments?.shell_id === 'string'
+                        ? toolCall.arguments.shell_id
+                        : undefined;
+                    if (stoppedTaskId && this.activeTasks.has(stoppedTaskId)) {
+                      await this.handleSystemTask(
+                        'task_notification',
+                        { task_id: stoppedTaskId, status: 'stopped', summary: 'Stopped explicitly' },
+                        sessionId,
+                        workspacePath,
+                        recoveryTurnId,
+                      );
+                    }
                   }
 
                   if (item.toolUseId) {
@@ -1521,7 +1650,29 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
                 if (item.subtype === 'task_notification') {
                   sawTaskNotificationThisTurn = true;
                 }
-                this.handleSystemTask(item.subtype, item.chunk, sessionId);
+                {
+                  const launchToolCall = item.chunk?.tool_use_id
+                    ? toolCallsById.get(item.chunk.tool_use_id)
+                    : undefined;
+                  const launchArgs = launchToolCall?.arguments;
+                  const explicitBackground = typeof launchArgs?.run_in_background === 'boolean'
+                    ? launchArgs.run_in_background
+                    : typeof launchArgs?.runInBackground === 'boolean'
+                      ? launchArgs.runInBackground
+                      : undefined;
+                  await this.handleSystemTask(
+                    item.subtype,
+                    item.chunk,
+                    sessionId,
+                    workspacePath,
+                    recoveryTurnId,
+                    launchArgs ? {
+                      // Agent defaults to background execution in the current SDK.
+                      runInBackground: explicitBackground ?? (launchToolCall?.name === 'Agent'),
+                      name: typeof launchArgs.name === 'string' ? launchArgs.name : undefined,
+                    } : undefined,
+                  );
+                }
                 break;
 
               case 'system_compact':
@@ -2024,6 +2175,18 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
         }
       }
     } finally {
+      if (sessionId) {
+        try {
+          await this.backgroundAgentRecovery.finishRecoveryTurn({
+            sessionId,
+            turnId: recoveryTurnId,
+            plannedGenerations: plannedRecoveryGenerations,
+          });
+        } catch (error) {
+          console.error('[CLAUDE-CODE] Failed to finalize background-agent recovery turn:', error);
+        }
+      }
+
       // Don't stop MCP health checks or clear mcpQuery between turns -
       // the SDK subprocess stays alive for session resume, so MCP operations
       // (health checks, reconnect) should keep working between turns.
@@ -2074,6 +2237,18 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
 
   abort(): void {
     console.log('[CLAUDE-CODE] Abort called, abortController:', this.abortController ? 'exists' : 'NULL');
+    if (!this.destroying && this.recoverySessionId) {
+      const recoverySessionId = this.recoverySessionId;
+      for (const task of this.activeTasks.values()) {
+        if (task.status === 'running') task.status = 'stopped';
+      }
+      this.emitTaskUpdate(recoverySessionId).catch(() => {});
+      this.backgroundAgentRecovery.suppressRunning(recoverySessionId, 'user-cancelled')
+        .then(() => this.emit('message:logged', { sessionId: recoverySessionId, direction: 'output' }))
+        .catch((error) => {
+          console.error('[CLAUDE-CODE] Failed to suppress background-agent recovery after user cancellation:', error);
+        });
+    }
     this.streamClosedRetryCount = 0;
     this.resetStreamClosedTurnState();
 
@@ -2490,6 +2665,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
    */
   destroy(): void {
     console.log('[CLAUDE-CODE] Destroying provider');
+    this.destroying = true;
 
     // Clean up permission service
     if (this.permissionService) {
@@ -2559,29 +2735,6 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     sessionId: string | undefined,
     hideMessages: boolean,
   ): Generator<StreamChunk> {
-    // Clean up stale "running" tasks from previous sessions/restarts
-    if (sessionId && this.activeTasks.size === 0) {
-      (async () => {
-        try {
-          const { AISessionsRepository } = await import('../../../storage/repositories/AISessionsRepository');
-          const currentSession = await AISessionsRepository.get(sessionId);
-          const tasks = currentSession?.metadata?.currentTasks;
-          if (Array.isArray(tasks) && tasks.some((t: any) => t.status === 'running')) {
-            const cleaned = tasks.map((t: any) =>
-              t.status === 'running' ? { ...t, status: 'stopped' } : t
-            );
-            await AISessionsRepository.updateMetadata(sessionId, {
-              metadata: { ...currentSession?.metadata, currentTasks: cleaned }
-            });
-            this.emit('message:logged', { sessionId, direction: 'output' });
-            // console.log(`[CLAUDE-CODE] Cleaned up ${tasks.filter((t: any) => t.status === 'running').length} stale running tasks`);
-          }
-        } catch {
-          // Non-critical cleanup
-        }
-      })();
-    }
-
     // Hydrate the in-memory task-list map from persisted metadata so TaskUpdate
     // deltas in a resumed session merge onto the existing board instead of
     // creating stubs (the map is per-provider-instance and starts empty).
@@ -2703,7 +2856,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
       this.emit('teammate:messageWhileIdle', {
         sessionId,
         message:
-          '[System: A sub-agent you launched did not finish — its process was interrupted before returning results. Do not keep waiting for it; continue without it, or retry the delegation if the work still matters.]',
+          '[System: A background agent process was interrupted before returning results. Continue this session; if durable recovery evidence is available, resume the original agent through SendMessage. Do not launch a replacement agent.]',
       });
       return;
     }
@@ -2742,7 +2895,14 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
   }
 
   /** Handle system task chunks (task_started, task_progress, task_notification) */
-  private handleSystemTask(subtype: string, chunk: any, sessionId: string | undefined): void {
+  private async handleSystemTask(
+    subtype: string,
+    chunk: any,
+    sessionId: string | undefined,
+    workspacePath: string,
+    recoveryTurnId: string,
+    launch?: { runInBackground?: boolean; name?: string },
+  ): Promise<void> {
     if (subtype === 'task_started') {
       this.activeTasks.set(chunk.task_id, {
         taskId: chunk.task_id,
@@ -2754,6 +2914,9 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
         toolCount: 0,
         tokenCount: 0,
         durationMs: 0,
+        sourceTurnId: recoveryTurnId,
+        agentName: launch?.name,
+        isBackgrounded: launch?.runInBackground === true,
       });
       console.log(`[CLAUDE-CODE] SUBAGENT_TASK started: id=${chunk.task_id} type=${chunk.task_type ?? 'n/a'} desc="${(chunk.description || '').substring(0, 80)}"`);
       this.emitTaskUpdate(sessionId).catch(() => {});
@@ -2810,6 +2973,22 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
         }
         if (typeof patch.error === 'string' && patch.error) existing.summary = patch.error;
         this.emitTaskUpdate(sessionId).catch(() => {});
+      }
+    }
+
+    const providerSessionId = sessionId ? this.sessions.getSessionId(sessionId) : null;
+    if (sessionId && providerSessionId) {
+      try {
+        await this.backgroundAgentRecovery.observeTaskEvent({
+          sessionId,
+          workspacePath,
+          providerSessionId,
+          turnId: recoveryTurnId,
+          launch,
+          event: { ...chunk, subtype },
+        });
+      } catch (error) {
+        console.error('[CLAUDE-CODE] Failed to persist background-agent task evidence:', error);
       }
     }
   }
@@ -2885,17 +3064,8 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
       // Update session metadata with the current todos
       // This will trigger session reloads which will update the UI
 
-      // Import AISessionsRepository dynamically
-      const { AISessionsRepository } = await import('../../../storage/repositories/AISessionsRepository');
-
-      // Get current session to merge metadata
-      const currentSession = await AISessionsRepository.get(sessionId);
-
-      const currentMetadata = currentSession?.metadata || {};
-
       await AISessionsRepository.updateMetadata(sessionId, {
         metadata: {
-          ...currentMetadata,
           currentTodos: todos
         }
       });
@@ -2917,13 +3087,8 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     if (!sessionId) return;
 
     try {
-      const { AISessionsRepository } = await import('../../../storage/repositories/AISessionsRepository');
-      const currentSession = await AISessionsRepository.get(sessionId);
-      const currentMetadata = currentSession?.metadata || {};
-
       await AISessionsRepository.updateMetadata(sessionId, {
         metadata: {
-          ...currentMetadata,
           currentTasks: Array.from(this.activeTasks.values()),
         }
       });
@@ -2958,13 +3123,8 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
   private async emitTaskListUpdate(sessionId: string | undefined): Promise<void> {
     if (!sessionId) return;
     try {
-      const { AISessionsRepository } = await import('../../../storage/repositories/AISessionsRepository');
-      const currentSession = await AISessionsRepository.get(sessionId);
-      const currentMetadata = currentSession?.metadata || {};
-
       await AISessionsRepository.updateMetadata(sessionId, {
         metadata: {
-          ...currentMetadata,
           // Sorted by numeric id so the board renders in creation order.
           currentTaskList: sortTaskList(this.taskListItems.values()),
         }

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -2457,7 +2457,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
       if (!leadQuery) {
         console.log('[CLAUDE-CODE] interruptCurrentTurn: no active lead query, falling back to abort');
         this.abortProviderRuntime();
-        return { method: 'abort', hadActiveTurn: false };
+        return { method: 'abort' };
       }
 
       console.log('[CLAUDE-CODE] interruptCurrentTurn: interrupting active lead query');
@@ -2475,7 +2475,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
         console.warn('[CLAUDE-CODE] interruptCurrentTurn: interrupt() failed (transport may be closed):', err);
       }
 
-      return { method: 'interrupt', hadActiveTurn: true };
+      return { method: 'interrupt' };
     } finally {
       if (persistenceFailed) {
         console.error(

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -144,9 +144,14 @@ import {
 import { applyTaskListMutation, sortTaskList, type TaskListItem } from './claudeCode/taskListReconstruct';
 import {
   BackgroundAgentRecoveryCoordinator,
-  buildBackgroundAgentRecoveryInstruction,
   inspectClaudeBackgroundAgentTranscript,
 } from './claudeCode/backgroundTaskRecovery';
+import {
+  getClaudeTaskStopTarget,
+  guardClaudeBackgroundAgentRecoveryTool,
+  observeClaudeBackgroundAgentRecoveryToolResult,
+  prepareClaudeBackgroundAgentRecoveryTurn,
+} from './claudeCode/backgroundTaskRecoveryLifecycle';
 
 
 /**
@@ -517,24 +522,18 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
       teammatePreToolHandler: async (toolName, toolInput, toolUseID, hookSessionId) => {
         if (toolName === 'SendMessage' && hookSessionId && recoveryTurnId && toolUseID) {
           try {
-            const recoveryDecision = await this.backgroundAgentRecovery.guardNativeSendMessage({
-              sessionId: hookSessionId,
-              turnId: recoveryTurnId,
-              toolUseId: toolUseID,
-              input: toolInput || {},
-            });
-            if (recoveryDecision.matched && !recoveryDecision.allow) {
-              return {
-                handled: true,
-                result: {
-                  hookSpecificOutput: {
-                    hookEventName: 'PreToolUse',
-                    permissionDecision: 'deny',
-                    permissionDecisionReason: recoveryDecision.reason,
-                  },
-                },
-              };
-            }
+            const recoveryGuard = await guardClaudeBackgroundAgentRecoveryTool(
+              this.backgroundAgentRecovery,
+              {
+                toolName,
+                sessionId: hookSessionId,
+                turnId: recoveryTurnId,
+                toolUseId: toolUseID,
+                toolInput: toolInput || {},
+                plannedGenerations: plannedRecoveryGenerations,
+              },
+            );
+            if (recoveryGuard.handled) return recoveryGuard;
           } catch (error) {
             console.error('[CLAUDE-CODE] Failed to guard native background-agent recovery dispatch:', error);
             if ((plannedRecoveryGenerations?.length ?? 0) > 0) {
@@ -868,22 +867,32 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
 
       const providerSessionId = sessionId ? this.sessions.getSessionId(sessionId) ?? undefined : undefined;
       const recovery = sessionId
-        ? await this.backgroundAgentRecovery.claimResumeDispatches({
-          sessionId,
-          workspacePath,
-          providerSessionId,
-          turnId: recoveryTurnId,
-          isResume: Boolean(providerSessionId),
-        }).catch((error) => {
+        ? await prepareClaudeBackgroundAgentRecoveryTurn(
+          this.backgroundAgentRecovery,
+          {
+            sessionId,
+            workspacePath,
+            providerSessionId,
+            turnId: recoveryTurnId,
+            isResume: Boolean(providerSessionId),
+          },
+        ).catch((error) => {
           console.error('[CLAUDE-CODE] Failed to inspect durable background-agent recovery state:', error);
-          return { dispatches: [], notices: [] };
+          return {
+            dispatches: [],
+            notices: [],
+            plannedGenerations: [],
+            systemInstruction: '',
+          };
         })
-        : { dispatches: [], notices: [] };
-      plannedRecoveryGenerations.push(...recovery.dispatches.map((dispatch) => dispatch.generation));
-      const recoveryInstruction = buildBackgroundAgentRecoveryInstruction(
-        recovery.dispatches,
-        recovery.notices,
-      );
+        : {
+          dispatches: [],
+          notices: [],
+          plannedGenerations: [],
+          systemInstruction: '',
+        };
+      plannedRecoveryGenerations.push(...recovery.plannedGenerations);
+      const recoveryInstruction = recovery.systemInstruction;
       if (sessionId && providerSessionId) {
         this.emit('message:logged', { sessionId, direction: 'output' });
       }
@@ -1528,17 +1537,27 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
                     }
                   }
 
-                  if (toolCall.name === 'SendMessage' && sessionId) {
+                  const stoppedTaskId = getClaudeTaskStopTarget(
+                    toolCall.name,
+                    toolCall.arguments,
+                    item.isError === true,
+                  );
+                  if (toolCall.name === 'SendMessage' || stoppedTaskId) {
                     try {
-                      await this.backgroundAgentRecovery.observeNativeSendMessageResult({
-                        sessionId,
-                        turnId: recoveryTurnId,
-                        toolUseId: item.toolUseId,
-                        isError: item.isError === true,
-                        content: item.content,
-                      });
+                      await observeClaudeBackgroundAgentRecoveryToolResult(
+                        this.backgroundAgentRecovery,
+                        {
+                          sessionId,
+                          turnId: recoveryTurnId,
+                          toolName: toolCall.name,
+                          toolUseId: item.toolUseId,
+                          isError: item.isError === true,
+                          toolArguments: toolCall.arguments,
+                          content: item.content,
+                        },
+                      );
                     } catch (error) {
-                      console.error('[CLAUDE-CODE] Failed to persist native background-agent recovery result:', error);
+                      console.error('[CLAUDE-CODE] Failed to persist native background-agent recovery tool result:', error);
                     }
                   }
 
@@ -1552,11 +1571,6 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
                   }
 
                   if (toolCall.name === 'TaskStop' && !item.isError) {
-                    const stoppedTaskId = typeof toolCall.arguments?.task_id === 'string'
-                      ? toolCall.arguments.task_id
-                      : typeof toolCall.arguments?.shell_id === 'string'
-                        ? toolCall.arguments.shell_id
-                        : undefined;
                     if (stoppedTaskId && this.activeTasks.has(stoppedTaskId)) {
                       await this.handleSystemTask(
                         'task_notification',

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -329,7 +329,10 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
   private recoveryTurnSequence = 0;
   private recoverySessionId: string | undefined;
   private destroying = false;
-  private explicitUserStopRequested = false;
+  // Monotonic high-water mark for turns covered by explicit user stop intent.
+  // Later turns receive a greater sequence and remain eligible, while late SDK
+  // chunks from any stopped turn stay gated without an unbounded identity set.
+  private explicitUserStopThroughRecoveryTurnSequence = 0;
 
   // Terminal task_notification chunks received while draining background tasks
   // after the lead turn ended. Consumed by finalizeBackgroundDrain to wake the
@@ -705,6 +708,9 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     return resolveClaudeCodeModelVariant(this.config.model, CLAUDE_CODE_SAFE_FALLBACK_MODEL);
   }
 
+  private beginRecoveryTurn(): string {
+    return `${this.recoveryInstanceId}:turn-${++this.recoveryTurnSequence}`;
+  }
 
 
   async *sendMessage(
@@ -716,8 +722,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     attachments?: any[]
   ): AsyncIterableIterator<StreamChunk> {
     const startTime = Date.now();
-    this.explicitUserStopRequested = false;
-    const recoveryTurnId = `${this.recoveryInstanceId}:turn-${++this.recoveryTurnSequence}`;
+    const recoveryTurnId = this.beginRecoveryTurn();
     const plannedRecoveryGenerations: string[] = [];
     if (sessionId) this.recoverySessionId = sessionId;
 
@@ -2253,7 +2258,10 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
 
   private async persistExplicitUserStopBoundary(): Promise<void> {
     if (this.destroying) return;
-    this.explicitUserStopRequested = true;
+    this.explicitUserStopThroughRecoveryTurnSequence = Math.max(
+      this.explicitUserStopThroughRecoveryTurnSequence,
+      this.recoveryTurnSequence,
+    );
 
     for (const task of this.activeTasks.values()) {
       if (task.status === 'running') task.status = 'stopped';
@@ -2428,6 +2436,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
    */
   async interruptCurrentTurn(): Promise<InterruptTurnResult> {
     const leadQuery = this.leadQuery;
+    const interruptResolve = this.interruptResolve;
     if (leadQuery) {
       // Mark the turn as explicitly interrupted immediately so a naturally
       // closing stream cannot inject teammate follow-up while the durable stop
@@ -2435,28 +2444,47 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
       this.wasInterrupted = true;
     }
 
-    await this.persistExplicitUserStopBoundary();
-
-    if (!leadQuery) {
-      console.log('[CLAUDE-CODE] interruptCurrentTurn: no active lead query, falling back to abort');
-      this.abortProviderRuntime();
-      return { method: 'abort', hadActiveTurn: false };
-    }
-
-    console.log('[CLAUDE-CODE] interruptCurrentTurn: interrupting active lead query');
-
-    if (this.interruptResolve) {
-      this.interruptResolve();
-      this.interruptResolve = null;
+    let persistenceFailed = false;
+    let persistenceError: unknown;
+    try {
+      await this.persistExplicitUserStopBoundary();
+    } catch (error) {
+      persistenceFailed = true;
+      persistenceError = error;
     }
 
     try {
-      await leadQuery.interrupt();
-    } catch (err) {
-      console.warn('[CLAUDE-CODE] interruptCurrentTurn: interrupt() failed (transport may be closed):', err);
-    }
+      if (!leadQuery) {
+        console.log('[CLAUDE-CODE] interruptCurrentTurn: no active lead query, falling back to abort');
+        this.abortProviderRuntime();
+        return { method: 'abort', hadActiveTurn: false };
+      }
 
-    return { method: 'interrupt', hadActiveTurn: true };
+      console.log('[CLAUDE-CODE] interruptCurrentTurn: interrupting active lead query');
+
+      if (interruptResolve) {
+        interruptResolve();
+        if (this.interruptResolve === interruptResolve) {
+          this.interruptResolve = null;
+        }
+      }
+
+      try {
+        await leadQuery.interrupt();
+      } catch (err) {
+        console.warn('[CLAUDE-CODE] interruptCurrentTurn: interrupt() failed (transport may be closed):', err);
+      }
+
+      return { method: 'interrupt', hadActiveTurn: true };
+    } finally {
+      if (persistenceFailed) {
+        console.error(
+          '[CLAUDE-CODE] Explicit user stop runtime cleanup was attempted, but durable recovery suppression failed:',
+          persistenceError,
+        );
+        throw persistenceError;
+      }
+    }
   }
 
   /**
@@ -2946,9 +2974,21 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     recoveryTurnId: string,
     launch?: { runInBackground?: boolean; name?: string },
   ): Promise<void> {
-    // Once explicit stop intent is observed, do not let a late SDK chunk create
-    // fresh recoverable evidence behind the durable cancellation boundary.
-    if (this.explicitUserStopRequested) return;
+    // Do not let late SDK chunks from a stopped turn recreate recoverable
+    // evidence after a newer turn starts. Recovery turn ids are provider-owned
+    // and monotonic, so the stopped high-water mark is constant-space and
+    // remains valid for as long as an older stream can still emit.
+    const recoveryTurnPrefix = `${this.recoveryInstanceId}:turn-`;
+    const recoveryTurnSequence = recoveryTurnId.startsWith(recoveryTurnPrefix)
+      ? Number(recoveryTurnId.slice(recoveryTurnPrefix.length))
+      : Number.NaN;
+    if (
+      Number.isSafeInteger(recoveryTurnSequence)
+      && recoveryTurnSequence > 0
+      && recoveryTurnSequence <= this.explicitUserStopThroughRecoveryTurnSequence
+    ) {
+      return;
+    }
 
     if (subtype === 'task_started') {
       this.activeTasks.set(chunk.task_id, {

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -329,6 +329,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
   private recoveryTurnSequence = 0;
   private recoverySessionId: string | undefined;
   private destroying = false;
+  private explicitUserStopRequested = false;
 
   // Terminal task_notification chunks received while draining background tasks
   // after the lead turn ended. Consumed by finalizeBackgroundDrain to wake the
@@ -715,6 +716,7 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     attachments?: any[]
   ): AsyncIterableIterator<StreamChunk> {
     const startTime = Date.now();
+    this.explicitUserStopRequested = false;
     const recoveryTurnId = `${this.recoveryInstanceId}:turn-${++this.recoveryTurnSequence}`;
     const plannedRecoveryGenerations: string[] = [];
     if (sessionId) this.recoverySessionId = sessionId;
@@ -2249,20 +2251,34 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     }
   }
 
-  abort(): void {
-    console.log('[CLAUDE-CODE] Abort called, abortController:', this.abortController ? 'exists' : 'NULL');
-    if (!this.destroying && this.recoverySessionId) {
-      const recoverySessionId = this.recoverySessionId;
-      for (const task of this.activeTasks.values()) {
-        if (task.status === 'running') task.status = 'stopped';
-      }
-      this.emitTaskUpdate(recoverySessionId).catch(() => {});
-      this.backgroundAgentRecovery.suppressRunning(recoverySessionId, 'user-cancelled')
-        .then(() => this.emit('message:logged', { sessionId: recoverySessionId, direction: 'output' }))
-        .catch((error) => {
-          console.error('[CLAUDE-CODE] Failed to suppress background-agent recovery after user cancellation:', error);
-        });
+  private async persistExplicitUserStopBoundary(): Promise<void> {
+    if (this.destroying) return;
+    this.explicitUserStopRequested = true;
+
+    for (const task of this.activeTasks.values()) {
+      if (task.status === 'running') task.status = 'stopped';
     }
+
+    const recoverySessionId = this.recoverySessionId;
+    if (!recoverySessionId) return;
+
+    // Persist the provider's complete stopped task view first, then let the
+    // coordinator make the recovery ledger and currentTasks disposition the
+    // final authoritative write. Keeping suppression last prevents a later
+    // task snapshot from erasing the durable user-cancelled evidence.
+    await this.emitTaskUpdate(recoverySessionId);
+    await this.backgroundAgentRecovery.suppressRunning(
+      recoverySessionId,
+      'user-cancelled'
+    );
+    this.emit('message:logged', {
+      sessionId: recoverySessionId,
+      direction: 'output',
+    });
+  }
+
+  private abortProviderRuntime(): void {
+    console.log('[CLAUDE-CODE] Abort called, abortController:', this.abortController ? 'exists' : 'NULL');
     this.streamClosedRetryCount = 0;
     this.resetStreamClosedTurnState();
 
@@ -2313,6 +2329,15 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     this.currentSessionId = undefined;
   }
 
+  abort(): void {
+    // AIProvider.abort() is synchronous, so keep its historical best-effort
+    // persistence behavior. Explicit renderer stops go through
+    // interruptCurrentTurn(), which awaits this same boundary before returning.
+    void this.persistExplicitUserStopBoundary().catch((error) => {
+      console.error('[CLAUDE-CODE] Failed to suppress background-agent recovery after user cancellation:', error);
+    });
+    this.abortProviderRuntime();
+  }
   // Per-session "transcript processing already scheduled" flag. The streaming
   // chunk loop fires scheduleTranscriptProcessing per chunk, so without this
   // we'd queue one processNewMessages run per chunk; the per-session lock
@@ -2398,36 +2423,40 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
    * and the AIService completion handler runs normally (including queue processing).
    * This is a graceful stop — unlike abort(), it doesn't kill the SDK subprocess.
    *
-   * If there is no active lead query, defer to the BaseAIProvider default
-   * (hard abort) so the caller still gets a sensible signal back, and report
-   * `hadActiveTurn: false` — with no query and (usually) no abortController
-   * that abort is a no-op, so the caller has to clear the session's live state
-   * itself or a stuck-running session strands its queue forever (NIM-2434).
+   * If there is no active lead query, persist the same user-stop boundary
+   * before applying the provider's hard-abort cleanup.
    */
   async interruptCurrentTurn(): Promise<InterruptTurnResult> {
-    if (!this.leadQuery) {
+    const leadQuery = this.leadQuery;
+    if (leadQuery) {
+      // Mark the turn as explicitly interrupted immediately so a naturally
+      // closing stream cannot inject teammate follow-up while the durable stop
+      // boundary is being written.
+      this.wasInterrupted = true;
+    }
+
+    await this.persistExplicitUserStopBoundary();
+
+    if (!leadQuery) {
       console.log('[CLAUDE-CODE] interruptCurrentTurn: no active lead query, falling back to abort');
-      const outcome = await super.interruptCurrentTurn();
-      return { ...outcome, hadActiveTurn: false };
+      this.abortProviderRuntime();
+      return { method: 'abort', hadActiveTurn: false };
     }
 
     console.log('[CLAUDE-CODE] interruptCurrentTurn: interrupting active lead query');
-    this.wasInterrupted = true;
 
-    // Resolve the interrupt promise so the Promise.race in the streaming loop
-    // settles immediately without waiting for the SDK subprocess.
     if (this.interruptResolve) {
       this.interruptResolve();
       this.interruptResolve = null;
     }
 
     try {
-      await this.leadQuery.interrupt();
+      await leadQuery.interrupt();
     } catch (err) {
       console.warn('[CLAUDE-CODE] interruptCurrentTurn: interrupt() failed (transport may be closed):', err);
     }
 
-    return { method: 'interrupt' };
+    return { method: 'interrupt', hadActiveTurn: true };
   }
 
   /**
@@ -2917,6 +2946,10 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
     recoveryTurnId: string,
     launch?: { runInBackground?: boolean; name?: string },
   ): Promise<void> {
+    // Once explicit stop intent is observed, do not let a late SDK chunk create
+    // fresh recoverable evidence behind the durable cancellation boundary.
+    if (this.explicitUserStopRequested) return;
+
     if (subtype === 'task_started') {
       this.activeTasks.set(chunk.task_id, {
         taskId: chunk.task_id,

--- a/packages/runtime/src/ai/server/providers/TeammateManager.ts
+++ b/packages/runtime/src/ai/server/providers/TeammateManager.ts
@@ -1192,7 +1192,6 @@ export class TeammateManager {
 
       await AISessionsRepository.updateMetadata(sessionId, {
         metadata: {
-          ...currentMetadata,
           currentTeammates: updatedTeammates,
         }
       });

--- a/packages/runtime/src/ai/server/providers/claudeCode/__tests__/ClaudeCodeProvider.interruptRecovery.test.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/__tests__/ClaudeCodeProvider.interruptRecovery.test.ts
@@ -25,6 +25,7 @@ type MutableSession = RecoverySessionSnapshot & {
 type ProviderInternals = {
   backgroundAgentRecovery: BackgroundAgentRecoveryCoordinator;
   recoverySessionId?: string;
+  beginRecoveryTurn: () => string;
   activeTasks: Map<
     string,
     {
@@ -196,6 +197,7 @@ describe("ClaudeCodeProvider explicit-interrupt recovery boundary", () => {
     );
     const interrupt = vi.fn(async () => undefined);
     const resolveInterrupt = vi.fn();
+    const stoppedTurn = internals.beginRecoveryTurn();
     internals.leadQuery = { interrupt };
     internals.interruptResolve = resolveInterrupt;
     harness.blockNextWrite();
@@ -217,7 +219,7 @@ describe("ClaudeCodeProvider explicit-interrupt recovery boundary", () => {
         },
         SESSION_ID,
         WORKSPACE_PATH,
-        "provider-owner:turn-1",
+        stoppedTurn,
         { runInBackground: true }
       );
     } finally {
@@ -297,6 +299,175 @@ describe("ClaudeCodeProvider explicit-interrupt recovery boundary", () => {
         recoveryDisposition: "user-cancelled",
       }),
     ]);
+    provider.destroy();
+  });
+
+  it("keeps stopped turn A gated after turn B begins while accepting B task events", async () => {
+    const harness = createHarness("turn-safe-session");
+    const owner = harness.coordinator("turn-safe-owner");
+    await recordRunningAgent(owner, "turn-safe-session");
+    const { provider, internals } = wireProvider(
+      owner,
+      "turn-safe-session",
+      harness.sessions
+    );
+    const turnA = internals.beginRecoveryTurn();
+    internals.leadQuery = { interrupt: vi.fn(async () => undefined) };
+
+    await expect(provider.interruptCurrentTurn()).resolves.toEqual({
+      method: "interrupt",
+    });
+
+    const turnB = internals.beginRecoveryTurn();
+    await internals.handleSystemTask(
+      "task_started",
+      {
+        task_id: "late-task-from-turn-a",
+        tool_use_id: "late-agent-from-turn-a",
+        task_type: "local_agent",
+        description: "Late stopped-turn event",
+      },
+      "turn-safe-session",
+      WORKSPACE_PATH,
+      turnA,
+      { runInBackground: true }
+    );
+    await internals.handleSystemTask(
+      "task_started",
+      {
+        task_id: "legitimate-task-from-turn-b",
+        tool_use_id: "legitimate-agent-from-turn-b",
+        task_type: "local_agent",
+        description: "Legitimate next-turn event",
+      },
+      "turn-safe-session",
+      WORKSPACE_PATH,
+      turnB,
+      { runInBackground: true }
+    );
+
+    expect(internals.activeTasks.has("late-task-from-turn-a")).toBe(false);
+    expect(
+      internals.activeTasks.get("legitimate-task-from-turn-b")
+    ).toMatchObject({
+      status: "running",
+      sourceTurnId: turnB,
+    });
+    const records = Object.values(
+      getBackgroundAgentRecoveryLedger(
+        harness.sessions.get("turn-safe-session")!.metadata
+      ).tasks
+    );
+    expect(
+      records.some((record) => record.taskId === "late-task-from-turn-a")
+    ).toBe(false);
+    expect(
+      records.find((record) => record.taskId === "legitimate-task-from-turn-b")
+    ).toMatchObject({
+      recoveryState: "pending",
+      sourceTurnId: turnB,
+    });
+    provider.destroy();
+  });
+
+  it("still releases the graceful runtime and gates late chunks when durable suppression fails", async () => {
+    const harness = createHarness("graceful-failure-session");
+    const owner = harness.coordinator("graceful-failure-owner");
+    await recordRunningAgent(owner, "graceful-failure-session");
+    const { provider, internals } = wireProvider(
+      owner,
+      "graceful-failure-session",
+      harness.sessions
+    );
+    const stoppedTurn = internals.beginRecoveryTurn();
+    const interrupt = vi.fn(async () => undefined);
+    const resolveInterrupt = vi.fn();
+    internals.leadQuery = { interrupt };
+    internals.interruptResolve = resolveInterrupt;
+    vi.spyOn(owner, "suppressRunning").mockRejectedValueOnce(
+      new Error("durable suppression failed")
+    );
+
+    await expect(provider.interruptCurrentTurn()).rejects.toThrow(
+      "durable suppression failed"
+    );
+
+    expect(resolveInterrupt).toHaveBeenCalledOnce();
+    expect(interrupt).toHaveBeenCalledOnce();
+    await internals.handleSystemTask(
+      "task_started",
+      {
+        task_id: "late-task-after-graceful-failure",
+        tool_use_id: "late-agent-after-graceful-failure",
+        task_type: "local_agent",
+        description: "Must remain gated in memory",
+      },
+      "graceful-failure-session",
+      WORKSPACE_PATH,
+      stoppedTurn,
+      { runInBackground: true }
+    );
+    expect(internals.activeTasks.has("late-task-after-graceful-failure")).toBe(
+      false
+    );
+    expect(
+      Object.values(
+        getBackgroundAgentRecoveryLedger(
+          harness.sessions.get("graceful-failure-session")!.metadata
+        ).tasks
+      )[0]
+    ).toMatchObject({
+      recoveryState: "pending",
+    });
+    provider.destroy();
+  });
+
+  it("still aborts the no-lead runtime and gates late chunks when durable suppression fails", async () => {
+    const harness = createHarness("abort-failure-session");
+    const owner = harness.coordinator("abort-failure-owner");
+    await recordRunningAgent(owner, "abort-failure-session");
+    const { provider, internals } = wireProvider(
+      owner,
+      "abort-failure-session",
+      harness.sessions
+    );
+    const stoppedTurn = internals.beginRecoveryTurn();
+    const abortController = new AbortController();
+    internals.abortController = abortController;
+    vi.spyOn(owner, "suppressRunning").mockRejectedValueOnce(
+      new Error("durable suppression failed")
+    );
+
+    await expect(provider.interruptCurrentTurn()).rejects.toThrow(
+      "durable suppression failed"
+    );
+
+    expect(abortController.signal.aborted).toBe(true);
+    await internals.handleSystemTask(
+      "task_started",
+      {
+        task_id: "late-task-after-abort-failure",
+        tool_use_id: "late-agent-after-abort-failure",
+        task_type: "local_agent",
+        description: "Must remain gated in memory",
+      },
+      "abort-failure-session",
+      WORKSPACE_PATH,
+      stoppedTurn,
+      { runInBackground: true }
+    );
+    expect(internals.activeTasks.has("late-task-after-abort-failure")).toBe(
+      false
+    );
+    expect(
+      Object.values(
+        getBackgroundAgentRecoveryLedger(
+          harness.sessions.get("abort-failure-session")!.metadata
+        ).tasks
+      )[0]
+    ).toMatchObject({
+      recoveryState: "pending",
+    });
     provider.destroy();
   });
 

--- a/packages/runtime/src/ai/server/providers/claudeCode/__tests__/ClaudeCodeProvider.interruptRecovery.test.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/__tests__/ClaudeCodeProvider.interruptRecovery.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../../../../electron/src/main/HistoryManager", () => ({
+  historyManager: {},
+}));
+
+import { ClaudeCodeProvider } from "../../ClaudeCodeProvider";
+import {
+  BackgroundAgentRecoveryCoordinator,
+  encodeClaudeWorkspaceDir,
+  getBackgroundAgentRecoveryLedger,
+  type RecoverySessionSnapshot,
+} from "../backgroundTaskRecovery";
+
+const SESSION_ID = "interrupt-recovery-session";
+const PROVIDER_SESSION_ID = "interrupt-provider-session";
+const WORKSPACE_PATH = "D:\\fixtures\\interrupt-recovery";
+const TASK_ID = "task-agent-interrupt";
+const AGENT_ID = "toolu_agent_interrupt";
+
+type MutableSession = RecoverySessionSnapshot & {
+  metadata: Record<string, unknown>;
+};
+
+type ProviderInternals = {
+  backgroundAgentRecovery: BackgroundAgentRecoveryCoordinator;
+  recoverySessionId?: string;
+  activeTasks: Map<
+    string,
+    {
+      taskId: string;
+      description: string;
+      taskType?: string;
+      status: "running" | "completed" | "failed" | "stopped";
+      startedAt: number;
+      toolUseId?: string;
+      toolCount: number;
+      tokenCount: number;
+      durationMs: number;
+      isBackgrounded?: boolean;
+    }
+  >;
+  leadQuery: { interrupt: ReturnType<typeof vi.fn> } | null;
+  interruptResolve: (() => void) | null;
+  abortController: AbortController | null;
+  emitTaskUpdate: (sessionId: string | undefined) => Promise<void>;
+  handleSystemTask: (
+    subtype: string,
+    chunk: Record<string, unknown>,
+    sessionId: string | undefined,
+    workspacePath: string,
+    recoveryTurnId: string,
+    launch?: { runInBackground?: boolean; name?: string }
+  ) => Promise<void>;
+};
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function createHarness(sessionId = SESSION_ID) {
+  let clock = 1_000;
+  let blockNextMerge = false;
+  let mergeStarted = false;
+  let releaseMerge: (() => void) | undefined;
+  const sessions = new Map<string, MutableSession>([
+    [
+      sessionId,
+      {
+        id: sessionId,
+        provider: "claude-code",
+        providerSessionId: PROVIDER_SESSION_ID,
+        workspacePath: WORKSPACE_PATH,
+        metadata: {},
+      },
+    ],
+  ]);
+
+  const coordinator = (instanceId: string) =>
+    new BackgroundAgentRecoveryCoordinator({
+      instanceId,
+      now: () => ++clock,
+      getSession: async (id) => {
+        const session = sessions.get(id);
+        return session ? clone(session) : null;
+      },
+      mergeSessionMetadata: async (id, patch) => {
+        if (blockNextMerge) {
+          blockNextMerge = false;
+          mergeStarted = true;
+          await new Promise<void>((resolve) => {
+            releaseMerge = resolve;
+          });
+        }
+        const session = sessions.get(id);
+        if (session) {
+          session.metadata = { ...session.metadata, ...clone(patch) };
+        }
+      },
+      inspectTranscript: async (input) => ({
+        ok: true,
+        transcript: {
+          relativePath: `${encodeClaudeWorkspaceDir(
+            WORKSPACE_PATH
+          )}/${PROVIDER_SESSION_ID}/subagents/agent-${input.agentId}.jsonl`,
+          parentRelativePath: `${encodeClaudeWorkspaceDir(
+            WORKSPACE_PATH
+          )}/${PROVIDER_SESSION_ID}.jsonl`,
+          sizeBytes: 128,
+          mtimeMs: 256,
+          fingerprint: "128:256:last-entry",
+        },
+      }),
+    });
+
+  return {
+    sessions,
+    coordinator,
+    blockNextWrite() {
+      blockNextMerge = true;
+    },
+    hasBlockedWrite() {
+      return mergeStarted;
+    },
+    releaseBlockedWrite() {
+      releaseMerge?.();
+    },
+  };
+}
+
+async function recordRunningAgent(
+  coordinator: BackgroundAgentRecoveryCoordinator,
+  sessionId = SESSION_ID
+): Promise<void> {
+  await coordinator.observeTaskEvent({
+    sessionId,
+    workspacePath: WORKSPACE_PATH,
+    providerSessionId: PROVIDER_SESSION_ID,
+    turnId: "provider-owner:turn-1",
+    launch: { runInBackground: true, name: "interrupt-fixture" },
+    event: {
+      subtype: "task_started",
+      task_id: TASK_ID,
+      tool_use_id: AGENT_ID,
+      task_type: "local_agent",
+      description: "Keep working until explicitly stopped",
+    },
+  });
+}
+
+function wireProvider(
+  coordinator: BackgroundAgentRecoveryCoordinator,
+  sessionId = SESSION_ID,
+  sessions?: Map<string, MutableSession>
+): { provider: ClaudeCodeProvider; internals: ProviderInternals } {
+  const provider = new ClaudeCodeProvider();
+  const internals = provider as unknown as ProviderInternals;
+  internals.backgroundAgentRecovery = coordinator;
+  internals.recoverySessionId = sessionId;
+  provider.setProviderSessionData(sessionId, {
+    providerSessionId: PROVIDER_SESSION_ID,
+  });
+  internals.emitTaskUpdate = vi.fn(async () => {
+    const session = sessions?.get(sessionId);
+    if (session) {
+      session.metadata = {
+        ...session.metadata,
+        currentTasks: clone(Array.from(internals.activeTasks.values())),
+      };
+    }
+  });
+  internals.activeTasks.set(TASK_ID, {
+    taskId: TASK_ID,
+    description: "Keep working until explicitly stopped",
+    taskType: "local_agent",
+    status: "running",
+    startedAt: 1_000,
+    toolUseId: AGENT_ID,
+    toolCount: 0,
+    tokenCount: 0,
+    durationMs: 0,
+    isBackgrounded: true,
+  });
+  return { provider, internals };
+}
+
+describe("ClaudeCodeProvider explicit-interrupt recovery boundary", () => {
+  it("awaits durable cancellation before a graceful interrupt and prevents later recovery", async () => {
+    const harness = createHarness();
+    const owner = harness.coordinator("provider-owner");
+    await recordRunningAgent(owner);
+    const { provider, internals } = wireProvider(
+      owner,
+      SESSION_ID,
+      harness.sessions
+    );
+    const interrupt = vi.fn(async () => undefined);
+    const resolveInterrupt = vi.fn();
+    internals.leadQuery = { interrupt };
+    internals.interruptResolve = resolveInterrupt;
+    harness.blockNextWrite();
+
+    const resultPromise = provider.interruptCurrentTurn();
+    let lateTaskEvent: Promise<void> | undefined;
+    try {
+      await vi.waitFor(() => expect(harness.hasBlockedWrite()).toBe(true));
+      expect(resolveInterrupt).not.toHaveBeenCalled();
+      expect(internals.interruptResolve).toBe(resolveInterrupt);
+      expect(interrupt).not.toHaveBeenCalled();
+      lateTaskEvent = internals.handleSystemTask(
+        "task_started",
+        {
+          task_id: "late-task-after-stop",
+          tool_use_id: "late-agent-after-stop",
+          task_type: "local_agent",
+          description: "Must not become recoverable after explicit stop",
+        },
+        SESSION_ID,
+        WORKSPACE_PATH,
+        "provider-owner:turn-1",
+        { runInBackground: true }
+      );
+    } finally {
+      harness.releaseBlockedWrite();
+    }
+
+    await lateTaskEvent;
+    await expect(resultPromise).resolves.toEqual({ method: "interrupt" });
+    expect(resolveInterrupt).toHaveBeenCalledOnce();
+    expect(internals.interruptResolve).toBeNull();
+    expect(interrupt).toHaveBeenCalledOnce();
+    expect(internals.activeTasks.get(TASK_ID)?.status).toBe("stopped");
+
+    const session = harness.sessions.get(SESSION_ID)!;
+    const record = Object.values(
+      getBackgroundAgentRecoveryLedger(session.metadata).tasks
+    )[0];
+    expect(record).toMatchObject({
+      taskId: TASK_ID,
+      recoveryState: "cancelled",
+      lastReason: "user-cancelled",
+    });
+    expect(session.metadata.currentTasks).toEqual([
+      expect.objectContaining({
+        taskId: TASK_ID,
+        status: "stopped",
+        recoveryDisposition: "user-cancelled",
+      }),
+    ]);
+
+    const laterProcess = await harness
+      .coordinator("provider-resume")
+      .claimResumeDispatches({
+        sessionId: SESSION_ID,
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        turnId: "provider-resume:turn-1",
+        isResume: true,
+      });
+    expect(laterProcess.dispatches).toEqual([]);
+    provider.destroy();
+  });
+
+  it("awaits the same durable boundary before the no-lead abort fallback", async () => {
+    const harness = createHarness("no-lead-session");
+    const owner = harness.coordinator("no-lead-owner");
+    await recordRunningAgent(owner, "no-lead-session");
+    const { provider, internals } = wireProvider(
+      owner,
+      "no-lead-session",
+      harness.sessions
+    );
+    const abortController = new AbortController();
+    internals.abortController = abortController;
+    harness.blockNextWrite();
+
+    const resultPromise = provider.interruptCurrentTurn();
+    try {
+      await vi.waitFor(() => expect(harness.hasBlockedWrite()).toBe(true));
+      expect(abortController.signal.aborted).toBe(false);
+    } finally {
+      harness.releaseBlockedWrite();
+    }
+
+    await expect(resultPromise).resolves.toEqual({ method: "abort" });
+    expect(abortController.signal.aborted).toBe(true);
+    const session = harness.sessions.get("no-lead-session")!;
+    expect(
+      Object.values(getBackgroundAgentRecoveryLedger(session.metadata).tasks)[0]
+    ).toMatchObject({
+      recoveryState: "cancelled",
+      lastReason: "user-cancelled",
+    });
+    expect(session.metadata.currentTasks).toEqual([
+      expect.objectContaining({
+        status: "stopped",
+        recoveryDisposition: "user-cancelled",
+      }),
+    ]);
+    provider.destroy();
+  });
+
+  it("retains eventual durable cancellation for direct synchronous abort callers", async () => {
+    const harness = createHarness("direct-abort-session");
+    const owner = harness.coordinator("direct-abort-owner");
+    await recordRunningAgent(owner, "direct-abort-session");
+    const { provider, internals } = wireProvider(
+      owner,
+      "direct-abort-session",
+      harness.sessions
+    );
+    const abortController = new AbortController();
+    internals.abortController = abortController;
+
+    provider.abort();
+
+    expect(abortController.signal.aborted).toBe(true);
+    await vi.waitFor(() => {
+      const session = harness.sessions.get("direct-abort-session")!;
+      expect(
+        Object.values(
+          getBackgroundAgentRecoveryLedger(session.metadata).tasks
+        )[0]
+      ).toMatchObject({
+        recoveryState: "cancelled",
+        lastReason: "user-cancelled",
+      });
+      expect(session.metadata.currentTasks).toEqual([
+        expect.objectContaining({
+          status: "stopped",
+          recoveryDisposition: "user-cancelled",
+        }),
+      ]);
+    });
+    provider.destroy();
+  });
+
+  it("preserves recovery across destroy and teammate-message interruption", async () => {
+    const recycleHarness = createHarness("recycle-session");
+    const recycleOwner = recycleHarness.coordinator("recycle-owner");
+    await recordRunningAgent(recycleOwner, "recycle-session");
+    const recycleProvider = wireProvider(
+      recycleOwner,
+      "recycle-session",
+      recycleHarness.sessions
+    ).provider;
+    const recycleSuppress = vi.spyOn(recycleOwner, "suppressRunning");
+
+    recycleProvider.destroy();
+
+    expect(recycleSuppress).not.toHaveBeenCalled();
+    const recycled = await recycleHarness
+      .coordinator("recycle-resume")
+      .claimResumeDispatches({
+        sessionId: "recycle-session",
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        turnId: "recycle-resume:turn-1",
+        isResume: true,
+      });
+    expect(recycled.dispatches).toHaveLength(1);
+
+    const messageHarness = createHarness("message-session");
+    const messageOwner = messageHarness.coordinator("message-owner");
+    await recordRunningAgent(messageOwner, "message-session");
+    const { provider: messageProvider, internals: messageInternals } =
+      wireProvider(messageOwner, "message-session", messageHarness.sessions);
+    const messageSuppress = vi.spyOn(messageOwner, "suppressRunning");
+    const interrupt = vi.fn(async () => undefined);
+    messageInternals.leadQuery = { interrupt };
+
+    await messageProvider.interruptWithMessage("Teammate result is ready");
+
+    expect(interrupt).toHaveBeenCalledOnce();
+    expect(messageSuppress).not.toHaveBeenCalled();
+    const afterMessage = await messageHarness
+      .coordinator("message-resume")
+      .claimResumeDispatches({
+        sessionId: "message-session",
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        turnId: "message-resume:turn-1",
+        isResume: true,
+      });
+    expect(afterMessage.dispatches).toHaveLength(1);
+    messageProvider.destroy();
+  });
+});

--- a/packages/runtime/src/ai/server/providers/claudeCode/__tests__/backgroundTaskRecovery.test.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/__tests__/backgroundTaskRecovery.test.ts
@@ -1,0 +1,884 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  BackgroundAgentRecoveryCoordinator,
+  buildBackgroundAgentRecoveryInstruction,
+  encodeClaudeWorkspaceDir,
+  getBackgroundAgentRecoveryLedger,
+  inspectClaudeBackgroundAgentTranscript,
+  type RecoverySessionSnapshot,
+} from '../backgroundTaskRecovery';
+
+const SESSION_ID = 'nimbalyst-session-1';
+const PROVIDER_SESSION_ID = 'provider-session-1';
+const WORKSPACE_PATH = 'D:\\fixtures\\recovery-workspace';
+const TASK_ID = 'task-agent-1';
+const AGENT_ID = 'toolu_agent_1';
+
+type MutableSession = RecoverySessionSnapshot & {
+  metadata: Record<string, unknown>;
+};
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+describe('BackgroundAgentRecoveryCoordinator', () => {
+  let projectsDir: string;
+  let clock: number;
+  let sessions: Map<string, MutableSession>;
+
+  beforeEach(async () => {
+    projectsDir = await mkdtemp(path.join(tmpdir(), 'nim-253-recovery-'));
+    clock = 1_000;
+    sessions = new Map([
+      [
+        SESSION_ID,
+        {
+          id: SESSION_ID,
+          provider: 'claude-code',
+          providerSessionId: PROVIDER_SESSION_ID,
+          workspacePath: WORKSPACE_PATH,
+          metadata: { unrelatedLifecycleMetadata: { keep: true } },
+        },
+      ],
+    ]);
+  });
+
+  afterEach(async () => {
+    await rm(projectsDir, { recursive: true, force: true });
+  });
+
+  function coordinator(instanceId: string): BackgroundAgentRecoveryCoordinator {
+    return new BackgroundAgentRecoveryCoordinator({
+      instanceId,
+      now: () => ++clock,
+      getSession: async (sessionId) => {
+        const session = sessions.get(sessionId);
+        return session ? clone(session) : null;
+      },
+      mergeSessionMetadata: async (sessionId, patch) => {
+        const session = sessions.get(sessionId);
+        if (!session) return;
+        session.metadata = { ...session.metadata, ...clone(patch) };
+      },
+      inspectTranscript: (input) =>
+        inspectClaudeBackgroundAgentTranscript({
+          ...input,
+          projectsDir,
+        }),
+    });
+  }
+
+  async function writeTranscriptFixture(
+    options: {
+      providerSessionId?: string;
+      agentId?: string;
+      parentEntrySessionId?: string;
+      sidecarEntrySessionId?: string;
+      sidecarEntryAgentId?: string;
+      terminalStatus?: 'completed' | 'failed' | 'stopped';
+    } = {}
+  ): Promise<void> {
+    const providerSessionId = options.providerSessionId ?? PROVIDER_SESSION_ID;
+    const agentId = options.agentId ?? AGENT_ID;
+    const projectDir = path.join(
+      projectsDir,
+      encodeClaudeWorkspaceDir(WORKSPACE_PATH)
+    );
+    const subagentsDir = path.join(projectDir, providerSessionId, 'subagents');
+    await mkdir(subagentsDir, { recursive: true });
+
+    await writeFile(
+      path.join(projectDir, `${providerSessionId}.jsonl`),
+      `${JSON.stringify({
+        type: 'user',
+        uuid: 'parent-user-1',
+        sessionId: options.parentEntrySessionId ?? providerSessionId,
+        cwd: WORKSPACE_PATH,
+        message: { role: 'user', content: 'parent prompt' },
+      })}\n`,
+      'utf8'
+    );
+
+    const sidecarEntries: Record<string, unknown>[] = [
+      {
+        type: 'user',
+        uuid: 'agent-user-1',
+        sessionId: options.sidecarEntrySessionId ?? providerSessionId,
+        agentId: options.sidecarEntryAgentId ?? agentId,
+        isSidechain: true,
+        message: { role: 'user', content: 'original delegated task' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'agent-assistant-1',
+        sessionId: options.sidecarEntrySessionId ?? providerSessionId,
+        agentId: options.sidecarEntryAgentId ?? agentId,
+        isSidechain: true,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'still working' }],
+        },
+      },
+    ];
+    if (options.terminalStatus) {
+      sidecarEntries.push({
+        type: 'system',
+        subtype: 'task_notification',
+        sessionId: providerSessionId,
+        agentId,
+        status: options.terminalStatus,
+      });
+    }
+
+    await writeFile(
+      path.join(subagentsDir, `agent-${agentId}.jsonl`),
+      `${sidecarEntries.map((entry) => JSON.stringify(entry)).join('\n')}\n`,
+      'utf8'
+    );
+  }
+
+  async function recordRunningBackgroundAgent(
+    owner: BackgroundAgentRecoveryCoordinator,
+    turnId = 'provider-a:turn-1',
+    sessionId = SESSION_ID
+  ): Promise<void> {
+    await owner.observeTaskEvent({
+      sessionId,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId,
+      launch: { runInBackground: true, name: 'researcher' },
+      event: {
+        subtype: 'task_started',
+        task_id: TASK_ID,
+        tool_use_id: AGENT_ID,
+        task_type: 'local_agent',
+        description: 'Inspect the original source',
+      },
+    });
+    await owner.observeTaskEvent({
+      sessionId,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId,
+      event: {
+        subtype: 'task_updated',
+        task_id: TASK_ID,
+        patch: { is_backgrounded: true, status: 'running' },
+      },
+    });
+  }
+
+  it('recovers instance A through one native SendMessage dispatch on instance B', async () => {
+    await writeTranscriptFixture();
+    const instanceA = coordinator('provider-a');
+    await recordRunningBackgroundAgent(instanceA);
+
+    const instanceB = coordinator('provider-b');
+    const recovery = await instanceB.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+
+    expect(recovery.dispatches).toHaveLength(1);
+    expect(recovery.dispatches[0]).toMatchObject({
+      taskId: TASK_ID,
+      agentId: AGENT_ID,
+      providerSessionId: PROVIDER_SESSION_ID,
+      recipient: AGENT_ID,
+      priorState: 'running',
+    });
+    expect(recovery.dispatches[0].transcript.relativePath).toBe(
+      `${encodeClaudeWorkspaceDir(
+        WORKSPACE_PATH
+      )}/${PROVIDER_SESSION_ID}/subagents/agent-${AGENT_ID}.jsonl`
+    );
+
+    const preTool = await instanceB.guardNativeSendMessage({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'send-recovery-1',
+      input: { to: AGENT_ID, summary: 'Continue original source inspection' },
+    });
+    expect(preTool).toEqual(
+      expect.objectContaining({ matched: true, allow: true })
+    );
+
+    await instanceB.observeNativeSendMessageResult({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'send-recovery-1',
+      isError: false,
+      content: 'Message delivered',
+    });
+
+    const session = sessions.get(SESSION_ID)!;
+    const ledger = getBackgroundAgentRecoveryLedger(session.metadata);
+    expect(Object.values(ledger.tasks)).toEqual([
+      expect.objectContaining({
+        taskId: TASK_ID,
+        agentId: AGENT_ID,
+        recoveryState: 'dispatched',
+        dispatchToolUseId: 'send-recovery-1',
+      }),
+    ]);
+    expect(session.metadata.unrelatedLifecycleMetadata).toEqual({ keep: true });
+
+    const sameTurnDuplicate = await instanceB.guardNativeSendMessage({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'duplicate-after-success',
+      input: { to: AGENT_ID, summary: 'Do not send a duplicate' },
+    });
+    expect(sameTurnDuplicate).toEqual(
+      expect.objectContaining({ matched: true, allow: false })
+    );
+
+    const laterOrdinaryMessage = await instanceB.guardNativeSendMessage({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-2',
+      toolUseId: 'ordinary-after-auto',
+      input: { to: AGENT_ID, summary: 'A later ordinary message' },
+    });
+    expect(laterOrdinaryMessage).toEqual({ matched: false, allow: true });
+  });
+
+  it('targets the original task and transcript instead of reconstructing an agent from summary text', async () => {
+    await writeTranscriptFixture();
+    const instanceA = coordinator('provider-a');
+    await recordRunningBackgroundAgent(instanceA);
+
+    const recovery = await coordinator('provider-b').claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+    const instruction = buildBackgroundAgentRecoveryInstruction(
+      recovery.dispatches,
+      recovery.notices
+    );
+
+    expect(instruction).toContain('SendMessage');
+    expect(instruction).toContain(TASK_ID);
+    expect(instruction).toContain(AGENT_ID);
+    expect(instruction).toContain(`to: '${AGENT_ID}'`);
+    expect(instruction).toContain('surviving transcript');
+    expect(instruction).toContain('Do not launch a replacement Agent');
+    expect(instruction).not.toContain('still working');
+  });
+
+  it('rejects terminal and mismatched transcript provenance before claiming recovery', async () => {
+    await writeTranscriptFixture({ terminalStatus: 'completed' });
+    await expect(
+      inspectClaudeBackgroundAgentTranscript({
+        projectsDir,
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        agentId: AGENT_ID,
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        ok: false,
+        reason: 'terminal-subagent-transcript',
+        terminalStatus: 'completed',
+      })
+    );
+
+    await writeTranscriptFixture({ sidecarEntryAgentId: 'different-agent' });
+    await expect(
+      inspectClaudeBackgroundAgentTranscript({
+        projectsDir,
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        agentId: AGENT_ID,
+      })
+    ).resolves.toEqual({ ok: false, reason: 'mismatched-subagent-transcript' });
+
+    await writeTranscriptFixture({
+      parentEntrySessionId: 'different-provider-session',
+    });
+    await expect(
+      inspectClaudeBackgroundAgentTranscript({
+        projectsDir,
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        agentId: AGENT_ID,
+      })
+    ).resolves.toEqual({ ok: false, reason: 'mismatched-parent-transcript' });
+  });
+
+  it('revalidates transcript state immediately before the native dispatch', async () => {
+    await writeTranscriptFixture();
+    const instanceA = coordinator('provider-a');
+    await recordRunningBackgroundAgent(instanceA);
+    const instanceB = coordinator('provider-b');
+    await instanceB.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+
+    await writeTranscriptFixture({ terminalStatus: 'completed' });
+    await expect(
+      instanceB.guardNativeSendMessage({
+        sessionId: SESSION_ID,
+        turnId: 'provider-b:turn-1',
+        toolUseId: 'send-after-terminal',
+        input: { to: AGENT_ID, summary: 'Do not dispatch after completion' },
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        matched: true,
+        allow: false,
+        reason: 'terminal-subagent-transcript',
+      })
+    );
+
+    const record = Object.values(
+      getBackgroundAgentRecoveryLedger(sessions.get(SESSION_ID)!.metadata).tasks
+    )[0];
+    expect(record.recoveryState).toBe('completed');
+  });
+
+  it('deduplicates concurrent checks, repeated init events, replayed task events, and a third process', async () => {
+    await writeTranscriptFixture();
+    const instanceA = coordinator('provider-a');
+    await recordRunningBackgroundAgent(instanceA);
+
+    const instanceB = coordinator('provider-b');
+    const [first, concurrent, repeated] = await Promise.all([
+      instanceB.claimResumeDispatches({
+        sessionId: SESSION_ID,
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        turnId: 'provider-b:turn-1',
+        isResume: true,
+      }),
+      coordinator('provider-c').claimResumeDispatches({
+        sessionId: SESSION_ID,
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        turnId: 'provider-c:turn-1',
+        isResume: true,
+      }),
+      instanceB.claimResumeDispatches({
+        sessionId: SESSION_ID,
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        turnId: 'provider-b:turn-1',
+        isResume: true,
+      }),
+    ]);
+    expect(
+      first.dispatches.length +
+        concurrent.dispatches.length +
+        repeated.dispatches.length
+    ).toBe(1);
+
+    await instanceB.guardNativeSendMessage({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'send-recovery-1',
+      input: { to: AGENT_ID, summary: 'Continue original task' },
+    });
+    await instanceB.observeNativeSendMessageResult({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'send-recovery-1',
+      isError: false,
+      content: 'ok',
+    });
+
+    // Replay of the original SDK event does not create a new recovery generation.
+    await recordRunningBackgroundAgent(instanceA);
+    const instanceC = coordinator('provider-c');
+    const thirdProcess = await instanceC.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-c:turn-1',
+      isResume: true,
+    });
+    expect(thirdProcess.dispatches).toEqual([]);
+  });
+
+  it('reclaims a crashed dispatch only after its durable lease expires', async () => {
+    await writeTranscriptFixture();
+    const instanceA = coordinator('provider-a');
+    await recordRunningBackgroundAgent(instanceA);
+
+    const abandoned = await coordinator('provider-b').claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+    expect(abandoned.dispatches).toHaveLength(1);
+
+    const beforeLeaseExpiry = await coordinator(
+      'provider-c'
+    ).claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-c:turn-1',
+      isResume: true,
+    });
+    expect(beforeLeaseExpiry.dispatches).toEqual([]);
+
+    clock += 30_001;
+    const afterLeaseExpiry = await coordinator(
+      'provider-c'
+    ).claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-c:turn-2',
+      isResume: true,
+    });
+    expect(afterLeaseExpiry.dispatches).toHaveLength(1);
+    expect(afterLeaseExpiry.dispatches[0]?.generation).toBe(
+      abandoned.dispatches[0]?.generation
+    );
+  });
+
+  it('lets the first manual or automatic resume win without blocking later ordinary messages', async () => {
+    await writeTranscriptFixture();
+    const instanceA = coordinator('provider-a');
+    await recordRunningBackgroundAgent(instanceA);
+    const instanceB = coordinator('provider-b');
+    await instanceB.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+
+    const manualWinner = await coordinator('provider-c').guardNativeSendMessage(
+      {
+        sessionId: SESSION_ID,
+        turnId: 'provider-c:turn-1',
+        toolUseId: 'manual-send',
+        input: {
+          to: AGENT_ID,
+          summary: 'User requested original continuation',
+        },
+      }
+    );
+    const automaticLoser = await instanceB.guardNativeSendMessage({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'automatic-send',
+      input: { to: AGENT_ID, summary: 'Automatic recovery retry' },
+    });
+    expect(manualWinner).toEqual(
+      expect.objectContaining({ matched: true, allow: true })
+    );
+    expect(automaticLoser).toEqual(
+      expect.objectContaining({ matched: true, allow: false })
+    );
+
+    await coordinator('provider-c').observeNativeSendMessageResult({
+      sessionId: SESSION_ID,
+      turnId: 'provider-c:turn-1',
+      toolUseId: 'manual-send',
+      isError: false,
+      content: 'ok',
+    });
+
+    const laterOrdinaryMessage = await instanceB.guardNativeSendMessage({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-2',
+      toolUseId: 'ordinary-send',
+      input: { to: AGENT_ID, summary: 'A later ordinary message' },
+    });
+    expect(laterOrdinaryMessage).toEqual({ matched: false, allow: true });
+  });
+
+  it('never dispatches terminal, explicitly stopped, fresh, missing, mismatched, or malformed records', async () => {
+    await writeTranscriptFixture();
+
+    for (const status of ['completed', 'failed', 'stopped'] as const) {
+      const sessionId = `terminal-${status}`;
+      sessions.set(sessionId, {
+        ...clone(sessions.get(SESSION_ID)!),
+        id: sessionId,
+        metadata: {},
+      });
+      const owner = coordinator(`owner-${status}`);
+      await owner.observeTaskEvent({
+        sessionId,
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        turnId: `owner-${status}:turn-1`,
+        launch: { runInBackground: true },
+        event: {
+          subtype: 'task_started',
+          task_id: TASK_ID,
+          tool_use_id: AGENT_ID,
+          task_type: 'local_agent',
+          description: 'terminal fixture',
+        },
+      });
+      await owner.observeTaskEvent({
+        sessionId,
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        turnId: `owner-${status}:turn-1`,
+        event: { subtype: 'task_notification', task_id: TASK_ID, status },
+      });
+      const result = await coordinator(
+        `resume-${status}`
+      ).claimResumeDispatches({
+        sessionId,
+        workspacePath: WORKSPACE_PATH,
+        providerSessionId: PROVIDER_SESSION_ID,
+        turnId: `resume-${status}:turn-1`,
+        isResume: true,
+      });
+      expect(result.dispatches, status).toEqual([]);
+    }
+
+    const cancelledSession = 'explicitly-cancelled';
+    sessions.set(cancelledSession, {
+      ...clone(sessions.get(SESSION_ID)!),
+      id: cancelledSession,
+      metadata: {},
+    });
+    const cancelledOwner = coordinator('cancel-owner');
+    await cancelledOwner.observeTaskEvent({
+      sessionId: cancelledSession,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'cancel-owner:turn-1',
+      launch: { runInBackground: true },
+      event: {
+        subtype: 'task_started',
+        task_id: TASK_ID,
+        tool_use_id: AGENT_ID,
+        task_type: 'local_agent',
+        description: 'cancel fixture',
+      },
+    });
+    await cancelledOwner.suppressRunning(cancelledSession, 'user-cancelled');
+    expect(
+      (
+        await coordinator('cancel-resume').claimResumeDispatches({
+          sessionId: cancelledSession,
+          workspacePath: WORKSPACE_PATH,
+          providerSessionId: PROVIDER_SESSION_ID,
+          turnId: 'cancel-resume:turn-1',
+          isResume: true,
+        })
+      ).dispatches
+    ).toEqual([]);
+
+    const missingSession = 'missing-transcript';
+    sessions.set(missingSession, {
+      ...clone(sessions.get(SESSION_ID)!),
+      id: missingSession,
+      metadata: {},
+    });
+    const missingOwner = coordinator('missing-owner');
+    await missingOwner.observeTaskEvent({
+      sessionId: missingSession,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'missing-owner:turn-1',
+      launch: { runInBackground: true },
+      event: {
+        subtype: 'task_started',
+        task_id: 'missing-task',
+        tool_use_id: 'missing-agent',
+        task_type: 'local_agent',
+        description: 'missing fixture',
+      },
+    });
+    const missing = await coordinator('missing-resume').claimResumeDispatches({
+      sessionId: missingSession,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'missing-resume:turn-1',
+      isResume: true,
+    });
+    expect(missing.dispatches).toEqual([]);
+    expect(missing.notices[0]?.reason).toBe('missing-subagent-transcript');
+
+    await recordRunningBackgroundAgent(
+      coordinator('fresh-owner'),
+      'fresh-owner:turn-1'
+    );
+    const fresh = await coordinator('fresh').claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: undefined,
+      turnId: 'fresh:turn-1',
+      isResume: false,
+    });
+    expect(fresh.dispatches).toEqual([]);
+    expect(
+      Object.values(
+        getBackgroundAgentRecoveryLedger(sessions.get(SESSION_ID)!.metadata)
+          .tasks
+      )[0]
+    ).toEqual(
+      expect.objectContaining({
+        recoveryState: 'notify-only',
+        lastReason: 'non-resume-start',
+      })
+    );
+
+    const mismatchedSession = 'mismatched-provider-session';
+    sessions.set(mismatchedSession, {
+      ...clone(sessions.get(SESSION_ID)!),
+      id: mismatchedSession,
+      metadata: {},
+    });
+    await recordRunningBackgroundAgent(
+      coordinator('mismatched-owner'),
+      'mismatched-owner:turn-1',
+      mismatchedSession
+    );
+    const mismatched = await coordinator('mismatched').claimResumeDispatches({
+      sessionId: mismatchedSession,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: 'different-provider-session',
+      turnId: 'mismatched:turn-1',
+      isResume: true,
+    });
+    expect(mismatched.dispatches).toEqual([]);
+    expect(
+      Object.values(
+        getBackgroundAgentRecoveryLedger(
+          sessions.get(mismatchedSession)!.metadata
+        ).tasks
+      )[0]
+    ).toEqual(
+      expect.objectContaining({
+        recoveryState: 'notify-only',
+        lastReason: 'unverified-provider-session',
+      })
+    );
+
+    const malformedSession = sessions.get(SESSION_ID)!;
+    malformedSession.metadata = {
+      backgroundAgentRecovery: 'legacy-corrupt-value',
+      currentTasks: [{ taskId: 'legacy-task', status: 'running' }],
+    };
+    const malformed = await coordinator('malformed').claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'malformed:turn-1',
+      isResume: true,
+    });
+    expect(malformed.dispatches).toEqual([]);
+    expect(
+      (sessions.get(SESSION_ID)!.metadata.currentTasks as any[])[0].status
+    ).toBe('stopped');
+  });
+
+  it('keeps a rejected dispatch retryable once, then records notify-only without false running state', async () => {
+    await writeTranscriptFixture();
+    const instanceA = coordinator('provider-a');
+    await recordRunningBackgroundAgent(instanceA);
+
+    const instanceB = coordinator('provider-b');
+    const firstAttempt = await instanceB.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+    expect(firstAttempt.dispatches).toHaveLength(1);
+    await instanceB.guardNativeSendMessage({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'send-rejected',
+      input: { to: AGENT_ID, summary: 'Continue original task' },
+    });
+    await instanceB.observeNativeSendMessageResult({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'send-rejected',
+      isError: true,
+      content: 'native dispatch rejected',
+    });
+    await expect(
+      instanceB.guardNativeSendMessage({
+        sessionId: SESSION_ID,
+        turnId: 'provider-b:turn-1',
+        toolUseId: 'same-turn-retry',
+        input: { to: AGENT_ID, summary: 'Do not send this duplicate' },
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({ matched: true, allow: false })
+    );
+
+    const providerC = coordinator('provider-c');
+    const retry = await providerC.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-c:turn-1',
+      isResume: true,
+    });
+    expect(retry.dispatches).toHaveLength(1);
+    await expect(
+      providerC.guardNativeSendMessage({
+        sessionId: SESSION_ID,
+        turnId: 'provider-c:turn-1',
+        toolUseId: 'send-retry',
+        input: { to: AGENT_ID, summary: 'Retry original task continuation' },
+      })
+    ).resolves.toEqual(expect.objectContaining({ matched: true, allow: true }));
+    await providerC.finishRecoveryTurn({
+      sessionId: SESSION_ID,
+      turnId: 'provider-c:turn-1',
+      plannedGenerations: retry.dispatches.map(
+        (dispatch) => dispatch.generation
+      ),
+    });
+
+    const ledger = getBackgroundAgentRecoveryLedger(
+      sessions.get(SESSION_ID)!.metadata
+    );
+    expect(Object.values(ledger.tasks)[0]).toEqual(
+      expect.objectContaining({
+        recoveryState: 'notify-only',
+        lastReason: 'native-dispatch-not-observed',
+      })
+    );
+    expect(
+      (sessions.get(SESSION_ID)!.metadata.currentTasks as any[])[0].status
+    ).toBe('stopped');
+  });
+
+  it('does not let a late native result override explicit cancellation', async () => {
+    await writeTranscriptFixture();
+    const instanceA = coordinator('provider-a');
+    await recordRunningBackgroundAgent(instanceA);
+    const instanceB = coordinator('provider-b');
+    await instanceB.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+    await instanceB.guardNativeSendMessage({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'send-before-cancel',
+      input: { to: AGENT_ID, summary: 'Continue original task' },
+    });
+
+    await instanceB.suppressRunning(SESSION_ID, 'user-cancelled');
+    await instanceB.observeNativeSendMessageResult({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'send-before-cancel',
+      isError: false,
+      content: 'late success',
+    });
+    await instanceB.observeTaskEvent({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      launch: { runInBackground: true, name: 'researcher' },
+      event: {
+        subtype: 'task_started',
+        task_id: TASK_ID,
+        tool_use_id: AGENT_ID,
+        task_type: 'local_agent',
+        description: 'late cancelled replay',
+      },
+    });
+
+    const record = Object.values(
+      getBackgroundAgentRecoveryLedger(sessions.get(SESSION_ID)!.metadata).tasks
+    )[0];
+    expect(record).toEqual(
+      expect.objectContaining({
+        recoveryState: 'cancelled',
+        lastReason: 'user-cancelled',
+      })
+    );
+    expect(
+      (sessions.get(SESSION_ID)!.metadata.currentTasks as any[])[0].status
+    ).toBe('stopped');
+  });
+
+  it('creates a new generation only after a recovered agent actually starts again', async () => {
+    await writeTranscriptFixture();
+    const instanceA = coordinator('provider-a');
+    await recordRunningBackgroundAgent(instanceA);
+    const instanceB = coordinator('provider-b');
+    await instanceB.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+    await instanceB.guardNativeSendMessage({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'send-recovery-1',
+      input: { to: AGENT_ID, summary: 'Continue original task' },
+    });
+    await instanceB.observeNativeSendMessageResult({
+      sessionId: SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'send-recovery-1',
+      isError: false,
+      content: 'ok',
+    });
+
+    await instanceB.observeTaskEvent({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      launch: { runInBackground: true, name: 'researcher' },
+      event: {
+        subtype: 'task_started',
+        task_id: TASK_ID,
+        tool_use_id: AGENT_ID,
+        task_type: 'local_agent',
+        description: 'Inspect the original source',
+      },
+    });
+
+    const ledger = getBackgroundAgentRecoveryLedger(
+      sessions.get(SESSION_ID)!.metadata
+    );
+    const records = Object.values(ledger.tasks).sort(
+      (a, b) => a.generationNumber - b.generationNumber
+    );
+    expect(records).toHaveLength(2);
+    expect(records.map((record) => record.generationNumber)).toEqual([1, 2]);
+    expect(records[1]).toEqual(
+      expect.objectContaining({
+        sourceTurnId: 'provider-b:turn-1',
+        recoveryState: 'pending',
+        priorState: 'running',
+      })
+    );
+  });
+});

--- a/packages/runtime/src/ai/server/providers/claudeCode/__tests__/backgroundTaskRecovery.test.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/__tests__/backgroundTaskRecovery.test.ts
@@ -413,7 +413,7 @@ describe('BackgroundAgentRecoveryCoordinator', () => {
     expect(thirdProcess.dispatches).toEqual([]);
   });
 
-  it('reclaims a crashed dispatch only after its durable lease expires', async () => {
+  it('reclaims an expired claim that never reached the native send guard', async () => {
     await writeTranscriptFixture();
     const instanceA = coordinator('provider-a');
     await recordRunningBackgroundAgent(instanceA);
@@ -452,6 +452,97 @@ describe('BackgroundAgentRecoveryCoordinator', () => {
     expect(afterLeaseExpiry.dispatches[0]?.generation).toBe(
       abandoned.dispatches[0]?.generation
     );
+  });
+
+  it('never auto-dispatches a generation after the native send guard persisted an ambiguous dispatch', async () => {
+    await writeTranscriptFixture();
+    const instanceA = coordinator('provider-a');
+    await recordRunningBackgroundAgent(instanceA);
+
+    const instanceB = coordinator('provider-b');
+    const recovery = await instanceB.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+    expect(recovery.dispatches).toHaveLength(1);
+    await expect(
+      instanceB.guardNativeSendMessage({
+        sessionId: SESSION_ID,
+        turnId: 'provider-b:turn-1',
+        toolUseId: 'send-before-process-crash',
+        input: { to: AGENT_ID, summary: 'Continue the original task' },
+        plannedGenerations: recovery.dispatches.map(
+          (dispatch) => dispatch.generation
+        ),
+      })
+    ).resolves.toEqual(expect.objectContaining({ matched: true, allow: true }));
+
+    // The native send may have happened, but process B dies before it can
+    // persist the tool result or run turn finalization.
+    clock += 5 * 60_000 + 1;
+    const laterProcess = await coordinator(
+      'provider-c'
+    ).claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-c:turn-1',
+      isResume: true,
+    });
+
+    expect(laterProcess.dispatches).toEqual([]);
+    expect(laterProcess.notices).toEqual([
+      expect.objectContaining({
+        generation: recovery.dispatches[0]?.generation,
+        reason: 'ambiguous-dispatch',
+      }),
+    ]);
+    expect(
+      Object.values(
+        getBackgroundAgentRecoveryLedger(sessions.get(SESSION_ID)!.metadata)
+          .tasks
+      )[0]
+    ).toEqual(
+      expect.objectContaining({
+        recoveryState: 'notify-only',
+        lastReason: 'ambiguous-dispatch',
+        dispatchToolUseId: 'send-before-process-crash',
+      })
+    );
+  });
+
+  it('fails closed when a claimed recovery session is deleted before the native tool hook', async () => {
+    await writeTranscriptFixture();
+    await recordRunningBackgroundAgent(coordinator('provider-a'));
+    const instanceB = coordinator('provider-b');
+    const recovery = await instanceB.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+    expect(recovery.dispatches).toHaveLength(1);
+
+    sessions.delete(SESSION_ID);
+    await expect(
+      instanceB.guardNativeSendMessage({
+        sessionId: SESSION_ID,
+        turnId: 'provider-b:turn-1',
+        toolUseId: 'send-after-session-delete',
+        input: { to: AGENT_ID, summary: 'Must not leave deleted session' },
+        plannedGenerations: recovery.dispatches.map(
+          (dispatch) => dispatch.generation
+        ),
+      })
+    ).resolves.toEqual({
+      matched: true,
+      allow: false,
+      reason: 'background-agent-recovery-session-missing',
+    });
   });
 
   it('lets the first manual or automatic resume win without blocking later ordinary messages', async () => {
@@ -691,7 +782,7 @@ describe('BackgroundAgentRecoveryCoordinator', () => {
     ).toBe('stopped');
   });
 
-  it('keeps a rejected dispatch retryable once, then records notify-only without false running state', async () => {
+  it('keeps a rejected dispatch retryable once, then records an ambiguous dispatch without false running state', async () => {
     await writeTranscriptFixture();
     const instanceA = coordinator('provider-a');
     await recordRunningBackgroundAgent(instanceA);
@@ -760,7 +851,7 @@ describe('BackgroundAgentRecoveryCoordinator', () => {
     expect(Object.values(ledger.tasks)[0]).toEqual(
       expect.objectContaining({
         recoveryState: 'notify-only',
-        lastReason: 'native-dispatch-not-observed',
+        lastReason: 'ambiguous-dispatch',
       })
     );
     expect(
@@ -824,7 +915,54 @@ describe('BackgroundAgentRecoveryCoordinator', () => {
     ).toBe('stopped');
   });
 
-  it('creates a new generation only after a recovered agent actually starts again', async () => {
+  it('persists an explicit TaskStop for a ledger-known task after provider recycle', async () => {
+    await writeTranscriptFixture();
+    await recordRunningBackgroundAgent(coordinator('provider-a'));
+    const recycledProvider = coordinator('provider-b');
+    const recovery = await recycledProvider.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      isResume: true,
+    });
+    expect(recovery.dispatches).toHaveLength(1);
+
+    await expect(
+      recycledProvider.observeExplicitTaskStop({
+        sessionId: SESSION_ID,
+        taskId: TASK_ID,
+      })
+    ).resolves.toBe(true);
+
+    const session = sessions.get(SESSION_ID)!;
+    expect(
+      Object.values(getBackgroundAgentRecoveryLedger(session.metadata).tasks)[0]
+    ).toEqual(
+      expect.objectContaining({
+        recoveryState: 'stopped',
+        lastReason: 'native-task-stop-succeeded',
+      })
+    );
+    expect(session.metadata.currentTasks).toEqual([
+      expect.objectContaining({
+        taskId: TASK_ID,
+        status: 'stopped',
+        recoveryDisposition: 'native-task-stop-succeeded',
+      }),
+    ]);
+
+    const nextProcess = await coordinator('provider-c').claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-c:turn-1',
+      isResume: true,
+    });
+    expect(nextProcess.dispatches).toEqual([]);
+  });
+
+  it('dispatches each recovered-running generation once while same-generation replay stays at zero', async () => {
     await writeTranscriptFixture();
     const instanceA = coordinator('provider-a');
     await recordRunningBackgroundAgent(instanceA);
@@ -880,5 +1018,78 @@ describe('BackgroundAgentRecoveryCoordinator', () => {
         priorState: 'running',
       })
     );
+
+    // Replay of the recovered-running event is still generation 2, not a new
+    // candidate, and the next provider process dispatches that generation once.
+    await instanceB.observeTaskEvent({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-b:turn-1',
+      launch: { runInBackground: true, name: 'researcher' },
+      event: {
+        subtype: 'task_started',
+        task_id: TASK_ID,
+        tool_use_id: AGENT_ID,
+        task_type: 'local_agent',
+        description: 'Inspect the original source',
+      },
+    });
+    expect(
+      Object.values(
+        getBackgroundAgentRecoveryLedger(sessions.get(SESSION_ID)!.metadata)
+          .tasks
+      )
+    ).toHaveLength(2);
+
+    const instanceC = coordinator('provider-c');
+    const secondGeneration = await instanceC.claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-c:turn-1',
+      isResume: true,
+    });
+    expect(secondGeneration.dispatches).toHaveLength(1);
+    expect(secondGeneration.dispatches[0]?.generation).toBe(
+      records[1]?.generation
+    );
+    await expect(
+      instanceC.guardNativeSendMessage({
+        sessionId: SESSION_ID,
+        turnId: 'provider-c:turn-1',
+        toolUseId: 'send-recovery-2',
+        input: { to: AGENT_ID, summary: 'Continue recovered running work' },
+        plannedGenerations: secondGeneration.dispatches.map(
+          (dispatch) => dispatch.generation
+        ),
+      })
+    ).resolves.toEqual(expect.objectContaining({ matched: true, allow: true }));
+    await instanceC.observeNativeSendMessageResult({
+      sessionId: SESSION_ID,
+      turnId: 'provider-c:turn-1',
+      toolUseId: 'send-recovery-2',
+      isError: false,
+      content: 'ok',
+    });
+
+    const repeatedProcess = await coordinator(
+      'provider-d'
+    ).claimResumeDispatches({
+      sessionId: SESSION_ID,
+      workspacePath: WORKSPACE_PATH,
+      providerSessionId: PROVIDER_SESSION_ID,
+      turnId: 'provider-d:turn-1',
+      isResume: true,
+    });
+    expect(repeatedProcess.dispatches).toEqual([]);
+    expect(
+      Object.values(
+        getBackgroundAgentRecoveryLedger(sessions.get(SESSION_ID)!.metadata)
+          .tasks
+      )
+        .sort((a, b) => a.generationNumber - b.generationNumber)
+        .map((record) => record.recoveryState)
+    ).toEqual(['dispatched', 'dispatched']);
   });
 });

--- a/packages/runtime/src/ai/server/providers/claudeCode/__tests__/backgroundTaskRecoveryLifecycle.test.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/__tests__/backgroundTaskRecoveryLifecycle.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { BackgroundAgentRecoveryCoordinator } from '../backgroundTaskRecovery';
+import {
+  guardClaudeBackgroundAgentRecoveryTool,
+  observeClaudeBackgroundAgentRecoveryToolResult,
+  prepareClaudeBackgroundAgentRecoveryTurn
+} from '../backgroundTaskRecoveryLifecycle';
+
+describe('Claude background-agent recovery provider lifecycle', () => {
+  it('wires claim, system instruction, native guard, result, and recycled TaskStop persistence', async () => {
+    const generation = 'provider-session:toolu_agent:g1';
+    const coordinator = {
+      claimResumeDispatches: vi.fn(async () => ({
+        dispatches: [
+          {
+            generation,
+            taskId: 'task-agent-1',
+            agentId: 'toolu_agent',
+            providerSessionId: 'provider-session',
+            recipient: 'toolu_agent',
+            priorState: 'running' as const,
+            transcript: {
+              relativePath:
+                'workspace/provider-session/subagents/agent-toolu_agent.jsonl',
+              parentRelativePath: 'workspace/provider-session.jsonl',
+              sizeBytes: 100,
+              mtimeMs: 200,
+              fingerprint: '100:200:last-entry'
+            }
+          }
+        ],
+        notices: []
+      })),
+      guardNativeSendMessage: vi.fn(async () => ({
+        matched: true,
+        allow: true
+      })),
+      observeNativeSendMessageResult: vi.fn(async () => undefined),
+      observeExplicitTaskStop: vi.fn(async () => true)
+    } as unknown as BackgroundAgentRecoveryCoordinator;
+
+    const prepared = await prepareClaudeBackgroundAgentRecoveryTurn(
+      coordinator,
+      {
+        sessionId: 'session-1',
+        workspacePath: 'D:\\workspace',
+        providerSessionId: 'provider-session',
+        turnId: 'provider-b:turn-1',
+        isResume: true
+      }
+    );
+    expect(prepared.plannedGenerations).toEqual([generation]);
+    expect(prepared.systemInstruction).toContain(
+      "call native SendMessage exactly once with to: 'toolu_agent'"
+    );
+
+    const preTool = await guardClaudeBackgroundAgentRecoveryTool(coordinator, {
+      toolName: 'SendMessage',
+      sessionId: 'session-1',
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'native-send-1',
+      toolInput: { to: 'toolu_agent', summary: 'Continue original work' },
+      plannedGenerations: prepared.plannedGenerations
+    });
+    expect(preTool).toEqual({ handled: false });
+    expect(coordinator.guardNativeSendMessage).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'native-send-1',
+      input: { to: 'toolu_agent', summary: 'Continue original work' },
+      plannedGenerations: [generation]
+    });
+
+    await observeClaudeBackgroundAgentRecoveryToolResult(coordinator, {
+      sessionId: 'session-1',
+      turnId: 'provider-b:turn-1',
+      toolName: 'SendMessage',
+      toolUseId: 'native-send-1',
+      toolArguments: { to: 'toolu_agent' },
+      isError: false,
+      content: 'delivered'
+    });
+    expect(coordinator.observeNativeSendMessageResult).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      turnId: 'provider-b:turn-1',
+      toolUseId: 'native-send-1',
+      isError: false,
+      content: 'delivered'
+    });
+
+    const stopped = await observeClaudeBackgroundAgentRecoveryToolResult(
+      coordinator,
+      {
+        sessionId: 'session-1',
+        turnId: 'provider-b:turn-1',
+        toolName: 'TaskStop',
+        toolUseId: 'native-task-stop-1',
+        toolArguments: { task_id: 'task-agent-1' },
+        isError: false,
+        content: 'stopped'
+      }
+    );
+    expect(stopped).toEqual({ stoppedTaskId: 'task-agent-1' });
+    expect(coordinator.observeExplicitTaskStop).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      taskId: 'task-agent-1'
+    });
+  });
+
+  it('maps a missing-session recovery denial to the provider pre-tool hook boundary', async () => {
+    const coordinator = {
+      guardNativeSendMessage: vi.fn(async () => ({
+        matched: true,
+        allow: false,
+        reason: 'background-agent-recovery-session-missing'
+      }))
+    } as unknown as BackgroundAgentRecoveryCoordinator;
+
+    await expect(
+      guardClaudeBackgroundAgentRecoveryTool(coordinator, {
+        toolName: 'SendMessage',
+        sessionId: 'deleted-session',
+        turnId: 'provider-b:turn-1',
+        toolUseId: 'native-send-1',
+        toolInput: { to: 'toolu_agent' },
+        plannedGenerations: ['provider-session:toolu_agent:g1']
+      })
+    ).resolves.toEqual({
+      handled: true,
+      result: {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'background-agent-recovery-session-missing'
+        }
+      }
+    });
+  });
+});

--- a/packages/runtime/src/ai/server/providers/claudeCode/backgroundTaskRecovery.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/backgroundTaskRecovery.ts
@@ -1274,6 +1274,11 @@ export class BackgroundAgentRecoveryCoordinator {
   async suppressRunning(sessionId: string, reason: string): Promise<void> {
     await this.mutateSession(sessionId, (_session, ledger, currentTasks) => {
       const suppressedAt = this.now();
+      let stoppedTasks = stopRunningTasks(
+        currentTasks,
+        reason,
+        suppressedAt
+      );
       for (const record of Object.values(ledger.tasks)) {
         if (
           [
@@ -1289,11 +1294,16 @@ export class BackgroundAgentRecoveryCoordinator {
           record.updatedAt = suppressedAt;
           record.lastReason = reason;
           record.claimLeaseExpiresAt = undefined;
+          stoppedTasks = upsertCurrentTask(stoppedTasks, record.taskId, {
+            status: 'stopped',
+            recoveryDisposition: reason,
+            updatedAt: suppressedAt,
+          });
         }
       }
       return {
         result: undefined,
-        currentTasks: stopRunningTasks(currentTasks, reason, suppressedAt),
+        currentTasks: stoppedTasks,
       };
     });
   }

--- a/packages/runtime/src/ai/server/providers/claudeCode/backgroundTaskRecovery.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/backgroundTaskRecovery.ts
@@ -1,0 +1,1251 @@
+import { open, readFile, stat } from 'fs/promises';
+import path from 'path';
+
+const RECOVERY_LEDGER_VERSION = 1 as const;
+const MAX_RECOVERY_ATTEMPTS = 2;
+const RECOVERY_CLAIM_LEASE_MS = 30_000;
+const RECOVERY_DISPATCH_LEASE_MS = 5 * 60_000;
+const MAX_TRANSCRIPT_BYTES = 256 * 1024;
+const SAFE_TRANSCRIPT_ID = /^[A-Za-z0-9_-]+$/;
+
+export type BackgroundAgentRecoveryState =
+  | 'pending'
+  | 'claimed'
+  | 'dispatching'
+  | 'dispatched'
+  | 'retryable'
+  | 'notify-only'
+  | 'completed'
+  | 'failed'
+  | 'stopped'
+  | 'cancelled';
+
+export interface RecoverySessionSnapshot {
+  id: string;
+  provider?: string;
+  providerSessionId?: string;
+  workspacePath?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BackgroundAgentTranscriptEvidence {
+  relativePath: string;
+  parentRelativePath: string;
+  sizeBytes: number;
+  mtimeMs: number;
+  fingerprint: string;
+  lastEntryUuid?: string;
+}
+
+export interface BackgroundAgentRecoveryRecord {
+  generation: string;
+  generationNumber: number;
+  identity: string;
+  taskId: string;
+  agentId: string;
+  agentName?: string;
+  description?: string;
+  taskType: string;
+  ownerInstanceId: string;
+  providerSessionId: string;
+  workspacePath: string;
+  expectedTranscriptRelativePath: string;
+  expectedParentTranscriptRelativePath: string;
+  sourceTurnId: string;
+  priorState: 'running';
+  backgrounded: boolean;
+  recoveryState: BackgroundAgentRecoveryState;
+  attempts: number;
+  observedAt: number;
+  updatedAt: number;
+  terminalAt?: number;
+  claimedAt?: number;
+  claimedBy?: string;
+  claimedTurnId?: string;
+  claimLeaseExpiresAt?: number;
+  dispatchToolUseId?: string;
+  dispatchTurnId?: string;
+  dispatchedAt?: number;
+  transcript?: BackgroundAgentTranscriptEvidence;
+  lastReason?: string;
+}
+
+export interface BackgroundAgentRecoveryLedger {
+  version: typeof RECOVERY_LEDGER_VERSION;
+  tasks: Record<string, BackgroundAgentRecoveryRecord>;
+}
+
+export interface BackgroundAgentRecoveryDispatch {
+  generation: string;
+  taskId: string;
+  agentId: string;
+  agentName?: string;
+  description?: string;
+  providerSessionId: string;
+  recipient: string;
+  priorState: 'running';
+  transcript: BackgroundAgentTranscriptEvidence;
+}
+
+export interface BackgroundAgentRecoveryNotice {
+  generation: string;
+  taskId: string;
+  reason: string;
+}
+
+export interface TranscriptInspectionInput {
+  workspacePath: string;
+  providerSessionId: string;
+  agentId: string;
+}
+
+export type TranscriptInspectionResult =
+  | { ok: true; transcript: BackgroundAgentTranscriptEvidence }
+  | {
+      ok: false;
+      reason: string;
+      terminalStatus?: 'completed' | 'failed' | 'stopped' | 'cancelled';
+    };
+
+interface RecoveryCoordinatorDependencies {
+  instanceId: string;
+  now?: () => number;
+  getSession: (sessionId: string) => Promise<RecoverySessionSnapshot | null>;
+  mergeSessionMetadata: (
+    sessionId: string,
+    patch: Record<string, unknown>
+  ) => Promise<void>;
+  inspectTranscript?: (
+    input: TranscriptInspectionInput
+  ) => Promise<TranscriptInspectionResult>;
+}
+
+interface RecoveryTaskEventInput {
+  sessionId: string;
+  workspacePath: string;
+  providerSessionId: string;
+  turnId: string;
+  launch?: { runInBackground?: boolean; name?: string };
+  event:
+    | {
+        subtype: 'task_started';
+        task_id: string;
+        tool_use_id: string;
+        task_type?: string;
+        description?: string;
+      }
+    | {
+        subtype: 'task_updated';
+        task_id: string;
+        patch?: {
+          is_backgrounded?: boolean;
+          status?: string;
+          [key: string]: unknown;
+        };
+      }
+    | {
+        subtype: 'task_progress';
+        task_id: string;
+        description?: string;
+        [key: string]: unknown;
+      }
+    | {
+        subtype: 'task_notification';
+        task_id: string;
+        status?: string;
+        [key: string]: unknown;
+      };
+}
+
+interface CurrentTaskMetadata extends Record<string, unknown> {
+  taskId: string;
+  status: string;
+}
+
+const sessionMutationTails = new Map<string, Promise<void>>();
+
+async function withSessionMutationLock<T>(
+  sessionId: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = sessionMutationTails.get(sessionId) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = previous.catch(() => undefined).then(() => gate);
+  sessionMutationTails.set(sessionId, tail);
+
+  await previous.catch(() => undefined);
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (sessionMutationTails.get(sessionId) === tail) {
+      sessionMutationTails.delete(sessionId);
+    }
+  }
+}
+
+function emptyLedger(): BackgroundAgentRecoveryLedger {
+  return { version: RECOVERY_LEDGER_VERSION, tasks: {} };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isRecoveryRecord(
+  value: unknown
+): value is BackgroundAgentRecoveryRecord {
+  if (!isObject(value)) return false;
+  return (
+    typeof value.generation === 'string' &&
+    typeof value.generationNumber === 'number' &&
+    typeof value.identity === 'string' &&
+    typeof value.taskId === 'string' &&
+    typeof value.agentId === 'string' &&
+    typeof value.taskType === 'string' &&
+    typeof value.ownerInstanceId === 'string' &&
+    typeof value.providerSessionId === 'string' &&
+    typeof value.workspacePath === 'string' &&
+    typeof value.expectedTranscriptRelativePath === 'string' &&
+    typeof value.expectedParentTranscriptRelativePath === 'string' &&
+    typeof value.sourceTurnId === 'string' &&
+    value.priorState === 'running' &&
+    typeof value.backgrounded === 'boolean' &&
+    typeof value.recoveryState === 'string' &&
+    typeof value.attempts === 'number'
+  );
+}
+
+export function getBackgroundAgentRecoveryLedger(
+  metadata: Record<string, unknown> | undefined
+): BackgroundAgentRecoveryLedger {
+  const candidate = metadata?.backgroundAgentRecovery;
+  if (
+    !isObject(candidate) ||
+    candidate.version !== RECOVERY_LEDGER_VERSION ||
+    !isObject(candidate.tasks)
+  ) {
+    return emptyLedger();
+  }
+
+  const tasks: Record<string, BackgroundAgentRecoveryRecord> = {};
+  for (const [key, value] of Object.entries(candidate.tasks)) {
+    if (isRecoveryRecord(value)) tasks[key] = { ...value };
+  }
+  return { version: RECOVERY_LEDGER_VERSION, tasks };
+}
+
+export function encodeClaudeWorkspaceDir(workspacePath: string): string {
+  return workspacePath.replace(/[^A-Za-z0-9]/g, '-');
+}
+
+function normalizedWorkspace(workspacePath: string): string {
+  const normalized = path.normalize(workspacePath);
+  return process.platform === 'win32'
+    ? normalized.toLocaleLowerCase('en-US')
+    : normalized;
+}
+
+function asForwardSlashes(value: string): string {
+  return value.split(path.sep).join('/');
+}
+
+async function readBoundedJsonLines(filePath: string): Promise<{
+  entries: Record<string, unknown>[];
+  sizeBytes: number;
+  mtimeMs: number;
+}> {
+  const fileStat = await stat(filePath);
+  if (!fileStat.isFile() || fileStat.size === 0) {
+    return { entries: [], sizeBytes: fileStat.size, mtimeMs: fileStat.mtimeMs };
+  }
+
+  let text: string;
+  if (fileStat.size <= MAX_TRANSCRIPT_BYTES) {
+    text = await readFile(filePath, 'utf8');
+  } else {
+    const half = Math.floor(MAX_TRANSCRIPT_BYTES / 2);
+    const handle = await open(filePath, 'r');
+    try {
+      const head = Buffer.alloc(half);
+      const tail = Buffer.alloc(half);
+      const headRead = await handle.read(head, 0, half, 0);
+      const tailPosition = Math.max(0, fileStat.size - half);
+      const tailRead = await handle.read(tail, 0, half, tailPosition);
+      text = `${head.subarray(0, headRead.bytesRead).toString('utf8')}\n${tail
+        .subarray(0, tailRead.bytesRead)
+        .toString('utf8')}`;
+    } finally {
+      await handle.close();
+    }
+  }
+
+  const entries: Record<string, unknown>[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (isObject(parsed)) entries.push(parsed);
+    } catch {
+      // A bounded read can begin or end inside a JSON line. Complete lines remain usable.
+    }
+  }
+  return { entries, sizeBytes: fileStat.size, mtimeMs: fileStat.mtimeMs };
+}
+
+function terminalStatusFromEntries(
+  entries: Record<string, unknown>[]
+): 'completed' | 'failed' | 'stopped' | 'cancelled' | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const status = entries[index]?.status;
+    if (
+      status === 'completed' ||
+      status === 'failed' ||
+      status === 'stopped' ||
+      status === 'cancelled'
+    ) {
+      return status;
+    }
+  }
+  return undefined;
+}
+
+export async function inspectClaudeBackgroundAgentTranscript(
+  input: TranscriptInspectionInput & {
+    projectsDir: string;
+  }
+): Promise<TranscriptInspectionResult> {
+  const { projectsDir, workspacePath, providerSessionId, agentId } = input;
+  if (
+    !SAFE_TRANSCRIPT_ID.test(providerSessionId) ||
+    !SAFE_TRANSCRIPT_ID.test(agentId)
+  ) {
+    return { ok: false, reason: 'unsafe-transcript-identity' };
+  }
+
+  const encodedWorkspace = encodeClaudeWorkspaceDir(workspacePath);
+  const projectDir = path.join(projectsDir, encodedWorkspace);
+  const parentPath = path.join(projectDir, `${providerSessionId}.jsonl`);
+  const sidecarPath = path.join(
+    projectDir,
+    providerSessionId,
+    'subagents',
+    `agent-${agentId}.jsonl`
+  );
+
+  let parent;
+  try {
+    parent = await readBoundedJsonLines(parentPath);
+  } catch (error) {
+    return {
+      ok: false,
+      reason:
+        isObject(error) && error.code === 'ENOENT'
+          ? 'missing-parent-transcript'
+          : 'unreadable-parent-transcript',
+    };
+  }
+  if (parent.entries.length === 0)
+    return { ok: false, reason: 'malformed-parent-transcript' };
+  const parentMatches = parent.entries.some(
+    (entry) =>
+      entry.sessionId === providerSessionId &&
+      (typeof entry.cwd !== 'string' ||
+        normalizedWorkspace(entry.cwd) === normalizedWorkspace(workspacePath))
+  );
+  if (!parentMatches)
+    return { ok: false, reason: 'mismatched-parent-transcript' };
+
+  let sidecar;
+  try {
+    sidecar = await readBoundedJsonLines(sidecarPath);
+  } catch (error) {
+    return {
+      ok: false,
+      reason:
+        isObject(error) && error.code === 'ENOENT'
+          ? 'missing-subagent-transcript'
+          : 'unreadable-subagent-transcript',
+    };
+  }
+  if (sidecar.entries.length === 0)
+    return { ok: false, reason: 'malformed-subagent-transcript' };
+  const matchingSidecarEntries = sidecar.entries.filter(
+    (entry) =>
+      entry.sessionId === providerSessionId && entry.agentId === agentId
+  );
+  if (matchingSidecarEntries.length === 0) {
+    return { ok: false, reason: 'mismatched-subagent-transcript' };
+  }
+
+  const terminalStatus = terminalStatusFromEntries(matchingSidecarEntries);
+  if (terminalStatus) {
+    return {
+      ok: false,
+      reason: 'terminal-subagent-transcript',
+      terminalStatus,
+    };
+  }
+
+  const lastEntryUuid = [...matchingSidecarEntries]
+    .reverse()
+    .find((entry) => typeof entry.uuid === 'string')?.uuid as
+    | string
+    | undefined;
+  const relativePath = asForwardSlashes(
+    path.relative(projectsDir, sidecarPath)
+  );
+  const parentRelativePath = asForwardSlashes(
+    path.relative(projectsDir, parentPath)
+  );
+  return {
+    ok: true,
+    transcript: {
+      relativePath,
+      parentRelativePath,
+      sizeBytes: sidecar.sizeBytes,
+      mtimeMs: sidecar.mtimeMs,
+      fingerprint: `${sidecar.sizeBytes}:${Math.round(sidecar.mtimeMs)}:${
+        lastEntryUuid ?? 'none'
+      }`,
+      lastEntryUuid,
+    },
+  };
+}
+
+function currentTasksFromMetadata(
+  metadata: Record<string, unknown> | undefined
+): CurrentTaskMetadata[] {
+  if (!Array.isArray(metadata?.currentTasks)) return [];
+  return metadata.currentTasks
+    .filter(
+      (task): task is Record<string, unknown> =>
+        isObject(task) && typeof task.taskId === 'string'
+    )
+    .map((task) => ({
+      ...task,
+      taskId: task.taskId as string,
+      status: typeof task.status === 'string' ? task.status : 'unknown',
+    }));
+}
+
+function upsertCurrentTask(
+  tasks: CurrentTaskMetadata[],
+  taskId: string,
+  patch: Record<string, unknown>
+): CurrentTaskMetadata[] {
+  const index = tasks.findIndex((task) => task.taskId === taskId);
+  const previous = index >= 0 ? tasks[index] : undefined;
+  const next = {
+    ...(previous ?? {}),
+    taskId,
+    status:
+      typeof patch.status === 'string'
+        ? patch.status
+        : previous?.status ?? 'unknown',
+    ...patch,
+  } as CurrentTaskMetadata;
+  if (index < 0) return [...tasks, next];
+  return tasks.map((task, taskIndex) => (taskIndex === index ? next : task));
+}
+
+function stopRunningTasks(
+  tasks: CurrentTaskMetadata[],
+  reason: string,
+  now: number
+): CurrentTaskMetadata[] {
+  return tasks.map((task) =>
+    task.status === 'running'
+      ? {
+          ...task,
+          status: 'stopped',
+          recoveryDisposition: reason,
+          updatedAt: now,
+        }
+      : task
+  );
+}
+
+function latestRecordForTask(
+  ledger: BackgroundAgentRecoveryLedger,
+  taskId: string
+): BackgroundAgentRecoveryRecord | undefined {
+  return Object.values(ledger.tasks)
+    .filter((record) => record.taskId === taskId)
+    .sort((left, right) => right.generationNumber - left.generationNumber)[0];
+}
+
+function latestRecordForIdentity(
+  ledger: BackgroundAgentRecoveryLedger,
+  identity: string
+): BackgroundAgentRecoveryRecord | undefined {
+  return Object.values(ledger.tasks)
+    .filter((record) => record.identity === identity)
+    .sort((left, right) => right.generationNumber - left.generationNumber)[0];
+}
+
+function terminalRecoveryState(
+  status: string | undefined
+): BackgroundAgentRecoveryState | undefined {
+  if (status === 'completed') return 'completed';
+  if (status === 'failed') return 'failed';
+  if (status === 'stopped') return 'stopped';
+  if (status === 'cancelled') return 'cancelled';
+  return undefined;
+}
+
+function isTerminalRecoveryState(state: BackgroundAgentRecoveryState): boolean {
+  return [
+    'notify-only',
+    'completed',
+    'failed',
+    'stopped',
+    'cancelled',
+  ].includes(state);
+}
+
+export class BackgroundAgentRecoveryCoordinator {
+  private readonly instanceId: string;
+  private readonly now: () => number;
+  private readonly getSession: RecoveryCoordinatorDependencies['getSession'];
+  private readonly mergeSessionMetadata: RecoveryCoordinatorDependencies['mergeSessionMetadata'];
+  private readonly inspectTranscript: NonNullable<
+    RecoveryCoordinatorDependencies['inspectTranscript']
+  >;
+
+  constructor(dependencies: RecoveryCoordinatorDependencies) {
+    this.instanceId = dependencies.instanceId;
+    this.now = dependencies.now ?? Date.now;
+    this.getSession = dependencies.getSession;
+    this.mergeSessionMetadata = dependencies.mergeSessionMetadata;
+    this.inspectTranscript =
+      dependencies.inspectTranscript ??
+      (async () => ({
+        ok: false,
+        reason: 'transcript-inspector-unavailable',
+      }));
+  }
+
+  private async mutateSession<T>(
+    sessionId: string,
+    mutation: (
+      session: RecoverySessionSnapshot,
+      ledger: BackgroundAgentRecoveryLedger,
+      currentTasks: CurrentTaskMetadata[]
+    ) =>
+      | Promise<{
+          result: T;
+          currentTasks?: CurrentTaskMetadata[];
+          write?: boolean;
+        }>
+      | { result: T; currentTasks?: CurrentTaskMetadata[]; write?: boolean }
+  ): Promise<T | undefined> {
+    return withSessionMutationLock(sessionId, async () => {
+      const session = await this.getSession(sessionId);
+      if (!session) return undefined;
+      const ledger = getBackgroundAgentRecoveryLedger(session.metadata);
+      const currentTasks = currentTasksFromMetadata(session.metadata);
+      const outcome = await mutation(session, ledger, currentTasks);
+      if (outcome.write !== false) {
+        const patch: Record<string, unknown> = {
+          backgroundAgentRecovery: ledger,
+        };
+        if (outcome.currentTasks) patch.currentTasks = outcome.currentTasks;
+        await this.mergeSessionMetadata(sessionId, patch);
+      }
+      return outcome.result;
+    });
+  }
+
+  async observeTaskEvent(input: RecoveryTaskEventInput): Promise<void> {
+    await this.mutateSession(
+      input.sessionId,
+      (_session, ledger, currentTasks) => {
+        const observedAt = this.now();
+        if (input.event.subtype === 'task_started') {
+          const taskType = input.event.task_type ?? 'local_agent';
+          const identity = `${input.providerSessionId}:${input.event.tool_use_id}`;
+          const latest = latestRecordForIdentity(ledger, identity);
+          const shouldCreateRecoveredGeneration =
+            latest?.recoveryState === 'dispatched' &&
+            latest.dispatchTurnId === input.turnId;
+
+          if (
+            latest?.sourceTurnId === input.turnId &&
+            latest.recoveryState === 'pending'
+          ) {
+            latest.updatedAt = observedAt;
+            latest.backgrounded =
+              input.launch?.runInBackground ?? latest.backgrounded;
+            latest.agentName = input.launch?.name ?? latest.agentName;
+            return {
+              result: undefined,
+              currentTasks: upsertCurrentTask(
+                currentTasks,
+                input.event.task_id,
+                {
+                  status: 'running',
+                  description: input.event.description,
+                  taskType,
+                  toolUseId: input.event.tool_use_id,
+                  isBackgrounded: latest.backgrounded,
+                  updatedAt: observedAt,
+                }
+              ),
+            };
+          }
+
+          if (latest && !shouldCreateRecoveredGeneration) {
+            latest.updatedAt = observedAt;
+            return {
+              result: undefined,
+              currentTasks,
+            };
+          }
+
+          const generationNumber = (latest?.generationNumber ?? 0) + 1;
+          const generation = `${identity}:g${generationNumber}`;
+          ledger.tasks[generation] = {
+            generation,
+            generationNumber,
+            identity,
+            taskId: input.event.task_id,
+            agentId: input.event.tool_use_id,
+            agentName: input.launch?.name,
+            description: input.event.description,
+            taskType,
+            ownerInstanceId: this.instanceId,
+            providerSessionId: input.providerSessionId,
+            workspacePath: input.workspacePath,
+            expectedTranscriptRelativePath: `${encodeClaudeWorkspaceDir(
+              input.workspacePath
+            )}/${input.providerSessionId}/subagents/agent-${
+              input.event.tool_use_id
+            }.jsonl`,
+            expectedParentTranscriptRelativePath: `${encodeClaudeWorkspaceDir(
+              input.workspacePath
+            )}/${input.providerSessionId}.jsonl`,
+            sourceTurnId: input.turnId,
+            priorState: 'running',
+            backgrounded: input.launch?.runInBackground === true,
+            recoveryState: 'pending',
+            attempts: 0,
+            observedAt,
+            updatedAt: observedAt,
+          };
+          return {
+            result: undefined,
+            currentTasks: upsertCurrentTask(currentTasks, input.event.task_id, {
+              status: 'running',
+              description: input.event.description,
+              taskType,
+              toolUseId: input.event.tool_use_id,
+              isBackgrounded: input.launch?.runInBackground === true,
+              updatedAt: observedAt,
+            }),
+          };
+        }
+
+        const record = latestRecordForTask(ledger, input.event.task_id);
+        const ignoreLateNonTerminalEvent =
+          record !== undefined &&
+          isTerminalRecoveryState(record.recoveryState) &&
+          (input.event.subtype === 'task_progress' ||
+            (input.event.subtype === 'task_updated' &&
+              terminalRecoveryState(input.event.patch?.status) === undefined));
+        if (record) {
+          record.updatedAt = observedAt;
+          if (input.event.subtype === 'task_updated') {
+            if (typeof input.event.patch?.is_backgrounded === 'boolean') {
+              record.backgrounded = input.event.patch.is_backgrounded;
+            }
+            const terminalState = terminalRecoveryState(
+              input.event.patch?.status
+            );
+            if (terminalState) {
+              record.recoveryState = terminalState;
+              record.terminalAt = observedAt;
+              record.lastReason = `sdk-task-${terminalState}`;
+            }
+          } else if (input.event.subtype === 'task_notification') {
+            const terminalState = terminalRecoveryState(
+              input.event.status ?? 'completed'
+            );
+            if (terminalState) {
+              record.recoveryState = terminalState;
+              record.terminalAt = observedAt;
+              record.lastReason = `sdk-task-${terminalState}`;
+            }
+          }
+        }
+
+        if (ignoreLateNonTerminalEvent) {
+          return { result: undefined, currentTasks };
+        }
+
+        const taskPatch: Record<string, unknown> = { updatedAt: observedAt };
+        if (input.event.subtype === 'task_updated') {
+          Object.assign(taskPatch, input.event.patch);
+          if (typeof input.event.patch?.is_backgrounded === 'boolean') {
+            taskPatch.isBackgrounded = input.event.patch.is_backgrounded;
+          }
+        } else if (input.event.subtype === 'task_notification') {
+          taskPatch.status = input.event.status ?? 'completed';
+        } else if (input.event.description) {
+          taskPatch.description = input.event.description;
+        }
+        return {
+          result: undefined,
+          currentTasks: upsertCurrentTask(
+            currentTasks,
+            input.event.task_id,
+            taskPatch
+          ),
+        };
+      }
+    );
+  }
+
+  async claimResumeDispatches(input: {
+    sessionId: string;
+    workspacePath: string;
+    providerSessionId?: string;
+    turnId: string;
+    isResume: boolean;
+  }): Promise<{
+    dispatches: BackgroundAgentRecoveryDispatch[];
+    notices: BackgroundAgentRecoveryNotice[];
+  }> {
+    const result = await this.mutateSession(
+      input.sessionId,
+      async (session, ledger, currentTasks) => {
+        const dispatches: BackgroundAgentRecoveryDispatch[] = [];
+        const notices: BackgroundAgentRecoveryNotice[] = [];
+        const checkedAt = this.now();
+
+        if (!input.isResume || !input.providerSessionId) {
+          for (const record of Object.values(ledger.tasks)) {
+            if (
+              !['pending', 'retryable', 'claimed', 'dispatching'].includes(
+                record.recoveryState
+              )
+            )
+              continue;
+            record.recoveryState = 'notify-only';
+            record.lastReason = 'non-resume-start';
+            record.updatedAt = checkedAt;
+            notices.push({
+              generation: record.generation,
+              taskId: SAFE_TRANSCRIPT_ID.test(record.taskId)
+                ? record.taskId
+                : 'unverified-task',
+              reason: record.lastReason,
+            });
+          }
+          return {
+            result: { dispatches, notices },
+            currentTasks: stopRunningTasks(
+              currentTasks,
+              'non-resume-start',
+              checkedAt
+            ),
+          };
+        }
+        if (
+          (session.provider && session.provider !== 'claude-code') ||
+          session.providerSessionId !== input.providerSessionId ||
+          (session.workspacePath &&
+            normalizedWorkspace(session.workspacePath) !==
+              normalizedWorkspace(input.workspacePath))
+        ) {
+          for (const record of Object.values(ledger.tasks)) {
+            if (
+              !['pending', 'retryable', 'claimed', 'dispatching'].includes(
+                record.recoveryState
+              )
+            )
+              continue;
+            record.recoveryState = 'notify-only';
+            record.lastReason = 'unverified-provider-session';
+            record.updatedAt = checkedAt;
+            notices.push({
+              generation: record.generation,
+              taskId: SAFE_TRANSCRIPT_ID.test(record.taskId)
+                ? record.taskId
+                : 'unverified-task',
+              reason: record.lastReason,
+            });
+          }
+          return {
+            result: { dispatches, notices },
+            currentTasks: stopRunningTasks(
+              currentTasks,
+              'unverified-provider-session',
+              checkedAt
+            ),
+          };
+        }
+
+        const records = Object.values(ledger.tasks).sort(
+          (left, right) => left.observedAt - right.observedAt
+        );
+        const stoppedTasks = stopRunningTasks(
+          currentTasks,
+          'provider-recycled',
+          checkedAt
+        );
+        for (const record of records) {
+          if (record.sourceTurnId === input.turnId) continue;
+          if (
+            !['pending', 'retryable', 'claimed', 'dispatching'].includes(
+              record.recoveryState
+            )
+          )
+            continue;
+          if (record.claimedTurnId === input.turnId) continue;
+          if (
+            (record.recoveryState === 'claimed' ||
+              record.recoveryState === 'dispatching') &&
+            (record.claimLeaseExpiresAt ?? 0) > checkedAt
+          ) {
+            continue;
+          }
+          if (record.providerSessionId !== input.providerSessionId) {
+            record.recoveryState = 'notify-only';
+            record.lastReason = 'record-provider-session-mismatch';
+            record.updatedAt = checkedAt;
+            notices.push({
+              generation: record.generation,
+              taskId: record.taskId,
+              reason: record.lastReason,
+            });
+            continue;
+          }
+          if (
+            normalizedWorkspace(record.workspacePath) !==
+            normalizedWorkspace(input.workspacePath)
+          ) {
+            record.recoveryState = 'notify-only';
+            record.lastReason = 'record-workspace-mismatch';
+            record.updatedAt = checkedAt;
+            notices.push({
+              generation: record.generation,
+              taskId: record.taskId,
+              reason: record.lastReason,
+            });
+            continue;
+          }
+          if (record.attempts >= MAX_RECOVERY_ATTEMPTS) {
+            record.recoveryState = 'notify-only';
+            record.lastReason = 'recovery-attempt-limit';
+            record.updatedAt = checkedAt;
+            notices.push({
+              generation: record.generation,
+              taskId: record.taskId,
+              reason: record.lastReason,
+            });
+            continue;
+          }
+          if (
+            !SAFE_TRANSCRIPT_ID.test(record.taskId) ||
+            !SAFE_TRANSCRIPT_ID.test(record.agentId)
+          ) {
+            record.recoveryState = 'notify-only';
+            record.lastReason = 'unsafe-task-identity';
+            record.updatedAt = checkedAt;
+            notices.push({
+              generation: record.generation,
+              taskId: 'unverified-task',
+              reason: record.lastReason,
+            });
+            continue;
+          }
+          if (record.taskType !== 'local_agent' || !record.backgrounded) {
+            record.recoveryState = 'notify-only';
+            record.lastReason =
+              record.taskType !== 'local_agent'
+                ? 'unsupported-background-task-type'
+                : 'task-was-not-backgrounded';
+            record.updatedAt = checkedAt;
+            notices.push({
+              generation: record.generation,
+              taskId: record.taskId,
+              reason: record.lastReason,
+            });
+            continue;
+          }
+
+          const inspection = await this.inspectTranscript({
+            workspacePath: record.workspacePath,
+            providerSessionId: record.providerSessionId,
+            agentId: record.agentId,
+          });
+          if (!inspection.ok) {
+            const terminalState = inspection.terminalStatus
+              ? terminalRecoveryState(inspection.terminalStatus)
+              : undefined;
+            record.recoveryState = terminalState ?? 'notify-only';
+            record.lastReason = inspection.reason;
+            record.updatedAt = checkedAt;
+            if (terminalState) record.terminalAt = checkedAt;
+            notices.push({
+              generation: record.generation,
+              taskId: record.taskId,
+              reason: inspection.reason,
+            });
+            continue;
+          }
+          if (
+            inspection.transcript.relativePath !==
+              record.expectedTranscriptRelativePath ||
+            inspection.transcript.parentRelativePath !==
+              record.expectedParentTranscriptRelativePath
+          ) {
+            record.recoveryState = 'notify-only';
+            record.lastReason = 'transcript-provenance-mismatch';
+            record.updatedAt = checkedAt;
+            notices.push({
+              generation: record.generation,
+              taskId: record.taskId,
+              reason: record.lastReason,
+            });
+            continue;
+          }
+
+          record.attempts += 1;
+          record.recoveryState = 'claimed';
+          record.claimedAt = checkedAt;
+          record.claimedBy = this.instanceId;
+          record.claimedTurnId = input.turnId;
+          record.claimLeaseExpiresAt = checkedAt + RECOVERY_CLAIM_LEASE_MS;
+          record.dispatchToolUseId = undefined;
+          record.dispatchTurnId = undefined;
+          record.transcript = inspection.transcript;
+          record.lastReason = 'verified-surviving-transcript';
+          record.updatedAt = checkedAt;
+          dispatches.push({
+            generation: record.generation,
+            taskId: record.taskId,
+            agentId: record.agentId,
+            agentName: record.agentName,
+            description: record.description,
+            providerSessionId: record.providerSessionId,
+            recipient: record.agentId,
+            priorState: record.priorState,
+            transcript: inspection.transcript,
+          });
+        }
+        return { result: { dispatches, notices }, currentTasks: stoppedTasks };
+      }
+    );
+    return result ?? { dispatches: [], notices: [] };
+  }
+
+  async guardNativeSendMessage(input: {
+    sessionId: string;
+    turnId: string;
+    toolUseId: string;
+    input: Record<string, unknown>;
+  }): Promise<{ matched: boolean; allow: boolean; reason?: string }> {
+    const result = await this.mutateSession<{
+      matched: boolean;
+      allow: boolean;
+      reason?: string;
+    }>(input.sessionId, async (_session, ledger) => {
+      const messageType = input.input.type;
+      const recipient =
+        typeof input.input.to === 'string'
+          ? input.input.to
+          : input.input.recipient;
+      if (
+        (messageType !== undefined && messageType !== 'message') ||
+        typeof recipient !== 'string'
+      ) {
+        return { result: { matched: false, allow: true }, write: false };
+      }
+
+      const activeRecords = Object.values(ledger.tasks).filter((candidate) => {
+        if (candidate.transcript === undefined) return false;
+        if (
+          ['claimed', 'dispatching', 'retryable'].includes(
+            candidate.recoveryState
+          )
+        ) {
+          return true;
+        }
+        return (
+          candidate.claimedTurnId === input.turnId &&
+          (candidate.recoveryState === 'dispatched' ||
+            isTerminalRecoveryState(candidate.recoveryState))
+        );
+      });
+      const exactIdentityMatches = activeRecords.filter(
+        (candidate) =>
+          candidate.taskId === recipient || candidate.agentId === recipient
+      );
+      const nameMatches = activeRecords.filter(
+        (candidate) => candidate.agentName === recipient
+      );
+      const record = (
+        exactIdentityMatches.length > 0
+          ? exactIdentityMatches
+          : nameMatches.length === 1
+          ? nameMatches
+          : []
+      ).sort((left, right) => right.updatedAt - left.updatedAt)[0];
+      if (!record)
+        return { result: { matched: false, allow: true }, write: false };
+
+      if (
+        record.recoveryState === 'dispatched' ||
+        isTerminalRecoveryState(record.recoveryState)
+      ) {
+        return {
+          result: {
+            matched: true,
+            allow: false,
+            reason: `background-agent-recovery-${record.recoveryState}`,
+          },
+          write: false,
+        };
+      }
+
+      if (
+        record.recoveryState === 'retryable' &&
+        record.claimedTurnId === input.turnId
+      ) {
+        return {
+          result: {
+            matched: true,
+            allow: false,
+            reason: 'background-agent-recovery-attempt-finished',
+          },
+          write: false,
+        };
+      }
+      if (record.recoveryState === 'retryable') {
+        record.dispatchToolUseId = undefined;
+        record.dispatchTurnId = undefined;
+      }
+      if (record.dispatchToolUseId) {
+        if (record.dispatchToolUseId === input.toolUseId) {
+          return { result: { matched: true, allow: true }, write: false };
+        }
+        return {
+          result: {
+            matched: true,
+            allow: false,
+            reason: 'background-agent-recovery-already-dispatched',
+          },
+          write: false,
+        };
+      }
+
+      const inspection = await this.inspectTranscript({
+        workspacePath: record.workspacePath,
+        providerSessionId: record.providerSessionId,
+        agentId: record.agentId,
+      });
+      if (!inspection.ok) {
+        const terminalState = inspection.terminalStatus
+          ? terminalRecoveryState(inspection.terminalStatus)
+          : undefined;
+        record.recoveryState = terminalState ?? 'notify-only';
+        record.lastReason = inspection.reason;
+        record.updatedAt = this.now();
+        if (terminalState) record.terminalAt = record.updatedAt;
+        return {
+          result: { matched: true, allow: false, reason: inspection.reason },
+        };
+      }
+      if (
+        inspection.transcript.relativePath !==
+          record.expectedTranscriptRelativePath ||
+        inspection.transcript.parentRelativePath !==
+          record.expectedParentTranscriptRelativePath
+      ) {
+        record.recoveryState = 'notify-only';
+        record.lastReason = 'transcript-provenance-mismatch';
+        record.updatedAt = this.now();
+        return {
+          result: {
+            matched: true,
+            allow: false,
+            reason: record.lastReason,
+          },
+        };
+      }
+      if (
+        record.transcript &&
+        inspection.transcript.fingerprint !== record.transcript.fingerprint
+      ) {
+        record.recoveryState = 'notify-only';
+        record.lastReason = 'transcript-changed-after-claim';
+        record.updatedAt = this.now();
+        return {
+          result: {
+            matched: true,
+            allow: false,
+            reason: record.lastReason,
+          },
+        };
+      }
+      record.transcript = inspection.transcript;
+
+      const wasRetryable = record.recoveryState === 'retryable';
+      record.recoveryState = 'dispatching';
+      if (record.claimedTurnId !== input.turnId && wasRetryable) {
+        record.attempts = Math.min(MAX_RECOVERY_ATTEMPTS, record.attempts + 1);
+      }
+      record.claimedBy = this.instanceId;
+      record.claimedTurnId = input.turnId;
+      record.claimLeaseExpiresAt = this.now() + RECOVERY_DISPATCH_LEASE_MS;
+      record.dispatchToolUseId = input.toolUseId;
+      record.dispatchTurnId = input.turnId;
+      record.lastReason = 'native-sendmessage-dispatching';
+      record.updatedAt = this.now();
+      return { result: { matched: true, allow: true } };
+    });
+    return result ?? { matched: false, allow: true };
+  }
+
+  async observeNativeSendMessageResult(input: {
+    sessionId: string;
+    turnId: string;
+    toolUseId: string;
+    isError: boolean;
+    content?: unknown;
+  }): Promise<void> {
+    await this.mutateSession(input.sessionId, (_session, ledger) => {
+      const record = Object.values(ledger.tasks).find(
+        (candidate) =>
+          candidate.dispatchToolUseId === input.toolUseId &&
+          candidate.dispatchTurnId === input.turnId
+      );
+      if (!record) return { result: undefined, write: false };
+      if (
+        !['claimed', 'dispatching', 'retryable'].includes(record.recoveryState)
+      ) {
+        return { result: undefined, write: false };
+      }
+
+      const observedAt = this.now();
+      if (input.isError) {
+        record.recoveryState =
+          record.attempts < MAX_RECOVERY_ATTEMPTS ? 'retryable' : 'notify-only';
+        record.lastReason = 'native-dispatch-rejected';
+      } else {
+        record.recoveryState = 'dispatched';
+        record.dispatchedAt = observedAt;
+        record.lastReason = 'native-sendmessage-dispatched';
+      }
+      record.claimLeaseExpiresAt = undefined;
+      record.updatedAt = observedAt;
+      return { result: undefined };
+    });
+  }
+
+  async finishRecoveryTurn(input: {
+    sessionId: string;
+    turnId: string;
+    plannedGenerations: string[];
+  }): Promise<void> {
+    const planned = new Set(input.plannedGenerations);
+    await this.mutateSession(input.sessionId, (_session, ledger) => {
+      let changed = false;
+      const finishedAt = this.now();
+      for (const record of Object.values(ledger.tasks)) {
+        const belongsToTurn =
+          planned.has(record.generation) ||
+          record.dispatchTurnId === input.turnId ||
+          (record.claimedTurnId === input.turnId &&
+            record.transcript !== undefined);
+        if (!belongsToTurn || record.claimedTurnId !== input.turnId) continue;
+        if (
+          record.recoveryState !== 'claimed' &&
+          record.recoveryState !== 'dispatching'
+        )
+          continue;
+        record.recoveryState =
+          record.attempts < MAX_RECOVERY_ATTEMPTS ? 'retryable' : 'notify-only';
+        record.lastReason = 'native-dispatch-not-observed';
+        record.claimLeaseExpiresAt = undefined;
+        record.updatedAt = finishedAt;
+        changed = true;
+      }
+      return { result: undefined, write: changed };
+    });
+  }
+
+  async suppressRunning(sessionId: string, reason: string): Promise<void> {
+    await this.mutateSession(sessionId, (_session, ledger, currentTasks) => {
+      const suppressedAt = this.now();
+      for (const record of Object.values(ledger.tasks)) {
+        if (
+          [
+            'pending',
+            'claimed',
+            'dispatching',
+            'retryable',
+            'dispatched',
+          ].includes(record.recoveryState)
+        ) {
+          record.recoveryState = 'cancelled';
+          record.terminalAt = suppressedAt;
+          record.updatedAt = suppressedAt;
+          record.lastReason = reason;
+          record.claimLeaseExpiresAt = undefined;
+        }
+      }
+      return {
+        result: undefined,
+        currentTasks: stopRunningTasks(currentTasks, reason, suppressedAt),
+      };
+    });
+  }
+}
+
+export function buildBackgroundAgentRecoveryInstruction(
+  dispatches: BackgroundAgentRecoveryDispatch[],
+  notices: BackgroundAgentRecoveryNotice[]
+): string {
+  if (dispatches.length === 0 && notices.length === 0) return '';
+
+  const lines = [
+    '<background-agent-recovery>',
+    'Recover only the verified original Claude background agents listed below.',
+  ];
+  for (const dispatch of dispatches) {
+    lines.push(
+      `- For task ${dispatch.taskId}, call native SendMessage exactly once with to: '${dispatch.agentId}' and a 5-10 word summary to continue the original agent from its surviving transcript (${dispatch.transcript.relativePath}).`
+    );
+  }
+  if (dispatches.length > 1) {
+    lines.push(
+      'Make the recovery SendMessage calls sequentially, not in parallel.'
+    );
+  }
+  if (notices.length > 0) {
+    lines.push(
+      'Do not auto-resume these tasks; report their durable recovery status instead:'
+    );
+    for (const notice of notices) {
+      const safeTaskId = SAFE_TRANSCRIPT_ID.test(notice.taskId)
+        ? notice.taskId
+        : 'unverified-task';
+      const safeReason = /^[a-z0-9-]+$/.test(notice.reason)
+        ? notice.reason
+        : 'unverified-recovery-status';
+      lines.push(`- ${safeTaskId}: ${safeReason}`);
+    }
+  }
+  lines.push(
+    'Do not launch a replacement Agent and do not reconstruct an agent from summary text.',
+    "After the native SendMessage call, continue with the user's ordinary request.",
+    '</background-agent-recovery>'
+  );
+  return lines.join('\n');
+}

--- a/packages/runtime/src/ai/server/providers/claudeCode/backgroundTaskRecovery.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/backgroundTaskRecovery.ts
@@ -807,6 +807,26 @@ export class BackgroundAgentRecoveryCoordinator {
             continue;
           if (record.claimedTurnId === input.turnId) continue;
           if (
+            record.recoveryState === 'dispatching' &&
+            (record.claimLeaseExpiresAt ?? 0) <= checkedAt
+          ) {
+            // The native send begins only after guardNativeSendMessage has
+            // durably moved the generation to dispatching. If the process dies
+            // before the tool result is persisted, the send may already have
+            // reached Claude. There is no native idempotency key, so reclaiming
+            // this lease could duplicate the continuation.
+            record.recoveryState = 'notify-only';
+            record.lastReason = 'ambiguous-dispatch';
+            record.updatedAt = checkedAt;
+            record.claimLeaseExpiresAt = undefined;
+            notices.push({
+              generation: record.generation,
+              taskId: record.taskId,
+              reason: record.lastReason,
+            });
+            continue;
+          }
+          if (
             (record.recoveryState === 'claimed' ||
               record.recoveryState === 'dispatching') &&
             (record.claimLeaseExpiresAt ?? 0) > checkedAt
@@ -949,6 +969,7 @@ export class BackgroundAgentRecoveryCoordinator {
     turnId: string;
     toolUseId: string;
     input: Record<string, unknown>;
+    plannedGenerations?: readonly string[];
   }): Promise<{ matched: boolean; allow: boolean; reason?: string }> {
     const result = await this.mutateSession<{
       matched: boolean;
@@ -1109,7 +1130,15 @@ export class BackgroundAgentRecoveryCoordinator {
       record.updatedAt = this.now();
       return { result: { matched: true, allow: true } };
     });
-    return result ?? { matched: false, allow: true };
+    if (result) return result;
+    if ((input.plannedGenerations?.length ?? 0) > 0) {
+      return {
+        matched: true,
+        allow: false,
+        reason: 'background-agent-recovery-session-missing',
+      };
+    }
+    return { matched: false, allow: true };
   }
 
   async observeNativeSendMessageResult(input: {
@@ -1169,15 +1198,77 @@ export class BackgroundAgentRecoveryCoordinator {
           record.recoveryState !== 'dispatching'
         )
           continue;
-        record.recoveryState =
-          record.attempts < MAX_RECOVERY_ATTEMPTS ? 'retryable' : 'notify-only';
-        record.lastReason = 'native-dispatch-not-observed';
+        if (record.recoveryState === 'dispatching') {
+          // The pre-tool guard persisted dispatching before allowing the native
+          // call, so lack of a result is ambiguous and must never be retried.
+          record.recoveryState = 'notify-only';
+          record.lastReason = 'ambiguous-dispatch';
+        } else {
+          // A claimed generation that never reached the first-send guard is
+          // safe to offer on one later recovery turn.
+          record.recoveryState =
+            record.attempts < MAX_RECOVERY_ATTEMPTS
+              ? 'retryable'
+              : 'notify-only';
+          record.lastReason = 'native-dispatch-not-observed';
+        }
         record.claimLeaseExpiresAt = undefined;
         record.updatedAt = finishedAt;
         changed = true;
       }
       return { result: undefined, write: changed };
     });
+  }
+
+  async observeExplicitTaskStop(input: {
+    sessionId: string;
+    taskId: string;
+  }): Promise<boolean> {
+    const result = await this.mutateSession(
+      input.sessionId,
+      (_session, ledger, currentTasks) => {
+        const records = Object.values(ledger.tasks).filter(
+          (record) => record.taskId === input.taskId
+        );
+        if (records.length === 0) {
+          return { result: false, write: false };
+        }
+
+        const stoppedAt = this.now();
+        let changed = false;
+        for (const record of records) {
+          if (
+            ![
+              'pending',
+              'claimed',
+              'dispatching',
+              'dispatched',
+              'retryable',
+              'notify-only',
+            ].includes(record.recoveryState)
+          ) {
+            continue;
+          }
+          record.recoveryState = 'stopped';
+          record.terminalAt = stoppedAt;
+          record.updatedAt = stoppedAt;
+          record.lastReason = 'native-task-stop-succeeded';
+          record.claimLeaseExpiresAt = undefined;
+          changed = true;
+        }
+
+        if (!changed) return { result: true, write: false };
+        return {
+          result: true,
+          currentTasks: upsertCurrentTask(currentTasks, input.taskId, {
+            status: 'stopped',
+            recoveryDisposition: 'native-task-stop-succeeded',
+            updatedAt: stoppedAt,
+          }),
+        };
+      }
+    );
+    return result ?? false;
   }
 
   async suppressRunning(sessionId: string, reason: string): Promise<void> {

--- a/packages/runtime/src/ai/server/providers/claudeCode/backgroundTaskRecoveryLifecycle.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/backgroundTaskRecoveryLifecycle.ts
@@ -1,0 +1,143 @@
+import {
+  BackgroundAgentRecoveryCoordinator,
+  buildBackgroundAgentRecoveryInstruction,
+  type BackgroundAgentRecoveryDispatch,
+  type BackgroundAgentRecoveryNotice
+} from './backgroundTaskRecovery';
+
+type ClaimResumeInput = Parameters<
+  BackgroundAgentRecoveryCoordinator['claimResumeDispatches']
+>[0];
+
+export interface PreparedClaudeBackgroundAgentRecoveryTurn {
+  dispatches: BackgroundAgentRecoveryDispatch[];
+  notices: BackgroundAgentRecoveryNotice[];
+  plannedGenerations: string[];
+  systemInstruction: string;
+}
+
+export async function prepareClaudeBackgroundAgentRecoveryTurn(
+  coordinator: BackgroundAgentRecoveryCoordinator,
+  input: ClaimResumeInput
+): Promise<PreparedClaudeBackgroundAgentRecoveryTurn> {
+  const recovery = await coordinator.claimResumeDispatches(input);
+  return {
+    ...recovery,
+    plannedGenerations: recovery.dispatches.map(
+      (dispatch) => dispatch.generation
+    ),
+    systemInstruction: buildBackgroundAgentRecoveryInstruction(
+      recovery.dispatches,
+      recovery.notices
+    )
+  };
+}
+
+interface RecoveryToolGuardInput {
+  toolName: string;
+  sessionId?: string;
+  turnId?: string;
+  toolUseId?: string;
+  toolInput?: Record<string, unknown>;
+  plannedGenerations?: readonly string[];
+}
+
+export type ClaudeBackgroundAgentRecoveryToolGuardResult =
+  | { handled: false }
+  | {
+      handled: true;
+      result: {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse';
+          permissionDecision: 'deny';
+          permissionDecisionReason?: string;
+        };
+      };
+    };
+
+export async function guardClaudeBackgroundAgentRecoveryTool(
+  coordinator: BackgroundAgentRecoveryCoordinator,
+  input: RecoveryToolGuardInput
+): Promise<ClaudeBackgroundAgentRecoveryToolGuardResult> {
+  if (
+    input.toolName !== 'SendMessage' ||
+    !input.sessionId ||
+    !input.turnId ||
+    !input.toolUseId
+  ) {
+    return { handled: false };
+  }
+
+  const decision = await coordinator.guardNativeSendMessage({
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    toolUseId: input.toolUseId,
+    input: input.toolInput ?? {},
+    plannedGenerations: input.plannedGenerations
+  });
+  if (!decision.matched || decision.allow) return { handled: false };
+
+  return {
+    handled: true,
+    result: {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: decision.reason
+      }
+    }
+  };
+}
+
+export function getClaudeTaskStopTarget(
+  toolName: string,
+  toolArguments: Record<string, unknown> | undefined,
+  isError: boolean
+): string | undefined {
+  if (toolName !== 'TaskStop' || isError) return undefined;
+  if (typeof toolArguments?.task_id === 'string') {
+    return toolArguments.task_id;
+  }
+  return typeof toolArguments?.shell_id === 'string'
+    ? toolArguments.shell_id
+    : undefined;
+}
+
+interface RecoveryToolResultInput {
+  sessionId?: string;
+  turnId: string;
+  toolName: string;
+  toolUseId?: string;
+  toolArguments?: Record<string, unknown>;
+  isError: boolean;
+  content?: unknown;
+}
+
+export async function observeClaudeBackgroundAgentRecoveryToolResult(
+  coordinator: BackgroundAgentRecoveryCoordinator,
+  input: RecoveryToolResultInput
+): Promise<{ stoppedTaskId?: string }> {
+  const stoppedTaskId = getClaudeTaskStopTarget(
+    input.toolName,
+    input.toolArguments,
+    input.isError
+  );
+
+  if (input.sessionId && input.toolName === 'SendMessage' && input.toolUseId) {
+    await coordinator.observeNativeSendMessageResult({
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      toolUseId: input.toolUseId,
+      isError: input.isError,
+      content: input.content
+    });
+  }
+  if (input.sessionId && stoppedTaskId) {
+    await coordinator.observeExplicitTaskStop({
+      sessionId: input.sessionId,
+      taskId: stoppedTaskId
+    });
+  }
+
+  return { stoppedTaskId };
+}


### PR DESCRIPTION
## NIM-253 — recover persisted Claude background work

### User outcome

After a recycle, persisted Claude background tasks reattach safely while explicit user stops remain durable and turn-safe.

### Carry receipt

- Stable source / merge-base: `v0.73.2` / `c0f6b6cdd138dc707ec4688ae9013a4ea76f9534`
- Fork head: `4825820b7fa6ec312b5d2541196edfd16ba7c716`
- GitHub PR base: `nimbalyst/nimbalyst:main` / `4a42e0ad5cca7973251e3513db3ecd036171bd7d`
- Recovered provenance: re-authored series formerly ending `62efffa8d5ee792778118082dcbea278f2bf1ca2`, retained at `recovery/nim253-before-author-rewrite-62efffa8`.
- Source/reuse: stable and upstream main contain no `backgroundTaskRecovery` implementation; the recovered series applies cleanly to the stable base.
- Changed paths: recovery persistence/lifecycle implementation and focused tests under `packages/runtime/src/ai/server/providers/claudeCode/`, plus the related runtime/session-store integration paths.
- Focused tests: `backgroundTaskRecovery.test.ts`, `backgroundTaskRecoveryLifecycle.test.ts`, and `ClaudeCodeProvider.interruptRecovery.test.ts` — **3 files / 23 passed**.
- Author gate: every commit in the published candidate range is authored by `YoGitmeister <Yogitmeister@users.noreply.github.com>`.
- Normal Windows pre-push hook passed without bypass: fixture-author, dependency-override, tracked-NUL, prerequisite-build, 23-workspace typecheck, and focused pre-push tests all passed. The full Vitest suite remains intentionally skipped on local Windows per `docs/WINDOWS_PREPUSH_GATE.md`; CI runs it.

This CReq does not depend on unmerged upstream draft PR #1155. No merge or release is requested.

## Why this is worth merging

Background Claude work can outlive a renderer or app-process recycle. Without durable reattachment, valid work becomes orphaned or is restarted without respecting an explicit stop. This change restores the saved route and credentials, completes recovery before admitting replacement work, and keeps stop handling turn-safe and fail-safe.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
