### PR TITLE
fix: map the Claude CLI's shell status to idle so sessions leave Thinking

### DIFF
--- a/packages/electron/src/main/services/ai/__tests__/claudeCliPidState.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliPidState.test.ts
@@ -27,6 +27,10 @@ describe('parseClaudePidFile', () => {
     expect(parseClaudePidFile('{"status":"waiting"}')?.status).toBe('waiting');
   });
 
+  it('parses shell (CLI 2.1.141+ writes it in place of idle when a local_bash task is live)', () => {
+    expect(parseClaudePidFile('{"status":"shell","pid":4321}')?.status).toBe('shell');
+  });
+
   it('is case-insensitive and trims', () => {
     expect(parseClaudePidFile('{"status":" Busy "}')?.status).toBe('busy');
   });
@@ -54,7 +58,7 @@ describe('parseClaudePidFile', () => {
 });
 
 describe('isClaudePidFileStale', () => {
-  const at = (status: 'busy' | 'idle' | 'waiting', updatedAt?: number) =>
+  const at = (status: 'busy' | 'shell' | 'idle' | 'waiting', updatedAt?: number) =>
     ({ status, updatedAt, raw: {} } as ReturnType<typeof parseClaudePidFile> & object);
 
   it('flags an active file whose updatedAt is older than the threshold', () => {
@@ -66,8 +70,9 @@ describe('isClaudePidFileStale', () => {
     expect(isClaudePidFileStale(at('busy', 90_000), 100_000, 60_000)).toBe(false);
   });
 
-  it('never flags idle, and treats a missing updatedAt as fresh (cannot judge)', () => {
+  it('never flags idle or shell, and treats a missing updatedAt as fresh (cannot judge)', () => {
     expect(isClaudePidFileStale(at('idle', 1), 1e15, 60_000)).toBe(false);
+    expect(isClaudePidFileStale(at('shell', 1), 1e15, 60_000)).toBe(false);
     expect(isClaudePidFileStale(at('busy', undefined), 1e15, 60_000)).toBe(false);
   });
 });
@@ -77,6 +82,10 @@ describe('mapPidStatusToTurnState', () => {
     expect(mapPidStatusToTurnState('busy')).toBe('running');
     expect(mapPidStatusToTurnState('idle')).toBe('idle');
     expect(mapPidStatusToTurnState('waiting')).toBe('waiting_for_input');
+  });
+
+  it('resolves shell as idle: the turn is over, only a background shell remains', () => {
+    expect(mapPidStatusToTurnState('shell')).toBe('idle');
   });
 });
 
@@ -129,6 +138,25 @@ describe('watchClaudePidState liveness backstop', () => {
     });
     await vi.advanceTimersByTimeAsync(60_000);
     expect(states).toEqual(['running']);
+    stop();
+  });
+
+  it('releases running to idle when the turn ends as shell, with the process still alive', async () => {
+    // The regression: a turn that ends with a live local_bash task writes
+    // `shell` where the watcher expects `idle`. An unrecognized status parses
+    // to null, so the watcher holds `running`, and the liveness backstop stays
+    // quiet because the CLI is alive. The session sat on "Thinking".
+    let contents = JSON.stringify({ status: 'busy', pid: 999, updatedAt: 1_000 });
+    const { states, stop } = setup({
+      readFile: async () => contents,
+      isProcessAlive: () => true,
+    });
+    await vi.advanceTimersByTimeAsync(500);
+    expect(states).toEqual(['running']);
+
+    contents = JSON.stringify({ status: 'shell', pid: 999, updatedAt: 2_000 });
+    await vi.advanceTimersByTimeAsync(500);
+    expect(states).toEqual(['running', 'idle']);
     stop();
   });
 

--- a/packages/electron/src/main/services/ai/claudeCliPidState.ts
+++ b/packages/electron/src/main/services/ai/claudeCliPidState.ts
@@ -3,9 +3,9 @@
  *
  * The `claude` CLI maintains a per-process state
  * file at `~/.claude/sessions/{pid}.json` — the same file `claude ps` reads.
- * Polling it for `busy` / `idle` / `waiting` is a far more stable turn-level
- * signal than tailing the jsonl log or screen-scraping the TUI, and it needs no
- * configuration.
+ * Polling it for `busy` / `shell` / `idle` / `waiting` is a far more stable
+ * turn-level signal than tailing the jsonl log or screen-scraping the TUI, and
+ * it needs no configuration.
  *
  * The SDK-only `MessageStreamingHandler` never sees CLI turns, so this is how
  * the CLI path drives the session's running/idle/needs-action indicator.
@@ -20,8 +20,16 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { resolveClaudeConfigDir } from '@nimbalyst/runtime/ai/server/providers/claudeCode/claudeConfigDir';
 
-/** Statuses the CLI writes into the PID file. */
-export type ClaudePidStatus = 'busy' | 'idle' | 'waiting';
+/**
+ * Statuses the CLI writes into the PID file.
+ *
+ * `shell` (CLI 2.1.141+) means the turn finished while a `local_bash` task is
+ * still alive; the CLI writes it in place of `idle`. Until it was recognized
+ * here it fell through `KNOWN_STATUSES`, so `parseClaudePidFile` returned null
+ * on every poll and the watcher held `running` for the life of the process.
+ * The session sat on "Thinking" until the CLI exited.
+ */
+export type ClaudePidStatus = 'busy' | 'shell' | 'idle' | 'waiting';
 
 /** Nimbalyst-side turn states the CLI status maps to. */
 export type ClaudeTurnState = 'running' | 'idle' | 'waiting_for_input';
@@ -39,7 +47,7 @@ export interface ParsedClaudePidFile {
   raw: Record<string, unknown>;
 }
 
-const KNOWN_STATUSES: ReadonlySet<string> = new Set(['busy', 'idle', 'waiting']);
+const KNOWN_STATUSES: ReadonlySet<string> = new Set(['busy', 'shell', 'idle', 'waiting']);
 
 /**
  * Normalize an `updatedAt` value to epoch milliseconds. The CLI's unit is
@@ -94,15 +102,16 @@ export function parseClaudePidFile(contents: string): ParsedClaudePidFile | null
  * (`isProcessAlive`) for stuck detection; this check remains opt-in and unused
  * by production wiring.
  *
- * `idle` is never stale (an idle CLI legitimately stops refreshing the file), and
- * a file with no `updatedAt` is treated as fresh (we can't judge it).
+ * `idle` and `shell` are never stale (both mean the turn is over, and the CLI
+ * legitimately stops refreshing the file), and a file with no `updatedAt` is
+ * treated as fresh (we can't judge it).
  */
 export function isClaudePidFileStale(
   parsed: ParsedClaudePidFile,
   now: number,
   staleAfterMs: number
 ): boolean {
-  if (parsed.status === 'idle') return false;
+  if (parsed.status === 'idle' || parsed.status === 'shell') return false;
   if (parsed.updatedAt === undefined) return false;
   return now - parsed.updatedAt > staleAfterMs;
 }
@@ -114,6 +123,10 @@ export function mapPidStatusToTurnState(status: ClaudePidStatus): ClaudeTurnStat
       return 'running';
     case 'waiting':
       return 'waiting_for_input';
+    // `shell` is idle with a background shell task attached: the turn is over,
+    // so it resolves like `idle`. Holding `running` here strands every
+    // `onTurnState('idle')` consumer for the life of the process.
+    case 'shell':
     case 'idle':
     default:
       return 'idle';


### PR DESCRIPTION
## Summary

Claude CLI sessions display "…Thinking" for as long as the process lives, after the turn has finished.

`claudeCliPidState` accepts `busy` / `idle` / `waiting` from the CLI's PID file. Claude Code 2.1.141+ writes a fourth status, `shell`, in place of `idle` when a turn ends while a `local_bash` task is still alive. An unrecognized status parses to null, so the watcher holds the `running` state it was given at launch, and the liveness backstop cannot release it because the CLI is still alive.

This maps `shell` to `idle` and exempts it from `isClaudePidFileStale` for the same reason.

The knock-on effect is larger than the spinner: every consumer of `onTurnState('idle')` stops with it, including `fireClaudeCliTurnCompletion`, `maybeAutoNameClaudeCliSession`, and `flushNextClaudeCliQueuedPromptForSession`, so queued prompts silently never run.

## Related issue

Closes #1246

## Testing

`npx vitest --run packages/electron/src/main/services/ai/__tests__/claudeCliPidState.test.ts` → 21/21 pass.

Reverting only the source change and rerunning fails 3 tests, so the new tests do reproduce the bug. The one that matters is the watcher case:

```
AssertionError: expected [ 'running' ] to deeply equal [ 'running', 'idle' ]
```

That assertion is the stuck spinner: a live process, a finished turn, and no transition out of `running`. Its `isProcessAlive: () => true` is the point, since it shows the liveness backstop cannot cover this case.

Also verified against the live symptom on 0.72.8 with CLI 2.1.223: five sessions parked on `shell`, one of them for 13 minutes. Rewriting the parked PID files to `"status":"idle"` cleared all five within 90ms.

## Notes for reviewers

Two judgement calls worth a look.

I mapped `shell` to `idle` rather than adding a `ClaudeTurnState`. It keeps `isResolved()` in the interrupt-escalation path correct without touching every `onTurnState` consumer. Surfacing "idle, background shell attached" in the UI would be a larger change, and it seemed beyond a bug fix.

I deliberately left `staleAfterMs` unwired. My original issue claimed that was a second bug and recommended passing it; that was wrong and I have corrected the issue. NIM-814's docstring already explains why an `updatedAt` age threshold falsely idles long turns, and I ran into the same thing independently while writing a local workaround: demoting a stale `busy` would flush queued prompts into a CLI that is still working.

Affected versions, bisected from the published `claude-code-darwin-arm64` binaries:

```
2.1.110  no status field in the PID file at all
2.1.140  ["busy","idle","waiting"]
2.1.150  ["busy","shell","idle","waiting"]   ← landed in 2.1.141–2.1.150
2.1.223  ["busy","shell","idle","waiting"]
```

Only the "Claude Code CLI (Terminal Mode)" provider is affected; the SDK provider never reads the PID file.
