### PR TITLE
Don't observe the Claude CLI's prompt-suggestion fork

### DIFF
--- a/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
@@ -1404,7 +1404,7 @@ export async function handleRequestUserInput(
   if (fields.length === 0) {
     return {
       content: [
-        { type: "text", text: "Error: at least one field is required in RequestUserInput" },
+        { type: "text", text: "Error: at least one field is required in PromptForUserInput" },
       ],
       isError: true,
     };
@@ -1489,7 +1489,7 @@ export async function handleRequestUserInput(
   const fallbackResponseChannel = getRequestUserInputFallbackResponseChannel(sessionKey);
 
   console.log(
-    `[MCP Server] RequestUserInput waiting for response: promptId=${promptId}, sessionId=${sessionId}`,
+    `[MCP Server] PromptForUserInput waiting for response: promptId=${promptId}, sessionId=${sessionId}`,
   );
 
   // Update session status so all windows show the pending indicator.
@@ -1532,7 +1532,7 @@ export async function handleRequestUserInput(
       }
     }
   } catch (err) {
-    console.warn("[MCP Server] RequestUserInput: failed to notify renderer:", err);
+    console.warn("[MCP Server] PromptForUserInput: failed to notify renderer:", err);
   }
 
   // Show OS notification if the app is backgrounded.
@@ -1573,7 +1573,7 @@ export async function handleRequestUserInput(
       if (sessionId) clearLiveInteractivePrompt(sessionId);
 
       console.log(
-        `[MCP Server] RequestUserInput settled via ${source}: promptId=${promptId}, cancelled=${result?.cancelled}`,
+        `[MCP Server] PromptForUserInput settled via ${source}: promptId=${promptId}, cancelled=${result?.cancelled}`,
       );
 
       if (sessionId) {
@@ -1647,7 +1647,7 @@ export async function handleRequestUserInput(
             }),
           });
         } catch (err) {
-          console.warn("[MCP Server] Failed to persist synthetic RequestUserInput tool_result:", err);
+          console.warn("[MCP Server] Failed to persist synthetic PromptForUserInput tool_result:", err);
         }
       }
 

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -2720,6 +2720,20 @@ export class AIService {
           cancelled: false,
         });
 
+        // The auto-resume is an in-process recovery: it re-enters the provider
+        // with the answer so the SDK resumes from its stored providerSessionId.
+        // `claude-code-cli` has nothing of the sort to resume -- sendMessageHandler
+        // submits into a live CLI composer, so this would type "[Resuming after
+        // answering a question]" into whatever that terminal is doing now, as if
+        // the user had written it. The answer is already durable: the response row
+        // above settles the waiting MCP handler through its DB poll (see
+        // interactiveToolHandlers), and the tool_result just persisted completes
+        // the widget.
+        if (session.provider === 'claude-code-cli') {
+          logger.main.info(`[AIService] No live handler for AskUserQuestion on ${session.provider}; leaving the answer for the MCP handler rather than auto-resuming: ${resolvedSessionId}`);
+          return { success: true };
+        }
+
         const answerText = Object.entries(answers)
           .map(([question, answer]) => `${question}: ${answer}`)
           .join('\n');

--- a/packages/electron/src/main/services/ai/claudeCliObservation/__tests__/claudeApiProxy.test.ts
+++ b/packages/electron/src/main/services/ai/claudeCliObservation/__tests__/claudeApiProxy.test.ts
@@ -323,4 +323,70 @@ describe("claudeApiProxy", () => {
     expect(errors[0].retryAfter).toBe("42");
     expect(errors[0].body).toContain("rate_limit_error");
   });
+
+  it("neither observes nor tees a side request the filter rejects", async () => {
+    // The CLI's prompt-suggestion fork rides the same connection. Teeing it would
+    // persist a predicted *user* prompt as an assistant turn.
+    upstream = await startFakeUpstream();
+
+    const sseEvents: SSEEvent[] = [];
+    const bodies: Array<Record<string, unknown>> = [];
+    proxy = await startClaudeApiProxy(
+      {
+        onSSEEvent: (event) => sseEvents.push(event),
+        onRequestBody: (body) => bodies.push(body),
+        onProxyError: (err) => { throw err; },
+      },
+      { upstreamUrl: upstream.url },
+    );
+
+    const res = await postToProxy(
+      proxy.port,
+      JSON.stringify({
+        model: "claude-x",
+        messages: [
+          { role: "user", content: "hi" },
+          { role: "assistant", content: [{ type: "text", text: "hello" }] },
+          { role: "user", content: "[SUGGESTION MODE: Suggest what the user might naturally type next]" },
+        ],
+      }),
+      {},
+    );
+
+    expect(bodies).toEqual([]);
+    expect(sseEvents).toEqual([]);
+    // Passthrough is unconditional — the CLI still gets its suggestion.
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('"type":"message_stop"');
+  });
+
+  it("suppresses onUpstreamError for an unobserved side request, and still forwards the error body", async () => {
+    // The fork's own 400s are not the user's turn failing, so they must not
+    // render as a failed turn — but the bytes still have to reach the CLI.
+    const errorBody = JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "nope" } });
+    upstream = await startFakeErrorUpstream(400, errorBody);
+
+    const errors: Array<{ statusCode: number }> = [];
+    proxy = await startClaudeApiProxy(
+      {
+        onSSEEvent: () => {},
+        onUpstreamError: (info) => errors.push(info),
+        onProxyError: (err) => { throw err; },
+      },
+      { upstreamUrl: upstream.url },
+    );
+
+    const res = await postToProxy(
+      proxy.port,
+      JSON.stringify({
+        model: "claude-x",
+        messages: [{ role: "user", content: "[SUGGESTION MODE: predict the next prompt]" }],
+      }),
+      {},
+    );
+
+    expect(errors).toEqual([]);
+    expect(res.status).toBe(400);
+    expect(res.body).toContain("invalid_request_error");
+  });
 });

--- a/packages/electron/src/main/services/ai/claudeCliObservation/__tests__/claudeApiProxy.test.ts
+++ b/packages/electron/src/main/services/ai/claudeCliObservation/__tests__/claudeApiProxy.test.ts
@@ -389,4 +389,55 @@ describe("claudeApiProxy", () => {
     expect(res.status).toBe(400);
     expect(res.body).toContain("invalid_request_error");
   });
+
+  it("does not observe a /v1/messages body it cannot parse", async () => {
+    // The classifier has to read the body to recognise a side request, so a body
+    // it cannot parse is a body it cannot clear. Failing open would observe the
+    // one request we know least about; the filter is only worth having if an
+    // unreadable body is treated as unobservable.
+    upstream = await startFakeUpstream();
+
+    const sseEvents: SSEEvent[] = [];
+    const bodies: Array<Record<string, unknown>> = [];
+    proxy = await startClaudeApiProxy(
+      {
+        onSSEEvent: (event) => sseEvents.push(event),
+        onRequestBody: (body) => bodies.push(body),
+        onProxyError: (err) => { throw err; },
+      },
+      { upstreamUrl: upstream.url },
+    );
+
+    const res = await postToProxy(proxy.port, "{not json at all", {});
+
+    expect(bodies).toEqual([]);
+    expect(sseEvents).toEqual([]);
+    // Passthrough is unconditional here too: we decline to interpret the body,
+    // we do not decline to forward it.
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('"type":"message_stop"');
+  });
+
+  it("does not surface an upstream error for a /v1/messages body it cannot parse", async () => {
+    // Same reasoning as the fork's 400s: a request we never observed must not
+    // render its failures as the user's turn failing.
+    const errorBody = JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "nope" } });
+    upstream = await startFakeErrorUpstream(400, errorBody);
+
+    const errors: Array<{ statusCode: number }> = [];
+    proxy = await startClaudeApiProxy(
+      {
+        onSSEEvent: () => {},
+        onUpstreamError: (info) => errors.push(info),
+        onProxyError: (err) => { throw err; },
+      },
+      { upstreamUrl: upstream.url },
+    );
+
+    const res = await postToProxy(proxy.port, "{not json at all", {});
+
+    expect(errors).toEqual([]);
+    expect(res.status).toBe(400);
+    expect(res.body).toContain("invalid_request_error");
+  });
 });

--- a/packages/electron/src/main/services/ai/claudeCliObservation/__tests__/messageRequestFilter.test.ts
+++ b/packages/electron/src/main/services/ai/claudeCliObservation/__tests__/messageRequestFilter.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The genuine `claude` CLI issues side requests on the same API connection that
+ * are not part of the conversation. The proxy observation backend must skip
+ * them, or their replies land in the rich transcript as assistant turns nobody
+ * wrote — while never dropping a real turn, since a dropped turn goes missing
+ * from the transcript silently.
+ */
+
+import { describe, expect, it } from "vitest";
+import { shouldObserveMessagesRequest } from "../messageRequestFilter";
+
+/** The instruction the prompt-suggestion fork appends (CLI 2.1.233, abridged). */
+const SUGGESTION_PROMPT =
+  "[SUGGESTION MODE: Suggest what the user might naturally type next into Claude Code.]\n\n" +
+  "FIRST: Look at the user's recent messages and original request.\n\n" +
+  "Reply with ONLY the suggestion, no quotes or explanation.";
+
+describe("shouldObserveMessagesRequest", () => {
+  it("observes an ordinary conversational turn", () => {
+    expect(
+      shouldObserveMessagesRequest({
+        model: "claude-sonnet-5",
+        messages: [
+          { role: "user", content: "What is 17 * 23?" },
+          { role: "assistant", content: [{ type: "text", text: "391" }] },
+          {
+            role: "user",
+            content: [{ type: "text", text: "Now add 41.", cache_control: { type: "ephemeral" } }],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("skips the session-title side request", () => {
+    expect(
+      shouldObserveMessagesRequest({
+        system: 'Generate a concise, sentence-case title. Return JSON with a single "title" field.',
+        messages: [{ role: "user", content: "…transcript…" }],
+        output_config: {
+          format: { type: "json_schema", schema: { properties: { title: { type: "string" } }, required: ["title"] } },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("skips the prompt-suggestion fork, whose only tell is the trailing user message", () => {
+    // Everything else on this request — headers, model, sampling params, the
+    // whole conversation prefix — is identical to the real turn above.
+    expect(
+      shouldObserveMessagesRequest({
+        model: "claude-sonnet-5",
+        messages: [
+          { role: "user", content: "What is 17 * 23?" },
+          { role: "assistant", content: [{ type: "text", text: "391" }] },
+          { role: "user", content: SUGGESTION_PROMPT },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("skips it when the marker arrives as a text block rather than a bare string", () => {
+    expect(
+      shouldObserveMessagesRequest({
+        messages: [{ role: "user", content: [{ type: "text", text: SUGGESTION_PROMPT }] }],
+      }),
+    ).toBe(false);
+  });
+
+  it("still observes a turn that merely quotes the marker", () => {
+    // This file, and the filter it tests, get read by agents working in this
+    // repo; the marker then rides along in a tool_result. A body-wide scan would
+    // drop every subsequent turn of that session from the transcript.
+    expect(
+      shouldObserveMessagesRequest({
+        messages: [
+          { role: "user", content: `Why is "${SUGGESTION_PROMPT}" filtered out?` },
+          { role: "assistant", content: [{ type: "tool_use", id: "tu_1", name: "Read", input: {} }] },
+          {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "tu_1", content: SUGGESTION_PROMPT }],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("observes the assistant reply to a suggestion-shaped message the user actually sent", () => {
+    // The fork's request always ENDS on its instruction. Once a real turn follows,
+    // the conversation is the user's again.
+    expect(
+      shouldObserveMessagesRequest({
+        messages: [
+          { role: "user", content: SUGGESTION_PROMPT },
+          { role: "assistant", content: [{ type: "text", text: "run the tests" }] },
+          { role: "user", content: "why did you say that?" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("observes a body with no usable messages rather than guessing", () => {
+    expect(shouldObserveMessagesRequest({})).toBe(true);
+    expect(shouldObserveMessagesRequest({ messages: [] })).toBe(true);
+    expect(shouldObserveMessagesRequest({ messages: [{ role: "assistant", content: "hi" }] })).toBe(true);
+  });
+});

--- a/packages/electron/src/main/services/ai/claudeCliObservation/claudeApiProxy.ts
+++ b/packages/electron/src/main/services/ai/claudeCliObservation/claudeApiProxy.ts
@@ -147,7 +147,12 @@ export function createClaudeApiProxy(
           // otherwise indistinguishable from the observation layer being broken.
           else console.log(`[ClaudeApiProxy] CLI side request, not observed: ${requestId}`);
         } catch {
-          // Non-JSON body — forward it untouched; just don't observe.
+          // Non-JSON body — forward it untouched; just don't observe. Recognising
+          // a side request means reading its body, so a body we cannot parse is
+          // one we cannot clear: fail closed, or the request we understand least
+          // is the one we tee into the transcript as a genuine turn.
+          observe = false;
+          info.observe = false;
         }
       }
 

--- a/packages/electron/src/main/services/ai/claudeCliObservation/claudeApiProxy.ts
+++ b/packages/electron/src/main/services/ai/claudeCliObservation/claudeApiProxy.ts
@@ -143,6 +143,9 @@ export function createClaudeApiProxy(
           observe = shouldObserveMessagesRequest(parsedBody);
           info.observe = observe;
           if (observe) callbacks.onRequestBody?.(parsedBody, info);
+          // Say so out loud: a turn silently missing from the rich transcript is
+          // otherwise indistinguishable from the observation layer being broken.
+          else console.log(`[ClaudeApiProxy] CLI side request, not observed: ${requestId}`);
         } catch {
           // Non-JSON body — forward it untouched; just don't observe.
         }
@@ -170,10 +173,13 @@ export function createClaudeApiProxy(
           const contentType = (upstreamRes.headers["content-type"] as string) || "";
           const isSSE = contentType.includes("text/event-stream");
 
-          if (statusCode >= 400 && callbacks.onUpstreamError) {
+          if (statusCode >= 400 && callbacks.onUpstreamError && (!isMessages || observe)) {
             // Forward the error body to the client byte-for-byte while capturing a
             // bounded slice so the observation layer can classify the failure and
-            // render it in the rich transcript.
+            // render it in the rich transcript. A turn we chose not to observe
+            // must not render its failures either — a side request's 400 is not
+            // the user's turn failing. Non-`/v1/messages` errors (auth, oauth)
+            // still surface; they are never filtered.
             let errBuf = "";
             upstreamRes.on("data", (chunk: Buffer) => {
               clientRes.write(chunk);

--- a/packages/electron/src/main/services/ai/claudeCliObservation/messageRequestFilter.ts
+++ b/packages/electron/src/main/services/ai/claudeCliObservation/messageRequestFilter.ts
@@ -3,10 +3,11 @@
  * Claude CLI proxy observation backend (NIM-806, Phase 3 / B3).
  *
  * The genuine `claude` CLI issues side requests over the same API connection
- * that are NOT part of the user-visible conversation — most notably the
- * "generate a session title" request. Teeing those into the transcript would
- * inject a stray assistant turn, so we skip them. The request still forwards
- * upstream byte-for-byte; we only suppress *observation*, never the proxying.
+ * that are NOT part of the user-visible conversation — the "generate a session
+ * title" request, and the `--prompt-suggestions` fork. Teeing those into the
+ * transcript would inject a stray assistant turn, so we skip them. The request
+ * still forwards upstream byte-for-byte; we only suppress *observation*, never
+ * the proxying.
  *
  */
 
@@ -15,9 +16,50 @@ const SESSION_TITLE_PROMPT_MARKERS = [
   'Return JSON with a single "title" field',
 ];
 
+/**
+ * The CLI's prompt-suggestion fork appends this instruction as the final user
+ * message. Marker text extracted from CLI 2.1.233 and confirmed against a
+ * captured request body; nothing else on the request distinguishes it — headers,
+ * model, and sampling params are identical to a real turn's.
+ */
+const PROMPT_SUGGESTION_PROMPT_MARKER = "[SUGGESTION MODE:";
+
 /** True when this `/v1/messages` body is a real conversational turn to observe. */
 export function shouldObserveMessagesRequest(body: Record<string, unknown>): boolean {
-  return !isClaudeSessionTitleRequest(body);
+  return !isClaudeSessionTitleRequest(body) && !isPromptSuggestionRequest(body);
+}
+
+/**
+ * The `--prompt-suggestions` fork: after each turn the CLI runs a second,
+ * short-lived agent that predicts what the user might type next and renders it
+ * as Tab-to-accept ghost text in its own composer. It never reaches the CLI's
+ * transcript (the fork carries `skipTranscript`), but it does hit `/v1/messages`
+ * through our proxy — so unfiltered, its reply is assembled and persisted as a
+ * genuine assistant turn: a message the user never received and the agent never
+ * wrote, phrased as something the user would say.
+ *
+ * Match narrowly — only the LAST message, only when it is the user turn, only on
+ * a leading marker. A whole-body scan would drop real turns whose tool_results
+ * happen to quote this file.
+ */
+function isPromptSuggestionRequest(body: Record<string, unknown>): boolean {
+  const messages = body.messages;
+  if (!Array.isArray(messages) || messages.length === 0) return false;
+  const last = messages[messages.length - 1] as Record<string, unknown> | null;
+  if (!last || typeof last !== "object" || last.role !== "user") return false;
+  return leadingText(last.content).trimStart().startsWith(PROMPT_SUGGESTION_PROMPT_MARKER);
+}
+
+/** A message's leading text — content is either a bare string or a block list. */
+function leadingText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const obj = block as Record<string, unknown>;
+    if (obj.type === "text" && typeof obj.text === "string") return obj.text;
+  }
+  return "";
 }
 
 function isClaudeSessionTitleRequest(body: Record<string, unknown>): boolean {

--- a/scripts/__tests__/check-collab-bundle.test.mjs
+++ b/scripts/__tests__/check-collab-bundle.test.mjs
@@ -7,6 +7,7 @@ import {
   findBundledSingletons,
   findEmbeddedLaneViolations,
   findEntrySeparationViolations,
+  findPublicTypeLeaks,
 } from '../check-collab-bundle.mjs';
 import { findBrowserDependencyViolations } from '../browser-bundle-graph.mjs';
 
@@ -124,5 +125,44 @@ test('eager entry closure follows static imports but stops at dynamic imports', 
   assert.deepEqual(
     findEagerEntryFiles(report, 'editor'),
     ['editor.js', 'chunks/editor-core.js', 'chunks/static-transitive.js'],
+  );
+});
+
+// The public .d.ts files document the recommended `@nimbalyst/runtime` import,
+// which means writing that import inside an example block. Scanning raw source
+// reads the example as a real dependency and fails a tree with no leak in it —
+// and an unpassable check is not a stricter check, it is one everyone bypasses.
+test('ignores a private-package import that only appears in a comment', () => {
+  const source = [
+    '/**',
+    ' * New pattern (recommended):',
+    ' * ```typescript',
+    " * import type { EditorHostProps } from '@nimbalyst/runtime';",
+    ' * ```',
+    ' */',
+    '// see also: import { x } from "@nimbalyst/collab-client";',
+    'export type Foo = string;',
+  ].join('\n');
+  assert.deepEqual(findPublicTypeLeaks(['editor.d.ts'], () => source), []);
+});
+
+test('still catches a real private-package import outside comments', () => {
+  const source = [
+    '/** Docs mentioning @nimbalyst/runtime harmlessly. */',
+    "import type { Host } from '@nimbalyst/runtime';",
+    "export type { Doc } from '@nimbalyst/collab-client/doc';",
+  ].join('\n');
+  assert.deepEqual(
+    findPublicTypeLeaks(['editor.d.ts'], () => source),
+    ['editor.d.ts: @nimbalyst/runtime', 'editor.d.ts: @nimbalyst/collab-client/doc'],
+  );
+});
+
+test('a comment between the keyword and the specifier does not splice a new token', () => {
+  // Stripping to empty would turn this into a valid-looking `from'@nimbalyst/runtime'`.
+  const source = "export type { A } from/**/'@nimbalyst/runtime';";
+  assert.deepEqual(
+    findPublicTypeLeaks(['editor.d.ts'], () => source),
+    ['editor.d.ts: @nimbalyst/runtime'],
   );
 });

--- a/scripts/check-collab-bundle.mjs
+++ b/scripts/check-collab-bundle.mjs
@@ -261,17 +261,42 @@ function checkPublicJwtTypeBoundary() {
   }
 }
 
+/**
+ * Comments are stripped before scanning: these declaration files document the
+ * public API, and documenting the recommended `@nimbalyst/runtime` import means
+ * writing that import in an example. A raw source scan reads the example as a
+ * real one and fails on a tree that has no leak at all, which is worse than
+ * useless — it makes the check unpassable, so every push has to skip the hook
+ * and the check stops guarding anything.
+ *
+ * Strings are preserved, so a genuine `from '@nimbalyst/runtime'` is still
+ * caught wherever it appears in code.
+ */
+export function stripComments(source) {
+  // Replace with a space rather than nothing: `from/**/'@nimbalyst/runtime'`
+  // must not be spliced into a token that no longer matches.
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ');
+}
+
+export function findPublicTypeLeaks(declarationFiles, readFile) {
+  return declarationFiles.flatMap((fileName) => Array.from(
+    stripComments(readFile(fileName)).matchAll(
+      /(?:from\s+|import\s*\()(['"])(@nimbalyst\/(?:collab-client|runtime)(?:\/[^'"]*)?)\1/g,
+    ),
+    (match) => `${fileName}: ${match[2]}`,
+  ));
+}
+
 function checkSelfContainedPublicTypes() {
   const typesRoot = path.join(packageRoot, 'types');
   const declarationFiles = fs.readdirSync(typesRoot, { recursive: true })
     .filter((fileName) => fileName.endsWith('.d.ts'));
-  const leaks = declarationFiles.flatMap((fileName) => {
-    const source = fs.readFileSync(path.join(typesRoot, fileName), 'utf8');
-    return Array.from(
-      source.matchAll(/(?:from\s+|import\s*\()(['"])(@nimbalyst\/(?:collab-client|runtime)(?:\/[^'\"]*)?)\1/g),
-      (match) => `${fileName}: ${match[2]}`,
-    );
-  });
+  const leaks = findPublicTypeLeaks(
+    declarationFiles,
+    (fileName) => fs.readFileSync(path.join(typesRoot, fileName), 'utf8'),
+  );
   if (leaks.length > 0) {
     throw new Error(
       'public declarations leak private workspace package boundaries:\n'


### PR DESCRIPTION
# Don't observe the Claude CLI's prompt-suggestion fork

Fixes #1270.

## What happens

In a `claude-code-cli` session, messages appear in the rich transcript that nobody
wrote — short, plausible next-user-prompts phrased in the user's voice ("start on
the tier-1 descriptions", "file both reports", "commit this"), each arriving right
after a turn completes.

They come from Claude Code's `--prompt-suggestions` feature. After each turn the
CLI runs a **forked agent** that predicts what the user might type next and renders
it as Tab-to-accept ghost text in its own composer. The fork carries
`skipTranscript`, so it never enters the CLI's own transcript — but it issues its
own `/v1/messages` request, and in Nimbalyst that request goes through the
observation proxy on `ANTHROPIC_BASE_URL`.

`shouldObserveMessagesRequest()` filtered exactly one side request — the
session-title one. Everything else was assembled and persisted as a genuine
assistant turn.

Proof from a real session's `ai_agent_messages` row:

```json
{"type":"assistant","message":{"id":"msg_011Ce5aq7Gsn9V7LMtVvyrp9","role":"assistant",
 "model":"claude-opus-5","content":[{"type":"text","text":"start on the tier-1 descriptions"}],
 "usage":{"input_tokens":504,...}}}
```

`input_tokens: 504` matches the fork's usage in the CLI debug log for that turn
(`input=504 output=9`) — not the main turn's, which was tens of thousands.

## The fix

Filter the fork the way the title request is already filtered.

The fork is identifiable **only** by the instruction it appends as the final user
message. Its headers, model, sampling params, tools, and conversation prefix are
byte-identical to a real turn's — verified by capturing both requests off a live
CLI 2.1.233 through a logging pass-through proxy:

```
[SUGGESTION MODE: Suggest what the user might naturally type next into Claude Code.]
```

The match is deliberately narrow — last message only, `role: "user"` only, leading
marker only. A body-wide scan would drop real turns whose `tool_result` happens to
quote the marker (this PR's own diff does), and a dropped turn goes missing from
the transcript with no error at all. Silent transcript loss would be a worse bug
than the one being fixed.

**Same defect, second symptom:** `onUpstreamError` fired regardless of `observe`,
so when the fork 400s — it does, on replayed thinking blocks — the failure
rendered as *the user's turn* failing. Gated on `observe`, for `/v1/messages`
only; auth/oauth errors on other paths still surface. That's why the filter and
the error gate are one commit.

Passthrough is untouched throughout: observation is suppressed, never proxying, so
the CLI still receives and renders its own suggestion normally.

## Also here

**`chore: log PromptForUserInput under the name it is called by`** — the handler
already logs the full lifecycle (waiting / settle source / cancelled), but under
the internal name `RequestUserInput`. Grepping the log for the tool you actually
called turned up only the generic `Tool called:` line and none of the resolution
trail. Log text and one user-facing error string; channel helpers, handler, and
widget keep their names.

**`fix: don't auto-resume a CLI session with a synthesized user message`** — the
AskUserQuestion answer handler auto-resumes when no live handler picks the answer
up. That's an in-process recovery for the SDK path. On `claude-code-cli`,
`sendMessageHandler` submits into a live CLI composer, so the fallback types
`[Resuming after answering a question]` + the answers into whatever that terminal
is doing now, attributed to the user — #773/#774's failure mode with a worse blast
radius. Skipping the send loses nothing: the response row settles the waiting MCP
handler through its DB poll, and the terminal `tool_result` (#1116) completes the
widget. `claude-code` still auto-resumes.

Those two are one-provider-scoped and independent of commit 1; happy to split them
out if preferred.

**`fix: fail closed when a /v1/messages body cannot be parsed`** — the classifier
recognises a side request by reading its body, so a body that will not parse is one
it cannot clear. The `catch` said "just don't observe" but never reset `observe` or
`info.observe` from their `= isMessages` initializer, so an unparseable
`/v1/messages` POST was fully observed: SSE teed into the transcript as a genuine
turn, 4xx surfaced as the user's turn failing. That predates this branch, but
suppressing side requests is now this code's job, and a classifier that fails open
on the request it understands least is not doing it. Passthrough unchanged.

**`fix: don't read a doc-comment example as a private-package leak`** — unrelated
to the rest, and here only because it blocks the push. `checkSelfContainedPublicTypes`
greps the public `.d.ts` files for `@nimbalyst/{runtime,collab-client}` imports
against raw source, so it also matches the ones written inside doc comments —
including the recommended import documented in `editor.d.ts`'s "New pattern" block.
The check therefore cannot pass on a clean tree: `npm run typecheck` fails in
`packages/collab-bundle` on every platform, so `.githooks/pre-push` fails for every
push regardless of content, and the only way through is `--no-verify` — at which
point the gate guards nothing. Comments are stripped before scanning; strings
survive, so a real leak is still caught. Split out on request if you'd rather take
it separately — it is genuinely independent. Distinct from #878, which is the
Windows-only build-artifact ordering problem.

## Tests

`messageRequestFilter.test.ts` (new) covers the fork body, the marker as a text
block, the false-positive guard (a turn that merely quotes the marker stays
observed), and the empty/degenerate bodies. `claudeApiProxy.test.ts` gains the
end-to-end pair: a filtered request is neither teed nor observed but still passes
through, and its 400 does not fire `onUpstreamError` while the bytes still reach
the client. All four fail on `main` and pass here.

The fail-closed commit adds two more end-to-end cases (an unparseable body is
neither observed nor error-surfaced, and still passes through); both fail on its
parent.

The collab-bundle fix adds three cases to `scripts/__tests__/check-collab-bundle.test.mjs`
(comment-only match ignored, real leak still caught, and the splice guard); the
first fails against the previous implementation.

`npm run test:prepush` (full repo): 1,219 files / **9,582 passed**, 0 failed —
run through the real pre-push hook, not around it. `npm run test:prepush-gate`
passes. `npx vitest run packages/electron/src/main/services/ai` — the directory
that can see the four observation changes — 65 files / 644 passed.
`tsc --noEmit -p packages/electron/tsconfig.json` clean.

The AskUserQuestion guard has no test — AIService's IPC handlers have no harness
in this repo, and standing one up for a five-line guard is more risk than the
guard.

## Notes for the reviewer

Two claims in the originating report (#1270, mine) did not survive checking the source, and this
PR does not implement them:

- **It is not a stream-json handling bug.** Nimbalyst runs the CLI as an
  interactive TUI in a PTY and never passes `--output-format stream-json`
  (`claudeCliSpawnConfig.ts`); the CLI refuses `--prompt-suggestions` without it.
  No `prompt_suggestion` stream message can reach Nimbalyst, and there is no
  generic stream-type fallback to fix. The dispatch point is the observation
  proxy's request filter.
- **`PromptForUserInput` does log its resolution** — under the internal name. That
  is a naming problem, not a missing-audit-trail problem, hence a label change
  rather than new logging.

**Known adjacent gap, deliberately not fixed here.** `isMessages` is a path prefix
(`startsWith("/v1/messages")`), so it also matches `/v1/messages/count_tokens` —
which the CLI does call (43 occurrences of that path in the 2.1.233 binary). A
count_tokens body carrying an ordinary user turn matches neither the title detector
nor the suggestion detector, so it is observed like a real turn. That is
pre-existing on `main` and independent of this change, and fixing it means either
narrowing the path test or adding a third detector — scope this PR deliberately
does not take. Flagging it because it is the same shape of bug: a side request the
filter cannot see.

The report's "at least one was executed" is also not reproducible as a direct
injection: every occurrence landed as a `direction='output'` row, no
`direction='input'` row ever carried suggestion text, and no code path writes Tab
or a bare Enter to the PTY, so Nimbalyst cannot accept the CLI's ghost text. Two
*indirect* paths do read assistant rows back into a model's context —
`get_session_summary`'s last-assistant-response, and `MetaAgentService`, which
reads `direction='output'` rows and can then send a prompt — so a suggestion row
could influence a later prompt through an autonomous loop. This fix suppresses the
row at the source, which closes all of them.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

