### PR TITLE
fix: prime PromptForUserInput draft per prompt key, not per mount

### DIFF
--- a/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/RequestUserInputWidget.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/RequestUserInputWidget.tsx
@@ -75,6 +75,7 @@ import {
   draftToAnswers,
   fieldDraftValid,
   seedDraft,
+  decidePriming,
 } from './requestUserInputFieldLogic';
 import type {
   RequestUserInputAnswer,
@@ -997,18 +998,18 @@ export const RequestUserInputWidget: React.FC<CustomToolWidgetProps> = ({ messag
 
   const [draft, setDraft] = useAtom(requestUserInputDraftAtom(promptId));
 
-  // Prime the draft on first mount.
-  const primedRef = useRef(false);
+  // Prime the draft once per prompt KEY. Tracking which key was primed (not a
+  // bare "primed once" boolean) keeps this key-aware: if the atom key changes
+  // while the component stays mounted, the new draft is re-seeded rather than
+  // left as an empty, still-interactive form. See decidePriming + issue #1218.
+  const primedKeyRef = useRef<string | null>(null);
   useEffect(() => {
-    if (primedRef.current) return;
     if (!args) return;
-    if (draft.primed) {
-      primedRef.current = true;
-      return;
-    }
-    setDraft(seedDraft(args));
-    primedRef.current = true;
-  }, [args, draft.primed, setDraft]);
+    const decision = decidePriming(promptId, primedKeyRef.current, draft.primed);
+    if (decision === 'skip') return;
+    if (decision === 'seed') setDraft(seedDraft(args));
+    primedKeyRef.current = promptId;
+  }, [args, promptId, draft.primed, setDraft]);
 
   const setFieldDraft = useCallback(
     (fieldId: string, next: RequestUserInputFieldDraft) => {

--- a/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/requestUserInputFieldLogic.ts
+++ b/packages/runtime/src/ui/AgentTranscript/components/CustomToolWidgets/requestUserInputFieldLogic.ts
@@ -62,6 +62,34 @@ export function seedDraft(args: RequestUserInputArgs): RequestUserInputDraft {
   return { fields, primed: true };
 }
 
+/**
+ * The draft is stored in an atomFamily keyed by the tool call's promptId
+ * (`providerToolCallId`). Priming (seeding fields from the agent's defaults)
+ * must happen once per KEY, not once per component instance. A bare
+ * "primed once" boolean on the component suppresses seeding when the key
+ * changes while the widget stays mounted, leaving a live, interactive form
+ * rendered against an empty draft. Tracking which key was primed makes the
+ * guard key-aware, so a re-key (or a remount onto a new key) fails safe:
+ *
+ *  - 'skip'  : this key was already handled this mount; preserve in-progress edits.
+ *  - 'adopt' : a different key whose draft is already primed (e.g. it survived an
+ *              unmount in the module-level atom); keep it, do not reseed over the
+ *              user's text.
+ *  - 'seed'  : a different (or first) key with an empty draft; seed from defaults
+ *              so the form is never left blank.
+ */
+export type PrimeDecision = 'skip' | 'adopt' | 'seed';
+
+export function decidePriming(
+  promptId: string,
+  primedKey: string | null,
+  draftPrimed: boolean,
+): PrimeDecision {
+  if (primedKey === promptId) return 'skip';
+  if (draftPrimed) return 'adopt';
+  return 'seed';
+}
+
 export function fieldDraftValid(
   field: RequestUserInputField,
   draft: RequestUserInputFieldDraft | undefined,

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/requestUserInputPriming.test.ts
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/requestUserInputPriming.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { decidePriming } from '../CustomToolWidgets/requestUserInputFieldLogic';
+
+// Draft priming for the PromptForUserInput widget must be keyed to the prompt id
+// (providerToolCallId), not to a per-component "primed once" flag. See #1218:
+// when the atom key changes while the widget stays mounted, a component-local
+// boolean guard leaves a live, interactive form rendered against an empty draft
+// (silent loss of typed input).
+describe('decidePriming (#1218 draft key-awareness)', () => {
+  it('seeds the first time a key is seen with an empty draft', () => {
+    expect(decidePriming('call_a', null, false)).toBe('seed');
+  });
+
+  it('skips the same key so in-progress edits survive re-renders', () => {
+    // Same key already handled this mount: never reseed, or typed text is lost
+    // on the next render.
+    expect(decidePriming('call_a', 'call_a', true)).toBe('skip');
+    expect(decidePriming('call_a', 'call_a', false)).toBe('skip');
+  });
+
+  it('seeds a NEW key whose draft is empty instead of leaving the form blank', () => {
+    // The bug: a bare "primed once" boolean returned skip here, so a re-key left
+    // an empty, still-interactive form. Key-awareness re-seeds instead.
+    expect(decidePriming('call_b', 'call_a', false)).toBe('seed');
+  });
+
+  it('adopts a NEW key whose draft is already primed, without reseeding over user text', () => {
+    // Draft survived an unmount in the module-level atom; keep it as-is.
+    expect(decidePriming('call_b', 'call_a', true)).toBe('adopt');
+  });
+
+  it('adopts on first mount when the atom already holds a primed draft', () => {
+    expect(decidePriming('call_a', null, true)).toBe('adopt');
+  });
+});


### PR DESCRIPTION
Problem
Text typed into a PromptForUserInput field can be silently cleared while the dialog is still open and interactive (#1218) — values reset to empty with no warning.

Cause
The draft (per-field user input) lives in an atomFamily keyed by the tool call's providerToolCallId, module-level so it survives widget unmount. Priming (seeding fields from the agent's defaults) was guarded by a component-local "primed once" boolean (primedRef). That guard is not key-aware: if the atom key changes while the component stays mounted, primedRef.current is already true, so the effect early-returns and never seeds the new, empty draft — leaving a live, interactive form rendered against empty fields.

Fix
Track which key was primed, via a small pure helper decidePriming(promptId, primedKey, draftPrimed):

skip — same key already handled this mount → preserve in-progress edits.
adopt — a different key whose draft is already primed (survived an unmount) → keep it, don't reseed over the user's text.
seed — a different or first key with an empty draft → seed from defaults so the form is never left blank.
A re-key or remount now fails safe (re-seed or adopt) instead of fail silent (empty live form).

Honest scope
This is defensive hardening, and I want to be upfront: the exact runtime trigger in #1218 is not currently reproducible. The reporter confirmed on 0.73.2 that input survives backgrounding at 120s and a harness-forced turn-completion while the dialog is live. So this doesn't claim to be the sole cause — it closes the fail-silent data-loss path the key-unaware guard enables, which the reporter endorsed as worth landing regardless of the trigger. Uses Refs #1218 (not Fixes) so the issue stays open for the trigger hunt. Full design analysis is in the #1218 thread.

Tests
New requestUserInputPriming.test.ts: 5 pure cases for decidePriming. The helper follows the codebase's existing pattern of keeping widget logic testable without importing the Lexical editor tree.
Verified the tests fail against the unpatched code and pass with the fix.
typecheck clean; existing widget test suites (78 tests) pass.
Refs #1218