### PR TITLE
fix(startup): recover watcher attention obligations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Configured attention watchers can restore their pending deadlines after Nimbalyst restarts.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -14,6 +14,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { join } from 'path';
 import * as fs from 'fs';
+import { randomUUID } from 'crypto';
 import { appendFileSync, existsSync, renameSync, unlinkSync, writeFileSync } from 'fs';
 import {
     createWindow,
@@ -172,6 +173,7 @@ import { getSessionWakeupsStore, repositoryManager } from './services/Repository
 import { ExtensionDevService } from './services/ExtensionDevService';
 import { MetaAgentService } from './services/MetaAgentService';
 import { notificationService } from './services/NotificationService';
+import { runWatcherObligationStartupRecovery } from './services/WatcherObligationStartupRecovery';
 // SuperLoopProgressService import removed - server disabled (leaking into non-super-loop sessions)
 import { registerMockupHandlers } from './ipc/MockupHandlers';
 import { registerOffscreenEditorHandlers } from './ipc/OffscreenEditorHandlers';
@@ -2643,6 +2645,14 @@ app.whenReady().then(async () => {
         );
     } catch (error) {
         logger.mcp.error('Failed to start meta-agent MCP server:', error);
+    }
+
+    // Restore externally-owned attention deadlines only after the local control
+    // surface is ready, and before scheduled session wakeups resume work.
+    try {
+        await runWatcherObligationStartupRecovery({ hostBootId: randomUUID() });
+    } catch (error) {
+        logger.main.warn('[Main] Watcher-obligation startup recovery failed:', error);
     }
 
     // Start session wakeup scheduler (persistent scheduled re-invocations)

--- a/packages/electron/src/main/services/WatcherObligationStartupRecovery.ts
+++ b/packages/electron/src/main/services/WatcherObligationStartupRecovery.ts
@@ -1,0 +1,218 @@
+/**
+ * Gives an operator-configured watcher controller one bounded opportunity to
+ * re-establish durable attention deadlines after this app process restarts.
+ */
+import { spawn, type ChildProcess } from 'child_process';
+import { logger } from '../utils/logger';
+
+const ARGV_ENV_VAR = 'NIMBALYST_WATCHER_OBLIGATION_RECOVERY_ARGV';
+const CWD_ENV_VAR = 'NIMBALYST_WATCHER_OBLIGATION_RECOVERY_CWD';
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_OUTPUT_BYTES = 4096;
+const UUID_PATH_SEGMENT = /([\\/])[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=([\\/]|$))/gi;
+
+export interface WatcherObligationRecoveryResult {
+  recovered: boolean;
+  reason: string;
+  nonce: string;
+}
+
+export type RecoveryEnvSource = Record<string, string | undefined>;
+export type SpawnFn = (
+  command: string,
+  args: string[],
+  options: { cwd: string; shell: boolean; stdio: ['ignore', 'pipe', 'pipe'] }
+) => ChildProcess;
+
+export interface RunWatcherObligationStartupRecoveryOptions {
+  hostBootId: string;
+  env?: RecoveryEnvSource;
+  timeoutMs?: number;
+  spawnFn?: SpawnFn;
+}
+
+function redactUuidPathSegments(value: string): string {
+  return value.replace(UUID_PATH_SEGMENT, '$1...[redacted]');
+}
+
+function parseArgv(raw: string | undefined): string[] | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length === 0 ||
+      !parsed.every((entry) => typeof entry === 'string' && entry.length > 0)
+    ) {
+      return null;
+    }
+    return parsed as string[];
+  } catch {
+    return null;
+  }
+}
+
+const attemptsByBootId = new Map<string, Promise<WatcherObligationRecoveryResult>>();
+
+function runConfiguredRecovery(params: {
+  command: string;
+  args: string[];
+  cwd: string;
+  hostBootId: string;
+  timeoutMs: number;
+  spawnFn: SpawnFn;
+}): Promise<WatcherObligationRecoveryResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = '';
+    let outputBytes = 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (
+      result: WatcherObligationRecoveryResult,
+      beforeResolve?: () => void
+    ): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      beforeResolve?.();
+      resolve(result);
+    };
+
+    let child: ChildProcess;
+    try {
+      child = params.spawnFn(params.command, params.args, {
+        cwd: params.cwd,
+        shell: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      finish({
+        recovered: false,
+        reason: `spawn failed: ${redactUuidPathSegments(message)}`,
+        nonce: params.hostBootId,
+      });
+      return;
+    }
+
+    const stopChild = (): void => {
+      try {
+        child.kill();
+      } catch {
+        // The bounded attempt is already settled.
+      }
+    };
+
+    timer = setTimeout(() => {
+      finish(
+        { recovered: false, reason: 'timeout', nonce: params.hostBootId },
+        stopChild
+      );
+    }, params.timeoutMs);
+    timer.unref?.();
+
+    const collect = (chunk: Buffer, stream: 'stdout' | 'stderr'): void => {
+      if (settled) return;
+      outputBytes += chunk.length;
+      if (outputBytes > MAX_OUTPUT_BYTES) {
+        finish(
+          { recovered: false, reason: 'output exceeded size limit', nonce: params.hostBootId },
+          stopChild
+        );
+        return;
+      }
+      if (stream === 'stdout') stdout += chunk.toString('utf8');
+      // stderr is deliberately not retained: controller output may contain
+      // operator-sensitive details and is not needed for the bounded receipt.
+    };
+    child.stdout?.on('data', (chunk: Buffer) => collect(chunk, 'stdout'));
+    child.stderr?.on('data', (chunk: Buffer) => collect(chunk, 'stderr'));
+
+    child.on('error', (error: Error) => {
+      finish({
+        recovered: false,
+        reason: `spawn error: ${redactUuidPathSegments(error.message)}`,
+        nonce: params.hostBootId,
+      });
+    });
+
+    child.on('close', (code: number | null) => {
+      if (settled) return;
+      if (code !== 0) {
+        finish({
+          recovered: false,
+          reason: `recovery command exited ${code}`,
+          nonce: params.hostBootId,
+        });
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(stdout.trim()) as { status?: unknown };
+        if (parsed?.status !== 'recovered') throw new Error('unexpected schema');
+      } catch {
+        finish({
+          recovered: false,
+          reason: 'malformed recovery output',
+          nonce: params.hostBootId,
+        });
+        return;
+      }
+
+      finish({
+        recovered: true,
+        reason: 'recovery command reported recovered',
+        nonce: params.hostBootId,
+      });
+    });
+  });
+}
+
+export async function runWatcherObligationStartupRecovery(
+  options: RunWatcherObligationStartupRecoveryOptions
+): Promise<WatcherObligationRecoveryResult> {
+  const {
+    hostBootId,
+    env = process.env,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    spawnFn = spawn as unknown as SpawnFn,
+  } = options;
+
+  if (!hostBootId) {
+    return { recovered: false, reason: 'missing hostBootId', nonce: '' };
+  }
+
+  const priorAttempt = attemptsByBootId.get(hostBootId);
+  if (priorAttempt) return priorAttempt;
+
+  const argv = parseArgv(env[ARGV_ENV_VAR]);
+  if (!argv) {
+    return { recovered: false, reason: 'not configured', nonce: hostBootId };
+  }
+
+  const [command, ...leadingArgs] = argv;
+  const recoveryPromise = Promise.resolve().then(() =>
+    runConfiguredRecovery({
+      command,
+      args: [...leadingArgs, 'recover', '--nonce', hostBootId],
+      cwd: env[CWD_ENV_VAR] || process.cwd(),
+      hostBootId,
+      timeoutMs,
+      spawnFn,
+    })
+  );
+  attemptsByBootId.set(hostBootId, recoveryPromise);
+
+  const result = await recoveryPromise;
+  if (result.recovered) {
+    logger.main.info(`[WatcherObligationStartupRecovery] recovered (nonce=${result.nonce})`);
+  } else {
+    logger.main.warn(`[WatcherObligationStartupRecovery] not recovered: ${result.reason}`);
+  }
+  return result;
+}
+
+export function __resetWatcherObligationRecoveryForTests(): void {
+  attemptsByBootId.clear();
+}

--- a/packages/electron/src/main/services/__tests__/WatcherObligationStartupRecovery.test.ts
+++ b/packages/electron/src/main/services/__tests__/WatcherObligationStartupRecovery.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { EventEmitter } from 'events';
+import type { ChildProcess } from 'child_process';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { main: { info: vi.fn(), warn: vi.fn() } },
+}));
+
+import {
+  __resetWatcherObligationRecoveryForTests,
+  runWatcherObligationStartupRecovery,
+  type SpawnFn,
+} from '../WatcherObligationStartupRecovery';
+
+const ARGV_ENV_VAR = 'NIMBALYST_WATCHER_OBLIGATION_RECOVERY_ARGV';
+
+function fakeChild(): {
+  child: ChildProcess;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+} {
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  const kill = vi.fn(() => true);
+  const child = Object.assign(new EventEmitter(), { stdout, stderr, kill }) as unknown as ChildProcess;
+  return { child, stdout, stderr, kill };
+}
+
+function configuredEnv(): Record<string, string> {
+  return { [ARGV_ENV_VAR]: JSON.stringify(['watcher-controller', '--format', 'json']) };
+}
+
+describe('runWatcherObligationStartupRecovery', () => {
+  beforeEach(() => {
+    __resetWatcherObligationRecoveryForTests();
+  });
+
+  it('is a silent no-op when no controller is configured', async () => {
+    const spawnFn = vi.fn();
+    await expect(runWatcherObligationStartupRecovery({
+      hostBootId: 'boot-unconfigured',
+      env: {},
+      spawnFn: spawnFn as unknown as SpawnFn,
+    })).resolves.toEqual({
+      recovered: false,
+      reason: 'not configured',
+      nonce: 'boot-unconfigured',
+    });
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('passes a stable boot nonce and accepts only the recovered receipt', async () => {
+    const spawnFn = vi.fn(() => {
+      const { child, stdout } = fakeChild();
+      queueMicrotask(() => {
+        stdout.emit('data', Buffer.from('{"status":"recovered"}'));
+        child.emit('close', 0);
+      });
+      return child;
+    });
+
+    await expect(runWatcherObligationStartupRecovery({
+      hostBootId: 'boot-success',
+      env: configuredEnv(),
+      spawnFn: spawnFn as unknown as SpawnFn,
+    })).resolves.toMatchObject({ recovered: true, nonce: 'boot-success' });
+    expect(spawnFn).toHaveBeenCalledWith(
+      'watcher-controller',
+      ['--format', 'json', 'recover', '--nonce', 'boot-success'],
+      expect.objectContaining({ shell: false, stdio: ['ignore', 'pipe', 'pipe'] })
+    );
+  });
+
+  it('shares one in-flight recovery attempt for the same boot', async () => {
+    const fake = fakeChild();
+    const spawnFn = vi.fn(() => fake.child);
+    const options = {
+      hostBootId: 'boot-deduped',
+      env: configuredEnv(),
+      spawnFn: spawnFn as unknown as SpawnFn,
+    };
+
+    const first = runWatcherObligationStartupRecovery(options);
+    const second = runWatcherObligationStartupRecovery(options);
+    await Promise.resolve();
+    expect(spawnFn).toHaveBeenCalledOnce();
+
+    fake.stdout.emit('data', Buffer.from('{"status":"recovered"}'));
+    fake.child.emit('close', 0);
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ recovered: true }),
+      expect.objectContaining({ recovered: true }),
+    ]);
+  });
+
+  it('kills a controller that exceeds the startup bound', async () => {
+    const fake = fakeChild();
+    const spawnFn = vi.fn(() => fake.child);
+
+    await expect(runWatcherObligationStartupRecovery({
+      hostBootId: 'boot-timeout',
+      env: configuredEnv(),
+      timeoutMs: 10,
+      spawnFn: spawnFn as unknown as SpawnFn,
+    })).resolves.toMatchObject({ recovered: false, reason: 'timeout' });
+    expect(fake.kill).toHaveBeenCalledOnce();
+  });
+
+  it('does not report malformed output as recovered', async () => {
+    const spawnFn = vi.fn(() => {
+      const { child, stdout } = fakeChild();
+      queueMicrotask(() => {
+        stdout.emit('data', Buffer.from('{"status":"maybe"}'));
+        child.emit('close', 0);
+      });
+      return child;
+    });
+
+    await expect(runWatcherObligationStartupRecovery({
+      hostBootId: 'boot-malformed',
+      env: configuredEnv(),
+      spawnFn: spawnFn as unknown as SpawnFn,
+    })).resolves.toMatchObject({ recovered: false, reason: 'malformed recovery output' });
+  });
+});


### PR DESCRIPTION
## Summary

- gives an operator-configured watcher controller one bounded recovery attempt after local control services are ready and before wakeup scheduling starts
- passes a stable per-process boot nonce, deduplicates concurrent attempts, enforces a 15-second timeout and 4 KiB output cap, and accepts only a JSON `{"status":"recovered"}` receipt
- launches without a shell and does not retain or surface controller stderr
- is a silent no-op unless `NIMBALYST_WATCHER_OBLIGATION_RECOVERY_ARGV` is configured

## Source and reuse gate

This branch starts at stable `v0.73.2` (`c0f6b6cdd138dc707ec4688ae9013a4ea76f9534`). Current `upstream/main`, open PRs, and public upstream branches were checked before implementation; no current watcher-obligation startup recovery was found.

This is the distinct watcher-obligation residue recovered from the closed draft fork PR Yogitmeister/nimbalyst#1. The old branch is evidence only and was not merged wholesale. Queue FIFO, lease, startup-priority, and basic recovery work already absorbed by fork PRs #9/#10 and upstream PR #1062 is explicitly excluded.

## Verification

- focused Vitest: 1 file, 5 tests passed
- Electron typecheck passed
- `npm run typecheck:prepush`: 23/23 workspaces passed
- normal pre-push hook passed, including author, dependency, NUL-byte, typecheck, and platform gate checks

The local Windows gate used the exact uncommitted compatibility fixes from open PR #1227; those files are not part of this PR.

## Why this is worth merging

An attention obligation that disappears during startup recovery is worse than a missed toast: the system believes coverage exists while the operator never receives it. This patch restores bounded watcher obligations only after the control surface is ready and before wakeups resume, preserving one owner and preventing both silent loss and duplicate recovery.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
