### PR TITLE
feat(ai): expose approved DeepSeek launcher profiles (NIM-252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Added DeepSeek Pro and DeepSeek Flash as preferred Nimbalyst model pointers through the workspace Unified Model Launcher.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/main/services/SyncManager.ts
+++ b/packages/electron/src/main/services/SyncManager.ts
@@ -1252,6 +1252,7 @@ async function getAvailableModelsForMobile(): Promise<{ models: Array<{ id: stri
     if (providerSettings['openai-codex']?.enabled === true) enabledSet.add('openai-codex');
     if (providerSettings['openai-codex-acp']?.enabled === true) enabledSet.add('openai-codex-acp');
     if (providerSettings['lmstudio']?.enabled === true) enabledSet.add('lmstudio');
+    if (providerSettings['model-launcher']?.enabled !== false) enabledSet.add('model-launcher');
 
     const modelsConfig = {
       ...apiKeys,

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -815,7 +815,7 @@ export class AIService {
     // Claude Code is enabled by default (undefined means enabled).
     // This matches the logic in ai:getModels which uses `claudeCodeSettings.enabled !== false`.
     // Other providers require explicit enabling (undefined means disabled).
-    const globalEnabled = provider === 'claude-code'
+    const globalEnabled = provider === 'claude-code' || provider === 'model-launcher'
       ? providerSettings[provider]?.enabled !== false
       : providerSettings[provider]?.enabled ?? false;
 
@@ -1943,6 +1943,9 @@ export class AIService {
             break;
           case 'copilot-cli':
             // Copilot uses its own CLI auth (copilot auth login), no API key needed
+            break;
+          case 'model-launcher':
+            // The workspace launcher owns route authentication.
             break;
           case 'lmstudio':
             // LMStudio doesn't need an API key, just the base URL
@@ -3356,6 +3359,9 @@ export class AIService {
             // Copilot uses its own CLI auth, no API key needed
             apiKey = 'not-required';
             break;
+          case 'model-launcher':
+            apiKey = 'not-required';
+            break;
           case 'lmstudio':
             // LMStudio doesn't need an API key, just test the connection
             apiKey = 'not-required';
@@ -3558,6 +3564,7 @@ export class AIService {
       if (providerSettings['openai-codex']?.enabled === true) enabledSet.add('openai-codex');
       if (providerSettings['opencode']?.enabled === true) enabledSet.add('opencode');
       if (providerSettings['lmstudio']?.enabled === true) enabledSet.add('lmstudio');
+      if (providerSettings['model-launcher']?.enabled !== false) enabledSet.add('model-launcher');
 
       const modelsConfig = {
         ...apiKeys,
@@ -3722,6 +3729,13 @@ export class AIService {
           enabled: providerSettings['lmstudio']?.enabled === true,
           models: providerSettings['lmstudio']?.models,
           hiddenModels: providerSettings['lmstudio']?.hiddenModels
+        },
+        'model-launcher': {
+          // The adapter is credential-neutral; the workspace launcher owns its
+          // approved route and reports availability when invoked.
+          enabled: providerSettings['model-launcher']?.enabled !== false,
+          models: providerSettings['model-launcher']?.models,
+          hiddenModels: providerSettings['model-launcher']?.hiddenModels
         }
       };
 

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -534,6 +534,10 @@ export class MessageStreamingHandler {
             // Copilot uses its own CLI auth, no API key needed
             requiresApiKey = false;
             break;
+          case 'model-launcher':
+            // The workspace launcher owns route authentication.
+            requiresApiKey = false;
+            break;
           case 'lmstudio':
             // LMStudio doesn't need an API key, just the base URL
             apiKey = 'not-required'; // Dummy value since LMStudio doesn't need a key

--- a/packages/electron/src/renderer/components/UnifiedAI/ModelSelector.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/ModelSelector.tsx
@@ -24,7 +24,7 @@ import { AlphaBadge } from '../common/AlphaBadge';
 import { HelpTooltip } from '../../help';
 import { isDirectChatProvider, isProviderVisible } from '../../utils/chatProviderVisibility';
 
-const ALPHA_PROVIDERS = new Set(['opencode', 'copilot-cli']);
+const ALPHA_PROVIDERS = new Set(['opencode', 'copilot-cli', 'model-launcher']);
 const TYPEAHEAD_RESET_MS = 700;
 
 interface Model {
@@ -315,6 +315,7 @@ export function ModelSelector({
       case 'openai-codex-acp': return 'OpenAI Codex (ACP)';
       case 'opencode': return 'OpenCode';
       case 'copilot-cli': return 'GitHub Copilot';
+      case 'model-launcher': return 'Model Launcher';
       case 'lmstudio': return 'LMStudio';
       default: {
         // Extension-contributed providers carry their contribution id here

--- a/packages/electron/src/renderer/store/atoms/appSettings.ts
+++ b/packages/electron/src/renderer/store/atoms/appSettings.ts
@@ -1200,6 +1200,7 @@ const defaultProviders: Record<string, ProviderConfig> = {
   'openai-codex-acp': { enabled: false, testStatus: 'idle', installStatus: 'not-installed' },
   opencode: { enabled: false, testStatus: 'idle', installStatus: 'not-installed' },
   'copilot-cli': { enabled: false, testStatus: 'idle', installStatus: 'not-installed' },
+  'model-launcher': { enabled: true, testStatus: 'idle' },
   lmstudio: { enabled: false, baseUrl: 'http://127.0.0.1:8234', testStatus: 'idle' },
 };
 

--- a/packages/electron/src/renderer/utils/modelUtils.ts
+++ b/packages/electron/src/renderer/utils/modelUtils.ts
@@ -181,6 +181,7 @@ export function getProviderDisplayName(provider: string): string {
     case 'openai': return 'OpenAI';
     case 'lmstudio': return 'LMStudio';
     case 'copilot-cli': return 'GitHub Copilot';
+    case 'model-launcher': return 'Model Launcher';
     default: return provider;
   }
 }

--- a/packages/runtime/src/ai/modelConstants.ts
+++ b/packages/runtime/src/ai/modelConstants.ts
@@ -491,6 +491,7 @@ export const DEFAULT_MODELS = {
   lmstudio: 'lmstudio:local-model',
   opencode: 'opencode:anthropic/claude-sonnet-4-5',
   'copilot-cli': 'copilot-cli:default',
+  'model-launcher': 'model-launcher:deepseek-pro',
 };
 
 /**

--- a/packages/runtime/src/ai/server/ModelRegistry.ts
+++ b/packages/runtime/src/ai/server/ModelRegistry.ts
@@ -86,6 +86,10 @@ export class ModelRegistry {
           const { CopilotCLIProvider } = await import('./providers/CopilotCLIProvider');
           models = await CopilotCLIProvider.getModels();
           break;
+        case 'model-launcher':
+          const { ModelLauncherProvider } = await import('./providers/ModelLauncherProvider');
+          models = await ModelLauncherProvider.getModels();
+          break;
         default:
           assertExhaustiveProvider(provider);
       }
@@ -125,6 +129,7 @@ export class ModelRegistry {
     if (shouldFetch('opencode')) promises.push(this.getModelsForProvider('opencode'));
     if (shouldFetch('lmstudio')) promises.push(this.getModelsForProvider('lmstudio', undefined, apiKeys['lmstudio_url']));
     if (shouldFetch('copilot-cli')) promises.push(this.getModelsForProvider('copilot-cli'));
+    if (shouldFetch('model-launcher')) promises.push(this.getModelsForProvider('model-launcher'));
 
     const results = await Promise.allSettled(promises);
 
@@ -174,6 +179,9 @@ export class ModelRegistry {
       case 'copilot-cli':
         const { CopilotCLIProvider: CLP } = await import('./providers/CopilotCLIProvider');
         return CLP.getDefaultModel();
+      case 'model-launcher':
+        const { ModelLauncherProvider } = await import('./providers/ModelLauncherProvider');
+        return ModelLauncherProvider.getDefaultModel();
       default:
         assertExhaustiveProvider(provider);
     }

--- a/packages/runtime/src/ai/server/ProviderFactory.ts
+++ b/packages/runtime/src/ai/server/ProviderFactory.ts
@@ -12,6 +12,7 @@ import { OpenAICodexACPProvider } from './providers/OpenAICodexACPProvider';
 import { LMStudioProvider } from './providers/LMStudioProvider';
 import { OpenCodeProvider } from './providers/OpenCodeProvider';
 import { CopilotCLIProvider } from './providers/CopilotCLIProvider';
+import { ModelLauncherProvider } from './providers/ModelLauncherProvider';
 import { ExtensionAgentProvider } from './providers/ExtensionAgentProvider';
 import { ProviderConfig, AIProviderType, assertExhaustiveProvider } from './types';
 
@@ -81,6 +82,9 @@ export class ProviderFactory {
         break;
       case 'copilot-cli':
         provider = new CopilotCLIProvider();
+        break;
+      case 'model-launcher':
+        provider = new ModelLauncherProvider();
         break;
       default:
         assertExhaustiveProvider(type);

--- a/packages/runtime/src/ai/server/__tests__/modelLauncherProvider.wiring.test.ts
+++ b/packages/runtime/src/ai/server/__tests__/modelLauncherProvider.wiring.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest';
+import { ModelRegistry } from '../ModelRegistry';
+import { ProviderFactory } from '../ProviderFactory';
+import { ModelLauncherProvider } from '../providers/ModelLauncherProvider';
+
+describe('ModelLauncherProvider wiring', () => {
+  it('registers exactly the two preferred DeepSeek pointers', async () => {
+    const models = await ModelRegistry.getModelsForProvider('model-launcher');
+    expect(models.map((model) => model.id)).toEqual([
+      'model-launcher:deepseek-pro',
+      'model-launcher:deepseek-flash',
+    ]);
+  });
+
+  it('dispatches the selected profile and reviewed effort without fallback', async () => {
+    const invoke = vi.fn(async () => ({ output: 'answer', artifactPath: 'audit.json' }));
+    const provider = new ModelLauncherProvider({ invoke });
+    await provider.initialize({ model: 'model-launcher:deepseek-flash', effortLevel: 'xhigh' });
+    const chunks = [];
+    for await (const chunk of provider.sendMessage('question', undefined, 'session', [], 'D:\\CLAUDE')) {
+      chunks.push(chunk);
+    }
+    expect(invoke).toHaveBeenCalledWith(expect.objectContaining({
+      profile: expect.objectContaining({ launcherAlias: 'ollama-deepseek-flash' }),
+      effort: 'xhigh',
+      task: 'question',
+    }));
+    expect(chunks).toEqual([
+      { type: 'text', content: 'answer' },
+      { type: 'complete', content: 'answer', isComplete: true },
+    ]);
+  });
+
+  it('constructs through the provider factory and rejects unapproved profiles', async () => {
+    const provider = ProviderFactory.createProvider('model-launcher', 'launcher-test');
+    expect(provider).toBeInstanceOf(ModelLauncherProvider);
+    await expect(provider.initialize({ model: 'model-launcher:other' })).rejects.toThrow('Unsupported');
+    ProviderFactory.destroyProvider('launcher-test');
+  });
+});

--- a/packages/runtime/src/ai/server/index.ts
+++ b/packages/runtime/src/ai/server/index.ts
@@ -24,6 +24,8 @@ export {
 export type { SharedMcpServerConfig, PerProviderMcpDeps } from './services/mcpServerConfig';
 export * from './services/mcpTopology';
 export * from './services/mcpTokenBudget';
+export * from './providers/modelLauncher/modelLauncherProfiles';
+export * from './providers/modelLauncher/modelLauncherAdapter';
 export * from './attachments/attachmentDenyMatcher';
 export * from './attachments/stagedAttachmentRegistry';
 

--- a/packages/runtime/src/ai/server/providers/ModelLauncherProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ModelLauncherProvider.ts
@@ -1,0 +1,113 @@
+import { BaseAgentProvider } from './BaseAgentProvider';
+import type {
+  AIModel,
+  DocumentContext,
+  ProviderCapabilities,
+  ProviderConfig,
+  StreamChunk,
+} from '../types';
+import { buildUserMessageAddition } from './documentContextUtils';
+import { invokeModelLauncher } from './modelLauncher/modelLauncherAdapter';
+import {
+  getModelLauncherModels,
+  getModelLauncherProfile,
+  MODEL_LAUNCHER_PROVIDER_ID,
+} from './modelLauncher/modelLauncherProfiles';
+
+interface ModelLauncherProviderDeps {
+  invoke?: typeof invokeModelLauncher;
+}
+
+export class ModelLauncherProvider extends BaseAgentProvider {
+  static readonly DEFAULT_MODEL = `${MODEL_LAUNCHER_PROVIDER_ID}:deepseek-pro`;
+  private readonly invoke: typeof invokeModelLauncher;
+
+  constructor(deps?: ModelLauncherProviderDeps) {
+    super();
+    this.invoke = deps?.invoke ?? invokeModelLauncher;
+  }
+
+  async initialize(config: ProviderConfig): Promise<void> {
+    if (!getModelLauncherProfile(config.model ?? ModelLauncherProvider.DEFAULT_MODEL)) {
+      throw new Error(`Unsupported Unified Model Launcher profile: ${config.model || '(empty)'}`);
+    }
+    if (config.effortLevel && !['low', 'medium', 'high', 'xhigh'].includes(config.effortLevel)) {
+      throw new Error(`Unsupported Unified Model Launcher effort: ${config.effortLevel}`);
+    }
+    this.config = config;
+  }
+
+  getProviderName(): string {
+    return MODEL_LAUNCHER_PROVIDER_ID;
+  }
+
+  getDisplayName(): string {
+    return 'Model Launcher';
+  }
+
+  getDescription(): string {
+    return 'Approved workspace model profiles through the Unified Model Launcher';
+  }
+
+  getProviderSessionData(): null {
+    return null;
+  }
+
+  override getCapabilities(): ProviderCapabilities {
+    return {
+      streaming: false,
+      tools: false,
+      mcpSupport: false,
+      edits: false,
+      resumeSession: false,
+      supportsFileTools: false,
+    };
+  }
+
+  static async getModels(): Promise<AIModel[]> {
+    return getModelLauncherModels();
+  }
+
+  static getDefaultModel(): string {
+    return ModelLauncherProvider.DEFAULT_MODEL;
+  }
+
+  async *sendMessage(
+    message: string,
+    documentContext?: DocumentContext,
+    sessionId?: string,
+    _messages?: unknown[],
+    workspacePath?: string,
+  ): AsyncIterableIterator<StreamChunk> {
+    if (!workspacePath) {
+      yield { type: 'error', error: 'Unified Model Launcher requires an active workspace.' };
+      return;
+    }
+    const profile = getModelLauncherProfile(this.config.model ?? ModelLauncherProvider.DEFAULT_MODEL);
+    if (!profile) {
+      yield { type: 'error', error: 'The selected launcher profile is not approved.' };
+      return;
+    }
+
+    const { messageWithContext } = buildUserMessageAddition(message, documentContext);
+    const abortController = new AbortController();
+    this.abortController = abortController;
+    try {
+      const result = await this.invoke({
+        workspacePath,
+        profile,
+        task: messageWithContext,
+        effort: this.config.effortLevel as 'low' | 'medium' | 'high' | 'xhigh' | undefined,
+        sessionId,
+        signal: abortController.signal,
+      });
+      yield { type: 'text', content: result.output };
+      yield { type: 'complete', content: result.output, isComplete: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      yield { type: 'error', error: message };
+    } finally {
+      if (this.abortController === abortController) this.abortController = null;
+    }
+  }
+}

--- a/packages/runtime/src/ai/server/providers/modelLauncher/__tests__/modelLauncherAdapter.test.ts
+++ b/packages/runtime/src/ai/server/providers/modelLauncher/__tests__/modelLauncherAdapter.test.ts
@@ -2,10 +2,13 @@
 
 import { EventEmitter } from 'events';
 import { createHash } from 'crypto';
+import path from 'path';
 import { PassThrough } from 'stream';
 import { describe, expect, it, vi } from 'vitest';
 import { invokeModelLauncher } from '../modelLauncherAdapter';
 import { MODEL_LAUNCHER_PROFILES } from '../modelLauncherProfiles';
+
+const WORKSPACE_PATH = path.join(process.cwd(), 'test-workspace');
 
 function successfulChild() {
   const child = new EventEmitter() as EventEmitter & {
@@ -37,7 +40,7 @@ describe('model launcher adapter', () => {
     });
 
     const result = await invokeModelLauncher({
-      workspacePath: 'D:\\CLAUDE',
+      workspacePath: WORKSPACE_PATH,
       profile: MODEL_LAUNCHER_PROFILES[0],
       task: 'review this',
       effort: 'xhigh',
@@ -59,7 +62,7 @@ describe('model launcher adapter', () => {
       '--effort', 'xhigh',
     ]));
     expect(args).not.toContain('--fallback');
-    expect(options).toMatchObject({ cwd: 'D:\\CLAUDE', windowsHide: true });
+    expect(options).toMatchObject({ cwd: WORKSPACE_PATH, windowsHide: true });
   });
 
   it('fails closed when the launcher audit is not completed', async () => {
@@ -77,7 +80,7 @@ describe('model launcher adapter', () => {
     });
 
     await expect(invokeModelLauncher({
-      workspacePath: 'D:\\CLAUDE',
+      workspacePath: WORKSPACE_PATH,
       profile: MODEL_LAUNCHER_PROFILES[1],
       task: 'review this',
       deps: {
@@ -104,7 +107,7 @@ describe('model launcher adapter', () => {
     });
 
     await expect(invokeModelLauncher({
-      workspacePath: 'D:\\CLAUDE',
+      workspacePath: WORKSPACE_PATH,
       profile: MODEL_LAUNCHER_PROFILES[0],
       task: 'review this',
       deps: {

--- a/packages/runtime/src/ai/server/providers/modelLauncher/__tests__/modelLauncherAdapter.test.ts
+++ b/packages/runtime/src/ai/server/providers/modelLauncher/__tests__/modelLauncherAdapter.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+
+import { EventEmitter } from 'events';
+import { createHash } from 'crypto';
+import { PassThrough } from 'stream';
+import { describe, expect, it, vi } from 'vitest';
+import { invokeModelLauncher } from '../modelLauncherAdapter';
+import { MODEL_LAUNCHER_PROFILES } from '../modelLauncherProfiles';
+
+function successfulChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+  };
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  queueMicrotask(() => child.emit('close', 0));
+  return child;
+}
+
+describe('model launcher adapter', () => {
+  it('invokes the exact allowlisted alias over stdin and reads a completed audit', async () => {
+    const spawnProcess = vi.fn(() => successfulChild());
+    const readFile = vi.fn(async (filename: unknown) => {
+      if (String(filename).endsWith('launcher.py')) return '# launcher';
+      return JSON.stringify({
+        schema_version: 1,
+        requested: {
+          model: 'deepseek-v4-pro:cloud',
+          provider: 'ollama_cloud',
+          task_sha256: createHash('sha256').update('review this').digest('hex'),
+        },
+        result: { status: 'completed', raw_response: 'verified response' },
+      });
+    });
+
+    const result = await invokeModelLauncher({
+      workspacePath: 'D:\\CLAUDE',
+      profile: MODEL_LAUNCHER_PROFILES[0],
+      task: 'review this',
+      effort: 'xhigh',
+      sessionId: 'session/unsafe',
+      deps: {
+        spawnProcess: spawnProcess as never,
+        readFile: readFile as never,
+        randomId: () => 'fixed-id',
+      },
+    });
+
+    expect(result.output).toBe('verified response');
+    expect(spawnProcess).toHaveBeenCalledOnce();
+    const [, args, options] = spawnProcess.mock.calls[0] as unknown as [string, string[], Record<string, unknown>];
+    expect(args).toEqual(expect.arrayContaining([
+      '--model', 'ollama-deepseek-pro',
+      '--task-stdin',
+      '--audit-id', 'nimbalyst-session-unsafe-fixed-id',
+      '--effort', 'xhigh',
+    ]));
+    expect(args).not.toContain('--fallback');
+    expect(options).toMatchObject({ cwd: 'D:\\CLAUDE', windowsHide: true });
+  });
+
+  it('fails closed when the launcher audit is not completed', async () => {
+    const readFile = vi.fn(async (filename: unknown) => {
+      if (String(filename).endsWith('launcher.py')) return '# launcher';
+      return JSON.stringify({
+        schema_version: 1,
+        requested: {
+          model: 'deepseek-v4-flash:cloud',
+          provider: 'ollama_cloud',
+          task_sha256: createHash('sha256').update('review this').digest('hex'),
+        },
+        result: { status: 'failed', error: 'route denied' },
+      });
+    });
+
+    await expect(invokeModelLauncher({
+      workspacePath: 'D:\\CLAUDE',
+      profile: MODEL_LAUNCHER_PROFILES[1],
+      task: 'review this',
+      deps: {
+        spawnProcess: (() => successfulChild()) as never,
+        readFile: readFile as never,
+        randomId: () => 'fixed-id',
+      },
+    })).rejects.toThrow('route denied');
+  });
+
+  it('rejects a completed audit for a different resolved model', async () => {
+    const taskHash = createHash('sha256').update('review this').digest('hex');
+    const readFile = vi.fn(async (filename: unknown) => {
+      if (String(filename).endsWith('launcher.py')) return '# launcher';
+      return JSON.stringify({
+        schema_version: 1,
+        requested: {
+          model: 'deepseek-v4-flash:cloud',
+          provider: 'ollama_cloud',
+          task_sha256: taskHash,
+        },
+        result: { status: 'completed', raw_response: 'wrong route' },
+      });
+    });
+
+    await expect(invokeModelLauncher({
+      workspacePath: 'D:\\CLAUDE',
+      profile: MODEL_LAUNCHER_PROFILES[0],
+      task: 'review this',
+      deps: {
+        spawnProcess: (() => successfulChild()) as never,
+        readFile: readFile as never,
+        randomId: () => 'fixed-id',
+      },
+    })).rejects.toThrow('does not match the approved route and task');
+  });
+});

--- a/packages/runtime/src/ai/server/providers/modelLauncher/__tests__/modelLauncherProfiles.test.ts
+++ b/packages/runtime/src/ai/server/providers/modelLauncher/__tests__/modelLauncherProfiles.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import {
+  getModelLauncherModels,
+  getModelLauncherProfile,
+  MODEL_LAUNCHER_PROFILES,
+} from '../modelLauncherProfiles';
+
+describe('model launcher preferred profiles', () => {
+  it('exposes exactly DeepSeek Pro and Flash through Ollama Cloud aliases', () => {
+    expect(MODEL_LAUNCHER_PROFILES).toEqual([
+      expect.objectContaining({
+        modelId: 'deepseek-pro',
+        launcherAlias: 'ollama-deepseek-pro',
+        resolvedModel: 'deepseek-v4-pro:cloud',
+      }),
+      expect.objectContaining({
+        modelId: 'deepseek-flash',
+        launcherAlias: 'ollama-deepseek-flash',
+        resolvedModel: 'deepseek-v4-flash:cloud',
+      }),
+    ]);
+    expect(getModelLauncherModels().map((model) => model.id)).toEqual([
+      'model-launcher:deepseek-pro',
+      'model-launcher:deepseek-flash',
+    ]);
+  });
+
+  it('fails closed for all other exact launcher arguments', () => {
+    expect(getModelLauncherProfile('model-launcher:deepseek-pro')?.launcherAlias).toBe('ollama-deepseek-pro');
+    expect(getModelLauncherProfile('deepseek-flash')?.launcherAlias).toBe('ollama-deepseek-flash');
+    expect(getModelLauncherProfile('ollama-qwen35-397b')).toBeUndefined();
+    expect(getModelLauncherProfile('deepseek-v4-pro')).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/ai/server/providers/modelLauncher/modelLauncherAdapter.ts
+++ b/packages/runtime/src/ai/server/providers/modelLauncher/modelLauncherAdapter.ts
@@ -1,0 +1,132 @@
+import { spawn } from 'child_process';
+import { createHash, randomUUID } from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+import type { ModelLauncherProfile } from './modelLauncherProfiles';
+
+interface LauncherAuditPayload {
+  schema_version?: number;
+  requested?: { model?: string; provider?: string; task_sha256?: string };
+  result?: {
+    status?: string;
+    raw_response?: string;
+    raw_stdout?: string;
+    error?: string | null;
+  };
+}
+
+export interface ModelLauncherExecution {
+  output: string;
+  artifactPath: string;
+}
+
+export interface ModelLauncherAdapterDeps {
+  pythonExecutable?: string;
+  spawnProcess?: typeof spawn;
+  readFile?: typeof fs.readFile;
+  randomId?: () => string;
+}
+
+function safeAuditId(sessionId: string | undefined, randomId: () => string): string {
+  const session = (sessionId || 'session').replace(/[^A-Za-z0-9._-]/g, '-').slice(0, 60);
+  const suffix = randomId().replace(/[^A-Za-z0-9._-]/g, '-').slice(0, 36);
+  return `nimbalyst-${session}-${suffix}`.slice(0, 120);
+}
+
+function isWithin(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+export async function invokeModelLauncher(input: {
+  workspacePath: string;
+  profile: ModelLauncherProfile;
+  task: string;
+  effort?: 'low' | 'medium' | 'high' | 'xhigh';
+  sessionId?: string;
+  signal?: AbortSignal;
+  deps?: ModelLauncherAdapterDeps;
+}): Promise<ModelLauncherExecution> {
+  const workspacePath = path.resolve(input.workspacePath);
+  const launcherPath = path.resolve(workspacePath, 'tools', 'launcher', 'launcher.py');
+  const auditDir = path.resolve(workspacePath, 'Temp', 'model-consultations');
+  if (!isWithin(workspacePath, launcherPath) || !isWithin(workspacePath, auditDir)) {
+    throw new Error('Unified Model Launcher paths escaped the active workspace.');
+  }
+
+  const readFile = input.deps?.readFile ?? fs.readFile;
+  try {
+    await readFile(launcherPath, 'utf8');
+  } catch {
+    throw new Error(
+      `Unified Model Launcher is unavailable at ${launcherPath}. ` +
+      'Open the workspace that owns tools/launcher/launcher.py.'
+    );
+  }
+
+  const randomId = input.deps?.randomId ?? randomUUID;
+  const auditId = safeAuditId(input.sessionId, randomId);
+  const artifactPath = path.join(auditDir, `${auditId}.json`);
+  const args = [
+    launcherPath,
+    'invoke',
+    '--model', input.profile.launcherAlias,
+    '--task-stdin',
+    '--timeout', '600',
+    '--audit-dir', auditDir,
+    '--audit-id', auditId,
+    ...(input.effort ? ['--effort', input.effort] : []),
+  ];
+
+  const spawnProcess = input.deps?.spawnProcess ?? spawn;
+  await new Promise<void>((resolve, reject) => {
+    const child = spawnProcess(input.deps?.pythonExecutable ?? 'python', args, {
+      cwd: workspacePath,
+      windowsHide: true,
+      // The validated audit is the response source of truth. Ignoring stdout
+      // avoids a large model response filling an unread pipe and deadlocking.
+      stdio: ['pipe', 'ignore', 'pipe'],
+      signal: input.signal,
+    });
+    let stderr = '';
+    child.stderr?.setEncoding('utf8');
+    child.stderr?.on('data', (chunk) => {
+      stderr = `${stderr}${chunk}`.slice(-4000);
+    });
+    child.once('error', reject);
+    child.once('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`Unified Model Launcher exited with code ${code}: ${stderr.trim()}`));
+    });
+    child.stdin?.end(input.task, 'utf8');
+  });
+
+  let payload: LauncherAuditPayload;
+  try {
+    payload = JSON.parse(await readFile(artifactPath, 'utf8')) as LauncherAuditPayload;
+  } catch (error) {
+    throw new Error(`Unified Model Launcher did not produce a readable audit: ${String(error)}`);
+  }
+
+  if (payload.schema_version !== 1) {
+    throw new Error('Unified Model Launcher audit has an unsupported schema version.');
+  }
+  if (payload.result?.status !== 'completed') {
+    throw new Error(
+      `Unified Model Launcher audit is ${payload.result?.status || 'invalid'}: ` +
+      `${payload.result?.error || 'no completed response'}`
+    );
+  }
+  const taskSha256 = createHash('sha256').update(input.task, 'utf8').digest('hex');
+  if (payload.requested?.provider !== input.profile.approvedProvider
+    || payload.requested?.model !== input.profile.resolvedModel
+    || payload.requested?.task_sha256 !== taskSha256) {
+    throw new Error('Unified Model Launcher audit does not match the approved route and task.');
+  }
+  const output = payload.result.raw_response ?? payload.result.raw_stdout;
+  if (typeof output !== 'string' || !output.trim()) {
+    throw new Error('Unified Model Launcher completed without response content.');
+  }
+
+  return { output: output.trim(), artifactPath };
+}

--- a/packages/runtime/src/ai/server/providers/modelLauncher/modelLauncherProfiles.ts
+++ b/packages/runtime/src/ai/server/providers/modelLauncher/modelLauncherProfiles.ts
@@ -1,0 +1,50 @@
+import type { AIModel } from '../../types';
+
+export const MODEL_LAUNCHER_PROVIDER_ID = 'model-launcher' as const;
+
+export interface ModelLauncherProfile {
+  readonly modelId: string;
+  readonly launcherAlias: string;
+  readonly resolvedModel: string;
+  readonly approvedProvider: 'ollama_cloud';
+  readonly label: string;
+}
+
+/**
+ * Deliberately small user-selected launcher surface.
+ *
+ * Other Unified Model Launcher aliases remain available through its CLI by
+ * exact argument; they are not promoted into Nimbalyst's picker.
+ */
+export const MODEL_LAUNCHER_PROFILES: readonly ModelLauncherProfile[] = [
+  {
+    modelId: 'deepseek-pro',
+    launcherAlias: 'ollama-deepseek-pro',
+    resolvedModel: 'deepseek-v4-pro:cloud',
+    approvedProvider: 'ollama_cloud',
+    label: 'DeepSeek Pro (Ollama Cloud)',
+  },
+  {
+    modelId: 'deepseek-flash',
+    launcherAlias: 'ollama-deepseek-flash',
+    resolvedModel: 'deepseek-v4-flash:cloud',
+    approvedProvider: 'ollama_cloud',
+    label: 'DeepSeek Flash (Ollama Cloud)',
+  },
+] as const;
+
+export function getModelLauncherProfile(model: string | undefined): ModelLauncherProfile | undefined {
+  if (!model) return undefined;
+  const modelId = model.startsWith(`${MODEL_LAUNCHER_PROVIDER_ID}:`)
+    ? model.slice(MODEL_LAUNCHER_PROVIDER_ID.length + 1)
+    : model;
+  return MODEL_LAUNCHER_PROFILES.find((profile) => profile.modelId === modelId);
+}
+
+export function getModelLauncherModels(): AIModel[] {
+  return MODEL_LAUNCHER_PROFILES.map((profile) => ({
+    id: `${MODEL_LAUNCHER_PROVIDER_ID}:${profile.modelId}`,
+    name: profile.label,
+    provider: MODEL_LAUNCHER_PROVIDER_ID,
+  }));
+}

--- a/packages/runtime/src/ai/server/types.ts
+++ b/packages/runtime/src/ai/server/types.ts
@@ -176,7 +176,7 @@ export interface Message {
  * Add new providers here -- the type, runtime array, and exhaustiveness
  * checks all derive from this one definition.
  */
-export const AI_PROVIDER_TYPES = ['claude', 'claude-code', 'claude-code-cli', 'openai', 'openai-codex', 'openai-codex-acp', 'lmstudio', 'opencode', 'copilot-cli'] as const;
+export const AI_PROVIDER_TYPES = ['claude', 'claude-code', 'claude-code-cli', 'openai', 'openai-codex', 'openai-codex-acp', 'lmstudio', 'opencode', 'copilot-cli', 'model-launcher'] as const;
 
 export type AIProviderType = typeof AI_PROVIDER_TYPES[number];
 
@@ -195,8 +195,8 @@ export function assertExhaustiveProvider(provider: never): never {
   throw new Error(`Unhandled provider: ${provider}`);
 }
 
-export function isAgentProvider(provider: string | null | undefined): provider is 'claude-code' | 'claude-code-cli' | 'openai-codex' | 'openai-codex-acp' | 'opencode' | 'copilot-cli' {
-  return provider === 'claude-code' || provider === 'claude-code-cli' || provider === 'openai-codex' || provider === 'openai-codex-acp' || provider === 'opencode' || provider === 'copilot-cli';
+export function isAgentProvider(provider: string | null | undefined): provider is 'claude-code' | 'claude-code-cli' | 'openai-codex' | 'openai-codex-acp' | 'opencode' | 'copilot-cli' | 'model-launcher' {
+  return provider === 'claude-code' || provider === 'claude-code-cli' || provider === 'openai-codex' || provider === 'openai-codex-acp' || provider === 'opencode' || provider === 'copilot-cli' || provider === 'model-launcher';
 }
 
 /**

--- a/packages/runtime/src/ui/icons/ProviderIcons.tsx
+++ b/packages/runtime/src/ui/icons/ProviderIcons.tsx
@@ -11,6 +11,7 @@ const PROVIDER_ICON_MAP: Record<string, string> = {
   // ACP transport reuses the OpenAI Codex icon (same underlying agent).
   'openai-codex-acp': 'openai-codex',
   'claude-code-cli': 'claude-code',
+  'model-launcher': 'terminal',
   // Gemini Antigravity extension provider -> Gemini brand glyph.
   'antigravity-gemini-agent': 'gemini',
   'antigravity-gemini': 'gemini',


### PR DESCRIPTION
## User outcome

NIM-252 exposes exactly two user-selected DeepSeek pointers through Nimbalyst's workspace Unified Model Launcher adapter. The desktop/mobile model surfaces persist the exact identifier, the provider factory consumes it, and the adapter invokes only its paired allowlisted Ollama Cloud alias with no endpoint, credential, broad list, or fallback route.

## Exact base and head

- Stable source and merge-base: `v0.73.2` / `c0f6b6cdd138dc707ec4688ae9013a4ea76f9534`.
- Actual GitHub base: `nimbalyst/nimbalyst:main`; base OID at PR creation: `4a42e0ad5cca7973251e3513db3ecd036171bd7d`.
- Fork head: `Yogitmeister:carry/v14c-nim252-deepseek-pointers`.
- Exact head: `52bb798552a8b94c9ad174c329ce29432cf1f97b`.
- Stable implementation commit: `bb169f82e164770a43bfce80d0c4fa3601764609`; CI portability repair: `52bb798552a8b94c9ad174c329ce29432cf1f97b`.
- Later upstream-main changes are not imported.

## Exact exposed routes

- `model-launcher:deepseek-pro` -> alias `ollama-deepseek-pro` -> resolved model `deepseek-v4-pro:cloud` / provider `ollama_cloud`.
- `model-launcher:deepseek-flash` -> alias `ollama-deepseek-flash` -> resolved model `deepseek-v4-flash:cloud` / provider `ollama_cloud`.

No wildcard or prefix route is accepted. `getModelLauncherProfile()` matches only the two exact model IDs; all other launcher arguments fail closed.

## Source and exclusions

- Stable, current upstream main, prereleases, development heads, and open PRs contained no equivalent workspace-launcher adapter.
- Legacy `c20defc7b5ecd6d652c379ee6ef3a765cd149afa` / `aa8f6d8fc85ad6fe512e67549f996ba7f13a050c` were rejected because they add a prohibited direct DeepSeek endpoint/credential route.
- The existing workspace aliases are reused; Nimbalyst adds no endpoint or credential and passes no `--fallback` argument.
- No dependency on draft PR #1155.

## Exact consumer trace

1. Model surface: `ModelRegistry.getModelsForProvider('model-launcher')` calls `ModelLauncherProvider.getModels()`, which returns only the two exact IDs; `ModelSelector` presents them under the Model Launcher provider.
2. Persistence/input: the existing session launch/transcript path persists the full selected ID (`model-launcher:deepseek-pro` or `model-launcher:deepseek-flash`) as the session model; SyncManager and AIService include the credential-neutral provider in desktop/mobile discovery.
3. Runtime owner: `ProviderFactory.createProvider('model-launcher')` constructs `ModelLauncherProvider`; `initialize()` rejects an unknown ID and effort outside `low|medium|high|xhigh`.
4. Adapter consumer: `sendMessage()` resolves the exact profile and calls `invokeModelLauncher()` with the active workspace, selected profile, task over stdin, selected effort, session ID, and abort signal.
5. Fail-closed validation: the adapter passes only `--model <allowlisted alias>` and never `--fallback`. It accepts output only when audit schema is `1`, status is `completed`, provider is `ollama_cloud`, resolved model matches the selected profile, task SHA-256 matches the exact stdin task, and output is non-empty.

Head-bound source: [exact profile allowlist](https://github.com/Yogitmeister/nimbalyst/blob/52bb798552a8b94c9ad174c329ce29432cf1f97b/packages/runtime/src/ai/server/providers/modelLauncher/modelLauncherProfiles.ts), [provider consumer](https://github.com/Yogitmeister/nimbalyst/blob/52bb798552a8b94c9ad174c329ce29432cf1f97b/packages/runtime/src/ai/server/providers/ModelLauncherProvider.ts), [adapter and audit validation](https://github.com/Yogitmeister/nimbalyst/blob/52bb798552a8b94c9ad174c329ce29432cf1f97b/packages/runtime/src/ai/server/providers/modelLauncher/modelLauncherAdapter.ts), [factory wiring](https://github.com/Yogitmeister/nimbalyst/blob/52bb798552a8b94c9ad174c329ce29432cf1f97b/packages/runtime/src/ai/server/ProviderFactory.ts), and [consumer tests](https://github.com/Yogitmeister/nimbalyst/blob/52bb798552a8b94c9ad174c329ce29432cf1f97b/packages/runtime/src/ai/server/__tests__/modelLauncherProvider.wiring.test.ts).

## Completed audit and task-hash receipt

Command (no fallback):

```text
Return exactly: NIM252-AUDIT-OK\n
  | python tools/launcher/launcher.py invoke --model ollama-deepseek-flash --task-stdin --timeout 600 --audit-dir Temp/model-consultations --audit-id v14c-nim252-live-adapter-receipt-20260812 --effort high
python tools/launcher/launcher.py show-audit --file Temp/model-consultations/v14c-nim252-live-adapter-receipt-20260812.json
```

Validated artifact fields: `schema_version=1`; `requested.model=deepseek-v4-flash:cloud`; `requested.provider=ollama_cloud`; `requested.task_sha256=c514cde1637a5a078aecd4efd6a2c00e5c1452dced811098107ec2cbf65d2415`; `result.status=completed`; `raw_response_length=15`; output `NIM252-AUDIT-OK`. `show-audit` exited `0` and returned the non-empty output. The adapter test supplies the same schema and proves exact alias/stdin invocation plus model/provider/task-hash/status/output validation; mismatched or failed audits are rejected.

## Head-bound executable receipt

Local environment: Microsoft Windows 10 Home `10.0.19045` x64, Node `26.3.0`, npm `11.14.1`. Exact focused command:

```text
npm run test:unit -- --run packages/runtime/src/ai/server/providers/modelLauncher/__tests__/modelLauncherAdapter.test.ts packages/runtime/src/ai/server/providers/modelLauncher/__tests__/modelLauncherProfiles.test.ts packages/runtime/src/ai/server/__tests__/modelLauncherProvider.wiring.test.ts
```

Complete result at exact head: exit `0`; 3 test files passed; 8 tests passed; 0 failed; duration 12.28s. `git diff --check` exited `0`.

Normal publication command pushed exact SHA `52bb798552a8b94c9ad174c329ce29432cf1f97b` from the disposable validation checkout carrying reviewed Windows runner repair PR #1227; the validation-only head was not published. Hook exit `0`: override sync and NUL checks passed; extension-sdk/runtime/memory-engine builds passed; typecheck passed in 23/23 workspaces in 48.1s; `npm run test:prepush-gate` passed 42/42. The 42 checks are a separate hook/gate suite, not a sum of the 8 focused tests. The full local Vitest suite was skipped by the repository's existing Windows policy and is mandatory on hosted CI.

Trusted hosted CI at exact head `52bb7985...` on Ubuntu / Node 24:

- [Unit Tests: success](https://github.com/nimbalyst/nimbalyst/actions/runs/31631455570/job/94230972529) — repository command `npm run test:unit -- --run`; 9m22s.
- [TypeScript Check: success](https://github.com/nimbalyst/nimbalyst/actions/runs/31631455570/job/94230972409); 2m30s.
- [Transcript Bundle: success](https://github.com/nimbalyst/nimbalyst/actions/runs/31631455570/job/94230972185); 45s.
- [Android Build: success](https://github.com/nimbalyst/nimbalyst/actions/runs/31631455553/job/94230971756); 5m45s.

## Changed paths

- `CHANGELOG.md`
- renderer model-selection/settings/icon paths
- electron AIService/MessageStreamingHandler/SyncManager consumers
- runtime provider type, registry, factory, model constants, exports
- `ModelLauncherProvider`, exact profiles, adapter, and focused tests

Merge, release, Notion, and source-table credit remain out of scope.

## Why this is worth merging

This adds two useful DeepSeek routes without adding a new credential or endpoint surface. The selection is exact and allowlisted, the existing workspace launcher remains the only transport, and audit validation fails closed if the provider, resolved model, task hash, or output does not match. Users gain deliberate cost and capability choices while Nimbalyst retains a narrow trust boundary.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
