### PR TITLE
fix(queue): drive desktop queues across providers (NIM-465)

### DIFF
--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -144,6 +144,7 @@ import { ingestMobileQueuedPrompts } from './mobileQueuedPromptIngest';
 import { onWorkspaceWindowAvailable } from '../../window/workspaceWindowAvailability';
 import { dispatchQueuedPromptToClaudeCli } from './claudeCliQueueDispatch';
 import { ensureClaudeCliSession, claudeCliSessionSupportsPlugins } from './claudeCliLauncherSingleton';
+import { shouldDriveNewlyQueuedPrompt } from './queuedPromptDrivePolicy';
 import { supportsWorkspaceSlashWorkflowProvider } from '../../../shared/agentWorkflowProviders';
 import { captureTutorialMilestone } from '../tutorial/tutorialAnalytics';
 
@@ -2434,36 +2435,12 @@ export class AIService {
         promptCount: 1
       });
 
-      // claude-code-cli (NIM-806): the CLI queue normally drains on the PID
-      // watcher's running->idle transition. But a prompt queued while the CLI is
-      // ALREADY idle (e.g. smart-commit on a session sitting at its prompt) has no
-      // transition to ride, so it would sit forever. If the terminal is live and
-      // the session is idle right now, kick a flush directly. The flush singleton's
-      // in-flight guard + DB claim make this safe against a concurrent transition
-      // flush; if the CLI is mid-turn (running/waiting), we skip and let the next
-      // idle transition drain it.
-      //
-      // NIM-821: idleness is decided from the LIVE PID file, not just
-      // SessionStateManager's snapshot — the snapshot is updated asynchronously
-      // from the PID watcher, and a prompt queued inside that gap (PID already
-      // idle, state still 'running') skipped the kick with no future idle
-      // transition ever coming. Either signal saying idle kicks the flush; the
-      // claim is race-safe, so erring toward flushing is fine.
-      if (queuedSession?.provider === 'claude-code-cli') {
-        const terminalManager = getTerminalSessionManager();
-        const state = getSessionStateManager().getSessionState(sessionId);
-        const workspacePath = queuedSession.workspacePath ?? state?.workspacePath;
-        if (terminalManager.isTerminalActive(sessionId) && workspacePath) {
-          if (state?.status === 'idle') {
-            void flushNextClaudeCliQueuedPromptForSession(sessionId, workspacePath);
-          } else {
-            void terminalManager.getClaudeCliLiveTurnState(sessionId).then((live) => {
-              if (live === 'idle') {
-                void flushNextClaudeCliQueuedPromptForSession(sessionId, workspacePath);
-              }
-            }).catch(() => {});
-          }
-        }
+      // Queue admission must notify the provider-neutral driver. It handles
+      // immediate dispatch, busy-session retry, and Claude CLI's dedicated
+      // delivery rails; a provider-specific idle kick leaves the other desktop
+      // providers with no edge to start their queue.
+      if (shouldDriveNewlyQueuedPrompt(queuedSession)) {
+        this.requestQueueDrive(sessionId, queuedSession.workspacePath, 'renderer-trigger');
       }
 
       return {

--- a/packages/electron/src/main/services/ai/__tests__/aiServiceQueueScheduling.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/aiServiceQueueScheduling.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { shouldDriveNewlyQueuedPrompt } from '../queuedPromptDrivePolicy';
+
+describe('shouldDriveNewlyQueuedPrompt', () => {
+  it('schedules a queue drive for any provider with a workspace', () => {
+    expect(shouldDriveNewlyQueuedPrompt({ provider: 'openai-codex', workspacePath: 'D:/workspace' })).toBe(true);
+    expect(shouldDriveNewlyQueuedPrompt({ provider: 'claude-code-cli', workspacePath: 'D:/workspace' })).toBe(true);
+  });
+
+  it('does not schedule when the session cannot be routed to a workspace', () => {
+    expect(shouldDriveNewlyQueuedPrompt({ provider: 'openai-codex' })).toBe(false);
+    expect(shouldDriveNewlyQueuedPrompt(null)).toBe(false);
+  });
+});

--- a/packages/electron/src/main/services/ai/__tests__/aiServiceQueueScheduling.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/aiServiceQueueScheduling.test.ts
@@ -1,14 +1,24 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { shouldDriveNewlyQueuedPrompt } from '../queuedPromptDrivePolicy';
 
-describe('shouldDriveNewlyQueuedPrompt', () => {
-  it('schedules a queue drive for any provider with a workspace', () => {
-    expect(shouldDriveNewlyQueuedPrompt({ provider: 'openai-codex', workspacePath: 'D:/workspace' })).toBe(true);
-    expect(shouldDriveNewlyQueuedPrompt({ provider: 'claude-code-cli', workspacePath: 'D:/workspace' })).toBe(true);
-  });
+// Vitest may transform a worktree test through the shared package cache. Read
+// from the active checkout so this regression assertion always evaluates the
+// branch under test rather than that cache's source tree.
+const source = readFileSync(
+  resolve(process.cwd(), 'packages/electron/src/main/services/ai/AIService.ts'),
+  'utf8',
+);
+const start = source.indexOf("safeHandle('ai:createQueuedPrompt'");
+const end = source.indexOf("safeHandle('ai:deleteQueuedPrompt'", start);
+const createQueuedPromptHandler = source.slice(start, end);
 
-  it('does not schedule when the session cannot be routed to a workspace', () => {
-    expect(shouldDriveNewlyQueuedPrompt({ provider: 'openai-codex' })).toBe(false);
-    expect(shouldDriveNewlyQueuedPrompt(null)).toBe(false);
+describe('ai:createQueuedPrompt queue-drive admission', () => {
+  it('raises the provider-neutral queue-drive edge after persisting a prompt', () => {
+    expect(createQueuedPromptHandler).not.toContain("queuedSession?.provider === 'claude-code-cli'");
+    expect(createQueuedPromptHandler).toContain(
+      "this.requestQueueDrive(sessionId, queuedSession.workspacePath, 'renderer-trigger')",
+    );
   });
 });

--- a/packages/electron/src/main/services/ai/queuedPromptDrivePolicy.ts
+++ b/packages/electron/src/main/services/ai/queuedPromptDrivePolicy.ts
@@ -1,0 +1,10 @@
+/**
+ * Queue admission must raise a drive edge for every provider. The driver owns
+ * provider-specific dispatch and deferred retry; a caller only needs a usable
+ * workspace route.
+ */
+export function shouldDriveNewlyQueuedPrompt(
+  session: { provider?: string; workspacePath?: string } | null | undefined,
+): session is { workspacePath: string } {
+  return typeof session?.workspacePath === 'string' && session.workspacePath.length > 0;
+}


### PR DESCRIPTION
## NIM-465 — drive desktop queues across providers

### User outcome

A prompt accepted from the desktop for an idle non-CLI provider raises the existing provider-neutral queue-drive edge instead of remaining stranded.

### Carry receipt

- Stable source / merge-base: `v0.73.2` / `c0f6b6cdd138dc707ec4688ae9013a4ea76f9534`
- Fork head: `d3b8bcd11218b2be80c4d944f29c2f739b5575a6` (safe CI-retrigger commit; functional range ends at `53297645356a14799806e9f31db54dba9202291d`)
- GitHub PR base: `nimbalyst/nimbalyst:main` / `4a42e0ad5cca7973251e3513db3ecd036171bd7d`
- Recovered provenance: repair `671eddbdae489aecec0d6d2adb0786071d7b05c6`; regression receipt re-authored as `532976453` from `689beb485d54b491eb83c91c81d780ee9b753cb3`.
- Source/reuse: stable has the provider-neutral driver but `ai:createQueuedPrompt` raises its edge only for `claude-code-cli`; upstream main retains the same provider guard. The carry changes only queue admission to the existing driver.
- Changed paths:
  - `packages/electron/src/main/services/ai/AIService.ts`
  - `packages/electron/src/main/services/ai/queuedPromptDrivePolicy.ts`
  - `packages/electron/src/main/services/ai/__tests__/aiServiceQueueScheduling.test.ts`
- Clean-base reproduction: in fresh `v0.73.2` worktree `D:\nimbalyst-worktrees\v14c-nim465-repro-verified`, the focused test fails on the retained `claude-code-cli` provider guard.
- Focused repair test: `vitest run packages/electron/src/main/services/ai/__tests__/aiServiceQueueScheduling.test.ts` — **1 passed**.
- Normal Windows pre-push hook passed without bypass: fixture-author, dependency-override, tracked-NUL, prerequisite-build, 23-workspace typecheck, and focused pre-push tests all passed. The full Vitest suite remains intentionally skipped on local Windows per `docs/WINDOWS_PREPUSH_GATE.md`; CI runs it.
- Hygiene: no generated binary, lockfile, or workspace-manifest file is in the candidate range.

This CReq does not depend on unmerged upstream draft PR #1155. No merge or release is requested.

## Why this is worth merging

A queued prompt should not depend on a provider-specific follow-up event to begin moving. This patch makes queue admission and drive behavior provider-neutral, closes the gap where valid desktop work could remain parked indefinitely, and preserves ownership and settlement guards so the fix does not trade a stall for duplicate execution.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
