### PR TITLE
feat(ai): carry schema-driven provider controls (NIM-216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Added schema-driven reasoning controls with reviewed, persisted transport receipts for Claude Agent, Codex, and Unified Model Launcher sessions.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -22,6 +22,8 @@ import {
   isSlashCommandCatalogProvider,
   ClaudeCodeProvider,
   OpenAICodexProvider,
+  getBuiltInProviderControlEntry,
+  resolveProviderControlSnapshot,
 } from '@nimbalyst/runtime/ai/server';
 import { CLAUDE_CODE_SAFE_FALLBACK_MODEL } from '@nimbalyst/runtime/ai/modelConstants';
 import { reconcileClaudeCodeModels } from './claudeCodeModelReconcile';
@@ -781,6 +783,7 @@ export class AIService {
       ...(apiKey ? { apiKey } : {}),
       ...(effortLevel && { effortLevel }),
       thinkingMode: resolveThinkingMode((session.metadata as any)?.thinkingMode, getDefaultThinkingMode()),
+      ...(await this.buildProviderControlRuntimeConfig(session)),
     };
 
     const fullModel = session.model || session.providerConfig?.model;
@@ -795,6 +798,48 @@ export class AIService {
     }
 
     return config;
+  }
+
+  private async buildProviderControlRuntimeConfig(session: SessionData): Promise<Pick<ProviderConfig, 'providerControlSnapshot' | 'effortLevel' | 'thinkingMode'>> {
+    const modelId = session.model || session.providerConfig?.model;
+    const entry = getBuiltInProviderControlEntry(modelId);
+    if (!entry) return {};
+
+    const metadata = (session.metadata ?? {}) as Record<string, unknown>;
+    const storedValues = metadata.providerControlValues && typeof metadata.providerControlValues === 'object'
+      ? metadata.providerControlValues as Record<string, unknown>
+      : {};
+    const requested: Record<string, unknown> = { ...storedValues };
+    if (requested['effort-level'] === undefined && metadata.effortLevel !== undefined) {
+      requested['effort-level'] = metadata.effortLevel;
+    }
+    if (requested['thinking-mode'] === undefined && metadata.thinkingMode !== undefined) {
+      requested['thinking-mode'] = metadata.thinkingMode;
+    }
+
+    const snapshot = resolveProviderControlSnapshot({
+      catalog: [entry],
+      catalogEntryId: entry.id,
+      interfaceId: entry.interfaces[0],
+      consumer: 'main-session',
+      phase: metadata.providerControlSnapshot ? 'restart' : 'launch',
+      requested,
+    });
+
+    if (JSON.stringify(metadata.providerControlSnapshot) !== JSON.stringify(snapshot)) {
+      const { AISessionsRepository } = await import('@nimbalyst/runtime/storage/repositories/AISessionsRepository');
+      await AISessionsRepository.updateMetadata(session.id, {
+        metadata: { providerControlSnapshot: snapshot },
+      });
+      session.metadata = { ...metadata, providerControlSnapshot: snapshot };
+    }
+    const effort = snapshot.resolved['effort-level'];
+    const thinking = snapshot.resolved['thinking-mode'];
+    return {
+      providerControlSnapshot: snapshot,
+      ...(typeof effort === 'string' ? { effortLevel: effort as ProviderConfig['effortLevel'] } : {}),
+      ...(typeof thinking === 'string' ? { thinkingMode: thinking as ProviderConfig['thinkingMode'] } : {}),
+    };
   }
 
   /**
@@ -2120,6 +2165,8 @@ export class AIService {
           initConfig.effortLevel = effortLevel;
         }
       }
+
+      Object.assign(initConfig, await this.buildProviderControlRuntimeConfig(session));
 
       await providerInstance.initialize(initConfig);
 

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -164,6 +164,7 @@ interface AIServiceInternal {
   getSettingsStore(): Store<Record<string, unknown>>;
   getApiKeyForProvider(provider: string, workspacePath?: string): string | undefined;
   buildClaudeCodeRuntimeConfig(session: SessionData, workspacePath?: string): Promise<ProviderConfig>;
+  buildProviderControlRuntimeConfig(session: SessionData): Promise<Pick<ProviderConfig, 'providerControlSnapshot' | 'effortLevel' | 'thinkingMode'>>;
   continueQueuedPromptChain(
     sessionId: string,
     workspacePath: string,
@@ -589,6 +590,7 @@ export class MessageStreamingHandler {
         ...(isProviderClaudeCode ? {
           thinkingMode: resolveThinkingMode((session.metadata as any)?.thinkingMode, getDefaultThinkingMode()),
         } : {}),
+        ...(await this.svc.buildProviderControlRuntimeConfig(session)),
       };
 
       // Add baseUrl for LMStudio
@@ -1280,6 +1282,7 @@ export class MessageStreamingHandler {
           maxTokens: (session.providerConfig as any)?.maxTokens,
           temperature: (session.providerConfig as any)?.temperature,
           ...(turnEffortLevel && { effortLevel: turnEffortLevel }),
+          ...(await this.svc.buildProviderControlRuntimeConfig(session)),
         };
         const fullTurnModel = session.model || session.providerConfig?.model;
         if (fullTurnModel) {

--- a/packages/electron/src/renderer/components/UnifiedAI/AIInput.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/AIInput.tsx
@@ -11,6 +11,8 @@ import { ModeTag, AIMode } from './ModeTag';
 import { ModelSelector } from './ModelSelector';
 import { EffortLevelSelector } from './EffortLevelSelector';
 import { ThinkingModeSelector } from './ThinkingModeSelector';
+import { CatalogControlSelectors } from './CatalogControlSelectors';
+import { getBuiltInProviderControlEntry, type ProviderControlValue } from '@nimbalyst/runtime/ai/server';
 import { registerPendingVoiceCommandSetter } from './VoiceModeButton.tsx';
 import { PendingVoiceCommand } from './PendingVoiceCommand';
 import { pendingVoiceCommandAtom, voiceActiveSessionIdAtom, type PendingVoiceCommand as PendingVoiceCommandType } from '../../store/atoms/voiceModeState';
@@ -94,6 +96,7 @@ interface AIInputProps {
   showThinkingToggle?: boolean;
   reasoningControlsDisabled?: boolean;
   reasoningControlsDisabledTitle?: string;
+  reasoningControlsNotice?: string;
 
   // Token usage display support (for Claude Code)
   tokenUsage?: {
@@ -181,6 +184,7 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
     showThinkingToggle,
     reasoningControlsDisabled = false,
     reasoningControlsDisabledTitle,
+    reasoningControlsNotice,
     tokenUsage,
     provider,
     onQueue,
@@ -197,6 +201,18 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
     const [slashCommandOptions, setSlashCommandOptions] = useState<TypeaheadOption[]>([]);
     const [allSlashCommands, setAllSlashCommands] = useState<SlashCommandEntry[]>([]);
     const [dragActive, setDragActive] = useState(false);
+    const hasCatalogControls = Boolean(getBuiltInProviderControlEntry(currentModel));
+    const catalogControlValues = useMemo(() => ({
+      'effort-level': effortLevel,
+      'thinking-mode': thinkingMode,
+    }), [effortLevel, thinkingMode]);
+    const handleCatalogControlChange = useCallback((settingId: string, value: ProviderControlValue) => {
+      if (settingId === 'effort-level' && typeof value === 'string') {
+        onEffortLevelChange?.(value as EffortLevel);
+      } else if (settingId === 'thinking-mode' && typeof value === 'string') {
+        onThinkingModeChange?.(value as ThinkingMode);
+      }
+    }, [onEffortLevelChange, onThinkingModeChange]);
     const [isFocused, setIsFocused] = useState(false);
     const [modelPickerOpenRequest, setModelPickerOpenRequest] = useState(0);
 
@@ -1403,7 +1419,21 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
                 />
               </span>
             )}
-            {showEffortLevel && onEffortLevelChange && effortLevel && (
+            {hasCatalogControls && (onEffortLevelChange || onThinkingModeChange) && (
+              <CatalogControlSelectors
+                modelId={currentModel}
+                values={catalogControlValues}
+                onChange={handleCatalogControlChange}
+                disabled={reasoningControlsDisabled}
+                disabledTitle={reasoningControlsDisabledTitle}
+              />
+            )}
+            {reasoningControlsNotice && (
+              <span className="max-w-64 truncate text-[10px] text-[var(--nim-warning)]" title={reasoningControlsNotice}>
+                {reasoningControlsNotice}
+              </span>
+            )}
+            {!hasCatalogControls && showEffortLevel && onEffortLevelChange && effortLevel && (
               <EffortLevelSelector
                 level={effortLevel}
                 onLevelChange={onEffortLevelChange}
@@ -1411,7 +1441,7 @@ export const AIInput = forwardRef<AIInputRef, AIInputProps>(
                 disabledTitle={reasoningControlsDisabledTitle}
               />
             )}
-            {showThinkingToggle && onThinkingModeChange && thinkingMode && (
+            {!hasCatalogControls && showThinkingToggle && onThinkingModeChange && thinkingMode && (
               <ThinkingModeSelector
                 mode={thinkingMode}
                 onModeChange={onThinkingModeChange}

--- a/packages/electron/src/renderer/components/UnifiedAI/CatalogControlSelectors.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/CatalogControlSelectors.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+  getBuiltInProviderControlEntry,
+  type ProviderControlDefinition,
+  type ProviderControlValue,
+} from '@nimbalyst/runtime/ai/server';
+
+interface CatalogControlSelectorsProps {
+  modelId?: string;
+  values: Readonly<Record<string, ProviderControlValue | undefined>>;
+  onChange: (settingId: string, value: ProviderControlValue) => void;
+  disabled?: boolean;
+  disabledTitle?: string;
+}
+
+function controlValue(
+  control: ProviderControlDefinition,
+  values: CatalogControlSelectorsProps['values'],
+): ProviderControlValue {
+  const candidate = values[control.settingId];
+  if (control.type === 'boolean') {
+    return typeof candidate === 'boolean' ? candidate : control.defaultValue;
+  }
+  if (control.type === 'number') {
+    return typeof candidate === 'number'
+      && Number.isFinite(candidate)
+      && candidate >= control.minimum
+      && candidate <= control.maximum
+      ? candidate
+      : control.defaultValue;
+  }
+  return typeof candidate === 'string' && control.allowedValues.includes(candidate)
+    ? candidate
+    : control.defaultValue;
+}
+
+export function CatalogControlSelectors({
+  modelId,
+  values,
+  onChange,
+  disabled = false,
+  disabledTitle,
+}: CatalogControlSelectorsProps) {
+  const entry = getBuiltInProviderControlEntry(modelId);
+  if (!entry) return null;
+
+  return (
+    <>
+      {entry.controls.map((control) => {
+        const value = controlValue(control, values);
+        const title = disabled ? disabledTitle : control.helpText;
+        if (control.type === 'boolean') {
+          return (
+            <button
+              key={control.id}
+              type="button"
+              className="rounded-xl border border-[var(--nim-border)] bg-[var(--nim-bg-secondary)] px-2 py-[3px] text-[11px] text-[var(--nim-text-muted)] disabled:cursor-not-allowed disabled:opacity-45"
+              aria-label={control.label}
+              aria-pressed={Boolean(value)}
+              title={title}
+              disabled={disabled}
+              onClick={() => onChange(control.settingId, !value)}
+            >
+              {control.label}: {value ? 'On' : 'Off'}
+            </button>
+          );
+        }
+        if (control.type === 'number') {
+          return (
+            <label key={control.id} className="inline-flex items-center gap-1 text-[11px] text-[var(--nim-text-muted)]" title={title}>
+              {control.label}
+              <input
+                aria-label={control.label}
+                className="w-16 rounded border border-[var(--nim-border)] bg-[var(--nim-bg-secondary)] px-1 py-[2px]"
+                type="number"
+                value={Number(value)}
+                min={control.minimum}
+                max={control.maximum}
+                step={control.step}
+                disabled={disabled}
+                onChange={(event) => onChange(control.settingId, Number(event.target.value))}
+              />
+            </label>
+          );
+        }
+        return (
+          <label key={control.id} className="inline-flex items-center gap-1 text-[11px] text-[var(--nim-text-muted)]" title={title}>
+            {control.label}
+            <select
+              aria-label={control.label}
+              className="rounded-xl border border-[var(--nim-border)] bg-[var(--nim-bg-secondary)] px-2 py-[3px] text-[11px] text-[var(--nim-text-muted)] disabled:cursor-not-allowed disabled:opacity-45"
+              value={String(value)}
+              disabled={disabled}
+              onChange={(event) => onChange(control.settingId, event.target.value)}
+            >
+              {control.allowedValues.map((allowed) => (
+                <option key={allowed} value={allowed}>{allowed}</option>
+              ))}
+            </select>
+          </label>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionLaunchPopup.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionLaunchPopup.tsx
@@ -39,6 +39,7 @@ import {
   type ThinkingMode,
 } from '../../utils/modelUtils';
 import { isClaudeCliTerminalSession } from './claudeCliInputRouting';
+import { reconcileBuiltInProviderControlValues } from '@nimbalyst/runtime/ai/server';
 
 interface SessionLaunchPopupProps {
   workspacePath: string | null;
@@ -128,6 +129,7 @@ export const SessionLaunchPopup: React.FC<SessionLaunchPopupProps> = ({ workspac
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reasoningControlsNotice, setReasoningControlsNotice] = useState<string | undefined>();
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<AIInputRef>(null);
@@ -267,9 +269,25 @@ export const SessionLaunchPopup: React.FC<SessionLaunchPopupProps> = ({ workspac
   }, [setDraft]);
 
   const handleModelChange = useCallback((model: string) => {
-    setDraft((current) => ({ ...current, model }));
+    const reconciled = reconcileBuiltInProviderControlValues(model, {
+      'effort-level': effortLevel,
+      'thinking-mode': thinkingMode,
+    });
+    setDraft((current) => ({
+      ...current,
+      model,
+      effortLevel: typeof reconciled.values['effort-level'] === 'string'
+        ? reconciled.values['effort-level'] as EffortLevel
+        : current.effortLevel,
+      thinkingMode: typeof reconciled.values['thinking-mode'] === 'string'
+        ? reconciled.values['thinking-mode'] as ThinkingMode
+        : current.thinkingMode,
+    }));
+    setReasoningControlsNotice(reconciled.resets.length
+      ? `Reset unsupported controls: ${reconciled.resets.map((reset) => `${reset.settingId} ${reset.from} → ${reset.to}`).join(', ')}`
+      : undefined);
     setAgentModeSettings({ defaultModel: model });
-  }, [setDraft, setAgentModeSettings]);
+  }, [setDraft, setAgentModeSettings, effortLevel, thinkingMode]);
 
   const handleEffortLevelChange = useCallback((nextEffort: EffortLevel) => {
     setDraft((current) => ({ ...current, effortLevel: nextEffort }));
@@ -427,6 +445,7 @@ export const SessionLaunchPopup: React.FC<SessionLaunchPopupProps> = ({ workspac
           thinkingMode={thinkingMode}
           onThinkingModeChange={handleThinkingModeChange}
           showThinkingToggle={developerMode && supportsThinkingToggle(selectedModel)}
+          reasoningControlsNotice={reasoningControlsNotice}
           provider={provider}
           testId="session-launch-popup-input"
         />

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -119,6 +119,7 @@ import { diffPeekSizeAtom, setDiffPeekSizeAtom } from '../../store/atoms/diffPee
 import { registerSessionWorkspace, loadInitialSessionFileState } from '../../store/listeners/fileStateListeners';
 import { sessionFileEditsAtom } from '../../store/atoms/sessionFiles';
 import { SESSION_PHASE_COLUMNS, setSessionPhaseAtom, type SessionPhase } from '../../store/atoms/sessionKanban';
+import { reconcileBuiltInProviderControlValues } from '@nimbalyst/runtime/ai/server';
 
 /**
  * Detect a metadata value that's the artifact of `{...stringValue, ...}` -
@@ -657,6 +658,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
 
   // Track if we're currently queueing a message (prevents double-submission)
   const [isQueueing, setIsQueueing] = useState(false);
+  const [reasoningControlsNotice, setReasoningControlsNotice] = useState<string | undefined>();
 
   // claude-code-cli (NIM-806, Phase 3): the rich transcript is primary; the
   // genuine TUI lives in a collapsible "raw terminal" drawer. Default EXPANDED so
@@ -1544,6 +1546,21 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
     // Save as the default model for new sessions
     setAgentModeSettings({ defaultModel: modelId });
     try {
+      const reconciled = reconcileBuiltInProviderControlValues(modelId, {
+        'effort-level': effortLevel,
+        'thinking-mode': thinkingMode,
+      });
+      const nextEffort = reconciled.values['effort-level'];
+      const nextThinking = reconciled.values['thinking-mode'];
+      if (typeof nextEffort === 'string' && nextEffort !== effortLevel) {
+        await updateSessionMetadataField(sessionId, 'effortLevel', nextEffort, null, updateSessionStore);
+      }
+      if (typeof nextThinking === 'string' && nextThinking !== thinkingMode) {
+        await updateSessionMetadataField(sessionId, 'thinkingMode', nextThinking, null, updateSessionStore);
+      }
+      setReasoningControlsNotice(reconciled.resets.length
+        ? `Reset unsupported controls for ${modelId}: ${reconciled.resets.map((reset) => `${reset.settingId} ${reset.from} → ${reset.to}`).join(', ')}`
+        : undefined);
       // claude-code-cli (NIM-806): a RUNNING CLI session retunes via the
       // genuine CLI's `/model` slash command typed into its PTY (main-process
       // IPC) — no respawn. Must happen before the metadata update so a failed
@@ -1558,7 +1575,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
       setCurrentModel(previousModel);
       setAgentModeSettings({ defaultModel: previousModel });
     }
-  }, [currentModel, sessionId, setCurrentModel, setAgentModeSettings, provider, cliSessionCommitted]);
+  }, [currentModel, sessionId, setCurrentModel, setAgentModeSettings, provider, cliSessionCommitted, effortLevel, thinkingMode, updateSessionStore]);
 
   const handleEffortLevelChange = useCallback(async (level: EffortLevel) => {
     const previousLevel = effortLevel;
@@ -2672,6 +2689,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
         thinkingMode={thinkingMode}
         onThinkingModeChange={handleThinkingModeChange}
         showThinkingToggle={isClaudeCliTerminalSession(provider) && cliSessionCommitted ? false : showThinkingToggle}
+        reasoningControlsNotice={reasoningControlsNotice}
         tokenUsage={tokenUsage}
         provider={provider}
         onQueue={handleQueue}

--- a/packages/electron/src/renderer/components/UnifiedAI/__tests__/CatalogControlSelectors.test.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/__tests__/CatalogControlSelectors.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CatalogControlSelectors } from '../CatalogControlSelectors';
+
+describe('CatalogControlSelectors', () => {
+  it('renders only controls declared for the selected model and emits semantic settings', () => {
+    const onChange = vi.fn();
+    render(
+      <CatalogControlSelectors
+        modelId="claude-code:opus"
+        values={{ 'effort-level': 'high', 'thinking-mode': 'enabled' }}
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByLabelText('Reasoning effort')).toBeTruthy();
+    expect(screen.getByLabelText('Extended thinking')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Reasoning effort'), { target: { value: 'max' } });
+    expect(onChange).toHaveBeenCalledWith('effort-level', 'max');
+  });
+
+  it('renders no inferred controls for an unknown model', () => {
+    const { container } = render(
+      <CatalogControlSelectors modelId="model-launcher:other" values={{}} onChange={vi.fn()} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the reviewed default when persisted input is stale', () => {
+    render(
+      <CatalogControlSelectors
+        modelId="model-launcher:deepseek-pro"
+        values={{ 'effort-level': 'unsupported' }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect((screen.getByLabelText('Reasoning effort') as HTMLSelectElement).value).toBe('high');
+  });
+});

--- a/packages/runtime/src/ai/server/index.ts
+++ b/packages/runtime/src/ai/server/index.ts
@@ -22,6 +22,8 @@ export {
   isInternalMcpServerEnabled,
 } from './services/mcpServerConfig';
 export type { SharedMcpServerConfig, PerProviderMcpDeps } from './services/mcpServerConfig';
+export * from './providers/claudeCode/providerControlContract';
+export * from './providers/claudeCode/providerControlCatalogDefaults';
 export * from './services/mcpTopology';
 export * from './services/mcpTokenBudget';
 export * from './attachments/attachmentDenyMatcher';

--- a/packages/runtime/src/ai/server/providers/__tests__/sdkOptionsBuilder.envKeys.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/sdkOptionsBuilder.envKeys.test.ts
@@ -32,6 +32,8 @@ vi.mock('../../../../electron/claudeCodeEnvironment', () => ({
 }));
 
 import { buildSdkOptions } from '../claudeCode/sdkOptionsBuilder';
+import { getBuiltInProviderControlEntry } from '../claudeCode/providerControlCatalogDefaults';
+import { resolveProviderControlSnapshot } from '../claudeCode/providerControlContract';
 
 function makeDeps(overrides: Partial<Parameters<typeof buildSdkOptions>[0]> = {}) {
   return {
@@ -185,6 +187,34 @@ describe('buildSdkOptions env-key hardening', () => {
     );
 
     expect(options.env.CLAUDE_CODE_EFFORT_LEVEL).toBe('high');
+  });
+
+  it('uses the immutable catalog snapshot for exact effort and thinking transport', async () => {
+    const entry = getBuiltInProviderControlEntry('claude-code:opus')!;
+    const providerControlSnapshot = resolveProviderControlSnapshot({
+      catalog: [entry],
+      catalogEntryId: entry.id,
+      interfaceId: 'claude-agent-sdk',
+      consumer: 'main-session',
+      phase: 'launch',
+      requested: { 'effort-level': 'xhigh', 'thinking-mode': 'disabled' },
+    });
+    const teammateManager = {
+      resolveTeamContext: async () => undefined,
+      packagedBuildOptions: undefined as any,
+    };
+
+    const { options } = await buildSdkOptions(
+      makeDeps({
+        config: { effortLevel: 'low', thinkingMode: 'enabled', providerControlSnapshot },
+        teammateManager,
+      }),
+      makeParams(),
+    );
+
+    expect(options.env.CLAUDE_CODE_EFFORT_LEVEL).toBe('xhigh');
+    expect(options.thinking).toEqual({ type: 'disabled' });
+    expect(teammateManager.packagedBuildOptions.env.CLAUDE_CODE_EFFORT_LEVEL).toBe('xhigh');
   });
 
   it('disables SDK extended thinking for supported Claude Agent models', async () => {

--- a/packages/runtime/src/ai/server/providers/claudeCode/__tests__/providerControlCatalogDefaults.test.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/__tests__/providerControlCatalogDefaults.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import { getBuiltInProviderControlEntry, reconcileBuiltInProviderControlValues } from '../providerControlCatalogDefaults';
+import { resolveProviderControlSnapshot } from '../providerControlContract';
+
+describe('built-in provider control catalog', () => {
+  it('declares only reviewed Claude and paired launcher controls without nearby fallback', () => {
+    expect(getBuiltInProviderControlEntry('claude-code:opus')?.controls.map((control) => control.settingId)).toEqual([
+      'effort-level',
+      'thinking-mode',
+    ]);
+    expect(getBuiltInProviderControlEntry('openai-codex:gpt-5.6-sol')).toBeUndefined();
+    expect(getBuiltInProviderControlEntry('model-launcher:deepseek-pro')?.interfaces).toEqual(['unified-model-launcher']);
+    expect(getBuiltInProviderControlEntry('model-launcher:other')).toBeUndefined();
+    expect(getBuiltInProviderControlEntry('claude-code:haiku')).toBeUndefined();
+  });
+
+  it('resets incompatible model-switch values to the reviewed target default', () => {
+    expect(reconcileBuiltInProviderControlValues('model-launcher:deepseek-pro', {
+      'effort-level': 'max',
+      'thinking-mode': 'disabled',
+    })).toEqual({
+      values: { 'effort-level': 'high' },
+      resets: [{ settingId: 'effort-level', from: 'max', to: 'high' }],
+    });
+  });
+
+  it('resolves exact DeepSeek launcher effort and rejects unsupported max', () => {
+    const entry = getBuiltInProviderControlEntry('model-launcher:deepseek-flash')!;
+    const snapshot = resolveProviderControlSnapshot({
+      catalog: [entry],
+      catalogEntryId: entry.id,
+      interfaceId: 'unified-model-launcher',
+      consumer: 'consultation',
+      phase: 'launch',
+      requested: { 'effort-level': 'xhigh' },
+    });
+    expect(snapshot.parameters).toEqual([
+      expect.objectContaining({ target: 'launcher.effort', value: 'xhigh' }),
+    ]);
+    expect(() => resolveProviderControlSnapshot({
+      catalog: [entry],
+      catalogEntryId: entry.id,
+      interfaceId: 'unified-model-launcher',
+      consumer: 'consultation',
+      phase: 'launch',
+      requested: { 'effort-level': 'max' },
+    })).toThrow('unsupported value');
+  });
+});

--- a/packages/runtime/src/ai/server/providers/claudeCode/__tests__/providerControlContract.test.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/__tests__/providerControlContract.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import {
+  ProviderControlContractError,
+  resolveProviderControlSnapshot,
+  serializeProviderControlSnapshot,
+  type ProviderControlCatalogEntry,
+} from '../providerControlContract';
+
+const reviewedEntry: ProviderControlCatalogEntry = {
+  id: 'reviewed-model',
+  provider: 'reviewed-provider',
+  modelId: 'reviewed/model-v1',
+  interfaces: ['claude-agent-anthropic', 'consultation-launcher'],
+  consumers: ['main-session', 'subagent', 'consultation'],
+  controls: [
+    {
+      id: 'reasoning-profile',
+      settingId: 'reasoning.profile',
+      type: 'profile',
+      label: 'Reasoning profile',
+      helpText: 'Choose a reviewed reasoning profile.',
+      defaultValue: 'think-high',
+      allowedValues: ['off', 'think-high', 'think-max'],
+      applicability: { launch: true, restart: true, 'mid-session': false },
+      mappings: [
+        {
+          interfaceId: 'claude-agent-anthropic',
+          target: 'request.thinking.type',
+          values: [
+            { storedValue: 'off', resolvedValue: 'disabled' },
+            { storedValue: 'think-high', resolvedValue: 'enabled' },
+            { storedValue: 'think-max', resolvedValue: 'enabled' },
+          ],
+        },
+        {
+          interfaceId: 'claude-agent-anthropic',
+          target: 'request.output_config.effort',
+          values: [
+            { storedValue: 'off', operation: 'omit' },
+            { storedValue: 'think-high', resolvedValue: 'high' },
+            { storedValue: 'think-max', resolvedValue: 'max' },
+          ],
+        },
+        {
+          interfaceId: 'consultation-launcher',
+          target: 'launcher.profile',
+          values: [
+            { storedValue: 'off', resolvedValue: 'reviewed-model-off' },
+            { storedValue: 'think-high', resolvedValue: 'reviewed-model-high' },
+            { storedValue: 'think-max', resolvedValue: 'reviewed-model-max' },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function expectContractError(run: () => unknown, code: ProviderControlContractError['code']) {
+  try {
+    run();
+    throw new Error('Expected contract error');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ProviderControlContractError);
+    expect((error as ProviderControlContractError).code).toBe(code);
+  }
+}
+
+describe('providerControlContract', () => {
+  it('resolves and freezes an exact parameter snapshot without fallback', () => {
+    const snapshot = resolveProviderControlSnapshot({
+      catalog: [reviewedEntry],
+      catalogEntryId: reviewedEntry.id,
+      interfaceId: 'claude-agent-anthropic',
+      consumer: 'main-session',
+      phase: 'launch',
+      requested: { 'reasoning.profile': 'think-max' },
+    });
+
+    expect(snapshot).toEqual({
+      schemaVersion: 1,
+      catalogEntryId: 'reviewed-model',
+      provider: 'reviewed-provider',
+      modelId: 'reviewed/model-v1',
+      interfaceId: 'claude-agent-anthropic',
+      consumer: 'main-session',
+      phase: 'launch',
+      requested: { 'reasoning.profile': 'think-max' },
+      resolved: { 'reasoning.profile': 'think-max' },
+      parameters: [
+        {
+          controlId: 'reasoning-profile',
+          settingId: 'reasoning.profile',
+          interfaceId: 'claude-agent-anthropic',
+          target: 'request.thinking.type',
+          operation: 'set',
+          value: 'enabled',
+        },
+        {
+          controlId: 'reasoning-profile',
+          settingId: 'reasoning.profile',
+          interfaceId: 'claude-agent-anthropic',
+          target: 'request.output_config.effort',
+          operation: 'set',
+          value: 'max',
+        },
+      ],
+    });
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.parameters)).toBe(true);
+    expect(serializeProviderControlSnapshot(snapshot)).toBe(JSON.stringify(snapshot));
+  });
+
+  it('resolves the reviewed consultation profile rather than inventing a route', () => {
+    const snapshot = resolveProviderControlSnapshot({
+      catalog: [reviewedEntry],
+      catalogEntryId: reviewedEntry.id,
+      interfaceId: 'consultation-launcher',
+      consumer: 'consultation',
+      phase: 'launch',
+    });
+
+    expect(snapshot.parameters).toEqual([
+      expect.objectContaining({ target: 'launcher.profile', value: 'reviewed-model-high' }),
+    ]);
+  });
+
+  it('rejects missing entries, interfaces, consumers, and stale settings', () => {
+    expectContractError(() => resolveProviderControlSnapshot({
+      catalog: [reviewedEntry],
+      catalogEntryId: 'nearby-model',
+      interfaceId: 'claude-agent-anthropic',
+      consumer: 'main-session',
+      phase: 'launch',
+    }), 'route-not-found');
+    expectContractError(() => resolveProviderControlSnapshot({
+      catalog: [reviewedEntry],
+      catalogEntryId: reviewedEntry.id,
+      interfaceId: 'unknown-adapter',
+      consumer: 'main-session',
+      phase: 'launch',
+    }), 'unsupported-interface');
+    expectContractError(() => resolveProviderControlSnapshot({
+      catalog: [{ ...reviewedEntry, consumers: ['main-session'] }],
+      catalogEntryId: reviewedEntry.id,
+      interfaceId: 'claude-agent-anthropic',
+      consumer: 'subagent',
+      phase: 'launch',
+    }), 'unsupported-consumer');
+    expectContractError(() => resolveProviderControlSnapshot({
+      catalog: [reviewedEntry],
+      catalogEntryId: reviewedEntry.id,
+      interfaceId: 'claude-agent-anthropic',
+      consumer: 'main-session',
+      phase: 'launch',
+      requested: { 'old.hidden.setting': true },
+    }), 'invalid-controls');
+  });
+
+  it('rejects unsupported values and start-only changes', () => {
+    expectContractError(() => resolveProviderControlSnapshot({
+      catalog: [reviewedEntry],
+      catalogEntryId: reviewedEntry.id,
+      interfaceId: 'claude-agent-anthropic',
+      consumer: 'main-session',
+      phase: 'launch',
+      requested: { 'reasoning.profile': 'turbo' },
+    }), 'invalid-controls');
+    expectContractError(() => resolveProviderControlSnapshot({
+      catalog: [reviewedEntry],
+      catalogEntryId: reviewedEntry.id,
+      interfaceId: 'claude-agent-anthropic',
+      consumer: 'main-session',
+      phase: 'mid-session',
+      requested: { 'reasoning.profile': 'think-max' },
+    }), 'invalid-controls');
+  });
+
+  it('rejects executable or unreviewed catalog shapes at the boundary', () => {
+    const unsafe = {
+      ...reviewedEntry,
+      controls: [{
+        ...reviewedEntry.controls[0],
+        mappings: [{
+          interfaceId: 'claude-agent-anthropic',
+          target: 'shell.command',
+          values: [{ storedValue: 'think-high', resolvedValue: 'curl secret' }],
+        }],
+      }],
+    } as unknown as ProviderControlCatalogEntry;
+    expectContractError(() => resolveProviderControlSnapshot({
+      catalog: [unsafe],
+      catalogEntryId: unsafe.id,
+      interfaceId: 'claude-agent-anthropic',
+      consumer: 'main-session',
+      phase: 'launch',
+    }), 'invalid-catalog');
+  });
+});

--- a/packages/runtime/src/ai/server/providers/claudeCode/providerControlCatalogDefaults.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/providerControlCatalogDefaults.ts
@@ -1,0 +1,150 @@
+import type {
+  ProviderControlCatalogEntry,
+  ProviderControlDefinition,
+  ProviderControlMapping,
+  ProviderControlTarget,
+  ProviderControlValue,
+} from './providerControlContract';
+
+const ALL_PHASES = { launch: true, restart: true, 'mid-session': true } as const;
+const START_PHASES = { launch: true, restart: true, 'mid-session': false } as const;
+
+function mapping(
+  interfaceId: string,
+  target: ProviderControlTarget,
+  values: readonly string[],
+): ProviderControlMapping {
+  return {
+    interfaceId,
+    target,
+    values: values.map((value) => ({ storedValue: value, resolvedValue: value })),
+  };
+}
+
+function effortControl(interfaceId: string, target: ProviderControlTarget, allowedValues: readonly string[]): ProviderControlDefinition {
+  return {
+    id: 'reasoning-effort',
+    settingId: 'effort-level',
+    type: 'enum',
+    label: 'Reasoning effort',
+    helpText: 'Controls the reviewed reasoning-effort parameter for this model route.',
+    defaultValue: 'high',
+    allowedValues,
+    applicability: ALL_PHASES,
+    mappings: [mapping(interfaceId, target, allowedValues)],
+  };
+}
+
+function thinkingControl(interfaceId: string): ProviderControlDefinition {
+  return {
+    id: 'extended-thinking',
+    settingId: 'thinking-mode',
+    type: 'enum',
+    label: 'Extended thinking',
+    helpText: 'Keeps adaptive thinking enabled or explicitly disables it for supported Claude models.',
+    defaultValue: 'enabled',
+    allowedValues: ['enabled', 'disabled'],
+    applicability: START_PHASES,
+    mappings: [{
+      interfaceId,
+      target: 'sdk.thinking.type',
+      values: [
+        { storedValue: 'enabled', operation: 'omit' },
+        { storedValue: 'disabled', resolvedValue: 'disabled' },
+      ],
+    }],
+  };
+}
+
+function entry(input: {
+  id: string;
+  provider: string;
+  modelId: string;
+  interfaceId: string;
+  controls: readonly ProviderControlDefinition[];
+}): ProviderControlCatalogEntry {
+  return {
+    id: input.id,
+    provider: input.provider,
+    modelId: input.modelId,
+    interfaces: [input.interfaceId],
+    consumers: ['main-session', 'subagent', 'consultation'],
+    controls: input.controls,
+  };
+}
+
+function normalizeEntryId(modelId: string): string {
+  return modelId.toLowerCase().replace(/[^a-z0-9._:-]+/g, '-');
+}
+
+/**
+ * Built-in reviewed controls. Unknown models intentionally receive no entry;
+ * callers must not infer capabilities from a nearby provider or model.
+ */
+export function getBuiltInProviderControlEntry(modelId: string | undefined): ProviderControlCatalogEntry | undefined {
+  if (!modelId) return undefined;
+  const normalized = modelId.toLowerCase();
+
+  if (normalized.startsWith('claude-code:')) {
+    const variant = normalized.slice('claude-code:'.length).replace(/-1m$/, '');
+    const supportsEffort = variant === 'fable' || variant.startsWith('opus') || variant.startsWith('sonnet');
+    if (!supportsEffort) return undefined;
+    const controls: ProviderControlDefinition[] = [
+      effortControl('claude-agent-sdk', 'env.CLAUDE_CODE_EFFORT_LEVEL', ['low', 'medium', 'high', 'xhigh', 'max']),
+    ];
+    if (variant.startsWith('opus') || variant.startsWith('sonnet')) {
+      controls.push(thinkingControl('claude-agent-sdk'));
+    }
+    return entry({
+      id: normalizeEntryId(normalized),
+      provider: 'claude-code',
+      modelId,
+      interfaceId: 'claude-agent-sdk',
+      controls,
+    });
+  }
+
+  if (normalized === 'model-launcher:deepseek-pro' || normalized === 'model-launcher:deepseek-flash') {
+    return entry({
+      id: normalizeEntryId(normalized),
+      provider: 'model-launcher',
+      modelId,
+      interfaceId: 'unified-model-launcher',
+      controls: [effortControl('unified-model-launcher', 'launcher.effort', ['low', 'medium', 'high', 'xhigh'])],
+    });
+  }
+
+  return undefined;
+}
+
+export function getBuiltInProviderControlCatalog(modelId: string | undefined): readonly ProviderControlCatalogEntry[] {
+  const entry = getBuiltInProviderControlEntry(modelId);
+  return entry ? [entry] : [];
+}
+
+export function reconcileBuiltInProviderControlValues(
+  modelId: string | undefined,
+  values: Readonly<Record<string, ProviderControlValue | undefined>>,
+): { values: Record<string, ProviderControlValue>; resets: Array<{ settingId: string; from: ProviderControlValue; to: ProviderControlValue }> } {
+  const entry = getBuiltInProviderControlEntry(modelId);
+  if (!entry) return { values: {}, resets: [] };
+  const resolved: Record<string, ProviderControlValue> = {};
+  const resets: Array<{ settingId: string; from: ProviderControlValue; to: ProviderControlValue }> = [];
+  for (const control of entry.controls) {
+    const current = values[control.settingId];
+    let valid = current !== undefined;
+    if (control.type === 'boolean') valid = typeof current === 'boolean';
+    if (control.type === 'enum' || control.type === 'profile') {
+      valid = typeof current === 'string' && control.allowedValues.includes(current);
+    }
+    if (control.type === 'number') {
+      valid = typeof current === 'number' && Number.isFinite(current)
+        && current >= control.minimum && current <= control.maximum;
+    }
+    resolved[control.settingId] = valid ? current! : control.defaultValue;
+    if (current !== undefined && !valid) {
+      resets.push({ settingId: control.settingId, from: current, to: control.defaultValue });
+    }
+  }
+  return { values: resolved, resets };
+}

--- a/packages/runtime/src/ai/server/providers/claudeCode/providerControlContract.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/providerControlContract.ts
@@ -1,0 +1,403 @@
+/**
+ * Data-only contract for reviewed Claude Agent catalog controls.
+ *
+ * The catalog declares semantic settings and exact adapter mappings. It may
+ * not declare executable transforms, credentials, endpoints, or fallback
+ * routes. Runtime consumers resolve one exact entry/interface pair, persist
+ * the immutable receipt, and then hand the resolved parameters to a reviewed
+ * adapter.
+ */
+
+export const PROVIDER_CONTROL_CONTRACT_VERSION = 1 as const;
+
+export type ProviderControlConsumer = 'main-session' | 'subagent' | 'consultation';
+export type ProviderControlPhase = 'launch' | 'restart' | 'mid-session';
+export type ProviderControlValue = string | number | boolean;
+export type ProviderControlTarget =
+  | 'sdk.thinking.type'
+  | 'env.CLAUDE_CODE_EFFORT_LEVEL'
+  | 'request.thinking.type'
+  | 'request.output_config.effort'
+  | 'launcher.effort'
+  | 'launcher.profile';
+
+export interface ProviderControlMappingValue {
+  storedValue: ProviderControlValue;
+  operation?: 'set' | 'omit';
+  resolvedValue?: ProviderControlValue;
+}
+
+export interface ProviderControlMapping {
+  interfaceId: string;
+  target: ProviderControlTarget;
+  values: readonly ProviderControlMappingValue[];
+}
+
+interface ProviderControlBase {
+  id: string;
+  settingId: string;
+  label: string;
+  helpText: string;
+  defaultValue: ProviderControlValue;
+  applicability: Readonly<Record<ProviderControlPhase, boolean>>;
+  mappings: readonly ProviderControlMapping[];
+}
+
+export interface ProviderBooleanControl extends ProviderControlBase {
+  type: 'boolean';
+  defaultValue: boolean;
+}
+
+export interface ProviderEnumControl extends ProviderControlBase {
+  type: 'enum' | 'profile';
+  defaultValue: string;
+  allowedValues: readonly string[];
+}
+
+export interface ProviderNumberControl extends ProviderControlBase {
+  type: 'number';
+  defaultValue: number;
+  minimum: number;
+  maximum: number;
+  step?: number;
+}
+
+export type ProviderControlDefinition =
+  | ProviderBooleanControl
+  | ProviderEnumControl
+  | ProviderNumberControl;
+
+export interface ProviderControlCatalogEntry {
+  id: string;
+  provider: string;
+  modelId: string;
+  interfaces: readonly string[];
+  consumers: readonly ProviderControlConsumer[];
+  controls: readonly ProviderControlDefinition[];
+}
+
+export interface ResolvedProviderControlParameter {
+  controlId: string;
+  settingId: string;
+  interfaceId: string;
+  target: ProviderControlTarget;
+  operation: 'set' | 'omit';
+  value?: ProviderControlValue;
+}
+
+export interface ProviderControlSnapshot {
+  schemaVersion: typeof PROVIDER_CONTROL_CONTRACT_VERSION;
+  catalogEntryId: string;
+  provider: string;
+  modelId: string;
+  interfaceId: string;
+  consumer: ProviderControlConsumer;
+  phase: ProviderControlPhase;
+  requested: Readonly<Record<string, ProviderControlValue>>;
+  resolved: Readonly<Record<string, ProviderControlValue>>;
+  parameters: readonly ResolvedProviderControlParameter[];
+}
+
+export class ProviderControlContractError extends Error {
+  constructor(
+    public readonly code:
+      | 'invalid-catalog'
+      | 'route-not-found'
+      | 'unsupported-interface'
+      | 'unsupported-consumer'
+      | 'invalid-controls'
+      | 'adapter-required',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ProviderControlContractError';
+  }
+}
+
+const STABLE_ID = /^[a-z0-9][a-z0-9._:-]*$/;
+const TARGETS = new Set<ProviderControlTarget>([
+  'sdk.thinking.type',
+  'env.CLAUDE_CODE_EFFORT_LEVEL',
+  'request.thinking.type',
+  'request.output_config.effort',
+  'launcher.effort',
+  'launcher.profile',
+]);
+
+function fail(
+  code: ProviderControlContractError['code'],
+  message: string,
+): never {
+  throw new ProviderControlContractError(code, message);
+}
+
+function isControlValue(value: unknown): value is ProviderControlValue {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+function sameValue(left: ProviderControlValue, right: ProviderControlValue): boolean {
+  return typeof left === typeof right && left === right;
+}
+
+function deepFreeze<T>(value: T): Readonly<T> {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(child);
+    }
+  }
+  return value;
+}
+
+function assertStableId(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || !STABLE_ID.test(value)) {
+    fail('invalid-catalog', `${label} must be a stable lowercase identifier.`);
+  }
+}
+
+function assertControlValue(
+  control: ProviderControlDefinition,
+  value: unknown,
+): asserts value is ProviderControlValue {
+  if (!isControlValue(value)) {
+    fail('invalid-controls', `Control ${control.id} has a non-scalar value.`);
+  }
+  switch (control.type) {
+    case 'boolean':
+      if (typeof value !== 'boolean') {
+        fail('invalid-controls', `Control ${control.id} requires a boolean value.`);
+      }
+      break;
+    case 'enum':
+    case 'profile':
+      if (typeof value !== 'string' || !control.allowedValues.includes(value)) {
+        fail('invalid-controls', `Control ${control.id} received an unsupported value.`);
+      }
+      break;
+    case 'number': {
+      if (typeof value !== 'number' || !Number.isFinite(value)
+        || value < control.minimum || value > control.maximum) {
+        fail('invalid-controls', `Control ${control.id} is outside its reviewed range.`);
+      }
+      if (control.step !== undefined) {
+        const steps = (value - control.minimum) / control.step;
+        if (Math.abs(steps - Math.round(steps)) > Number.EPSILON * 10) {
+          fail('invalid-controls', `Control ${control.id} does not match its reviewed step.`);
+        }
+      }
+      break;
+    }
+  }
+}
+
+function validateCatalogEntry(entry: ProviderControlCatalogEntry): void {
+  assertStableId(entry.id, 'Catalog entry id');
+  assertStableId(entry.provider, `Catalog entry ${entry.id} provider`);
+  if (!entry.modelId || typeof entry.modelId !== 'string') {
+    fail('invalid-catalog', `Catalog entry ${entry.id} requires an exact model id.`);
+  }
+  if (!entry.interfaces.length || new Set(entry.interfaces).size !== entry.interfaces.length) {
+    fail('invalid-catalog', `Catalog entry ${entry.id} requires unique reviewed interfaces.`);
+  }
+  for (const interfaceId of entry.interfaces) {
+    assertStableId(interfaceId, `Catalog entry ${entry.id} interface`);
+  }
+  if (!entry.consumers.length || new Set(entry.consumers).size !== entry.consumers.length) {
+    fail('invalid-catalog', `Catalog entry ${entry.id} requires unique consumers.`);
+  }
+  const allowedConsumers = new Set<ProviderControlConsumer>(['main-session', 'subagent', 'consultation']);
+  if (entry.consumers.some((consumer) => !allowedConsumers.has(consumer))) {
+    fail('invalid-catalog', `Catalog entry ${entry.id} has an unsupported consumer.`);
+  }
+  if (!entry.controls.length) {
+    fail('invalid-catalog', `Catalog entry ${entry.id} requires at least one control.`);
+  }
+
+  const controlIds = new Set<string>();
+  const settingIds = new Set<string>();
+  for (const control of entry.controls) {
+    assertStableId(control.id, `Catalog entry ${entry.id} control id`);
+    assertStableId(control.settingId, `Catalog entry ${entry.id} setting id`);
+    if (controlIds.has(control.id) || settingIds.has(control.settingId)) {
+      fail('invalid-catalog', `Catalog entry ${entry.id} has duplicate control identities.`);
+    }
+    controlIds.add(control.id);
+    settingIds.add(control.settingId);
+    if (!control.label || !control.helpText) {
+      fail('invalid-catalog', `Control ${control.id} requires label and help text.`);
+    }
+    if (Object.values(control.applicability).some((value) => typeof value !== 'boolean')) {
+      fail('invalid-catalog', `Control ${control.id} has invalid applicability.`);
+    }
+    if ((control.type === 'enum' || control.type === 'profile')
+      && (!control.allowedValues.length || new Set(control.allowedValues).size !== control.allowedValues.length)) {
+      fail('invalid-catalog', `Control ${control.id} requires unique allowed values.`);
+    }
+    if (control.type === 'number'
+      && (!Number.isFinite(control.minimum) || !Number.isFinite(control.maximum)
+        || control.minimum > control.maximum
+        || (control.step !== undefined && (!Number.isFinite(control.step) || control.step <= 0)))) {
+      fail('invalid-catalog', `Control ${control.id} has an invalid numeric range.`);
+    }
+    assertControlValue(control, control.defaultValue);
+    if (!control.mappings.length) {
+      fail('invalid-catalog', `Control ${control.id} has no reviewed transport mapping.`);
+    }
+    for (const mapping of control.mappings) {
+      if (!entry.interfaces.includes(mapping.interfaceId)) {
+        fail('invalid-catalog', `Control ${control.id} maps an unreviewed interface.`);
+      }
+      if (!TARGETS.has(mapping.target) || !mapping.values.length) {
+        fail('invalid-catalog', `Control ${control.id} has an invalid transport mapping.`);
+      }
+      const mappedValues = new Set<string>();
+      for (const item of mapping.values) {
+        assertControlValue(control, item.storedValue);
+        const mappedKey = `${typeof item.storedValue}:${String(item.storedValue)}`;
+        if (mappedValues.has(mappedKey)) {
+          fail('invalid-catalog', `Control ${control.id} maps one stored value more than once.`);
+        }
+        mappedValues.add(mappedKey);
+        const operation = item.operation ?? 'set';
+        if (operation === 'set' && !isControlValue(item.resolvedValue)) {
+          fail('invalid-catalog', `Control ${control.id} has a set mapping without a value.`);
+        }
+        if (operation === 'omit' && item.resolvedValue !== undefined) {
+          fail('invalid-catalog', `Control ${control.id} has an omit mapping with a value.`);
+        }
+      }
+    }
+  }
+}
+
+function validateResolvedTarget(
+  target: ProviderControlTarget,
+  operation: 'set' | 'omit',
+  value: ProviderControlValue | undefined,
+): void {
+  if (operation === 'omit') return;
+  switch (target) {
+    case 'sdk.thinking.type':
+    case 'request.thinking.type':
+      if (value !== 'enabled' && value !== 'disabled' && value !== 'adaptive') {
+        fail('adapter-required', `${target} requires a reviewed thinking mode.`);
+      }
+      return;
+    case 'env.CLAUDE_CODE_EFFORT_LEVEL':
+      if (!['low', 'medium', 'high', 'xhigh', 'max'].includes(String(value))) {
+        fail('adapter-required', `${target} requires a reviewed effort level.`);
+      }
+      return;
+    case 'request.output_config.effort':
+      if (!['low', 'medium', 'high', 'xhigh', 'max'].includes(String(value))) {
+        fail('adapter-required', `${target} requires a reviewed effort level.`);
+      }
+      return;
+    case 'launcher.effort':
+      if (!['low', 'medium', 'high', 'xhigh'].includes(String(value))) {
+        fail('adapter-required', `${target} requires a launcher-supported effort level.`);
+      }
+      return;
+    case 'launcher.profile':
+      if (typeof value !== 'string' || !value.trim()) {
+        fail('adapter-required', `${target} requires an exact launcher profile.`);
+      }
+      return;
+  }
+}
+
+/**
+ * Resolve one exact catalog route. Missing entries, interfaces, settings, or
+ * mappings are errors; the contract never searches for a nearby model or
+ * provider and never silently drops a stale value.
+ */
+export function resolveProviderControlSnapshot(input: {
+  catalog: readonly ProviderControlCatalogEntry[];
+  catalogEntryId: string;
+  interfaceId: string;
+  consumer: ProviderControlConsumer;
+  phase: ProviderControlPhase;
+  requested?: Readonly<Record<string, unknown>>;
+}): Readonly<ProviderControlSnapshot> {
+  const ids = new Set<string>();
+  for (const entry of input.catalog) {
+    validateCatalogEntry(entry);
+    if (ids.has(entry.id)) fail('invalid-catalog', `Duplicate catalog entry ${entry.id}.`);
+    ids.add(entry.id);
+  }
+
+  const entry = input.catalog.find((candidate) => candidate.id === input.catalogEntryId);
+  if (!entry) fail('route-not-found', `No reviewed route exists for ${input.catalogEntryId}.`);
+  if (!entry.interfaces.includes(input.interfaceId)) {
+    fail('unsupported-interface', `Route ${entry.id} does not support ${input.interfaceId}.`);
+  }
+  if (!entry.consumers.includes(input.consumer)) {
+    fail('unsupported-consumer', `Route ${entry.id} does not support ${input.consumer}.`);
+  }
+
+  const controlsBySetting = new Map(entry.controls.map((control) => [control.settingId, control]));
+  for (const settingId of Object.keys(input.requested ?? {})) {
+    if (!controlsBySetting.has(settingId)) {
+      fail('invalid-controls', `Route ${entry.id} received stale setting ${settingId}.`);
+    }
+  }
+
+  const requested: Record<string, ProviderControlValue> = {};
+  const resolved: Record<string, ProviderControlValue> = {};
+  const parameters: ResolvedProviderControlParameter[] = [];
+  const usedTargets = new Set<ProviderControlTarget>();
+
+  for (const control of entry.controls) {
+    const supplied = input.requested?.[control.settingId];
+    if (supplied !== undefined && !control.applicability[input.phase]) {
+      fail('invalid-controls', `Control ${control.id} cannot change during ${input.phase}.`);
+    }
+    const value = supplied ?? control.defaultValue;
+    assertControlValue(control, value);
+    if (supplied !== undefined) requested[control.settingId] = value;
+    resolved[control.settingId] = value;
+
+    const mappings = control.mappings.filter((mapping) => mapping.interfaceId === input.interfaceId);
+    if (!mappings.length) {
+      fail('adapter-required', `Control ${control.id} has no ${input.interfaceId} adapter.`);
+    }
+    for (const mapping of mappings) {
+      if (usedTargets.has(mapping.target)) {
+        fail('invalid-catalog', `Route ${entry.id} maps ${mapping.target} more than once.`);
+      }
+      usedTargets.add(mapping.target);
+      const item = mapping.values.find((candidate) => sameValue(candidate.storedValue, value));
+      if (!item) {
+        fail('adapter-required', `Control ${control.id} has no mapping for its resolved value.`);
+      }
+      const operation = item.operation ?? 'set';
+      validateResolvedTarget(mapping.target, operation, item.resolvedValue);
+      parameters.push({
+        controlId: control.id,
+        settingId: control.settingId,
+        interfaceId: input.interfaceId,
+        target: mapping.target,
+        operation,
+        ...(operation === 'set' && { value: item.resolvedValue }),
+      });
+    }
+  }
+
+  return deepFreeze({
+    schemaVersion: PROVIDER_CONTROL_CONTRACT_VERSION,
+    catalogEntryId: entry.id,
+    provider: entry.provider,
+    modelId: entry.modelId,
+    interfaceId: input.interfaceId,
+    consumer: input.consumer,
+    phase: input.phase,
+    requested,
+    resolved,
+    parameters,
+  });
+}
+
+/** Stable, redacted persistence form for the immutable per-session receipt. */
+export function serializeProviderControlSnapshot(snapshot: ProviderControlSnapshot): string {
+  return JSON.stringify(snapshot);
+}

--- a/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
+++ b/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts
@@ -13,6 +13,7 @@ import { ClaudeCodeDeps } from './dependencyInjection';
 import { resolveClaudeAgentCliPath } from './cliPathResolver';
 import { hasEnterpriseManagedMcpConfig } from './enterpriseMcpConfig';
 import { type ThinkingMode } from '../../effortLevels';
+import type { ProviderControlSnapshot } from './providerControlContract';
 
 type SessionMode = 'planning' | 'agent' | 'auto' | undefined;
 
@@ -43,7 +44,7 @@ export interface BuildSdkOptionsDeps {
     resolveTeamContext: (sessionId?: string) => Promise<string | undefined>;
   };
   sessions: { getSessionId: (sessionId: string) => string | null | undefined };
-  config: { model?: string; apiKey?: string; effortLevel?: string; thinkingMode?: ThinkingMode };
+  config: { model?: string; apiKey?: string; effortLevel?: string; thinkingMode?: ThinkingMode; providerControlSnapshot?: Readonly<ProviderControlSnapshot> };
   abortController: AbortController;
   /**
    * True when an enterprise `managed-mcp.json` forbids passing MCP servers at
@@ -309,7 +310,13 @@ export async function buildSdkOptions(
     },
   };
 
-  if (config.thinkingMode === 'disabled') {
+  const thinkingParameter = config.providerControlSnapshot?.parameters.find(
+    (parameter) => parameter.target === 'sdk.thinking.type'
+  );
+  const thinkingMode = thinkingParameter
+    ? (thinkingParameter.operation === 'set' ? thinkingParameter.value : undefined)
+    : config.thinkingMode;
+  if (thinkingMode === 'disabled') {
     if (canDisableThinkingForModel(resolvedModel)) {
       options.thinking = { type: 'disabled' as const };
     } else {
@@ -369,6 +376,12 @@ export async function buildSdkOptions(
   const { ANTHROPIC_API_KEY: _settingsAnthropicKey, OPENAI_API_KEY: _settingsOpenaiKey, ...sanitizedSettingsEnv } = settingsEnv;
 
   const enableAgentTeams = sanitizedSettingsEnv.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === '1';
+  const effortParameter = config.providerControlSnapshot?.parameters.find(
+    (parameter) => parameter.target === 'env.CLAUDE_CODE_EFFORT_LEVEL'
+  );
+  const resolvedEffort = effortParameter
+    ? (effortParameter.operation === 'set' ? String(effortParameter.value) : undefined)
+    : config.effortLevel;
   const env: any = {
     ...sanitizedProcessEnv,
     ...sanitizedShellEnv,
@@ -401,8 +414,8 @@ export async function buildSdkOptions(
     // The Claude CLI currently defaults to xhigh when this variable is absent.
     // Always forward a resolved Nimbalyst selection, including "high", so the
     // effort shown in the selector matches the request sent to the CLI.
-    ...(config.effortLevel && {
-      CLAUDE_CODE_EFFORT_LEVEL: config.effortLevel
+    ...(resolvedEffort && {
+      CLAUDE_CODE_EFFORT_LEVEL: resolvedEffort
     }),
     // The bundled claude binary runs a per-tool idle-timeout watchdog (default
     // 300s) over MCP servers whose transport is http/sse/ws. ALL Nimbalyst
@@ -525,6 +538,13 @@ export async function buildSdkOptions(
   }
 
   options.env = env;
+  // Subagent/team consumers inherit the exact reviewed environment snapshot
+  // in both development and packaged builds. The executable path remains
+  // packaged-only, but semantic controls must not disappear in development.
+  teammateManager.packagedBuildOptions = {
+    ...teammateManager.packagedBuildOptions,
+    env: env as Record<string, string | undefined>,
+  };
 
   // Handle session resumption and branching
   if (sessionId) {

--- a/packages/runtime/src/ai/server/types.ts
+++ b/packages/runtime/src/ai/server/types.ts
@@ -13,6 +13,7 @@ import {
   normalizeClaudeCodeVariant,
 } from '../modelConstants';
 import type { TranscriptViewMessage } from './transcript/TranscriptProjector';
+import type { ProviderControlSnapshot } from './providers/claudeCode/providerControlContract';
 export type { ToolDefinition } from '../tools';
 export { ModelIdentifier } from './ModelIdentifier';
 export type { ToolResult } from './protocols/ProtocolInterface';
@@ -430,6 +431,7 @@ export interface ProviderConfig {
   allowedTools?: string[];  // List of allowed tool names, ['*'] for all tools
   effortLevel?: EffortLevel;  // Effort level for Opus 4.6 adaptive reasoning (low/medium/high/max)
   thinkingMode?: ThinkingMode;  // Extended thinking mode for Claude Agent (enabled/disabled)
+  providerControlSnapshot?: Readonly<ProviderControlSnapshot>; // Immutable reviewed route/control receipt
   responseFormat?: ProviderResponseFormat;  // Response format constraint (extension chat completions)
   skipLogging?: boolean;  // Skip message logging to DB (extension stateless completions)
 }


### PR DESCRIPTION
## User outcome

NIM-216 carries one atomic, reviewed Claude Agent control behavior from stable `v0.73.2`: an allowed control selected in the session UI is reconciled and persisted, resolved into an immutable runtime snapshot, and consumed by the Claude Agent SDK transport. Existing Extended-thinking UI from merged PR #912 is reused rather than reintroduced.

## Exact base and head

- Stable source and merge-base: `v0.73.2` / `c0f6b6cdd138dc707ec4688ae9013a4ea76f9534`.
- Actual GitHub base: `nimbalyst/nimbalyst:main`; base OID at PR creation: `4a42e0ad5cca7973251e3513db3ecd036171bd7d`.
- Fork head: `Yogitmeister:carry/v14c-nim216-schema-transport-r2`.
- Exact head: `2095a0db0519a9c5659de1053dcb9f0fabd5a98f`.
- The head is a one-commit child of the stable source; later `main` changes are not imported.

## Source, reuse, and PR #912

- PR #912 is not an open dependency. It merged as `effd010ecd478694e98f00aa49b48f9916be8e35` on 2026-07-17, and `git merge-base --is-ancestor effd010e c0f6b6c` exits `0`; the complete Extended-thinking implementation is already contained in stable `v0.73.2`.
- This CReq reuses that contained UI/persistence path and adds the missing reviewed catalog, reconciliation, immutable snapshot, and transport consumption.
- Legacy `5be21cc407ec5966f9f013e18a720cf57f232e1b` and upstream PR #1154 were line-level evidence only; no unrelated development history was imported.
- No dependency on draft PR #1155.

## Scope boundary and atomic consumer trace

This is not a broad provider catalog. The built-in data is a closed allowlist: reviewed Claude Agent SDK entries plus the two paired NIM-252 launcher profiles; unknown models return no entry, unknown controls fail closed, and targets are restricted to the reviewed target enum. The behavior is atomic because the same setting identity crosses every stage below; removing any stage leaves the user's selected control unapplied.

1. Catalog: `getBuiltInProviderControlEntry()` returns only exact reviewed model/interface/control mappings; `reconcileBuiltInProviderControlValues()` resets stale or unsupported values.
2. UI/input: `AIInput` renders `CatalogControlSelectors` from that entry. `SessionLaunchPopup` reconciles on model change and persists launch values in session metadata; `SessionTranscript` persists mid-session `effortLevel` / `thinkingMode` changes.
3. Runtime/persistence: `AIService.buildProviderControlRuntimeConfig()` reads stored metadata, calls `resolveProviderControlSnapshot()`, persists `providerControlSnapshot`, and returns only resolved values plus the immutable snapshot. Launch, restart, queued-turn, and provider initialization paths all call this builder.
4. Consumer: `MessageStreamingHandler` places the snapshot in `ProviderConfig`; `sdkOptionsBuilder` reads only the reviewed `sdk.thinking.type` and `env.CLAUDE_CODE_EFFORT_LEVEL` parameters and copies the reviewed env snapshot to subagent/team options.

Head-bound source: [catalog and fail-closed contract](https://github.com/Yogitmeister/nimbalyst/blob/2095a0db0519a9c5659de1053dcb9f0fabd5a98f/packages/runtime/src/ai/server/providers/claudeCode/providerControlContract.ts), [built-in allowlist](https://github.com/Yogitmeister/nimbalyst/blob/2095a0db0519a9c5659de1053dcb9f0fabd5a98f/packages/runtime/src/ai/server/providers/claudeCode/providerControlCatalogDefaults.ts), [UI consumer](https://github.com/Yogitmeister/nimbalyst/blob/2095a0db0519a9c5659de1053dcb9f0fabd5a98f/packages/electron/src/renderer/components/UnifiedAI/CatalogControlSelectors.tsx), [runtime snapshot owner](https://github.com/Yogitmeister/nimbalyst/blob/2095a0db0519a9c5659de1053dcb9f0fabd5a98f/packages/electron/src/main/services/ai/AIService.ts), and [SDK consumer](https://github.com/Yogitmeister/nimbalyst/blob/2095a0db0519a9c5659de1053dcb9f0fabd5a98f/packages/runtime/src/ai/server/providers/claudeCode/sdkOptionsBuilder.ts).

## Head-bound executable receipt

Local environment: Microsoft Windows 10 Home `10.0.19045` x64, Node `26.3.0`, npm `11.14.1`. The normal hook was executed in the disposable validation checkout carrying the reviewed Windows runner repair from PR #1227, while the pushed ref remained exact head `2095a0db...`; the validation-only head was not published.

Focused command:

```text
npm run test:unit -- --run packages/electron/src/renderer/components/UnifiedAI/__tests__/CatalogControlSelectors.test.tsx packages/runtime/src/ai/server/providers/claudeCode/__tests__/providerControlCatalogDefaults.test.ts packages/runtime/src/ai/server/providers/claudeCode/__tests__/providerControlContract.test.ts packages/runtime/src/ai/server/providers/__tests__/sdkOptionsBuilder.envKeys.test.ts
```

Complete result: exit `0`; 4 test files passed; 27 tests passed; 0 failed. `git diff --check` exited `0`.

Normal pre-push hook result, without bypass: exit `0`; extension-sdk/runtime/memory-engine builds passed; typecheck passed in 23/23 workspaces; `npm run test:prepush-gate` passed 42/42. The 42 checks are the separate hook/gate suite, not a sum of the 27 focused tests. The full local Vitest suite was skipped by the repository's existing Windows policy and is required on CI.

Trusted hosted CI at exact head `2095a0db...` on Ubuntu / Node 24:

- [Unit Tests: success](https://github.com/nimbalyst/nimbalyst/actions/runs/31629929711/job/94225792104) — repository command `npm run test:unit -- --run`.
- [TypeScript Check: success](https://github.com/nimbalyst/nimbalyst/actions/runs/31629929711/job/94225792207).
- [Transcript Bundle: success](https://github.com/nimbalyst/nimbalyst/actions/runs/31629929711/job/94225792108).
- [Android Build: success](https://github.com/nimbalyst/nimbalyst/actions/runs/31629929601/job/94225788949).

## Changed paths

- `CHANGELOG.md`
- `packages/electron/src/main/services/ai/{AIService,MessageStreamingHandler}.ts`
- `packages/electron/src/renderer/components/UnifiedAI/{AIInput,CatalogControlSelectors,SessionLaunchPopup,SessionTranscript}.tsx`
- focused renderer/runtime tests
- `packages/runtime/src/ai/server/{index,types}.ts`
- `packages/runtime/src/ai/server/providers/claudeCode/{providerControlContract,providerControlCatalogDefaults,sdkOptionsBuilder}.ts`

Merge, release, Notion, and source-table credit remain out of scope.

## Why this is worth merging

Provider capabilities change faster than hardcoded UI controls. Carrying a typed schema from provider catalog through launch, persistence, desktop, and mobile keeps the interface aligned with what the selected provider can actually accept. That prevents unsupported settings, lost choices, and provider-specific conditionals from spreading across consumers.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
