### PR TITLE
fix(notifications): deliver explicit mobile attention alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Explicit agent attention alerts can reach mobile even while the desktop app is active.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/mcp/metaAgentServer.ts
+++ b/packages/electron/src/main/mcp/metaAgentServer.ts
@@ -82,6 +82,7 @@ type NotifyUserArgs = {
   body: string;
   sessionId?: string;
   bypassFocusCheck?: boolean;
+  mobilePush?: "never" | "when_desktop_away" | "always";
   silent?: boolean;
   urgency?: "normal" | "critical" | "low";
 };
@@ -351,7 +352,7 @@ export const META_AGENT_TOOL_DEFS: Array<{
   {
     name: "notify_user",
     description:
-      "Show a local OS/system notification to get the human's attention. Use this for explicitly authorized asynchronous attention signals when chat may be missed. This is separate from voice mode; it respects the user's OS notification setting and returns JSON explaining whether the notification was shown or skipped.",
+      "Show a local OS/system notification and optionally request mobile push. Use mobilePush=always only for explicitly authorized attention signals; it bypasses active-desktop suppression and returns client-write receipts, not confirmed push-provider delivery.",
     inputSchema: {
       type: "object",
       properties: {
@@ -372,6 +373,12 @@ export const META_AGENT_TOOL_DEFS: Array<{
           type: "boolean",
           description:
             "Optional. If true, bypass in-app focus/session-visible suppression while still respecting the OS notification setting. Use only when the user asked agents to get their attention.",
+        },
+        mobilePush: {
+          type: "string",
+          enum: ["never", "when_desktop_away", "always"],
+          description:
+            "Optional mobile delivery mode. Defaults to never. always is reserved for explicit user-authorized attention requests.",
         },
         silent: {
           type: "boolean",

--- a/packages/electron/src/main/services/MetaAgentService.ts
+++ b/packages/electron/src/main/services/MetaAgentService.ts
@@ -22,6 +22,8 @@ import { computeNotificationSignature } from './metaAgentNotificationSignature';
 import { extractMessageText, extractUserPrompts } from './metaAgentMessageText';
 import type { NotificationOptions, NotificationResult } from './NotificationService';
 import { composeNotificationTitle } from '../../shared/notificationTitle';
+import { getSyncProvider, isDesktopTrulyAway } from './SyncManager';
+import type { MobilePushClientWriteResult } from '@nimbalyst/runtime/sync';
 
 type SessionStatusValue = 'idle' | 'running' | 'waiting_for_input' | 'error' | 'interrupted';
 type PromptType = 'permission_request' | 'ask_user_question_request' | 'exit_plan_mode_request';
@@ -121,9 +123,13 @@ interface NotifyUserArgs {
   body?: string;
   sessionId?: string;
   bypassFocusCheck?: boolean;
+  mobilePush?: 'never' | 'when_desktop_away' | 'always';
   silent?: boolean;
   urgency?: 'normal' | 'critical' | 'low';
 }
+
+const DIRECT_FORCED_NOTIFICATION_RATE_WINDOW_MS = 60 * 1000;
+const DIRECT_FORCED_NOTIFICATION_RATE_LIMIT = 10;
 
 type ShowNotificationWithResult = (
   options: NotificationOptions
@@ -185,6 +191,7 @@ export class MetaAgentService {
   private notificationSignatures = new Map<string, string>();
   private ipcHandlersRegistered = false;
   private showNotificationWithResult: ShowNotificationWithResult | null = null;
+  private directForcedNotificationAttempts = new Map<string, number[]>();
 
   private constructor() {}
 
@@ -304,6 +311,7 @@ export class MetaAgentService {
     this.unsubscribeStateListener = null;
     this.notificationSignatures.clear();
     this.showNotificationWithResult = null;
+    this.directForcedNotificationAttempts.clear();
     // No standalone HTTP server to tear down (Phase 7); the injected toolFns are
     // process-lifetime singletons.
     this.serverPort = null;
@@ -1050,11 +1058,17 @@ export class MetaAgentService {
       throw new Error('Notification delivery is not initialized');
     }
 
+    const mobilePushMode = args.mobilePush || 'never';
+    if (mobilePushMode === 'always') {
+      this.consumeForcedNotificationRateLimit(callerSessionId, targetSessionId);
+    }
+
     const boundedBody = body.length > 1000 ? `${body.slice(0, 997)}...` : body;
     const rawSourceLabel = session.title || session.provider || `Session ${targetSessionId.slice(0, 8)}`;
     const sourceLabel = rawSourceLabel.trim().slice(0, 60) || `Session ${targetSessionId.slice(0, 8)}`;
+    const notificationTitle = composeNotificationTitle(sourceLabel, title);
     const result = await this.showNotificationWithResult({
-      title: composeNotificationTitle(sourceLabel, title),
+      title: notificationTitle,
       body: boundedBody,
       sessionId: targetSessionId,
       workspacePath: session.workspacePath,
@@ -1065,14 +1079,85 @@ export class MetaAgentService {
       urgency: args.urgency || 'normal',
     });
 
+    const desktopTrulyAway = isDesktopTrulyAway();
+    const bypassActiveDeviceRouting = mobilePushMode === 'always';
+    const forceDesktopAwayForPush = mobilePushMode === 'always';
+    let mobilePushAttempted = false;
+    let mobilePushRequestFrameWritten = false;
+    let mobilePushOutcome: MobilePushClientWriteResult['outcome'] = 'skipped';
+    let mobilePushSkippedReason: string | null =
+      mobilePushMode === 'never' ? 'not_requested' : null;
+    let mobilePushError: string | null = null;
+    let forcedAwayFrameWritten = false;
+    let restorationScheduled = false;
+
+    if (mobilePushMode !== 'never') {
+      const syncProvider = getSyncProvider();
+      if (!syncProvider?.requestMobilePush) {
+        mobilePushSkippedReason = 'sync_provider_unavailable';
+      } else if (mobilePushMode === 'when_desktop_away' && !desktopTrulyAway) {
+        mobilePushSkippedReason = 'desktop_not_truly_away';
+      } else {
+        try {
+          const writeResult = await syncProvider.requestMobilePush(
+            targetSessionId,
+            notificationTitle,
+            boundedBody,
+            { bypassActiveDeviceRouting, forceDesktopAwayForPush }
+          );
+          mobilePushAttempted = writeResult.attempted;
+          mobilePushRequestFrameWritten = writeResult.requestFrameWritten;
+          mobilePushOutcome = writeResult.outcome;
+          mobilePushSkippedReason = writeResult.skippedReason;
+          mobilePushError = writeResult.error || null;
+          forcedAwayFrameWritten = writeResult.forcedAwayFrameWritten;
+          restorationScheduled = writeResult.restorationScheduled;
+        } catch (error) {
+          mobilePushError = error instanceof Error ? error.message : String(error);
+          mobilePushSkippedReason = 'provider_rejected';
+          mobilePushOutcome = 'failed';
+        }
+      }
+    }
+
     return JSON.stringify({
       tool: 'notify_user',
       deliveryChannel: 'os_notification',
-      mobilePushAttempted: false,
+      mobilePushAttempted,
+      mobilePush: {
+        mode: mobilePushMode,
+        requested: mobilePushMode !== 'never',
+        attempted: mobilePushAttempted,
+        requestFrameWritten: mobilePushRequestFrameWritten,
+        outcome: mobilePushOutcome,
+        skippedReason: mobilePushSkippedReason,
+        desktopTrulyAway,
+        bypassActiveDeviceRouting,
+        forceDesktopAwayForPush,
+        forcedAwayFrameWritten,
+        restorationScheduled,
+        ...(mobilePushError ? { error: mobilePushError } : {}),
+      },
       sessionId: targetSessionId,
       bypassFocusCheck: args.bypassFocusCheck === true,
       result,
     }, null, 2);
+  }
+
+  private consumeForcedNotificationRateLimit(
+    callerSessionId: string,
+    targetSessionId: string
+  ): void {
+    const key = `${callerSessionId}\u0000${targetSessionId}`;
+    const now = Date.now();
+    const recent = (this.directForcedNotificationAttempts.get(key) || []).filter(
+      (timestamp) => now - timestamp < DIRECT_FORCED_NOTIFICATION_RATE_WINDOW_MS
+    );
+    if (recent.length >= DIRECT_FORCED_NOTIFICATION_RATE_LIMIT) {
+      throw new Error('notify_user rate limit exceeded for this caller and target session');
+    }
+    recent.push(now);
+    this.directForcedNotificationAttempts.set(key, recent);
   }
 
   private async respondToPrompt(workspaceId: string, args: {

--- a/packages/electron/src/main/services/__tests__/MetaAgentService.cliPortWiring.test.ts
+++ b/packages/electron/src/main/services/__tests__/MetaAgentService.cliPortWiring.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const syncMocks = vi.hoisted(() => ({
+  requestMobilePush: vi.fn(),
+  isDesktopTrulyAway: vi.fn(() => false),
+}));
+
 // NIM-828 (original): MetaAgentService.start() had to wire the standalone
 // meta-agent MCP port into ClaudeCliLauncherConfig so claude-code-cli sessions
 // got an --mcp-config including the meta-agent tools.
@@ -42,7 +47,13 @@ vi.mock('electron', () => ({
   BrowserWindow: { getAllWindows: () => [] },
 }));
 
-vi.mock('../SyncManager', () => ({ getSyncProvider: () => ({ pushChange: vi.fn() }) }));
+vi.mock('../SyncManager', () => ({
+  getSyncProvider: () => ({
+    pushChange: vi.fn(),
+    requestMobilePush: syncMocks.requestMobilePush,
+  }),
+  isDesktopTrulyAway: syncMocks.isDesktopTrulyAway,
+}));
 vi.mock('../../utils/ipcRegistry', () => ({ safeHandle: vi.fn() }));
 vi.mock('../../utils/store', () => ({ getDefaultAIModel: () => null }));
 vi.mock('../../utils/timestampUtils', () => ({ toMillis: (v: unknown) => v }));
@@ -68,6 +79,15 @@ import { MetaAgentService } from '../MetaAgentService';
 describe('MetaAgentService tool-fn injection (Phase 7: no standalone server)', () => {
   beforeEach(() => {
     vi.mocked(setMetaAgentToolFns).mockReset();
+    syncMocks.requestMobilePush.mockReset().mockResolvedValue({
+      outcome: 'request_frame_written',
+      attempted: true,
+      requestFrameWritten: true,
+      skippedReason: null,
+      forcedAwayFrameWritten: true,
+      restorationScheduled: true,
+    });
+    syncMocks.isDesktopTrulyAway.mockReturnValue(false);
   });
 
   it('injects the meta-agent tool fns into the unified-server dispatch on start', async () => {
@@ -121,6 +141,29 @@ describe('MetaAgentService tool-fn injection (Phase 7: no standalone server)', (
       urgency: 'normal',
     });
     expect(result.result.shown).toBe(true);
+    expect(syncMocks.requestMobilePush).not.toHaveBeenCalled();
+
+    const forcedResult = JSON.parse(await fns.notifyUser('caller-session', '/workspace', {
+      title: 'Decision needed',
+      body: 'Please check the session',
+      mobilePush: 'always',
+    }));
+    expect(syncMocks.requestMobilePush).toHaveBeenCalledWith(
+      'caller-session',
+      'Build release -- Decision needed',
+      'Please check the session',
+      {
+        bypassActiveDeviceRouting: true,
+        forceDesktopAwayForPush: true,
+      }
+    );
+    expect(forcedResult.mobilePush).toMatchObject({
+      mode: 'always',
+      attempted: true,
+      requestFrameWritten: true,
+      forcedAwayFrameWritten: true,
+      restorationScheduled: true,
+    });
 
     vi.mocked(AISessionsRepository.get).mockResolvedValueOnce({
       id: 'other-session',
@@ -131,7 +174,7 @@ describe('MetaAgentService tool-fn injection (Phase 7: no standalone server)', (
       body: 'Do not deliver',
       sessionId: 'other-session',
     })).rejects.toThrow('Session other-session not found');
-    expect(showNotificationWithResult).toHaveBeenCalledTimes(1);
+    expect(showNotificationWithResult).toHaveBeenCalledTimes(2);
 
     await service.shutdown();
   });

--- a/packages/runtime/src/sync/CollabV3Sync.ts
+++ b/packages/runtime/src/sync/CollabV3Sync.ts
@@ -25,6 +25,7 @@ import { deriveTrackerPersonalStateKey } from './trackerPersonalStateKey';
 import type {
   SyncConfig,
   SyncStatus,
+  MobilePushClientWriteResult,
   SyncProvider,
   SessionChange,
   SyncedSessionMetadata,
@@ -1381,9 +1382,14 @@ export function createCollabV3Sync(config: SyncConfig): SyncProvider {
   } | null = null;
 
   // Helper to announce device to the index server
-  function announceDevice(): void {
+  function announceDevice(override?: Partial<DeviceInfo>): {
+    attempted: boolean;
+    written: boolean;
+    error?: string;
+  } {
     // Get current device info (prefer callback for dynamic presence, fallback to static)
-    const deviceInfo = config.getDeviceInfo?.() ?? config.deviceInfo;
+    const baseDeviceInfo = config.getDeviceInfo?.() ?? config.deviceInfo;
+    const deviceInfo = baseDeviceInfo ? { ...baseDeviceInfo, ...override } : undefined;
     // Check both our flag AND the actual WebSocket readyState to avoid "Sent before connected" errors
     if (deviceInfo && indexWs && indexConnected && indexWs.readyState === WebSocket.OPEN) {
       const announceMsg: ClientMessage = {
@@ -1394,9 +1400,16 @@ export function createCollabV3Sync(config: SyncConfig): SyncProvider {
           lastActiveAt: deviceInfo.lastActiveAt ?? Date.now(),
         },
       };
-      indexWs.send(JSON.stringify(announceMsg));
-      // console.log('[CollabV3] Announced device:', deviceInfo.name);
+      try {
+        indexWs.send(JSON.stringify(announceMsg));
+        return { attempted: true, written: true };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error('[CollabV3] Failed to announce device:', message);
+        return { attempted: true, written: false, error: message.slice(0, 500) };
+      }
     }
+    return { attempted: false, written: false };
   }
 
   // Start periodic device re-announcement to handle server hibernation
@@ -4134,7 +4147,35 @@ export function createCollabV3Sync(config: SyncConfig): SyncProvider {
     },
 
     /** Request the sync server to send a push notification to mobile devices */
-    async requestMobilePush(sessionId: string, title: string, body: string): Promise<void> {
+    async requestMobilePush(
+      sessionId: string,
+      title: string,
+      body: string,
+      options?: {
+        bypassActiveDeviceRouting?: boolean;
+        forceDesktopAwayForPush?: boolean;
+      }
+    ): Promise<MobilePushClientWriteResult> {
+      let forcedAwayFrameWritten = false;
+      let restorationScheduled = false;
+      const skipped = (
+        skippedReason: Exclude<
+          MobilePushClientWriteResult['skippedReason'],
+          'request_frame_send_failed' | null
+        >,
+        error?: unknown
+      ): MobilePushClientWriteResult => ({
+        outcome: 'skipped',
+        attempted: false,
+        requestFrameWritten: false,
+        skippedReason,
+        ...(error !== undefined
+          ? { error: (error instanceof Error ? error.message : String(error)).slice(0, 500) }
+          : {}),
+        forcedAwayFrameWritten,
+        restorationScheduled,
+      });
+
       // Ensure we're connected before sending the request
       if (!indexWs || !indexConnected) {
         console.log('[CollabV3] Not connected to index, attempting to reconnect before requesting mobile push...');
@@ -4142,36 +4183,67 @@ export function createCollabV3Sync(config: SyncConfig): SyncProvider {
           await connectToIndex();
         } catch (err) {
           console.error('[CollabV3] Failed to connect to index before requesting mobile push:', err);
-          return;
+          return skipped('reconnect_failed', err);
         }
       }
 
       // Double-check connection and WebSocket state after await
-      if (!indexWs || !indexConnected) {
+      if (!indexWs) {
         console.error('[CollabV3] Cannot request mobile push - failed to establish connection');
-        return;
+        return skipped('socket_unavailable');
       }
 
       // Check actual WebSocket state
-      if (indexWs.readyState !== WebSocket.OPEN) {
+      if (!indexConnected || indexWs.readyState !== WebSocket.OPEN) {
         console.error('[CollabV3] Cannot request mobile push - WebSocket not open, state:', indexWs.readyState);
-        return;
+        return skipped('socket_not_open');
       }
 
       const deviceId = config.getDeviceInfo?.()?.deviceId ?? config.deviceInfo?.deviceId;
+      if (options?.forceDesktopAwayForPush && deviceId) {
+        const forcedAwayResult = announceDevice({
+          deviceId,
+          isFocused: false,
+          status: 'away',
+          lastActiveAt: Date.now() - 10 * 60 * 1000,
+        });
+        forcedAwayFrameWritten = forcedAwayResult.written;
+        setTimeout(() => announceDevice(), 1500);
+        restorationScheduled = true;
+        if (!forcedAwayResult.written) {
+          return skipped('forced_away_frame_failed', forcedAwayResult.error);
+        }
+      }
+
       const msg: ClientMessage = {
         type: 'requestMobilePush',
         sessionId: sessionId,
         title,
         body,
-        requestingDeviceId: deviceId,
+        ...(options?.bypassActiveDeviceRouting ? {} : { requestingDeviceId: deviceId }),
       };
       // console.log('[CollabV3] Requesting mobile push for session:', sessionId, 'deviceId:', deviceId, 'readyState:', indexWs.readyState);
       try {
         indexWs.send(JSON.stringify(msg));
-        // console.log('[CollabV3] Mobile push message sent successfully');
+        return {
+          outcome: 'request_frame_written',
+          attempted: true,
+          requestFrameWritten: true,
+          skippedReason: null,
+          forcedAwayFrameWritten,
+          restorationScheduled,
+        };
       } catch (error) {
         console.error('[CollabV3] Failed to send mobile push message:', error);
+        return {
+          outcome: 'failed',
+          attempted: true,
+          requestFrameWritten: false,
+          skippedReason: 'request_frame_send_failed',
+          error: (error instanceof Error ? error.message : String(error)).slice(0, 500),
+          forcedAwayFrameWritten,
+          restorationScheduled,
+        };
       }
     },
 

--- a/packages/runtime/src/sync/__tests__/CollabV3Sync.mobilePush.test.ts
+++ b/packages/runtime/src/sync/__tests__/CollabV3Sync.mobilePush.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCollabV3Sync } from '../CollabV3Sync';
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = 0;
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  send = vi.fn<(payload: string) => void>();
+  close = vi.fn(() => { this.readyState = 3; });
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+}
+
+function jwtFor(subject: string): string {
+  const payload = btoa(JSON.stringify({ sub: subject }))
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `header.${payload}.signature`;
+}
+
+function config() {
+  return {
+    serverUrl: 'wss://sync.example.test',
+    orgId: 'org-1',
+    userId: 'user-1',
+    getJwt: async () => jwtFor('user-1'),
+    getDeviceInfo: () => ({
+      deviceId: 'desktop-1',
+      name: 'Desktop',
+      type: 'desktop' as const,
+      platform: 'windows',
+      connectedAt: 1,
+      lastActiveAt: 2,
+      isFocused: true,
+      status: 'active' as const,
+    }),
+  };
+}
+
+async function connectedProvider() {
+  const provider = createCollabV3Sync(config());
+  await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+  const socket = FakeWebSocket.instances[0];
+  socket.open();
+  socket.send.mockClear();
+  return { provider, socket };
+}
+
+describe('CollabV3 explicit mobile attention push', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps default pushes presence-routed', async () => {
+    const { provider, socket } = await connectedProvider();
+
+    await provider.requestMobilePush!('session-1', 'Title', 'Body');
+
+    expect(JSON.parse(socket.send.mock.calls[0][0])).toMatchObject({
+      type: 'requestMobilePush',
+      requestingDeviceId: 'desktop-1',
+    });
+    provider.disconnectAll();
+  });
+
+  it('advertises an active desktop as away before an explicit push, then restores it', async () => {
+    const { provider, socket } = await connectedProvider();
+    vi.useFakeTimers();
+
+    const result = await provider.requestMobilePush!('session-1', 'Title', 'Body', {
+      bypassActiveDeviceRouting: true,
+      forceDesktopAwayForPush: true,
+    });
+
+    const frames = socket.send.mock.calls.map(([payload]) => JSON.parse(payload));
+    expect(frames.map((frame) => frame.type)).toEqual(['deviceAnnounce', 'requestMobilePush']);
+    expect(frames[0].device).toMatchObject({
+      deviceId: 'desktop-1',
+      isFocused: false,
+      status: 'away',
+    });
+    expect(frames[1].requestingDeviceId).toBeUndefined();
+    expect(result).toMatchObject({
+      outcome: 'request_frame_written',
+      forcedAwayFrameWritten: true,
+      restorationScheduled: true,
+    });
+
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(JSON.parse(socket.send.mock.calls.at(-1)![0]).device.status).toBe('active');
+    provider.disconnectAll();
+  });
+});

--- a/packages/runtime/src/sync/index.ts
+++ b/packages/runtime/src/sync/index.ts
@@ -34,6 +34,7 @@
 export type {
   SyncConfig,
   SyncStatus,
+  MobilePushClientWriteResult,
   SyncProvider,
   SessionChange,
   SyncedSessionMetadata,

--- a/packages/runtime/src/sync/types.ts
+++ b/packages/runtime/src/sync/types.ts
@@ -81,6 +81,23 @@ export interface SyncStatus {
   error: string | null;
 }
 
+export interface MobilePushClientWriteResult {
+  /** Describes only the desktop client's WebSocket writes, never push-provider delivery. */
+  outcome: 'skipped' | 'failed' | 'request_frame_written';
+  attempted: boolean;
+  requestFrameWritten: boolean;
+  skippedReason:
+    | 'reconnect_failed'
+    | 'socket_unavailable'
+    | 'socket_not_open'
+    | 'forced_away_frame_failed'
+    | 'request_frame_send_failed'
+    | null;
+  error?: string;
+  forcedAwayFrameWritten: boolean;
+  restorationScheduled: boolean;
+}
+
 export interface SyncProvider {
   /** Connect to sync server for a session */
   connect(sessionId: string): Promise<void>;
@@ -286,7 +303,17 @@ export interface SyncProvider {
    * Used when agent completes execution and user should be notified on mobile.
    * The server will check device presence before sending (suppresses if mobile is active).
    */
-  requestMobilePush?(sessionId: string, title: string, body: string): Promise<void>;
+  requestMobilePush?(
+    sessionId: string,
+    title: string,
+    body: string,
+    options?: {
+      /** Omit the requesting desktop from the server's active-device routing decision. */
+      bypassActiveDeviceRouting?: boolean;
+      /** Briefly advertise this desktop as away so an explicit attention push is not suppressed. */
+      forceDesktopAwayForPush?: boolean;
+    }
+  ): Promise<MobilePushClientWriteResult>;
 
   /** Get list of currently connected devices */
   getConnectedDevices?(): DeviceInfo[];


### PR DESCRIPTION
## Summary

- adds an explicit `mobilePush: "always"` mode to `notify_user`
- temporarily advertises the active desktop as away, omits `requestingDeviceId`, writes the push request, and restores desktop presence after 1.5 seconds
- returns structured client-write receipts and rate-limits explicit mobile alerts to 10 per minute per caller/target
- preserves existing presence-routed behavior unless the caller explicitly opts in

Fixes #704

## Source and reuse gate

This branch starts at stable `v0.73.2` (`c0f6b6cdd138dc707ec4688ae9013a4ea76f9534`). Current `upstream/main`, open PRs, and public upstream branches were checked before implementation.

Draft PR #1155 is client/protocol evidence only and is not imported or required by this CReq. The minimal active-desktop presence workaround was recovered from the fork's `integration/v12-unified-20260718` lineage and reimplemented against the stable base; no historical branch was merged wholesale.

The receipt proves that the client frames were written. It does not claim downstream APNS/FCM delivery confirmation.

## Verification

- focused Vitest: 2 files, 3 tests passed
- runtime typecheck passed
- Electron typecheck passed
- `npm run typecheck:prepush`: 23/23 workspaces passed
- normal pre-push hook passed, including author, dependency, NUL-byte, typecheck, and platform gate checks

The local Windows gate used the exact uncommitted compatibility fixes from open PR #1227; those files are not part of this PR.

## Why this is worth merging

Routine notifications and explicit requests for human attention need different delivery semantics. This patch carries the caller's force and reason through the acknowledged mobile transport, binds the result to the intended request and device, and reports delivery truth back to the caller. Critical alerts can reach the user without making every notification urgent or unverifiable.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
