### PR TITLE
fix(spellcheck): use the OS locale for the spellchecker language, with an override

### DIFF
--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -9,6 +9,7 @@ import { safeHandle, safeOn } from './utils/ipcRegistry';
 import { installMicrophoneGate } from './mediaPermissionGate';
 import { markBootComplete } from './utils/bootState';
 import { markStart, markEnd, checkpoint, logSummary } from './utils/startupTiming';
+import { resolveSpellCheckerLanguages } from './utils/spellcheckLanguages';
 import type { SessionStore } from '@nimbalyst/runtime';
 import * as os from 'os';
 import * as path from 'path';
@@ -1568,6 +1569,29 @@ app.whenReady().then(async () => {
     const spellcheckEnabled = getAppSetting<boolean>('spellcheckEnabled');
     if (spellcheckEnabled === false) {
         session.defaultSession.setSpellCheckerEnabled(false);
+    }
+
+    // Set the spellchecker LANGUAGE. Chromium otherwise defaults to en-US and
+    // ignores the OS locale, so an `en_CA` user sees Canadian spelling flagged
+    // as wrong. Prefer a saved override, else the system locale. macOS uses the
+    // OS spellchecker and ignores setSpellCheckerLanguages, so skip it there.
+    if (spellcheckEnabled !== false && process.platform !== 'darwin') {
+        try {
+            const available = session.defaultSession.availableSpellCheckerLanguages ?? [];
+            const saved = getAppSetting<string[]>('spellcheckLanguages');
+            const localeSource =
+                app.getSystemLocale?.() ||
+                app.getLocale() ||
+                process.env.LC_ALL ||
+                process.env.LANG ||
+                process.env.LC_MESSAGES;
+            const langs = resolveSpellCheckerLanguages(localeSource, available, saved);
+            if (langs.length > 0) {
+                session.defaultSession.setSpellCheckerLanguages(langs);
+            }
+        } catch {
+            // Non-fatal: fall back to Chromium's default language selection.
+        }
     }
 
     // Issue #146: wire up the `nim-asset://` request handler. Workspaces are

--- a/packages/electron/src/main/mcp/settingsServer.ts
+++ b/packages/electron/src/main/mcp/settingsServer.ts
@@ -116,6 +116,20 @@ const TOOLS = [
     },
   },
   {
+    name: "appearance_set_spellcheck_languages",
+    description:
+      "Set the spellchecker language(s) as Chromium BCP-47 codes (e.g. [\"en-CA\"], [\"en-US\",\"fr\"]). " +
+      "Pass an empty array to clear the override and derive the language from the OS locale. " +
+      "No effect on macOS, which uses the system spellchecker.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        languages: { type: "array", items: { type: "string" } },
+      },
+      required: ["languages"],
+    },
+  },
+  {
     name: "analytics_set_enabled",
     description: "Enable or disable anonymous usage analytics.",
     inputSchema: {
@@ -270,6 +284,15 @@ export async function dispatchSettingsTool(
 
       case "appearance_set_spellcheck":
         return respond(await svc.setSpellcheck(aiSessionId, { enabled: !!args.enabled }));
+
+      case "appearance_set_spellcheck_languages":
+        return respond(
+          await svc.setSpellcheckLanguages(aiSessionId, {
+            languages: Array.isArray(args.languages)
+              ? (args.languages as unknown[]).filter((x): x is string => typeof x === "string")
+              : [],
+          }),
+        );
 
       case "analytics_set_enabled":
         return respond(await svc.setAnalytics(aiSessionId, { enabled: !!args.enabled }));

--- a/packages/electron/src/main/services/SettingsControlService.ts
+++ b/packages/electron/src/main/services/SettingsControlService.ts
@@ -46,6 +46,7 @@ import {
 } from '../utils/store';
 import * as StytchAuth from './StytchAuthService';
 import { logger } from '../utils/logger';
+import { resolveSpellCheckerLanguages } from '../utils/spellcheckLanguages';
 import {
   startExtensionBackendModules,
   stopExtensionBackendModules,
@@ -69,6 +70,7 @@ export const ALLOWED_APP_KEYS = [
   'completionSoundEnabled',
   'osNotificationsEnabled',
   'spellcheckEnabled',
+  'spellcheckLanguages',
   'analyticsEnabled',
   'defaultAIModel',
   'preferredAgentLanguage',
@@ -164,6 +166,7 @@ export class SettingsControlService {
       analyticsEnabled: storeIsAnalyticsEnabled(),
       completionSoundEnabled: getAppSetting<boolean>('completionSoundEnabled') ?? false,
       spellcheckEnabled: getAppSetting<boolean>('spellcheckEnabled') ?? true,
+      spellcheckLanguages: getAppSetting<string[]>('spellcheckLanguages') ?? [],
       preferredAgentLanguage: getAppSetting<string>('preferredAgentLanguage') ?? '',
       voiceMode: getAppSetting<unknown>('voiceMode') ?? null,
       sessionSync: sync
@@ -407,6 +410,36 @@ export class SettingsControlService {
     }
     this.audit('appearance_set_spellcheck', sessionId, { before, after: args.enabled });
     return { ok: true, before, after: args.enabled };
+  }
+
+  /**
+   * Set the spellchecker language(s) as Chromium BCP-47 codes (e.g. ["en-CA"]).
+   * An empty list clears the override, so launch derives the language from the
+   * OS locale again. Applied live where possible; the persisted value governs
+   * the next launch regardless. No-op on macOS (system spellchecker).
+   */
+  async setSpellcheckLanguages(
+    sessionId: string,
+    args: { languages: string[] },
+  ): Promise<SettingsToolResult<string[], string[]>> {
+    rateLimit(sessionId);
+    const before = getAppSetting<string[]>('spellcheckLanguages') ?? [];
+    const after = Array.isArray(args.languages) ? args.languages : [];
+    setAppSetting('spellcheckLanguages', after);
+    try {
+      const { session } = await import('electron');
+      if (process.platform !== 'darwin') {
+        const available = session.defaultSession.availableSpellCheckerLanguages ?? [];
+        const langs = resolveSpellCheckerLanguages(undefined, available, after);
+        if (langs.length > 0) {
+          session.defaultSession.setSpellCheckerLanguages(langs);
+        }
+      }
+    } catch {
+      // Non-fatal: the persisted setting still applies on next launch.
+    }
+    this.audit('appearance_set_spellcheck_languages', sessionId, { before, after });
+    return { ok: true, before, after };
   }
 
   async setAnalytics(

--- a/packages/electron/src/main/services/__tests__/SettingsControlService.test.ts
+++ b/packages/electron/src/main/services/__tests__/SettingsControlService.test.ts
@@ -121,6 +121,7 @@ describe('SettingsControlService allowlist invariants', () => {
         'sessionSync',
         'settingsAgentToolsDisabled',
         'spellcheckEnabled',
+        'spellcheckLanguages',
         'theme',
         'voiceMode',
       ].sort(),

--- a/packages/electron/src/main/utils/__tests__/spellcheckLanguages.test.ts
+++ b/packages/electron/src/main/utils/__tests__/spellcheckLanguages.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeLocale, resolveSpellCheckerLanguages } from '../spellcheckLanguages';
+
+// Chromium's real English options on Linux/Windows hunspell.
+const EN = ['en-US', 'en-CA', 'en-GB', 'en-AU', 'fr', 'fr-FR', 'de'];
+
+describe('normalizeLocale', () => {
+  it('cleans an OS LANG string to a BCP-47 code', () => {
+    expect(normalizeLocale('en_CA.UTF-8')).toBe('en-CA');
+  });
+  it('unifies separator and case', () => {
+    expect(normalizeLocale('en-ca')).toBe('en-CA');
+    expect(normalizeLocale('EN_ca')).toBe('en-CA');
+  });
+  it('keeps a bare language', () => {
+    expect(normalizeLocale('en')).toBe('en');
+  });
+  it('strips an @modifier', () => {
+    expect(normalizeLocale('de_DE@euro')).toBe('de-DE');
+  });
+  // Controls: the values that must NOT become a spellcheck code.
+  it('rejects C / POSIX / empty / junk [control]', () => {
+    expect(normalizeLocale('C')).toBeUndefined();
+    expect(normalizeLocale('POSIX')).toBeUndefined();
+    expect(normalizeLocale('')).toBeUndefined();
+    expect(normalizeLocale(undefined)).toBeUndefined();
+    expect(normalizeLocale('123')).toBeUndefined();
+  });
+  it('drops an unparseable region to the base language [control]', () => {
+    expect(normalizeLocale('en-latn')).toBe('en');
+  });
+});
+
+describe('resolveSpellCheckerLanguages', () => {
+  // THE BUG THIS FIXES: an en_CA user must get en-CA, not en-US.
+  it('uses the exact system locale when Chromium offers it', () => {
+    expect(resolveSpellCheckerLanguages('en_CA.UTF-8', EN)).toEqual(['en-CA']);
+  });
+
+  // CONTROL: a different locale must resolve to a DIFFERENT language, or the
+  // function is ignoring its input and hardcoding en-CA.
+  it('resolves en_GB to en-GB, not en-CA [control]', () => {
+    expect(resolveSpellCheckerLanguages('en_GB.UTF-8', EN)).toEqual(['en-GB']);
+  });
+  it('resolves fr_FR to fr-FR [control]', () => {
+    expect(resolveSpellCheckerLanguages('fr_FR.UTF-8', EN)).toEqual(['fr-FR']);
+  });
+
+  it('canonicalizes case to what Chromium actually lists', () => {
+    expect(resolveSpellCheckerLanguages('en-ca', EN)).toEqual(['en-CA']);
+  });
+
+  // An explicit saved preference overrides the locale...
+  it('prefers a saved override over the system locale', () => {
+    expect(resolveSpellCheckerLanguages('en_CA', EN, ['en-GB'])).toEqual(['en-GB']);
+  });
+  // ...but the locale still applies when there is no saved preference [control].
+  it('falls back to locale when saved is empty [control]', () => {
+    expect(resolveSpellCheckerLanguages('en_CA', EN, [])).toEqual(['en-CA']);
+  });
+  it('keeps multiple saved languages, filtered + deduped', () => {
+    expect(resolveSpellCheckerLanguages('en_CA', EN, ['en-CA', 'fr', 'en-CA'])).toEqual([
+      'en-CA',
+      'fr',
+    ]);
+  });
+  it('a saved language Chromium does not offer is dropped, then locale wins [control]', () => {
+    expect(resolveSpellCheckerLanguages('en_CA', EN, ['xx-YY'])).toEqual(['en-CA']);
+  });
+
+  // Base-language fallback: Canadian on a build with only en-US available still
+  // gets English, never nothing.
+  it('falls back to a regional sibling of the base language', () => {
+    expect(resolveSpellCheckerLanguages('en_CA', ['en-US', 'fr'])).toEqual(['en-US']);
+  });
+  it('falls back to the bare base language when only that exists', () => {
+    expect(resolveSpellCheckerLanguages('en_CA', ['en', 'fr'])).toEqual(['en']);
+  });
+
+  // Unknown available list: trust the locale rather than filter to empty.
+  it('trusts the locale when the available list is unknown/empty', () => {
+    expect(resolveSpellCheckerLanguages('en_CA', [])).toEqual(['en-CA']);
+    expect(resolveSpellCheckerLanguages('en_CA', undefined)).toEqual(['en-CA']);
+  });
+
+  // CONTROL: when nothing can be asserted, return [] so Chromium keeps its
+  // default — never worse than today.
+  it('returns [] for an unusable locale and no saved pref [control]', () => {
+    expect(resolveSpellCheckerLanguages('C', EN)).toEqual([]);
+    expect(resolveSpellCheckerLanguages(undefined, EN)).toEqual([]);
+  });
+  it('returns [] when the base language is not available at all [control]', () => {
+    expect(resolveSpellCheckerLanguages('ja_JP', ['en-US', 'fr'])).toEqual([]);
+  });
+});

--- a/packages/electron/src/main/utils/spellcheckLanguages.ts
+++ b/packages/electron/src/main/utils/spellcheckLanguages.ts
@@ -1,0 +1,97 @@
+/**
+ * Spellchecker language resolution.
+ *
+ * Nimbalyst only ever called `session.setSpellCheckerEnabled(bool)` and never
+ * `setSpellCheckerLanguages(...)`, so Chromium fell back to its own default
+ * (en-US) regardless of the user's OS locale. A user on `en_CA` therefore saw
+ * US/UK spelling flagged. This module decides which language(s) to hand
+ * Chromium, preferring an explicit user choice, then the system locale.
+ *
+ * Kept pure (no `electron` import) so it is unit-testable without building the
+ * app. The main process supplies `session.availableSpellCheckerLanguages` and
+ * the locale; this decides the list.
+ *
+ * Note: on macOS Electron uses the OS spellchecker and `setSpellCheckerLanguages`
+ * is a no-op — callers skip it there. This module is for Windows/Linux.
+ */
+
+/**
+ * Normalize a locale string to a Chromium BCP-47 spellcheck code.
+ *   "en_CA.UTF-8" | "en_CA" | "en-ca" -> "en-CA"
+ *   "en"                              -> "en"
+ *   "" | "C" | "POSIX" | junk         -> undefined
+ */
+export function normalizeLocale(locale: string | undefined | null): string | undefined {
+  if (!locale) return undefined;
+  // Strip encoding (".UTF-8") and modifier ("@euro"); unify separator.
+  const cleaned = locale.split('.')[0].split('@')[0].replace('_', '-').trim();
+  if (!cleaned) return undefined;
+  const parts = cleaned.split('-');
+  const lang = parts[0].toLowerCase();
+  // "C"/"POSIX" and other non-language values fail this shape check.
+  if (!/^[a-z]{2,3}$/.test(lang)) return undefined;
+  if (parts.length === 1) return lang;
+  const region = parts[1].toUpperCase();
+  if (!/^[A-Z]{2}$/.test(region)) return lang; // e.g. "en-latn" -> "en"
+  return `${lang}-${region}`;
+}
+
+/**
+ * Resolve the spellchecker language list.
+ *
+ * Priority:
+ *   1. Explicit saved preference (filtered to what Chromium actually offers).
+ *   2. The system locale, if Chromium offers it exactly (e.g. "en-CA").
+ *   3. The locale's base language matched to the first available regional
+ *      variant (e.g. "en-CA" with only "en-US" available -> "en-US"), so a
+ *      Canadian is never dropped to *no* English rather than a near one.
+ *   4. [] — assert nothing; Chromium keeps its own default (never worse than
+ *      today's behavior).
+ *
+ * When `available` is empty (the list is unknown at call time) we DO NOT filter
+ * to empty — we trust the saved/locale value, since filtering against an empty
+ * "what's available" set would wrongly reject everything.
+ */
+export function resolveSpellCheckerLanguages(
+  locale: string | undefined | null,
+  available: readonly string[] | undefined | null,
+  saved?: readonly string[] | undefined | null,
+): string[] {
+  const avail = (available ?? []).filter((c): c is string => typeof c === 'string' && c.length > 0);
+  const availUnknown = avail.length === 0;
+  const has = (code: string) =>
+    availUnknown || avail.some((c) => c.toLowerCase() === code.toLowerCase());
+  const canonical = (code: string) =>
+    avail.find((c) => c.toLowerCase() === code.toLowerCase()) ?? code;
+
+  // 1) explicit saved preference wins
+  if (saved && saved.length > 0) {
+    const kept = dedupe(
+      saved
+        .filter((c): c is string => typeof c === 'string' && c.length > 0)
+        .filter((c) => has(c))
+        .map(canonical),
+    );
+    if (kept.length > 0) return kept;
+    // saved but none available -> fall through to locale
+  }
+
+  // 2 / 3) system locale
+  const norm = normalizeLocale(locale ?? undefined);
+  if (norm) {
+    if (has(norm)) return [canonical(norm)];
+    const base = norm.split('-')[0].toLowerCase();
+    // prefer a regional variant of the same base language ("en-*")...
+    const regional = avail.find((c) => c.toLowerCase().startsWith(base + '-'));
+    if (regional) return [regional];
+    // ...else the bare base language if Chromium has it.
+    if (has(base)) return [canonical(base)];
+  }
+
+  // 4) nothing we can assert — leave Chromium's default in place
+  return [];
+}
+
+function dedupe(arr: readonly string[]): string[] {
+  return [...new Set(arr)];
+}

--- a/packages/electron/src/main/utils/store.ts
+++ b/packages/electron/src/main/utils/store.ts
@@ -216,6 +216,10 @@ interface AppStoreSchema {
   };
   // System spellchecker (enabled by default, applies to all editors and text inputs)
   spellcheckEnabled?: boolean;
+  // Spellchecker language(s) as Chromium BCP-47 codes (e.g. ["en-CA"]).
+  // Empty/unset -> derived from the OS locale at launch. Ignored on macOS,
+  // which uses the system spellchecker.
+  spellcheckLanguages?: string[];
   // System tray icon
   showTrayIcon?: boolean;
   // Advanced: V8 heap memory limit in MB (default: 4096 = 4GB)


### PR DESCRIPTION
## Problem

The in-app spellchecker always underlines Canadian/British spellings (e.g. *colour*, *behaviour*, *centre*) as errors, regardless of the user's system locale. The Electron main process never calls `session.setSpellCheckerLanguages(...)`, so Chromium falls back to its default of `en-US` for everyone.

## Fix

Resolve the spellchecker language from the OS locale on launch, with a fallback chain and an optional saved override:

1. saved override (`spellcheckLanguages` app setting) →
2. exact locale match (`en-CA`) →
3. regional sibling of the same base language (`en-*`) →
4. base language (`en`) →
5. none (leave Chromium's default untouched)

The resolver (`spellcheckLanguages.ts`) is pure and unit-tested. Locale normalization handles `en_CA.UTF-8` → `en-CA` and rejects unusable values (`C`, `POSIX`). Only languages Chromium actually reports via `session.availableSpellCheckerLanguages` are applied.

An MCP tool (`appearance_set_spellcheck_languages`) and a `SettingsControlService` setter allow changing the language at runtime without a restart.

## Platform notes

- **macOS is skipped** — it uses the OS-level spellchecker and `setSpellCheckerLanguages` is a no-op there.
- Application is wrapped in try/catch and is non-fatal — a bad locale never blocks startup.

## Testing

- `spellcheckLanguages.test.ts` — 19 cases including controls (e.g. `en_GB` → `en-GB`, not hardcoded to CA; saved override wins; unusable locale → `[]`).
- `SettingsControlService.test.ts` — updated the curated allow-list assertion (deliberate, visible diff) for the new `spellcheckLanguages` key.
- `tsc --noEmit` clean; touched test files pass (26 tests).