### PR TITLE
feat: keep every project in one window with the project rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening an editor no longer fetches a font from a third-party server.
 - Codex no longer offers slash commands it cannot actually run.
 - The Compact action is now hidden for agents that cannot compact, instead of offering a button that quietly does nothing.
+- Multi-project mode is now on by default for new installs; if you already work with several windows open, Nimbalyst leaves your setup alone until you turn it on yourself.
 
 ### Fixed
 <!-- Bug fixes go here -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ask a teammate for structured feedback: your agent drafts the question, you approve it, and it arrives in their inbox to answer, with results and outstanding replies in their own tab. Copy a link to send anyone who does not have Nimbalyst installed, and they can answer and discuss the request in a browser.
 - Tracker items that have not been shared yet now show a number of their own, like NIM.12, so you can refer to one before it is published.
 - Desktop notifications now carry their own icon, so you can tell a finished agent, a question, an approval request, and a teammate's message apart at a glance.
+- Multi-project mode now keeps every project in one window: opening a project adds it to the project rail, your projects come back together after a restart, and Window > Merge All Windows folds windows you already have open into one.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/e2e/multi-project/multi-project-rail.spec.ts
+++ b/packages/electron/e2e/multi-project/multi-project-rail.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from 'playwright';
 import { launchElectronApp, createTempWorkspace, TEST_TIMEOUTS } from '../helpers';
+import { openFileFromTree, PLAYWRIGHT_TEST_SELECTORS } from '../utils/testHelpers';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -17,7 +18,8 @@ test.describe.configure({ mode: 'serial' });
  *   3. Per-workspace UI state (sidebar width, tabs) survives a switch.
  *   4. Closing the active project from the rail promotes the next entry
  *      and tears down only the closed project's services.
- *   5. Cap at 8 projects: the 9th add is rejected without altering the rail.
+ *   5. Cap at 12 projects (`MAX_OPEN_PROJECTS`): the 13th add is rejected
+ *      without altering the rail.
  *
  * Tests assume the dev server is running (helpers.ts enforces this) and
  * that the renderer exposes `window.electronAPI`. Reads/writes go through
@@ -106,7 +108,10 @@ test.describe('Multi-Project Rail', () => {
     const items = rail.locator('[data-testid="project-rail-item"]');
     await expect(items).toHaveCount(2);
 
-    const active = rail.locator('[data-testid="project-rail-item"].active');
+    // NB: the rendered class is `is-active` (see ProjectRail.tsx /
+    // ProjectRail.css), not `active` -- `.active` as a CSS class selector
+    // never matches and silently returns zero elements.
+    const active = rail.locator('[data-testid="project-rail-item"].is-active');
     await expect(active).toHaveCount(1);
   });
 
@@ -160,6 +165,61 @@ test.describe('Multi-Project Rail', () => {
     await expect(page.locator('.agent-mode-empty')).toBeVisible({ timeout: TEST_TIMEOUTS.SIDEBAR_LOAD });
   });
 
+  test('switching rail entries rescopes the file tree without losing the other project\'s tab state', async () => {
+    // Scenario 3 of the single-window-multi-project plan: rail switch must
+    // rescope the visible project (file tree / active indicator) while
+    // *not* tearing down the tab state of the project switching away.
+    // `TabsContext` keeps a persistent tab slot per workspace path
+    // specifically so this works -- this is the first E2E test to actually
+    // exercise it via real tab opens rather than just the workspace-context
+    // (summary header / agent panel) checks the previous test covers.
+    const rail = page.locator('[data-testid="project-rail"]');
+    const items = rail.locator('[data-testid="project-rail-item"]');
+    await expect(items).toHaveCount(2);
+
+    // Scoped to the file tabs strip (not `.tab` unscoped) so this can never
+    // match an unrelated `.tab`-classed element elsewhere in the DOM (e.g. a
+    // hidden AgentMode session tab) -- same scoping `closeTabByFileName`
+    // uses.
+    const fileTabs = page.locator(PLAYWRIGHT_TEST_SELECTORS.fileTabsContainer).locator(PLAYWRIGHT_TEST_SELECTORS.tab);
+
+    // Coming out of the previous test, the second item (workspaceB) is
+    // active. Open b.md there.
+    await openFileFromTree(page, 'b.md');
+    await expect(fileTabs.filter({ hasText: 'b.md' })).toBeVisible();
+
+    // Switch to the first item (workspaceA) and confirm the file tree
+    // rescoped: a.md is the file this project actually has on disk.
+    await items.first().click();
+    await page.waitForTimeout(300);
+    await expect(page.locator('.file-tree-name', { hasText: 'a.md' })).toBeVisible({
+      timeout: TEST_TIMEOUTS.FILE_TREE_LOAD,
+    });
+    await openFileFromTree(page, 'a.md');
+    await expect(fileTabs.filter({ hasText: 'a.md' })).toBeVisible();
+
+    // Switch back to workspaceB: its b.md tab must still be open, and
+    // workspaceA's a.md tab (a different project's tab slot) must not leak
+    // across.
+    await items.nth(1).click();
+    await page.waitForTimeout(300);
+    await expect(fileTabs.filter({ hasText: 'b.md' })).toBeVisible();
+    await expect(fileTabs.filter({ hasText: 'a.md' })).toHaveCount(0);
+
+    // Switch to workspaceA again: a.md's tab must still be there too --
+    // opening it once, in the earlier switch, was not lost.
+    await items.first().click();
+    await page.waitForTimeout(300);
+    await expect(fileTabs.filter({ hasText: 'a.md' })).toBeVisible();
+    await expect(fileTabs.filter({ hasText: 'b.md' })).toHaveCount(0);
+
+    // Return to workspaceB so the rail is in the state the next test
+    // ("closing the active project") expects: 2 items, workspaceB active.
+    await items.nth(1).click();
+    await page.waitForTimeout(300);
+    await expect(items.nth(1)).toHaveClass(/is-active/);
+  });
+
   test('closing the active project promotes the next entry', async () => {
     const rail = page.locator('[data-testid="project-rail"]');
     const items = rail.locator('[data-testid="project-rail-item"]');
@@ -167,7 +227,8 @@ test.describe('Multi-Project Rail', () => {
 
     // Click the active item to surface its close button (CSS shows it on
     // hover or when active).
-    const activeItem = rail.locator('[data-testid="project-rail-item"].active');
+    // See the earlier `.is-active` note -- `active` is not a real class here.
+    const activeItem = rail.locator('[data-testid="project-rail-item"].is-active');
     await activeItem.hover();
 
     // Auto-accept the streaming-confirm dialog (none expected here, but
@@ -214,7 +275,8 @@ test.describe('Multi-Project Rail', () => {
       // panel must show its empty state — no leaked tabs from the
       // previously active workspace.
       const rail = page.locator('[data-testid="project-rail"]');
-      const activeItem = rail.locator('[data-testid="project-rail-item"].active');
+      // See the earlier `.is-active` note -- `active` is not a real class here.
+      const activeItem = rail.locator('[data-testid="project-rail-item"].is-active');
       await expect(activeItem).toHaveCount(1);
 
       const empty = page.locator('.agent-mode-empty');
@@ -225,8 +287,10 @@ test.describe('Multi-Project Rail', () => {
   });
 
   test('rail rejects projects beyond the cap', async () => {
+    // MAX_OPEN_PROJECTS (openProjects.ts) is 12; one over that exercises the
+    // truncation in `normalizeProjectPaths` on reload.
     const extraPaths: string[] = [];
-    for (let i = 0; i < 9; i++) {
+    for (let i = 0; i < 13; i++) {
       const dir = await createTempWorkspace();
       await fs.writeFile(path.join(dir, 'x.md'), `# ${i}\n`, 'utf8');
       extraPaths.push(dir);
@@ -244,7 +308,7 @@ test.describe('Multi-Project Rail', () => {
       await page.waitForSelector('.workspace-sidebar', { timeout: TEST_TIMEOUTS.SIDEBAR_LOAD });
 
       const items = page.locator('[data-testid="project-rail"] [data-testid="project-rail-item"]');
-      await expect(items).toHaveCount(8);
+      await expect(items).toHaveCount(12);
     } finally {
       await Promise.all(extraPaths.map((p) => fs.rm(p, { recursive: true, force: true }).catch(() => undefined)));
     }

--- a/packages/electron/e2e/multi-project/multi-project-session-restore.spec.ts
+++ b/packages/electron/e2e/multi-project/multi-project-session-restore.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from 'playwright';
+import { launchElectronApp, createTempWorkspace, waitForAppReady, TEST_TIMEOUTS } from '../helpers';
+import { getOpenWorkspaceWindowPaths } from '../utils/testHelpers';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+test.describe.configure({ mode: 'serial' });
+
+/**
+ * E2E coverage for session-restore collapse (single-window-multi-project
+ * plan, Phase 1.3 -- `computeSessionRestorePlan` in `main/session/SessionState.ts`).
+ *
+ * Restart-to-verify by nature (per
+ * .claude/rules/end-to-end-verification.md): N saved workspace windows +
+ * Multi-Project Mode on must collapse into ONE restored window with an
+ * N-entry rail and the previously-active project visible, instead of N
+ * windows reopening as before the feature. This requires two full
+ * `launchElectronApp` cycles against the SAME userData directory, so it
+ * cannot join the shared-`beforeAll`-instance pattern the other
+ * multi-project specs use (see docs/E2E_TESTING.md's "When Tests CANNOT
+ * Share an App").
+ *
+ * Two environment-dependent assumptions this test relies on, called out so
+ * a future flake investigation starts here first:
+ *   1. `launchElectronApp`'s second call MUST omit `workspace` and pass
+ *      `preserveTestDatabase: true` -- a `--workspace` CLI arg makes
+ *      `main/index.ts` skip `restoreSessionState()` entirely
+ *      (`shouldSkipSessionRestore`), and the default `launchElectronApp`
+ *      behavior wipes `TEST_USER_DATA_DIR` (which holds both the saved
+ *      session and the `multiProjectMode` setting) on every launch.
+ *   2. Explicitly focusing workspaceB's `BrowserWindow` (via
+ *      `electronApp.evaluate`, not a `Page`-level `bringToFront()`, which
+ *      goes through Playwright/CDP rather than the Electron API whose
+ *      `focus()` call actually fires the native 'focus' event
+ *      `windowFocusOrder` listens to) is relied on to make workspaceB
+ *      (opened second) the saved window with the highest `focusOrder` --
+ *      the "previously active project" `computeSessionRestorePlan` should
+ *      keep visible after collapse. If this assertion is ever flaky in CI,
+ *      suspect this mechanism first, not a routing bug.
+ */
+test.describe('Multi-Project Session Restore Collapse', () => {
+  let workspaceA: string;
+  let workspaceB: string;
+
+  test.beforeAll(async () => {
+    workspaceA = await createTempWorkspace();
+    workspaceB = await createTempWorkspace();
+    await fs.writeFile(path.join(workspaceA, 'a.md'), '# A\n', 'utf8');
+    await fs.writeFile(path.join(workspaceB, 'b.md'), '# B\n', 'utf8');
+  });
+
+  test.afterAll(async () => {
+    await Promise.all([
+      fs.rm(workspaceA, { recursive: true, force: true }).catch(() => undefined),
+      fs.rm(workspaceB, { recursive: true, force: true }).catch(() => undefined),
+    ]);
+  });
+
+  test('N saved workspace windows + mode on collapse into one window with N rail entries on relaunch', async () => {
+    test.setTimeout(60000);
+
+    // --- Launch 1: create two separate saved workspace windows, turn the
+    // mode on, and quit gracefully so a real session gets written to disk. ---
+    let electronApp: ElectronApplication = await launchElectronApp({
+      workspace: workspaceA,
+      env: { NODE_ENV: 'test' },
+    });
+
+    const pageA: Page = await electronApp.firstWindow();
+    await waitForAppReady(pageA);
+
+    const [pageB] = await Promise.all([
+      electronApp.waitForEvent('window'),
+      pageA.evaluate(async (workspacePath) => {
+        await window.electronAPI.workspaceManager.openWorkspace(workspacePath);
+      }, workspaceB),
+    ]);
+    await pageB.waitForLoadState('domcontentloaded');
+    await waitForAppReady(pageB);
+
+    // Focus B's BrowserWindow last -- see assumption (2) above.
+    await electronApp.evaluate(({ BrowserWindow }, title) => {
+      BrowserWindow.getAllWindows().find((w) => w.getTitle() === title)?.focus();
+    }, path.basename(workspaceB));
+    await pageB.waitForTimeout(500);
+
+    await pageB.evaluate(async () => {
+      await window.electronAPI.invoke('app:set-multi-project-mode', true);
+    });
+
+    // Let the window-created / focus-order bookkeeping settle before the
+    // graceful quit saves session state over live `windowStates`.
+    await pageA.waitForTimeout(1500);
+    await electronApp.close();
+    // Give the just-closed process a moment to fully exit before relaunching
+    // against the same userData dir -- the single-instance lock (still
+    // enforced once `PLAYWRIGHT` is deleted for this launch, see assumption
+    // (1)) would otherwise make launch 2 hand off to launch 1 and quit
+    // immediately instead of actually restoring. Same gap
+    // `workspace-agent-state-persistence.spec.ts` uses between its two launches.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // --- Launch 2: relaunch with session restore enabled, no explicit
+    // --workspace, and the userData directory preserved -- see assumption
+    // (1) above. ---
+    electronApp = await launchElectronApp({
+      env: { NODE_ENV: 'test', ENABLE_SESSION_RESTORE: '1' },
+      preserveTestDatabase: true,
+    });
+
+    try {
+      const restoredPage = await electronApp.firstWindow();
+      await waitForAppReady(restoredPage);
+
+      // Exactly one workspace-mode window restored, not two.
+      await expect
+        .poll(() => getOpenWorkspaceWindowPaths(electronApp), { timeout: TEST_TIMEOUTS.SIDEBAR_LOAD })
+        .toHaveLength(1);
+
+      // Its rail holds both restored projects.
+      const rail = restoredPage.locator('[data-testid="project-rail"]');
+      const items = rail.locator('[data-testid="project-rail-item"]');
+      await expect(items).toHaveCount(2, { timeout: TEST_TIMEOUTS.SIDEBAR_LOAD });
+
+      const paths = await items.evaluateAll((elements) =>
+        elements.map((element) => element.getAttribute('data-project-path'))
+      );
+      expect(new Set(paths)).toEqual(new Set([workspaceA, workspaceB]));
+
+      // The previously-active project (B, brought to front last before
+      // quit) is the one visible after restore.
+      const activeItem = rail.locator('[data-testid="project-rail-item"].is-active');
+      await expect(activeItem).toHaveAttribute('data-project-path', workspaceB);
+    } finally {
+      await electronApp.close();
+    }
+  });
+});

--- a/packages/electron/e2e/multi-project/multi-project-window-routing.spec.ts
+++ b/packages/electron/e2e/multi-project/multi-project-window-routing.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from 'playwright';
+import { launchElectronApp, createTempWorkspace, waitForAppReady, TEST_TIMEOUTS } from '../helpers';
+import {
+  getOpenWorkspaceWindowPaths,
+  findWorkspaceWindowByPath,
+  getProjectRailItemByPath,
+} from '../utils/testHelpers';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+test.describe.configure({ mode: 'serial' });
+
+/**
+ * E2E coverage for the "open this project" routing chokepoint
+ * (`openOrFocusWorkspaceWindow` / `resolveProjectOpenTarget.ts`) and the
+ * "Merge All Windows" command, from the single-window-multi-project plan
+ * (nimbalyst-local/plans/single-window-multi-project.md).
+ *
+ * Unlike `multi-project-rail.spec.ts` (which drives the rail UI directly via
+ * `workspace:register-additional` + atom IPC, independent of routing), these
+ * tests go through the real production entry point --
+ * `window.electronAPI.workspaceManager.openWorkspace()`, exactly what "Open
+ * Recent" / the Workspace Manager UI / Quick Open call -- so the routing
+ * DECISION itself (same window's rail vs. a brand new `BrowserWindow`) is
+ * under test, not just the rail's own rendering once a project is on it.
+ *
+ * Each test sets `multiProjectMode` explicitly and opens/closes exactly the
+ * windows it needs, so a test does not depend on execution order beyond the
+ * shared `electronApp` and its first window (workspaceA) staying alive
+ * across tests 1-2. The merge test (which may end up closing that very
+ * window as a "donor") is deliberately last and discovers its survivor
+ * window dynamically rather than assuming which one it is.
+ */
+test.describe('Multi-Project Window Routing', () => {
+  let electronApp: ElectronApplication;
+  let page: Page; // workspaceA's window; alive for the whole file except possibly during the last test
+  let workspaceA: string;
+  let workspaceB: string;
+  let workspaceC: string;
+
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.setTimeout(30_000);
+    workspaceA = await createTempWorkspace();
+    workspaceB = await createTempWorkspace();
+    workspaceC = await createTempWorkspace();
+
+    await fs.writeFile(path.join(workspaceA, 'a.md'), '# A\n', 'utf8');
+    await fs.writeFile(path.join(workspaceB, 'b.md'), '# B\n', 'utf8');
+    await fs.writeFile(path.join(workspaceC, 'c.md'), '# C\n', 'utf8');
+
+    electronApp = await launchElectronApp({
+      workspace: workspaceA,
+      env: { NODE_ENV: 'test' },
+    });
+
+    page = await electronApp.firstWindow();
+    await waitForAppReady(page);
+  });
+
+  test.afterAll(async () => {
+    await electronApp?.close();
+    await Promise.all([
+      fs.rm(workspaceA, { recursive: true, force: true }).catch(() => undefined),
+      fs.rm(workspaceB, { recursive: true, force: true }).catch(() => undefined),
+      fs.rm(workspaceC, { recursive: true, force: true }).catch(() => undefined),
+    ]);
+  });
+
+  test("mode ON: opening a second project joins this window's rail instead of opening a new window", async () => {
+    // Reload + waitForAppReady + a SIDEBAR_LOAD-scale poll can exceed the
+    // 15s default (playwright.config.ts).
+    test.setTimeout(30_000);
+
+    await page.evaluate(async () => {
+      await window.electronAPI.invoke('app:set-multi-project-mode', true);
+    });
+    // `multiProjectModeAtom` is only read once at renderer boot
+    // (`initOpenProjects`), so reload for the rail to actually paint. The
+    // main-process routing decision itself does not need this --
+    // `getMultiProjectMode()` is read fresh on every
+    // `openOrFocusWorkspaceWindow` call.
+    await page.reload();
+    await waitForAppReady(page);
+
+    await expect.poll(() => getOpenWorkspaceWindowPaths(electronApp)).toHaveLength(1);
+    const windowCountBefore = electronApp.windows().length;
+
+    await page.evaluate(async (workspacePath) => {
+      await window.electronAPI.workspaceManager.openWorkspace(workspacePath);
+    }, workspaceB);
+
+    const rail = page.locator('[data-testid="project-rail"]');
+    const items = rail.locator('[data-testid="project-rail-item"]');
+    await expect(items).toHaveCount(2, { timeout: TEST_TIMEOUTS.SIDEBAR_LOAD });
+
+    const bItem = getProjectRailItemByPath(page, workspaceB);
+    await expect(bItem).toHaveClass(/is-active/);
+
+    // No second BrowserWindow was created, and `windowStates` still has only
+    // one workspace-mode window (workspaceA's primary path) -- workspaceB
+    // joined the rail as an *additional* path, not a new window's primary.
+    expect(electronApp.windows().length).toBe(windowCountBefore);
+    await expect.poll(() => getOpenWorkspaceWindowPaths(electronApp)).toHaveLength(1);
+
+    // Clean up: close workspaceB from the rail so later tests in this file
+    // (in particular the merge test's expected rail count) start from a
+    // known one-project rail state. `ProjectRail`'s close handler both
+    // drops the atom entry (synchronous -- what `toHaveCount(1)` below
+    // observes) and awaits `workspace:unregister-additional` so window1
+    // stops referencing workspaceB in main's `additionalWorkspacePaths`;
+    // the extra wait gives that IPC round trip time to land before a later
+    // test relies on it.
+    await bItem.hover();
+    page.once('dialog', (dialog) => dialog.accept());
+    await bItem.locator('.project-rail-item-close').click();
+    await expect(items).toHaveCount(1);
+    await page.waitForTimeout(500);
+  });
+
+  test('mode OFF: opening a second project still opens a new window (regression guard)', async () => {
+    test.setTimeout(30_000);
+
+    await page.evaluate(async () => {
+      await window.electronAPI.invoke('app:set-multi-project-mode', false);
+    });
+
+    await expect.poll(() => getOpenWorkspaceWindowPaths(electronApp)).toHaveLength(1);
+
+    const [newWindow] = await Promise.all([
+      electronApp.waitForEvent('window'),
+      page.evaluate(async (workspacePath) => {
+        await window.electronAPI.workspaceManager.openWorkspace(workspacePath);
+      }, workspaceC),
+    ]);
+    await newWindow.waitForLoadState('domcontentloaded');
+    await expect.poll(() => newWindow.title()).toBe(path.basename(workspaceC));
+
+    await expect.poll(() => getOpenWorkspaceWindowPaths(electronApp)).toHaveLength(2);
+
+    // Close the window this test opened so it doesn't leak into the merge test.
+    await electronApp.evaluate(({ BrowserWindow }, title) => {
+      BrowserWindow.getAllWindows().find((w) => w.getTitle() === title)?.close();
+    }, path.basename(workspaceC));
+
+    await expect.poll(() => getOpenWorkspaceWindowPaths(electronApp)).toHaveLength(1);
+  });
+
+  test('"Merge All Windows" folds every open workspace window into one', async () => {
+    // Two window opens plus a merge poll (up to 15s) exceeds the 15s default.
+    test.setTimeout(45_000);
+
+    const workspaceD = await createTempWorkspace();
+    const workspaceE = await createTempWorkspace();
+    await fs.writeFile(path.join(workspaceD, 'd.md'), '# D\n', 'utf8');
+    await fs.writeFile(path.join(workspaceE, 'e.md'), '# E\n', 'utf8');
+
+    try {
+      // Two genuinely separate windows -- opened with the mode OFF so each
+      // spawns its own BrowserWindow. This reproduces the plan's "windows
+      // already open stay open" gap (Phase 1.4) that "Merge All Windows"
+      // exists to relieve without a quit/relaunch.
+      await page.evaluate(async () => {
+        await window.electronAPI.invoke('app:set-multi-project-mode', false);
+      });
+
+      const [windowD] = await Promise.all([
+        electronApp.waitForEvent('window'),
+        page.evaluate(async (workspacePath) => {
+          await window.electronAPI.workspaceManager.openWorkspace(workspacePath);
+        }, workspaceD),
+      ]);
+      await windowD.waitForLoadState('domcontentloaded');
+
+      const [windowE] = await Promise.all([
+        electronApp.waitForEvent('window'),
+        page.evaluate(async (workspacePath) => {
+          await window.electronAPI.workspaceManager.openWorkspace(workspacePath);
+        }, workspaceE),
+      ]);
+      await windowE.waitForLoadState('domcontentloaded');
+
+      await expect.poll(() => getOpenWorkspaceWindowPaths(electronApp)).toHaveLength(3);
+
+      // "Merge All Windows" only makes sense -- and only does anything --
+      // with the mode on.
+      await page.evaluate(async () => {
+        await window.electronAPI.invoke('app:set-multi-project-mode', true);
+      });
+
+      // `ApplicationMenu.ts`'s click handler shows a native
+      // `dialog.showMessageBox` if anything was refused or a donor was
+      // skipped ("Some Windows Stayed Open"). That is not expected in this
+      // scenario (no cap, no unsaved changes), but a native modal blocks
+      // until dismissed and is NOT interceptable via Playwright's
+      // page-level `dialog` event (that only covers renderer
+      // alert/confirm/prompt) -- stub it so an unexpected one can't hang
+      // the test instead of failing it.
+      await electronApp.evaluate(({ dialog }) => {
+        dialog.showMessageBox = (() =>
+          Promise.resolve({ response: 0, checkboxChecked: false })) as typeof dialog.showMessageBox;
+      });
+
+      // There is no test-only IPC channel for this command (it is a native
+      // menu item -- `ApplicationMenu.ts`'s Window menu). Locate it on the
+      // live application menu and invoke its `click` handler directly in
+      // the main process. This bypasses the item's `enabled` flag (which is
+      // only recomputed when the menu is rebuilt, e.g. on org-window focus
+      // change -- not on every window open/close), but that is safe here:
+      // `consolidateWorkspaceWindows()` independently re-validates
+      // (`getMultiProjectMode()` + window count) before doing anything, per
+      // its own doc comment.
+      const invoked = await electronApp.evaluate(({ Menu }) => {
+        const appMenu = Menu.getApplicationMenu();
+        const windowMenu = appMenu?.items.find((item) => item.label === 'Window');
+        const mergeItem = windowMenu?.submenu?.items.find(
+          (item) => item.label === 'Merge All Windows'
+        );
+        if (!mergeItem) return false;
+        mergeItem.click();
+        return true;
+      });
+      expect(invoked).toBe(true);
+
+      // `consolidateWorkspaceWindows()` seeds donor paths sequentially, each
+      // ack up to 2000ms, then closes drained donors -- poll rather than
+      // assume a fixed delay.
+      await expect
+        .poll(() => getOpenWorkspaceWindowPaths(electronApp), { timeout: 15000 })
+        .toHaveLength(1);
+
+      // Discover the survivor rather than assuming which window absorbed
+      // the others (focus-order-dependent, and not the point of this test).
+      const [survivorPrimaryPath] = await getOpenWorkspaceWindowPaths(electronApp);
+      const survivor = await findWorkspaceWindowByPath(electronApp, survivorPrimaryPath);
+      expect(survivor).not.toBeNull();
+      if (!survivor) throw new Error('unreachable');
+
+      await survivor.reload();
+      await waitForAppReady(survivor);
+
+      const rail = survivor.locator('[data-testid="project-rail"]');
+      const items = rail.locator('[data-testid="project-rail-item"]');
+      await expect(items).toHaveCount(3, { timeout: TEST_TIMEOUTS.SIDEBAR_LOAD });
+
+      const paths = await items.evaluateAll((elements) =>
+        elements.map((element) => element.getAttribute('data-project-path'))
+      );
+      expect(new Set(paths)).toEqual(new Set([workspaceA, workspaceD, workspaceE]));
+
+      // `page` (workspaceA's original window) may have been the donor that
+      // got closed by the merge -- reassign it to the survivor so
+      // `afterAll`'s cleanup (and any test added after this one) keeps
+      // working against a live window.
+      page = survivor;
+    } finally {
+      await Promise.all([
+        fs.rm(workspaceD, { recursive: true, force: true }).catch(() => undefined),
+        fs.rm(workspaceE, { recursive: true, force: true }).catch(() => undefined),
+      ]);
+    }
+  });
+});

--- a/packages/electron/e2e/utils/testHelpers.ts
+++ b/packages/electron/e2e/utils/testHelpers.ts
@@ -1128,3 +1128,61 @@ export async function getWalkthroughProgress(page: Page): Promise<string> {
   const progress = page.locator(PLAYWRIGHT_TEST_SELECTORS.walkthroughCalloutProgress);
   return await progress.textContent() ?? '';
 }
+
+/**
+ * Multi-Project Mode: primary workspace paths of every open workspace-mode
+ * (`state.mode === 'workspace'`) `BrowserWindow`, via the existing
+ * `workspace-manager:get-open-workspaces` IPC handler
+ * (`WorkspaceManagerWindow.ts`). This is the right way to count/verify
+ * "workspace windows" in a multi-window test -- it walks main's
+ * `windowStates` map, which auxiliary windows (WorkspaceManager, About,
+ * TrayPanel, DeveloperDashboard, AIUsageReport, ...) never register into, so
+ * it naturally excludes them without the test needing to know their titles
+ * or filter `BrowserWindow.getAllWindows()` itself. Rail-additional paths
+ * (Multi-Project Mode) are NOT included -- only each window's own primary
+ * path -- so this is also a direct proxy for "how many separate workspace
+ * windows are open".
+ *
+ * Takes the `ElectronApplication` rather than a single `Page` because a
+ * multi-window test (e.g. "Merge All Windows") may close the specific page
+ * a caller would otherwise have cached -- this picks any currently-open,
+ * non-closed page to make the (window-agnostic, main-process-global) IPC
+ * call.
+ */
+export async function getOpenWorkspaceWindowPaths(app: ElectronApplication): Promise<string[]> {
+  const candidates = app.windows().filter((candidate) => !candidate.isClosed());
+  let lastError: unknown;
+  for (const candidate of candidates) {
+    try {
+      return await candidate.evaluate(() =>
+        window.electronAPI.invoke('workspace-manager:get-open-workspaces')
+      );
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw new Error(
+    `getOpenWorkspaceWindowPaths: no open window could answer workspace-manager:get-open-workspaces (${candidates.length} candidate(s) tried): ${String(lastError)}`
+  );
+}
+
+/**
+ * Find the `Page` for the workspace-mode window whose PRIMARY path is
+ * `workspacePath`, by matching `WindowManager.ts`'s window title
+ * (`basename(workspacePath)` for workspace-mode windows). Returns `null` if
+ * no open window currently has that title -- e.g. the path only lives in
+ * some other window's rail as an *additional* path, or no window has it at
+ * all.
+ */
+export async function findWorkspaceWindowByPath(
+  app: ElectronApplication,
+  workspacePath: string
+): Promise<Page | null> {
+  const target = path.basename(workspacePath);
+  for (const candidate of app.windows()) {
+    if (candidate.isClosed()) continue;
+    const title = await candidate.title().catch(() => null);
+    if (title === target) return candidate;
+  }
+  return null;
+}

--- a/packages/electron/src/main/file/FileOperations.ts
+++ b/packages/electron/src/main/file/FileOperations.ts
@@ -3,10 +3,22 @@ import { writeFileSync } from 'fs';
 import { basename } from 'path';
 import { windowStates, getWindowId } from '../window/WindowManager';
 import { addToRecentItems } from '../utils/store';
+import { logger } from '../utils/logger';
 
 // Function to open a file in a window - sends open-document event to renderer
 // which triggers handleWorkspaceFileSelect to load content and create tab
-export function loadFileIntoWindow(window: BrowserWindow, filePath: string) {
+//
+// `expectedWorkspacePath`, when passed, is a warn-only sanity check: a window
+// can now host N projects (Multi-Project Mode's rail), but `open-document`'s
+// payload is still a bare `{ path }` with no workspace field -- the renderer
+// resolves it against whichever project is currently *active* at delivery
+// time (`App.tsx`'s `handleWorkspaceFileSelect`), not a project named in this
+// call. Callers that know which project the file belongs to can pass it so a
+// caller-side bug (delivering into a window that never actually registered
+// that project) is logged instead of silently opening in the wrong tree. This
+// does NOT make delivery itself workspace-targeted -- see the call sites in
+// `main/index.ts` for the full caveat.
+export function loadFileIntoWindow(window: BrowserWindow, filePath: string, expectedWorkspacePath?: string) {
     try {
         const windowId = getWindowId(window);
         if (windowId === null) {
@@ -18,6 +30,16 @@ export function loadFileIntoWindow(window: BrowserWindow, filePath: string) {
         if (state) {
             state.filePath = filePath;
             state.documentEdited = false;
+
+            if (expectedWorkspacePath) {
+                const knownPaths = [state.workspacePath, ...(state.additionalWorkspacePaths ?? [])];
+                if (!knownPaths.includes(expectedWorkspacePath)) {
+                    logger.main.warn(
+                        '[LOAD_FILE] Delivering into a window that has not registered the expected workspace:',
+                        { expectedWorkspacePath, filePath, knownPaths },
+                    );
+                }
+            }
         } else {
             console.error('[LOAD_FILE] No window state found for window ID:', windowId);
         }
@@ -36,6 +58,42 @@ export function loadFileIntoWindow(window: BrowserWindow, filePath: string) {
     } catch (error) {
         console.error('[LOAD_FILE] Error loading file from OS:', error);
     }
+}
+
+/** Narrow shape `deliverAfterWorkspaceSeed` needs from a workspace-open
+ *  outcome -- matches `ProjectOpenOutcomeAsync` from `WorkspaceManagerWindow.ts`
+ *  structurally so callers don't need to import that module's type here. */
+export type WorkspaceOpenOutcomeForDelivery = { kind: string };
+export type BlockedWorkspaceOpenOutcome = { kind: 'blocked'; reason: string };
+
+/**
+ * Sequencing guard for delivering a payload into a window that may still be
+ * mid rail-seed (`openOrFocusWorkspaceWindowAwaitingRailSeed`). Awaits
+ * `outcomePromise` and only calls `deliver` if it did not resolve to
+ * `{ kind: 'blocked' }`; otherwise calls `onBlocked` (if given) and returns
+ * without delivering anything.
+ *
+ * Pure -- no Electron, no I/O -- so the ordering guarantee this whole fix
+ * depends on ("never deliver before the seed resolves; never deliver at all
+ * on 'at-cap'/'timeout'") is unit-testable without mocking Electron or
+ * pulling in `main/index.ts`'s import graph.
+ */
+export async function deliverAfterWorkspaceSeed<O extends WorkspaceOpenOutcomeForDelivery>(
+    // `null` means the opener was never registered (a caller reaching the
+    // chokepoint through `window/workspaceOpenRef.ts` before startup wired it
+    // up). Treated exactly like a blocked seed: never deliver a payload into
+    // a window that may not host the project.
+    outcomePromise: Promise<O | null>,
+    deliver: (outcome: Exclude<O, BlockedWorkspaceOpenOutcome>) => void,
+    onBlocked?: (outcome: Extract<O, BlockedWorkspaceOpenOutcome> | null) => void,
+): Promise<boolean> {
+    const outcome = await outcomePromise;
+    if (!outcome || outcome.kind === 'blocked') {
+        onBlocked?.(outcome as Extract<O, BlockedWorkspaceOpenOutcome> | null);
+        return false;
+    }
+    deliver(outcome as Exclude<O, BlockedWorkspaceOpenOutcome>);
+    return true;
 }
 
 // Save file

--- a/packages/electron/src/main/file/OptimizedWorkspaceWatcher.ts
+++ b/packages/electron/src/main/file/OptimizedWorkspaceWatcher.ts
@@ -1,7 +1,8 @@
 import { BrowserWindow } from 'electron';
 import { getFolderContents } from '../utils/FileTree';
 import { logger } from '../utils/logger';
-import { getWindowId, markRecentlyDeleted } from '../window/WindowManager';
+import { getWindowId, markRecentlyDeleted, windows, windowStates } from '../window/WindowManager';
+import { windowReferencesWorkspace } from '../window/windowState';
 import * as workspaceEventBus from './WorkspaceEventBus';
 
 /**
@@ -17,6 +18,19 @@ export class OptimizedWorkspaceWatcher {
     private watchedPaths = new Map<number, Set<string>>();
     /** Subscriber IDs we've registered with the bus, keyed by windowId */
     private subscriberIds = new Map<number, string>();
+
+    /**
+     * Content-only watches kept alive for rail projects that are registered
+     * (warm) in a window but not the window's currently-visible project.
+     * Keyed by resolved workspacePath -> number of logical callers that
+     * asked for a background watch on that path (normally 1; can exceed 1
+     * if two windows both keep the same path warm). Only ever forwards
+     * `file-changed-on-disk` / `file-deleted` -- never rebuilds or pushes
+     * the file tree, because `workspace-file-tree-updated` lands in a
+     * renderer atom that isn't workspace-scoped (see WorkspaceWatcher.ts
+     * docs on `startBackgroundWorkspaceWatch`).
+     */
+    private backgroundRefCounts = new Map<string, number>();
 
     async start(window: BrowserWindow, workspacePath: string) {
         const windowId = getWindowId(window);
@@ -101,6 +115,133 @@ export class OptimizedWorkspaceWatcher {
     }
 
     // ---------------------------------------------------------------
+    // Background (warm, non-visible rail project) watching
+    // ---------------------------------------------------------------
+
+    /**
+     * Send an IPC event to every window that actually references
+     * `workspacePath` (primary or warm rail path) instead of broadcasting to
+     * every window in the process, so the fan-out stays bounded by how many
+     * windows chose to keep the project warm.
+     */
+    private sendToReferencingWindows(workspacePath: string, channel: string, payload: unknown): void {
+        for (const [windowId, window] of windows) {
+            if (window.isDestroyed()) continue;
+            if (!windowReferencesWorkspace(windowStates.get(windowId), workspacePath)) continue;
+            window.webContents.send(channel, payload);
+        }
+    }
+
+    /**
+     * Start a content-only watch for a warm rail project that is registered
+     * in a window but not currently visible. Forwards `file-changed-on-disk`
+     * / `file-deleted` so open editor buffers for that project stay correct
+     * while it's in the background, but deliberately never triggers a file
+     * tree rebuild/push: `workspace-file-tree-updated` lands in a single
+     * global renderer atom with no workspacePath on the payload, so pushing
+     * a background project's tree would silently clobber whatever tree is
+     * currently visible. The visible project's tree is always fetched fresh
+     * on activation instead (`initFileTreeListeners` -> `getFolderContents`,
+     * an uncached disk read), so no push channel is needed for correctness.
+     *
+     * Ref-counted per workspacePath (not per window) so multiple callers
+     * asking for the same background path don't create duplicate bus
+     * subscriptions or race each other's unsubscribe.
+     */
+    async startBackground(workspacePath: string): Promise<void> {
+        const count = this.backgroundRefCounts.get(workspacePath) ?? 0;
+        this.backgroundRefCounts.set(workspacePath, count + 1);
+        if (count > 0) {
+            // Already subscribed for this path; just tracked another caller.
+            return;
+        }
+
+        const subscriberId = `workspace-watcher-bg-${workspacePath}`;
+        await workspaceEventBus.subscribe(workspacePath, subscriberId, {
+            onChange: (filePath: string) => {
+                this.sendToReferencingWindows(workspacePath, 'file-changed-on-disk', { path: filePath });
+            },
+            onAdd: (filePath: string, gitignoreBypassed?: boolean) => {
+                if (gitignoreBypassed) return; // SessionFileWatcher handles editor notifications
+                this.sendToReferencingWindows(workspacePath, 'file-changed-on-disk', { path: filePath });
+            },
+            onUnlink: (filePath: string, gitignoreBypassed?: boolean) => {
+                markRecentlyDeleted(filePath);
+                if (gitignoreBypassed) return; // SessionFileWatcher handles editor notifications
+                this.sendToReferencingWindows(workspacePath, 'file-changed-on-disk', { path: filePath });
+                this.sendToReferencingWindows(workspacePath, 'file-deleted', { filePath });
+            },
+            // This listener does editor-buffer notification, not file-tree
+            // structure tracking (it never rebuilds the tree), so it should
+            // NOT opt in to gitignored structural events -- WorkspaceEventBus
+            // reserves that flag for tree listeners and explicitly calls out
+            // "editor notification" listeners as the case that should leave
+            // it off. We already discard gitignoreBypassed events above, so
+            // this only saves the bus the round trip of calling us for them.
+            receiveGitignoredStructureEvents: false,
+        });
+    }
+
+    /**
+     * Release ONE caller's hold on a background watch started via
+     * `startBackground`. No-op if the path was never backgrounded, or if
+     * other callers still hold it warm.
+     *
+     * This is the "I know exactly which single reference I'm dropping"
+     * variant -- its only caller is `releaseWarmWatchOnPromotion` (a window
+     * promoting ITS OWN warm path to active), which is NOT gated on
+     * `anyWindowReferencesWorkspace`: other windows may legitimately still
+     * hold the same path warm, and a plain decrement is what keeps their
+     * subscription alive. Any release site that has already proven (via
+     * `anyWindowReferencesWorkspace`) that NO window references the path
+     * anymore must use `releaseAllBackgroundRefs` instead -- decrementing by
+     * one there is the bug this pair of methods exists to avoid: with two
+     * windows both keeping a path warm, only the LAST window's release call
+     * ever runs while the boolean gate is false, so a plain decrement never
+     * reaches zero and leaks the bus subscription forever.
+     */
+    stopBackground(workspacePath: string): void {
+        const count = this.backgroundRefCounts.get(workspacePath) ?? 0;
+        if (count <= 0) return;
+
+        const next = count - 1;
+        if (next > 0) {
+            this.backgroundRefCounts.set(workspacePath, next);
+            return;
+        }
+
+        this.backgroundRefCounts.delete(workspacePath);
+        workspaceEventBus.unsubscribe(workspacePath, `workspace-watcher-bg-${workspacePath}`);
+    }
+
+    /**
+     * Fully release a background watch for `workspacePath`, regardless of
+     * how many callers `startBackground` ever counted for it. Callers MUST
+     * have independently proven -- via `anyWindowReferencesWorkspace` --
+     * that no window references this path anymore before calling this; once
+     * that is true there is no live window left to still need the shared bus
+     * subscription, no matter what the refcount says. Idempotent: safe to
+     * call for a path that was never backgrounded, or one another caller
+     * already released.
+     */
+    releaseAllBackgroundRefs(workspacePath: string): void {
+        if (!this.backgroundRefCounts.has(workspacePath)) return;
+
+        this.backgroundRefCounts.delete(workspacePath);
+        workspaceEventBus.unsubscribe(workspacePath, `workspace-watcher-bg-${workspacePath}`);
+    }
+
+    /** Number of paths currently held warm in the background. Test/diagnostics only. */
+    getBackgroundWatchCount(): number {
+        return this.backgroundRefCounts.size;
+    }
+
+    /** Paths currently held warm in the background. Used to sweep orphans on `stop`/`stopAll`. */
+    getBackgroundWatchPaths(): string[] {
+        return [...this.backgroundRefCounts.keys()];
+    }
+
+    // ---------------------------------------------------------------
     // Folder expansion tracking
     // ---------------------------------------------------------------
 
@@ -179,11 +320,18 @@ export class OptimizedWorkspaceWatcher {
     }
 
     async stopAll() {
-        logger.workspaceWatcher.info(`[CLEANUP] Stopping all workspace watchers (${this.workspacePaths.size} windows)`);
+        logger.workspaceWatcher.info(
+            `[CLEANUP] Stopping all workspace watchers (${this.workspacePaths.size} windows, ${this.backgroundRefCounts.size} background)`
+        );
 
         for (const windowId of [...this.subscriberIds.keys()]) {
             this.stop(windowId);
         }
+
+        for (const workspacePath of [...this.backgroundRefCounts.keys()]) {
+            workspaceEventBus.unsubscribe(workspacePath, `workspace-watcher-bg-${workspacePath}`);
+        }
+        this.backgroundRefCounts.clear();
 
         for (const timer of this.updateTimers.values()) {
             clearTimeout(timer);
@@ -207,6 +355,7 @@ export class OptimizedWorkspaceWatcher {
             type: busStats.type,
             activeWorkspaces: this.workspacePaths.size,
             workspaces: stats,
+            backgroundWorkspaces: [...this.backgroundRefCounts.keys()],
         };
     }
 }

--- a/packages/electron/src/main/file/WorkspaceWatcher.ts
+++ b/packages/electron/src/main/file/WorkspaceWatcher.ts
@@ -2,6 +2,7 @@ import { BrowserWindow } from 'electron';
 import { safeHandle } from '../utils/ipcRegistry';
 import { logger } from '../utils/logger';
 import { getWindowId, windowStates } from '../window/WindowManager';
+import { anyWindowReferencesWorkspace } from '../window/windowState';
 import { clearGitStatusCache } from '../ipc/GitStatusHandlers';
 import { optimizedWorkspaceWatcher } from './OptimizedWorkspaceWatcher';
 import { gitRefWatcher } from './GitRefWatcher';
@@ -113,6 +114,88 @@ export function startWorkspaceWatcher(window: BrowserWindow, workspacePath: stri
     });
 }
 
+// ============================================================================
+// Warm (rail-registered, not-currently-visible) workspace watching
+//
+// The rail lets a window keep several projects registered while only one is
+// visible. `OptimizedWorkspaceWatcher` is single-active-per-window (the
+// `start`/`stop` pair above), so a warm-but-invisible project historically
+// had no watcher at all: its open editor buffers never learned about disk
+// changes, and its GitRefWatcher (commit detection / pending-review
+// auto-approve / git-status cache invalidation) went dark the moment it
+// stopped being the visible project.
+//
+// The three functions below keep a warm project's *content* events flowing
+// without paying the cost -- or the renderer-side risk -- of also pushing
+// `workspace-file-tree-updated` for it:
+//   - `workspace-file-tree-updated` lands in a single global (not
+//     workspace-scoped) renderer atom with no workspacePath on the payload,
+//     so pushing a background project's tree would silently clobber
+//     whatever tree is currently visible.
+//   - The visible project's tree is already fetched fresh on every
+//     activation (`initFileTreeListeners` -> `getFolderContents`, an
+//     uncached disk read), so no push channel is needed there for
+//     correctness -- multiplexing it would be pure waste.
+//   - `file-changed-on-disk` / `file-deleted`, by contrast, are consumed by
+//     per-file-path atom families (`fileChangedOnDiskAtomFamily`,
+//     `fileDeletedAtomFamily`) that DiskBackedStore subscribes to per open
+//     tab regardless of which project is visible, so multiplexing those two
+//     is both safe and the only way an inactive project's open editor
+//     buffers ever learn a file changed underneath them.
+// ============================================================================
+
+/**
+ * Start (or keep alive) a content-only background watch for a rail project
+ * that is registered in a window but not currently visible: forwards
+ * `file-changed-on-disk` / `file-deleted`, never pushes a file tree rebuild,
+ * and keeps GitRefWatcher running for it (idempotent if already running).
+ *
+ * Called both when a path is first registered as warm
+ * (`workspace:register-additional`) and when the previously-active path is
+ * demoted during a rail switch (`workspace:set-active`).
+ */
+export function startWarmWorkspaceWatch(workspacePath: string): void {
+    optimizedWorkspaceWatcher.startBackground(workspacePath).catch((error) => {
+        logger.workspaceWatcher.error('Failed to start background workspace watch:', error);
+    });
+    gitRefWatcher.start(workspacePath).catch((error) => {
+        logger.workspaceWatcher.error('Failed to start GitRefWatcher for warm project:', error);
+    });
+}
+
+/**
+ * Release the content-only background watch for a path that is being
+ * promoted to a window's full/active watch. Deliberately does NOT touch
+ * GitRefWatcher: `startWorkspaceWatcher` starts it for the active path
+ * (idempotent no-op if `startWarmWorkspaceWatch` already had it running),
+ * and it should keep running uninterrupted across the promotion rather than
+ * being stopped and immediately restarted.
+ */
+export function releaseWarmWatchOnPromotion(workspacePath: string): void {
+    optimizedWorkspaceWatcher.stopBackground(workspacePath);
+}
+
+/**
+ * Fully release the resources started by `startWarmWorkspaceWatch` because a
+ * path is no longer referenced by any window (closed from the rail). Callers
+ * must gate this on `!anyWindowReferencesWorkspace(path)` first -- see
+ * `workspace:unregister-additional` in MultiProjectRailHandlers.ts.
+ *
+ * Uses `releaseAllBackgroundRefs`, NOT a plain decrement: every caller has
+ * already proven no window references this path anymore, which can be true
+ * while `startWarmWorkspaceWatch` was called more than once for it (two
+ * windows both kept it warm). A plain per-caller decrement only ever gets
+ * called once here -- by definition, the boolean gate flips to "unreferenced"
+ * exactly once, on whichever window's release happens last -- so it would
+ * never fully unwind a refcount above 1 and would leak the bus subscription.
+ */
+export function stopWarmWorkspaceWatch(workspacePath: string): void {
+    optimizedWorkspaceWatcher.releaseAllBackgroundRefs(workspacePath);
+    gitRefWatcher.stop(workspacePath).catch((error) => {
+        logger.workspaceWatcher.error('Failed to stop GitRefWatcher:', error);
+    });
+}
+
 // Stop watching a workspace
 export function stopWorkspaceWatcher(windowId: number) {
     // Stop project file sync for any workspace this window referenced
@@ -140,8 +223,40 @@ export function stopWorkspaceWatcher(windowId: number) {
     }
 
     optimizedWorkspaceWatcher.stop(windowId);
-    // Note: gitRefWatcher is keyed by workspacePath, not windowId.
-    // It will be stopped when stopAllWorkspaceWatchers is called.
+
+    // Sweep orphaned warm-project watches: a path can end up backgrounded
+    // (via startWarmWorkspaceWatch, called both from register-additional and
+    // from the demote step in workspace:set-active) and then never
+    // explicitly released if its owning window closes outright rather than
+    // going through workspace:unregister-additional. This runs on every
+    // call (switch, unregister, window close) but is a no-op unless a
+    // background path has actually gone unreferenced, so it's cheap; it is
+    // the only reliable place to catch the window-close case, since by the
+    // time WindowManager's 'closed' handler runs, `windowStates` no longer
+    // has an entry for this window to read paths off of.
+    //
+    // `releaseAllBackgroundRefs`, not `stopBackground`: this loop has already
+    // proven `!anyWindowReferencesWorkspace(path)`, so whatever the refcount
+    // is, there is no live window left to need the subscription -- a plain
+    // decrement would leak it when more than one window had kept the path
+    // warm (see the leak this replaced, NIM single-window-multi-project
+    // review Fix 1).
+    for (const path of optimizedWorkspaceWatcher.getBackgroundWatchPaths()) {
+        if (anyWindowReferencesWorkspace(path)) continue;
+        optimizedWorkspaceWatcher.releaseAllBackgroundRefs(path);
+        gitRefWatcher.stop(path).catch((error) => {
+            logger.workspaceWatcher.error('Failed to stop orphaned GitRefWatcher:', error);
+        });
+    }
+    // Note: gitRefWatcher for a path that is still its window's *active*
+    // (never-backgrounded) path at the moment that window closes is not
+    // caught by the sweep above -- it was never demoted to a background
+    // watch, so it isn't in `getBackgroundWatchPaths()`. That is pre-existing
+    // behavior (gitRefWatcher has always only fully stopped at app quit via
+    // stopAllWorkspaceWatchers) and releasing it here would need the
+    // window's pre-close path list, which WindowManager.ts already captures
+    // as `savedState` for its own doc/fs-service cleanup -- see the 'closed'
+    // handler there for the equivalent pattern.
 }
 
 // Get workspace watcher info for debugging

--- a/packages/electron/src/main/file/__tests__/FileOperations.test.ts
+++ b/packages/electron/src/main/file/__tests__/FileOperations.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  windowStates: new Map<number, any>(),
+  getWindowId: vi.fn(),
+  addToRecentItems: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock('../../window/WindowManager', () => ({
+  windowStates: mocks.windowStates,
+  getWindowId: mocks.getWindowId,
+}));
+
+vi.mock('../../utils/store', () => ({
+  addToRecentItems: mocks.addToRecentItems,
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    main: { warn: mocks.loggerWarn, error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+import { loadFileIntoWindow, deliverAfterWorkspaceSeed } from '../FileOperations';
+
+function fakeWindow() {
+  return {
+    webContents: { send: vi.fn() },
+    setRepresentedFilename: vi.fn(),
+  };
+}
+
+/** Deferred promise so tests can control exactly when the seed "resolves"
+ *  relative to assertions about `deliver`/`onBlocked` not having run yet. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('loadFileIntoWindow', () => {
+  beforeEach(() => {
+    mocks.windowStates.clear();
+    mocks.getWindowId.mockReset();
+    mocks.loggerWarn.mockClear();
+  });
+
+  it('warns when expectedWorkspacePath was never registered on the target window', () => {
+    mocks.getWindowId.mockReturnValue(1);
+    mocks.windowStates.set(1, { workspacePath: '/ws/a', additionalWorkspacePaths: [] });
+
+    loadFileIntoWindow(fakeWindow() as any, '/ws/b/file.md', '/ws/b');
+
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('not registered the expected workspace'),
+      expect.objectContaining({ expectedWorkspacePath: '/ws/b' }),
+    );
+  });
+
+  it('does not warn when expectedWorkspacePath is the window primary workspace', () => {
+    mocks.getWindowId.mockReturnValue(1);
+    mocks.windowStates.set(1, { workspacePath: '/ws/a', additionalWorkspacePaths: [] });
+
+    loadFileIntoWindow(fakeWindow() as any, '/ws/a/file.md', '/ws/a');
+
+    expect(mocks.loggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when expectedWorkspacePath is a rail-seeded additional workspace', () => {
+    mocks.getWindowId.mockReturnValue(1);
+    mocks.windowStates.set(1, { workspacePath: '/ws/a', additionalWorkspacePaths: ['/ws/b'] });
+
+    loadFileIntoWindow(fakeWindow() as any, '/ws/b/file.md', '/ws/b');
+
+    expect(mocks.loggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when no expectedWorkspacePath is passed (existing callers unaffected)', () => {
+    mocks.getWindowId.mockReturnValue(1);
+    mocks.windowStates.set(1, { workspacePath: '/ws/a', additionalWorkspacePaths: [] });
+
+    loadFileIntoWindow(fakeWindow() as any, '/ws/a/file.md');
+
+    expect(mocks.loggerWarn).not.toHaveBeenCalled();
+  });
+});
+
+describe('deliverAfterWorkspaceSeed', () => {
+  it('does not call deliver until the outcome promise resolves', async () => {
+    const { promise, resolve } = deferred<{ kind: 'add-to-rail' }>();
+    const deliver = vi.fn();
+
+    const resultPromise = deliverAfterWorkspaceSeed(promise, deliver);
+
+    // Outcome is still in flight -- deliver must not have run yet.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deliver).not.toHaveBeenCalled();
+
+    resolve({ kind: 'add-to-rail' });
+    await resultPromise;
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver).toHaveBeenCalledWith({ kind: 'add-to-rail' });
+  });
+
+  it('calls deliver for a non-blocked outcome and returns true', async () => {
+    const deliver = vi.fn();
+    const onBlocked = vi.fn();
+
+    const delivered = await deliverAfterWorkspaceSeed(
+      Promise.resolve({ kind: 'focus-existing' as const }),
+      deliver,
+      onBlocked,
+    );
+
+    expect(delivered).toBe(true);
+    expect(deliver).toHaveBeenCalledWith({ kind: 'focus-existing' });
+    expect(onBlocked).not.toHaveBeenCalled();
+  });
+
+  it.each(['at-cap', 'timeout'] as const)(
+    'never calls deliver when the seed resolves "blocked" (reason: %s) -- the payload must not land in the wrong project',
+    async (reason) => {
+      const deliver = vi.fn();
+      const onBlocked = vi.fn();
+
+      const delivered = await deliverAfterWorkspaceSeed(
+        Promise.resolve({ kind: 'blocked' as const, reason }),
+        deliver,
+        onBlocked,
+      );
+
+      expect(delivered).toBe(false);
+      expect(deliver).not.toHaveBeenCalled();
+      expect(onBlocked).toHaveBeenCalledWith({ kind: 'blocked', reason });
+    },
+  );
+
+  it('does not throw when onBlocked is omitted for a blocked outcome', async () => {
+    const deliver = vi.fn();
+
+    await expect(
+      deliverAfterWorkspaceSeed(Promise.resolve({ kind: 'blocked' as const, reason: 'timeout' as const }), deliver),
+    ).resolves.toBe(false);
+    expect(deliver).not.toHaveBeenCalled();
+  });
+});

--- a/packages/electron/src/main/file/__tests__/OptimizedWorkspaceWatcher.test.ts
+++ b/packages/electron/src/main/file/__tests__/OptimizedWorkspaceWatcher.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
   return {
-    subscribe: vi.fn(async () => {}),
+    subscribe: vi.fn(async (_workspacePath: string, _subscriberId: string, _listener: any) => {}),
     unsubscribe: vi.fn(),
     addWatchedPath: vi.fn(),
     removeWatchedPath: vi.fn(),
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => {
     getFolderContents: vi.fn(async () => []),
     getWindowId: vi.fn((window: any) => window?.id ?? null),
     markRecentlyDeleted: vi.fn(),
+    windows: new Map<number, any>(),
+    windowStates: new Map<number, any>(),
   };
 });
 
@@ -32,6 +34,16 @@ vi.mock('../../utils/FileTree', () => ({
 vi.mock('../../window/WindowManager', () => ({
   getWindowId: mocks.getWindowId,
   markRecentlyDeleted: mocks.markRecentlyDeleted,
+  windows: mocks.windows,
+  windowStates: mocks.windowStates,
+}));
+
+vi.mock('../../window/windowState', () => ({
+  windowReferencesWorkspace: (state: any, path: string) => {
+    if (!state) return false;
+    if (state.workspacePath === path) return true;
+    return state.additionalWorkspacePaths?.includes(path) === true;
+  },
 }));
 
 vi.mock('../../utils/logger', () => ({
@@ -60,6 +72,8 @@ describe('OptimizedWorkspaceWatcher', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.windows.clear();
+    mocks.windowStates.clear();
     watcher = new OptimizedWorkspaceWatcher();
   });
 
@@ -169,6 +183,112 @@ describe('OptimizedWorkspaceWatcher', () => {
       const stats = watcher.getStats();
       expect(stats.activeWorkspaces).toBe(2);
       expect(stats.workspaces.map((w: any) => w.workspacePath).sort()).toEqual(['/ws/a', '/ws/b']);
+    });
+  });
+
+  describe('startBackground / stopBackground', () => {
+    it('subscribes once for a warm (not-visible) rail project', async () => {
+      await watcher.startBackground('/ws/warm');
+
+      expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+      expect(mocks.subscribe).toHaveBeenCalledWith(
+        '/ws/warm',
+        'workspace-watcher-bg-/ws/warm',
+        expect.any(Object),
+      );
+      expect(watcher.getBackgroundWatchCount()).toBe(1);
+    });
+
+    it('is ref-counted: a second caller for the same path does not re-subscribe', async () => {
+      await watcher.startBackground('/ws/warm');
+      await watcher.startBackground('/ws/warm');
+
+      expect(mocks.subscribe).toHaveBeenCalledTimes(1);
+      expect(watcher.getBackgroundWatchCount()).toBe(1);
+    });
+
+    it('does not unsubscribe until every caller has released it', async () => {
+      await watcher.startBackground('/ws/warm');
+      await watcher.startBackground('/ws/warm');
+
+      watcher.stopBackground('/ws/warm');
+      expect(mocks.unsubscribe).not.toHaveBeenCalled();
+
+      watcher.stopBackground('/ws/warm');
+      expect(mocks.unsubscribe).toHaveBeenCalledWith('/ws/warm', 'workspace-watcher-bg-/ws/warm');
+      expect(watcher.getBackgroundWatchCount()).toBe(0);
+    });
+
+    it('stopBackground is a no-op for a path that was never backgrounded', () => {
+      expect(() => watcher.stopBackground('/ws/never')).not.toThrow();
+      expect(mocks.unsubscribe).not.toHaveBeenCalled();
+    });
+
+    it('forwards file-changed-on-disk only to windows referencing the path, never a tree rebuild', async () => {
+      const visible = fakeWindow(1);
+      const unrelated = fakeWindow(2);
+      mocks.windows.set(1, visible);
+      mocks.windows.set(2, unrelated);
+      mocks.windowStates.set(1, { workspacePath: '/ws/warm' });
+      mocks.windowStates.set(2, { workspacePath: '/ws/other' });
+
+      await watcher.startBackground('/ws/warm');
+      const listener = mocks.subscribe.mock.calls[0][2];
+
+      listener.onChange('/ws/warm/file.md');
+
+      expect(visible.webContents.send).toHaveBeenCalledWith('file-changed-on-disk', { path: '/ws/warm/file.md' });
+      expect(unrelated.webContents.send).not.toHaveBeenCalled();
+      // The whole point of a background watch: never push a tree rebuild for
+      // a project nobody is looking at (the renderer's file tree atom is
+      // global, not workspace-scoped -- see WorkspaceWatcher.ts).
+      expect(visible.webContents.send).not.toHaveBeenCalledWith(
+        'workspace-file-tree-updated',
+        expect.anything(),
+      );
+      expect(mocks.getFolderContents).not.toHaveBeenCalled();
+    });
+
+    it('forwards file-deleted and marks the path recently-deleted on unlink', async () => {
+      const visible = fakeWindow(1);
+      mocks.windows.set(1, visible);
+      mocks.windowStates.set(1, { workspacePath: '/ws/warm' });
+
+      await watcher.startBackground('/ws/warm');
+      const listener = mocks.subscribe.mock.calls[0][2];
+
+      listener.onUnlink('/ws/warm/deleted.md');
+
+      expect(mocks.markRecentlyDeleted).toHaveBeenCalledWith('/ws/warm/deleted.md');
+      expect(visible.webContents.send).toHaveBeenCalledWith('file-changed-on-disk', { path: '/ws/warm/deleted.md' });
+      expect(visible.webContents.send).toHaveBeenCalledWith('file-deleted', { filePath: '/ws/warm/deleted.md' });
+    });
+
+    it('skips gitignore-bypassed add/unlink notifications (SessionFileWatcher already handles those)', async () => {
+      const visible = fakeWindow(1);
+      mocks.windows.set(1, visible);
+      mocks.windowStates.set(1, { workspacePath: '/ws/warm' });
+
+      await watcher.startBackground('/ws/warm');
+      const listener = mocks.subscribe.mock.calls[0][2];
+
+      listener.onAdd('/ws/warm/bypassed.md', true);
+      listener.onUnlink('/ws/warm/bypassed.md', true);
+
+      expect(visible.webContents.send).not.toHaveBeenCalled();
+      // Deletion tracking still needs to happen regardless of bypass status.
+      expect(mocks.markRecentlyDeleted).toHaveBeenCalledWith('/ws/warm/bypassed.md');
+    });
+
+    it('stopAll releases every background watch', async () => {
+      await watcher.startBackground('/ws/warm-a');
+      await watcher.startBackground('/ws/warm-b');
+
+      await watcher.stopAll();
+
+      expect(mocks.unsubscribe).toHaveBeenCalledWith('/ws/warm-a', 'workspace-watcher-bg-/ws/warm-a');
+      expect(mocks.unsubscribe).toHaveBeenCalledWith('/ws/warm-b', 'workspace-watcher-bg-/ws/warm-b');
+      expect(watcher.getBackgroundWatchCount()).toBe(0);
     });
   });
 });

--- a/packages/electron/src/main/file/__tests__/WorkspaceWatcher.test.ts
+++ b/packages/electron/src/main/file/__tests__/WorkspaceWatcher.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Covers the orphan-sweep behavior added to `stopWorkspaceWatcher` for
+ * Phase 2 of single-window-multi-project: a warm rail project's background
+ * watch (content-only file-changed-on-disk/file-deleted forwarding +
+ * GitRefWatcher) must be released once no window references it any more,
+ * even when that happens via a window closing outright rather than an
+ * explicit `workspace:unregister-additional` call.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  return {
+    windowStates: new Map<number, any>(),
+    getWindowId: vi.fn((window: any) => window?.id ?? null),
+    optimizedStop: vi.fn(),
+    optimizedReleaseAllBackgroundRefs: vi.fn(),
+    getBackgroundWatchPaths: vi.fn(() => [] as string[]),
+    gitRefWatcherStop: vi.fn(async () => {}),
+    anyWindowReferencesWorkspace: vi.fn((_path: string) => false),
+  };
+});
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+vi.mock('../../window/WindowManager', () => ({
+  getWindowId: mocks.getWindowId,
+  windowStates: mocks.windowStates,
+}));
+
+vi.mock('../../window/windowState', () => ({
+  anyWindowReferencesWorkspace: mocks.anyWindowReferencesWorkspace,
+}));
+
+vi.mock('../../ipc/GitStatusHandlers', () => ({
+  clearGitStatusCache: vi.fn(),
+}));
+
+vi.mock('../OptimizedWorkspaceWatcher', () => ({
+  optimizedWorkspaceWatcher: {
+    start: vi.fn(),
+    stop: mocks.optimizedStop,
+    releaseAllBackgroundRefs: mocks.optimizedReleaseAllBackgroundRefs,
+    getBackgroundWatchPaths: mocks.getBackgroundWatchPaths,
+  },
+}));
+
+vi.mock('../GitRefWatcher', () => ({
+  gitRefWatcher: {
+    start: vi.fn(async () => {}),
+    stop: mocks.gitRefWatcherStop,
+    stopAll: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock('../WorkspaceEventBus', () => ({
+  setGitignoreChangeHandler: vi.fn(),
+  subscribe: vi.fn(async () => {}),
+  unsubscribe: vi.fn(),
+  stopAll: vi.fn(async () => {}),
+}));
+
+vi.mock('../../services/analytics/AnalyticsService', () => ({
+  AnalyticsService: { getInstance: () => ({ sendEvent: vi.fn() }) },
+}));
+
+vi.mock('../../services/ProjectFileSyncService', () => ({
+  getProjectFileSyncService: () => ({
+    isRecentlyWrittenFromRemote: () => false,
+    handleFileSaved: vi.fn(),
+    handleFileDeletedByPath: vi.fn(),
+    syncProject: vi.fn(async () => {}),
+    disconnectProject: vi.fn(),
+  }),
+}));
+
+vi.mock('../../services/SyncManager', () => ({
+  isSyncEnabled: () => false,
+}));
+
+vi.mock('../../utils/store', () => ({
+  getReleaseChannel: () => 'stable',
+  getSessionSyncConfig: () => null,
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    workspaceWatcher: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    main: { info: vi.fn(), error: vi.fn() },
+  },
+}));
+
+import { stopWorkspaceWatcher } from '../WorkspaceWatcher';
+
+describe('stopWorkspaceWatcher orphan sweep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.windowStates.clear();
+    mocks.getBackgroundWatchPaths.mockReturnValue([]);
+    mocks.anyWindowReferencesWorkspace.mockReturnValue(false);
+  });
+
+  it('releases a background watch that no window references any more', () => {
+    mocks.getBackgroundWatchPaths.mockReturnValue(['/ws/orphan']);
+    mocks.anyWindowReferencesWorkspace.mockReturnValue(false);
+
+    stopWorkspaceWatcher(1);
+
+    expect(mocks.optimizedReleaseAllBackgroundRefs).toHaveBeenCalledWith('/ws/orphan');
+    expect(mocks.gitRefWatcherStop).toHaveBeenCalledWith('/ws/orphan');
+  });
+
+  it('leaves a background watch alone when another window still references it', () => {
+    mocks.getBackgroundWatchPaths.mockReturnValue(['/ws/still-warm']);
+    mocks.anyWindowReferencesWorkspace.mockReturnValue(true);
+
+    stopWorkspaceWatcher(1);
+
+    expect(mocks.optimizedReleaseAllBackgroundRefs).not.toHaveBeenCalled();
+    expect(mocks.gitRefWatcherStop).not.toHaveBeenCalled();
+  });
+
+  it('sweeps every orphaned background path, not just ones tied to the closing window', () => {
+    mocks.getBackgroundWatchPaths.mockReturnValue(['/ws/orphan-a', '/ws/orphan-b', '/ws/still-warm']);
+    mocks.anyWindowReferencesWorkspace.mockImplementation((path: string) => path === '/ws/still-warm');
+
+    stopWorkspaceWatcher(1);
+
+    expect(mocks.optimizedReleaseAllBackgroundRefs).toHaveBeenCalledWith('/ws/orphan-a');
+    expect(mocks.optimizedReleaseAllBackgroundRefs).toHaveBeenCalledWith('/ws/orphan-b');
+    expect(mocks.optimizedReleaseAllBackgroundRefs).not.toHaveBeenCalledWith('/ws/still-warm');
+  });
+
+  it('is a no-op sweep when there are no background watches', () => {
+    mocks.getBackgroundWatchPaths.mockReturnValue([]);
+
+    expect(() => stopWorkspaceWatcher(1)).not.toThrow();
+    expect(mocks.optimizedReleaseAllBackgroundRefs).not.toHaveBeenCalled();
+    expect(mocks.gitRefWatcherStop).not.toHaveBeenCalled();
+  });
+});

--- a/packages/electron/src/main/file/__tests__/backgroundWatchRefcountLeak.test.ts
+++ b/packages/electron/src/main/file/__tests__/backgroundWatchRefcountLeak.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Regression coverage for the background-watch refcount leak described in
+ * the single-window-multi-project review (Fix 1): `startBackground` counts
+ * once per WINDOW that keeps a path warm, but every release site
+ * (`WorkspaceWatcher.ts`'s orphan sweep, `workspace:unregister-additional`,
+ * `WindowManager.ts`'s `closed` handler) gates on the BOOLEAN
+ * `anyWindowReferencesWorkspace(path)` and then calls `stopBackground`
+ * exactly once. With two windows both keeping the same path warm, the
+ * refcount reaches 2 but only ONE gated decrement ever fires (the second
+ * window's close/unregister is the first call to see the boolean flip to
+ * false), leaving the `WorkspaceEventBus` subscription and the
+ * `backgroundRefCounts` entry alive forever.
+ *
+ * Deliberately drives the REAL `OptimizedWorkspaceWatcher`, `WorkspaceWatcher`,
+ * and `MultiProjectRailHandlers` modules through the actual
+ * `workspace:register-additional` / `workspace:unregister-additional` IPC
+ * handlers -- only the leaf `WorkspaceEventBus` (the chokidar/fs.watch
+ * boundary) and unrelated services are mocked. A test that mocks
+ * `OptimizedWorkspaceWatcher` or `stopBackground` itself (as the existing
+ * per-module unit tests do) cannot see this bug: the leak is in how the real
+ * release contract between these three modules disagrees, not in any single
+ * function's own logic.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { WindowState } from '../../types';
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<string, (event: any, data: any) => Promise<any>>();
+  return {
+    handlers,
+    windowStates: new Map<number, WindowState>(),
+    windows: new Map<number, any>(),
+    documentServices: new Map<string, any>(),
+    fileSystemServices: new Map<string, any>(),
+    subscribe: vi.fn(async (_workspacePath: string, _subscriberId: string, _listener: any) => {}),
+    unsubscribe: vi.fn(),
+    getWindowId: vi.fn((window: any) => window?.id ?? null),
+    markRecentlyDeleted: vi.fn(),
+    gitRefWatcherStart: vi.fn(async () => {}),
+    gitRefWatcherStop: vi.fn(async () => {}),
+    addToRecentItems: vi.fn(),
+    getWorkspaceNavigationHistory: vi.fn(() => null),
+    setupDocumentServiceHandlers: vi.fn(),
+    addNimAssetRoot: vi.fn(),
+    addNimPreviewWorkspaceRoot: vi.fn(),
+    getMcpConfigService: vi.fn(() => ({ stopWatchingWorkspaceConfig: vi.fn() })),
+    restoreNavigationState: vi.fn(),
+    setFileSystemService: vi.fn(),
+    clearFileSystemService: vi.fn(),
+    setFileSystemServiceFor: vi.fn(),
+    clearFileSystemServiceFor: vi.fn(),
+    fakeBrowserWindowId: 1,
+  };
+});
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    fromWebContents: () => ({ id: mocks.fakeBrowserWindowId }),
+    getAllWindows: () => [],
+  },
+}));
+
+vi.mock('../../utils/ipcRegistry', () => ({
+  safeHandle: (channel: string, fn: (event: any, data: any) => Promise<any>) => {
+    mocks.handlers.set(channel, fn);
+  },
+}));
+
+vi.mock('../WorkspaceEventBus', () => ({
+  subscribe: mocks.subscribe,
+  unsubscribe: mocks.unsubscribe,
+  addWatchedPath: vi.fn(),
+  removeWatchedPath: vi.fn(),
+  getStats: vi.fn(() => ({ type: 'chokidar' })),
+  setGitignoreChangeHandler: vi.fn(),
+}));
+
+vi.mock('../GitRefWatcher', () => ({
+  gitRefWatcher: {
+    start: mocks.gitRefWatcherStart,
+    stop: mocks.gitRefWatcherStop,
+    stopAll: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock('../../ipc/GitStatusHandlers', () => ({
+  clearGitStatusCache: vi.fn(),
+}));
+
+vi.mock('../../services/analytics/AnalyticsService', () => ({
+  AnalyticsService: { getInstance: () => ({ sendEvent: vi.fn() }) },
+}));
+
+vi.mock('../../services/ProjectFileSyncService', () => ({
+  getProjectFileSyncService: () => ({
+    isRecentlyWrittenFromRemote: () => false,
+    handleFileSaved: vi.fn(),
+    handleFileDeletedByPath: vi.fn(),
+    syncProject: vi.fn(async () => {}),
+    disconnectProject: vi.fn(),
+  }),
+}));
+
+vi.mock('../../services/SyncManager', () => ({
+  isSyncEnabled: () => false,
+}));
+
+vi.mock('../../utils/store', () => ({
+  getReleaseChannel: () => 'stable',
+  getSessionSyncConfig: () => null,
+  addToRecentItems: mocks.addToRecentItems,
+  getWorkspaceNavigationHistory: mocks.getWorkspaceNavigationHistory,
+}));
+
+vi.mock('../../utils/FileTree', () => ({
+  getFolderContents: vi.fn(async () => []),
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    workspaceWatcher: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    main: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  },
+}));
+
+vi.mock('../../window/WindowManager', () => ({
+  getWindowId: mocks.getWindowId,
+  markRecentlyDeleted: mocks.markRecentlyDeleted,
+  windows: mocks.windows,
+  windowStates: mocks.windowStates,
+  documentServices: mocks.documentServices,
+}));
+
+vi.mock('../../window/windowState', () => ({
+  windowReferencesWorkspace: (state: WindowState | undefined, path: string) => {
+    if (!state) return false;
+    if (state.workspacePath === path) return true;
+    return state.additionalWorkspacePaths?.includes(path) === true;
+  },
+  anyWindowReferencesWorkspace: (path: string, excludeWindowId?: number) => {
+    for (const [id, state] of mocks.windowStates) {
+      if (excludeWindowId !== undefined && id === excludeWindowId) continue;
+      if (state.workspacePath === path) return true;
+      if (state.additionalWorkspacePaths?.includes(path)) return true;
+    }
+    return false;
+  },
+  resolveDocumentServicePath: (state: WindowState | undefined) => {
+    if (!state) return null;
+    return state.activeWorkspacePath ?? state.workspacePath ?? null;
+  },
+}));
+
+class FakeService {
+  destroy = vi.fn();
+}
+
+vi.mock('../../services/ElectronDocumentService', () => ({
+  ElectronDocumentService: vi.fn(function () {
+    return new FakeService();
+  }),
+  setupDocumentServiceHandlers: mocks.setupDocumentServiceHandlers,
+}));
+
+vi.mock('../../services/ElectronFileSystemService', () => ({
+  ElectronFileSystemService: vi.fn(function () {
+    return new FakeService();
+  }),
+}));
+
+vi.mock('../../protocols/nimAssetProtocol', () => ({
+  addNimAssetRoot: mocks.addNimAssetRoot,
+}));
+
+vi.mock('../../protocols/nimPreviewProtocol', () => ({
+  addNimPreviewWorkspaceRoot: mocks.addNimPreviewWorkspaceRoot,
+}));
+
+vi.mock('../../index', () => ({
+  getMcpConfigService: mocks.getMcpConfigService,
+}));
+
+vi.mock('../../services/NavigationHistoryService', () => ({
+  navigationHistoryService: { restoreNavigationState: mocks.restoreNavigationState },
+}));
+
+vi.mock('@nimbalyst/runtime', () => ({
+  setFileSystemService: mocks.setFileSystemService,
+  clearFileSystemService: mocks.clearFileSystemService,
+  setFileSystemServiceFor: mocks.setFileSystemServiceFor,
+  clearFileSystemServiceFor: mocks.clearFileSystemServiceFor,
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return { ...actual, existsSync: () => true };
+});
+
+// Imported AFTER mocks: the real OptimizedWorkspaceWatcher / WorkspaceWatcher
+// modules are exercised for real (only WorkspaceEventBus is a leaf mock), and
+// `registerMultiProjectRailHandlers` is the real handler registration so
+// `safeHandle` captures the real `workspace:register-additional` /
+// `workspace:unregister-additional` logic.
+import { registerMultiProjectRailHandlers } from '../../ipc/MultiProjectRailHandlers';
+import { optimizedWorkspaceWatcher } from '../OptimizedWorkspaceWatcher';
+
+function makeState(partial: Partial<WindowState> = {}): WindowState {
+  return {
+    mode: 'workspace',
+    filePath: null,
+    workspacePath: null,
+    documentEdited: false,
+    ...partial,
+  };
+}
+
+function event() {
+  return { sender: {} as any };
+}
+
+async function invoke(channel: string, data: any, windowId: number) {
+  mocks.fakeBrowserWindowId = windowId;
+  const handler = mocks.handlers.get(channel);
+  if (!handler) throw new Error(`No handler registered for ${channel}`);
+  return handler(event(), data);
+}
+
+describe('background watch refcount leak (Fix 1)', () => {
+  beforeEach(async () => {
+    mocks.handlers.clear();
+    mocks.windowStates.clear();
+    mocks.windows.clear();
+    mocks.documentServices.clear();
+    mocks.fileSystemServices.clear();
+    vi.clearAllMocks();
+    // The watcher is a module-level singleton shared across the whole file
+    // graph in production; reset it between tests so leftover state from a
+    // previous test can't mask (or fake) red/green here.
+    await optimizedWorkspaceWatcher.stopAll();
+    registerMultiProjectRailHandlers();
+  });
+
+  it('fully releases the background watch once the last of two windows sharing it unregisters', async () => {
+    mocks.windowStates.set(1, makeState({ workspacePath: '/ws/primary1' }));
+    mocks.windowStates.set(2, makeState({ workspacePath: '/ws/primary2' }));
+
+    // Both windows independently keep /ws/warm warm in their rail -- the real
+    // production path for two windows sharing a project (each user action
+    // goes through `workspace:register-additional`, which calls
+    // `startWarmWorkspaceWatch` -> `OptimizedWorkspaceWatcher.startBackground`).
+    await invoke('workspace:register-additional', { workspacePath: '/ws/warm' }, 1);
+    await invoke('workspace:register-additional', { workspacePath: '/ws/warm' }, 2);
+
+    expect(mocks.subscribe).toHaveBeenCalledTimes(1); // subscribe-once guarantee held
+    expect(optimizedWorkspaceWatcher.getBackgroundWatchPaths()).toEqual(['/ws/warm']);
+
+    // Window 1 closes the project from its rail first. Window 2 still
+    // references /ws/warm, so `anyWindowReferencesWorkspace` gates this
+    // release off -- nothing should be torn down yet.
+    await invoke('workspace:unregister-additional', { workspacePath: '/ws/warm' }, 1);
+
+    expect(mocks.unsubscribe).not.toHaveBeenCalled();
+    expect(optimizedWorkspaceWatcher.getBackgroundWatchPaths()).toEqual(['/ws/warm']);
+
+    // Window 2 is now the LAST window referencing /ws/warm. This is the
+    // provably-final release: `anyWindowReferencesWorkspace('/ws/warm')` is
+    // false by the time this call's gate check runs.
+    await invoke('workspace:unregister-additional', { workspacePath: '/ws/warm' }, 2);
+
+    // The bug: a plain per-caller decrement only drops the refcount from 2
+    // to 1 here (this is the ONLY gated release call that ever fires for this
+    // path), so the bus subscription and the refcount map entry never clear.
+    expect(mocks.unsubscribe).toHaveBeenCalledWith('/ws/warm', 'workspace-watcher-bg-/ws/warm');
+    expect(optimizedWorkspaceWatcher.getBackgroundWatchCount()).toBe(0);
+    expect(optimizedWorkspaceWatcher.getBackgroundWatchPaths()).toEqual([]);
+  });
+});

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -23,8 +23,10 @@ import {
     getMostRecentlyFocusedWorkspaceWindow,
 } from './window/WindowManager';
 import { beginStartupActivation, finishStartupWindowCreation } from './window/StartupActivation';
-import { loadFileIntoWindow } from './file/FileOperations';
-import { createApplicationMenu } from './menu/ApplicationMenu';
+import { loadFileIntoWindow, deliverAfterWorkspaceSeed } from './file/FileOperations';
+import { createApplicationMenu, updateApplicationMenu } from './menu/ApplicationMenu';
+import { setApplicationMenuRefresher } from './menu/applicationMenuRef';
+import { setWorkspaceOpener } from './window/workspaceOpenRef';
 import { updateNativeTheme, updateWindowTitleBars } from './theme/ThemeManager';
 import { restoreSessionState, saveSessionState } from './session/SessionState';
 import { setSafeModeSessionStateProtection } from './session/safeModeSessionState';
@@ -35,7 +37,7 @@ import {
     dispatchAppActionLink,
     type AppAction,
 } from './utils/appActionLinks';
-import { createWorkspaceManagerWindow, setupWorkspaceManagerHandlers, wasWorkspaceManagerManuallyClosed } from './window/WorkspaceManagerWindow.ts';
+import { createWorkspaceManagerWindow, openOrFocusWorkspaceWindow, openOrFocusWorkspaceWindowAwaitingRailSeed, setupWorkspaceManagerHandlers, wasWorkspaceManagerManuallyClosed } from './window/WorkspaceManagerWindow.ts';
 import { createTeamManagementWindow, setupTeamManagementHandlers } from './window/TeamManagementWindow';
 import { setupTrayPanelHandlers } from './window/TrayPanelWindow';
 import { applyDockIcon } from './utils/dockIcon';
@@ -102,7 +104,6 @@ import {
     shouldShowRosettaWarning,
     dismissRosettaWarning,
     getSessionSyncConfig,
-    addToRecentItems,
     getTheme,
     hasCheckedClaudeCodeInstallation,
     getLaunchCount,
@@ -497,6 +498,11 @@ let mcpConfigServiceCleanedUp = false;
 // live MCPConfigService without back-importing this entry-point file (which
 // would drag the whole app graph in at module load). See mcpConfigServiceRef.
 setMcpConfigServiceGetter(() => mcpConfigService);
+// Lets settings handlers rebuild the menu without importing the menu graph.
+setApplicationMenuRefresher(() => updateApplicationMenu());
+// Lets the MCP settings server open a project without importing the menu/
+// tracker-sync graph that the chokepoint's own module pulls in.
+setWorkspaceOpener((workspacePath) => openOrFocusWorkspaceWindow(workspacePath));
 
 export { getMcpConfigService } from './mcpConfigServiceRef';
 
@@ -1234,10 +1240,40 @@ async function openSharedDocumentFromDeepLink(documentId: string, orgId: string)
         return true;
     }
 
-    // No window has this workspace open — create one. The renderer's
-    // deep-link listener will drain the pending queue once it mounts.
-    logger.main.info('[DeepLink] Opening new window for shared doc workspace:', { workspacePath, documentId });
-    createWindow(false, true, workspacePath);
+    // No window has this workspace open — focus/add-to-rail/create one via
+    // the shared chokepoint. In Multi-Project Mode this may add the project
+    // to an already-loaded window's rail rather than a fresh one, in which
+    // case there is no mount for the renderer's deep-link listener to drain
+    // the pending queue from -- deliver the live event ourselves, same as
+    // the "existing window" branch above. The awaiting variant makes sure
+    // that live send only fires after the rail registration actually lands
+    // -- otherwise it can race the renderer and land on whichever project
+    // was visible before the switch (see WorkspaceManagerWindow.ts).
+    logger.main.info('[DeepLink] Opening window for shared doc workspace:', { workspacePath, documentId });
+    await deliverAfterWorkspaceSeed(
+        openOrFocusWorkspaceWindowAwaitingRailSeed(workspacePath),
+        (outcome) => {
+            if (outcome.kind !== 'new-window') {
+                outcome.window.webContents.send('deep-link:open-shared-document', {
+                    documentId,
+                    orgId,
+                    workspacePath,
+                });
+            }
+        },
+        (outcome) => {
+            // pendingSharedDocLinks already has this entry queued above; leave
+            // it queued rather than deleting it -- if a window for this
+            // workspace ever mounts later, its deep-link listener still
+            // drains it. There is no window it is currently safe to deliver
+            // the live event into.
+            logger.main.warn('[DeepLink] Rail seed did not land for shared doc workspace, not delivering:', {
+                workspacePath,
+                documentId,
+                reason: outcome?.reason ?? 'no-opener',
+            });
+        },
+    );
     return true;
 }
 
@@ -1276,8 +1312,29 @@ async function openSharedFolderFromDeepLink(folderId: string, orgId: string): Pr
         return;
     }
 
-    logger.main.info('[DeepLink] Opening new window for shared folder workspace:', { workspacePath, folderId });
-    createWindow(false, true, workspacePath);
+    logger.main.info('[DeepLink] Opening window for shared folder workspace:', { workspacePath, folderId });
+    await deliverAfterWorkspaceSeed(
+        openOrFocusWorkspaceWindowAwaitingRailSeed(workspacePath),
+        (outcome) => {
+            if (outcome.kind !== 'new-window') {
+                outcome.window.webContents.send('deep-link:open-shared-folder', {
+                    folderId,
+                    orgId,
+                    workspacePath,
+                });
+            }
+        },
+        (outcome) => {
+            // pendingSharedFolderLinks already has this entry queued above;
+            // leave it queued for a later mount, same reasoning as the
+            // shared-doc path.
+            logger.main.warn('[DeepLink] Rail seed did not land for shared folder workspace, not delivering:', {
+                workspacePath,
+                folderId,
+                reason: outcome?.reason ?? 'no-opener',
+            });
+        },
+    );
 }
 
 /**
@@ -1409,12 +1466,32 @@ async function openTrackerFromDeepLink(
         return true;
     }
 
-    logger.main.info('[DeepLink] Opening new window for tracker workspace:', {
+    logger.main.info('[DeepLink] Opening window for tracker workspace:', {
         workspacePath,
         trackerId,
         view,
     });
-    createWindow(false, true, workspacePath);
+    await deliverAfterWorkspaceSeed(
+        openOrFocusWorkspaceWindowAwaitingRailSeed(workspacePath),
+        (outcome) => {
+            if (outcome.kind !== 'new-window') {
+                outcome.window.webContents.send('deep-link:open-tracker', {
+                    ...trackerLink,
+                    workspacePath,
+                });
+            }
+        },
+        (outcome) => {
+            // pendingTrackerLinks already has this entry queued above; leave
+            // it queued for a later mount, same reasoning as the other deep
+            // links.
+            logger.main.warn('[DeepLink] Rail seed did not land for tracker workspace, not delivering:', {
+                workspacePath,
+                trackerId,
+                reason: outcome?.reason ?? 'no-opener',
+            });
+        },
+    );
     return true;
 }
 
@@ -1432,7 +1509,10 @@ app.on('open-file', (event, path) => {
 });
 
 // Helper function to open a file with workspace detection
-async function openFileWithWorkspaceDetection(filePath: string): Promise<void> {
+async function openFileWithWorkspaceDetection(
+    filePath: string,
+    options?: { seedTimeoutMs?: number },
+): Promise<void> {
     // Check if file is already open in a window
     const existingWindow = findWindowByFilePath(filePath);
     if (existingWindow) {
@@ -1440,68 +1520,71 @@ async function openFileWithWorkspaceDetection(filePath: string): Promise<void> {
         return;
     }
 
+    // Find/focus/add-to-rail/create the workspace window via the shared
+    // chokepoint, then deliver `filePath` into it. Sequenced through
+    // `openOrFocusWorkspaceWindowAwaitingRailSeed` so a rail add-to-rail
+    // outcome is not acted on until the project is actually registered and
+    // active in the target window -- delivering `open-document` before that
+    // lands would open the file against whatever project was visible before
+    // the switch (see WorkspaceManagerWindow.ts's doc comment). If the seed
+    // never lands ('at-cap' / 'timeout'), the file is not delivered anywhere
+    // rather than risk the wrong project.
+    const openWorkspaceAndLoadFile = async (targetWorkspacePath: string): Promise<void> => {
+        await deliverAfterWorkspaceSeed(
+            openOrFocusWorkspaceWindowAwaitingRailSeed(targetWorkspacePath, {
+                startupReveal: true,
+                startupFrontmost: true,
+                seedTimeoutMs: options?.seedTimeoutMs,
+            }),
+            (outcome) => {
+                if (outcome.kind === 'new-window') {
+                    updateTrackerSchemaWorkspace(targetWorkspacePath);
+                    // createWindow reveals the window itself — inactive while this
+                    // runs during launch, activating for a file opened later.
+                    outcome.window.once('ready-to-show', () => {
+                        loadFileIntoWindow(outcome.window, filePath, targetWorkspacePath);
+                    });
+                } else {
+                    // Window already loaded (existing, or just added to the rail)
+                    // - no need to focus, let macOS handle window ordering.
+                    loadFileIntoWindow(outcome.window, filePath, targetWorkspacePath);
+                }
+            },
+            (outcome) => {
+                logger.main.warn('[FileOpen] Rail seed did not land for workspace, not delivering file:', {
+                    workspacePath: targetWorkspacePath,
+                    filePath,
+                    reason: outcome?.reason ?? 'no-opener',
+                });
+            },
+        );
+    };
+
     // Detect which workspace this file belongs to
     const workspacePath = detectFileWorkspace(filePath);
 
     if (workspacePath) {
         // File belongs to a known workspace
         logger.main.info(`File belongs to workspace: ${workspacePath}`);
-
-        // Find or create workspace window
-        let workspaceWindow = findWindowByWorkspace(workspacePath);
-
-        if (workspaceWindow) {
-            // Workspace window exists, use it - no need to focus, let macOS handle window ordering
-            await loadFileIntoWindow(workspaceWindow, filePath);
-        } else {
-            // Create new workspace window for this workspace
-            workspaceWindow = createWindow(false, true, workspacePath, undefined, {
-                startupReveal: true,
-                startupFrontmost: true,
-            });
-            updateTrackerSchemaWorkspace(workspacePath);
-            // createWindow reveals the window itself — inactive while this runs
-            // during launch, activating for a file opened later.
-            workspaceWindow.once('ready-to-show', async () => {
-                // Window state is already set by createWindow with workspace path
-                // Just load the file
-                await loadFileIntoWindow(workspaceWindow!, filePath);
-            });
-        }
+        await openWorkspaceAndLoadFile(workspacePath);
     } else {
         // File is not in a known workspace - open it in the frontmost workspace window as an external file
         logger.main.info(`File not in known workspace, opening as external file in frontmost window`);
 
         const frontmostWindow = getMostRecentlyFocusedWorkspaceWindow();
         if (frontmostWindow) {
-            await loadFileIntoWindow(frontmostWindow, filePath);
+            loadFileIntoWindow(frontmostWindow, filePath);
         } else {
             // No workspace windows open - try to detect a project root and open it
             const suggestedWorkspace = suggestWorkspaceForFile(filePath);
             if (suggestedWorkspace && suggestedWorkspace !== path.dirname(filePath)) {
                 logger.main.info(`Opening suggested workspace: ${suggestedWorkspace}`);
-                addToRecentItems('workspaces', suggestedWorkspace, path.basename(suggestedWorkspace));
-                const newWindow = createWindow(false, true, suggestedWorkspace, undefined, {
-                    startupReveal: true,
-                    startupFrontmost: true,
-                });
-                updateTrackerSchemaWorkspace(suggestedWorkspace);
-                newWindow.once('ready-to-show', async () => {
-                    await loadFileIntoWindow(newWindow, filePath);
-                });
+                await openWorkspaceAndLoadFile(suggestedWorkspace);
             } else {
                 // No project root detected - use the file's directory as workspace
                 const fileDir = path.dirname(filePath);
                 logger.main.info(`Using file directory as workspace: ${fileDir}`);
-                addToRecentItems('workspaces', fileDir, path.basename(fileDir));
-                const newWindow = createWindow(false, true, fileDir, undefined, {
-                    startupReveal: true,
-                    startupFrontmost: true,
-                });
-                updateTrackerSchemaWorkspace(fileDir);
-                newWindow.once('ready-to-show', async () => {
-                    await loadFileIntoWindow(newWindow, filePath);
-                });
+                await openWorkspaceAndLoadFile(fileDir);
             }
         }
     }
@@ -2998,7 +3081,14 @@ app.whenReady().then(async () => {
         // Handle pending file with workspace detection
         const fileToOpen = pendingFilePath;
         pendingFilePath = null;
-        await openFileWithWorkspaceDetection(fileToOpen);
+        // This await gates `finishStartupWindowCreation()` below, so a
+        // rail-seed 'timeout' (default 2000ms, see railSeeding.ts) would
+        // delay Nimbalyst coming to the front by that much in the rare case
+        // multi-project restore already created a focused workspace window
+        // by the time this runs. Bound that worst case with a shorter
+        // startup-only timeout rather than threading a startup flag through
+        // every deep-link path too.
+        await openFileWithWorkspaceDetection(fileToOpen, { seedTimeoutMs: 750 });
     }
 
     // Handle pending deep link URL (e.g., auth callback)

--- a/packages/electron/src/main/ipc/MultiProjectRailHandlers.ts
+++ b/packages/electron/src/main/ipc/MultiProjectRailHandlers.ts
@@ -26,7 +26,13 @@ import {
     windowStates,
     documentServices,
 } from '../window/WindowManager';
-import { startWorkspaceWatcher, stopWorkspaceWatcher } from '../file/WorkspaceWatcher.ts';
+import {
+    startWorkspaceWatcher,
+    stopWorkspaceWatcher,
+    startWarmWorkspaceWatch,
+    releaseWarmWatchOnPromotion,
+    stopWarmWorkspaceWatch,
+} from '../file/WorkspaceWatcher.ts';
 import { anyWindowReferencesWorkspace, resolveDocumentServicePath } from '../window/windowState';
 import { ElectronDocumentService, setupDocumentServiceHandlers } from '../services/ElectronDocumentService';
 import { ElectronFileSystemService } from '../services/ElectronFileSystemService';
@@ -132,6 +138,13 @@ export function registerMultiProjectRailHandlers(): void {
         state.additionalWorkspacePaths = [...additional, workspacePath];
 
         ensureServicesForPath(window, workspacePath);
+        // Keep this warm-but-invisible project's editors observing disk
+        // changes and its commit detection running (see WorkspaceWatcher.ts
+        // for why this is safe to multiplex while the file tree push is
+        // deliberately not). Does NOT start the FULL watcher or flip the
+        // global FileSystemService -- those stay reserved for the active
+        // path (regression guard: workspace:set-active owns both).
+        startWarmWorkspaceWatch(workspacePath);
         addToRecentItems('workspaces', workspacePath, basename(workspacePath));
 
         return { success: true };
@@ -195,6 +208,20 @@ export function registerMultiProjectRailHandlers(): void {
             } catch (error) {
                 logger.main.error('[MultiProject] Error stopping MCP config watcher:', error);
             }
+
+            // Release the warm-project watch started by register-additional
+            // (or by the demote step in workspace:set-active). If the path
+            // was `wasActive` above, its background subscription was never
+            // created (it went straight from full-active to closed), so
+            // this just stops GitRefWatcher; for a plain rail close of a
+            // background project it releases both. `stopWorkspaceWatcher`
+            // above also sweeps any orphaned background watch for this
+            // window's OTHER paths, so this call plus that sweep together
+            // cover every path that was ever registered in this window
+            // except one still its window's active (never-backgrounded)
+            // path at close time -- see the sweep's comment in
+            // WorkspaceWatcher.ts for that residual gap.
+            stopWarmWorkspaceWatch(workspacePath);
         }
 
         return { success: true };
@@ -230,15 +257,32 @@ export function registerMultiProjectRailHandlers(): void {
             return { success: true, alreadyActive: true };
         }
 
-        // Transition: stop the watcher tied to the previous active path,
-        // start a fresh one for the new active path. The watcher API is
-        // single-active-per-window, so we always tear down + restart on
-        // every flip. Watcher is the only "active-only" main-process
-        // resource (services in `documentServices`/`fileSystemServices`
-        // remain warm for inactive rail projects).
+        // Transition: stop the FULL watcher tied to the previous active
+        // path, start a fresh one for the new active path. The
+        // OptimizedWorkspaceWatcher active-tree-push API is
+        // single-active-per-window, so we always tear down + restart that
+        // part on every flip. Watcher is otherwise not an "active-only"
+        // resource anymore (services in `documentServices`/
+        // `fileSystemServices` remain warm for inactive rail projects, and
+        // so now do file-change notifications + git commit detection --
+        // see WorkspaceWatcher.ts's warm-watch functions):
+        //
+        // 1. Demote the outgoing path to a background (content-only) watch
+        //    *before* tearing down its full subscription, so the shared OS
+        //    watcher for that path stays alive across the handoff instead
+        //    of being torn down and immediately recreated.
+        if (previousActive) {
+            startWarmWorkspaceWatch(previousActive);
+        }
         stopWorkspaceWatcher(windowId);
         state.activeWorkspacePath = workspacePath;
+
+        // 2. Promote the incoming path from a background watch (if it was
+        //    warm) to the full active watch, then drop the now-redundant
+        //    background subscription. GitRefWatcher.start() below is a
+        //    no-op if startWarmWorkspaceWatch already had it running.
         startWorkspaceWatcher(window, workspacePath);
+        releaseWarmWatchOnPromotion(workspacePath);
 
         // Flip the runtime-global FileSystemService so AI tools that resolve
         // via `getFileSystemService()` (no-arg) read from the visible

--- a/packages/electron/src/main/ipc/SettingsHandlers.ts
+++ b/packages/electron/src/main/ipc/SettingsHandlers.ts
@@ -59,6 +59,7 @@ import {
     updateSleepPrevention,
 } from '../services/SyncManager';
 import { getDocSyncStatusForWorkspace } from '../file/WorkspaceWatcher';
+import { refreshApplicationMenu } from '../menu/applicationMenuRef';
 import * as StytchAuth from '../services/StytchAuthService';
 import { getRestartSignalPath } from '../utils/appPaths';
 import { TrayManager } from '../tray/TrayManager';
@@ -629,6 +630,10 @@ export function registerSettingsHandlers() {
 
     safeHandle('app:set-multi-project-mode', async (_event, enabled: boolean) => {
         setMultiProjectMode(enabled);
+        // Rebuild the menu so items gated on multi-project mode (e.g. "Merge
+        // All Windows") pick up the new enabled/disabled state immediately,
+        // rather than staying stale until some unrelated rebuild happens.
+        refreshApplicationMenu();
     });
 
     safeHandle('app:get-open-projects', async () => {

--- a/packages/electron/src/main/ipc/__tests__/MultiProjectRailHandlers.test.ts
+++ b/packages/electron/src/main/ipc/__tests__/MultiProjectRailHandlers.test.ts
@@ -12,6 +12,9 @@ const mocks = vi.hoisted(() => {
     handlers,
     startWorkspaceWatcher: vi.fn(),
     stopWorkspaceWatcher: vi.fn(),
+    startWarmWorkspaceWatch: vi.fn(),
+    releaseWarmWatchOnPromotion: vi.fn(),
+    stopWarmWorkspaceWatch: vi.fn(),
     setFileSystemService: vi.fn(),
     clearFileSystemService: vi.fn(),
     setFileSystemServiceFor: vi.fn(),
@@ -38,6 +41,9 @@ vi.mock('../../utils/ipcRegistry', () => ({
 vi.mock('../../file/WorkspaceWatcher.ts', () => ({
   startWorkspaceWatcher: mocks.startWorkspaceWatcher,
   stopWorkspaceWatcher: mocks.stopWorkspaceWatcher,
+  startWarmWorkspaceWatch: mocks.startWarmWorkspaceWatch,
+  releaseWarmWatchOnPromotion: mocks.releaseWarmWatchOnPromotion,
+  stopWarmWorkspaceWatch: mocks.stopWarmWorkspaceWatch,
 }));
 
 vi.mock('@nimbalyst/runtime', () => ({
@@ -166,6 +172,9 @@ describe('MultiProjectRailHandlers', () => {
     mocks.windowStates.clear();
     mocks.startWorkspaceWatcher.mockReset();
     mocks.stopWorkspaceWatcher.mockReset();
+    mocks.startWarmWorkspaceWatch.mockReset();
+    mocks.releaseWarmWatchOnPromotion.mockReset();
+    mocks.stopWarmWorkspaceWatch.mockReset();
     mocks.setFileSystemService.mockReset();
     mocks.clearFileSystemService.mockReset();
     registerMultiProjectRailHandlers();
@@ -203,6 +212,12 @@ describe('MultiProjectRailHandlers', () => {
       mocks.windowStates.set(1, makeState({ workspacePath: '/ws/a' }));
       await invoke('workspace:register-additional', { workspacePath: '/ws/b' }, 1);
       expect(mocks.setFileSystemService).not.toHaveBeenCalled();
+    });
+
+    it('starts a warm (background-only) watch for the newly registered path', async () => {
+      mocks.windowStates.set(1, makeState({ workspacePath: '/ws/a' }));
+      await invoke('workspace:register-additional', { workspacePath: '/ws/b' }, 1);
+      expect(mocks.startWarmWorkspaceWatch).toHaveBeenCalledWith('/ws/b');
     });
 
     it('is idempotent for an already-registered path', async () => {
@@ -254,6 +269,29 @@ describe('MultiProjectRailHandlers', () => {
       expect(mocks.windowStates.get(1)?.activeWorkspacePath).toBe('/ws/b');
     });
 
+    it('demotes the outgoing path to a background watch and promotes the incoming one (Phase 2 staleness fix)', async () => {
+      await invoke('workspace:set-active', { workspacePath: '/ws/a' }, 1);
+      mocks.startWarmWorkspaceWatch.mockClear();
+      mocks.releaseWarmWatchOnPromotion.mockClear();
+
+      await invoke('workspace:set-active', { workspacePath: '/ws/b' }, 1);
+
+      // /ws/a (outgoing) is demoted to a background watch so its open
+      // editors keep observing disk changes while it's not visible.
+      expect(mocks.startWarmWorkspaceWatch).toHaveBeenCalledWith('/ws/a');
+      // /ws/b (incoming) drops its now-redundant background subscription
+      // once promoted to the full watch.
+      expect(mocks.releaseWarmWatchOnPromotion).toHaveBeenCalledWith('/ws/b');
+
+      // Demote must happen before the full watcher is torn down, so the
+      // shared OS watcher for the outgoing path survives the handoff.
+      const demoteOrder = mocks.startWarmWorkspaceWatch.mock.invocationCallOrder[0];
+      const stopOrder = mocks.stopWorkspaceWatcher.mock.invocationCallOrder[
+        mocks.stopWorkspaceWatcher.mock.invocationCallOrder.length - 1
+      ];
+      expect(demoteOrder).toBeLessThan(stopOrder);
+    });
+
     it('is idempotent when the path is already active', async () => {
       await invoke('workspace:set-active', { workspacePath: '/ws/a' }, 1);
       mocks.stopWorkspaceWatcher.mockClear();
@@ -301,6 +339,20 @@ describe('MultiProjectRailHandlers', () => {
 
       expect(mocks.documentServices.has('/ws/warm')).toBe(true);
       expect(mocks.fileSystemServices.has('/ws/warm')).toBe(true);
+    });
+
+    it('releases the warm watch (GitRefWatcher + background subscription) when no other window references the path', async () => {
+      await invoke('workspace:unregister-additional', { workspacePath: '/ws/warm' }, 1);
+
+      expect(mocks.stopWarmWorkspaceWatch).toHaveBeenCalledWith('/ws/warm');
+    });
+
+    it('does not release the warm watch when another window still references the path', async () => {
+      mocks.windowStates.set(2, makeState({ workspacePath: '/ws/warm' }));
+
+      await invoke('workspace:unregister-additional', { workspacePath: '/ws/warm' }, 1);
+
+      expect(mocks.stopWarmWorkspaceWatch).not.toHaveBeenCalled();
     });
 
     it('does not stop the watcher when the closed path was not active', async () => {

--- a/packages/electron/src/main/menu/ApplicationMenu.ts
+++ b/packages/electron/src/main/menu/ApplicationMenu.ts
@@ -28,7 +28,7 @@ import { existsSync } from 'fs';
 import * as fs from 'fs';
 import { windowStates, createWindow, findWindowByFilePath, getWindowId } from '../window/WindowManager';
 import { createAboutWindow } from '../window/AboutWindow';
-import { createWorkspaceManagerWindow } from '../window/WorkspaceManagerWindow.ts';
+import { createWorkspaceManagerWindow, openOrFocusWorkspaceWindow } from '../window/WorkspaceManagerWindow.ts';
 import { launchTutorialFromMenu } from './helpMenuActions';
 import {
     createTeamManagementWindow,
@@ -41,7 +41,8 @@ import { createDatabaseBrowserWindow } from '../window/DatabaseBrowserWindow';
 import { createDeveloperDashboardWindow } from '../window/DeveloperDashboardWindow';
 import { runDiffErgonomicsHarness } from '../file/DiffErgonomicsFixture';
 import { loadFileIntoWindow } from '../file/FileOperations';
-import { getRecentItems, clearRecentItems, addToRecentItems, getTheme, setTheme, store, getWorkspaceState, getWorkspaceWindowState, isExtensionDevToolsEnabled, setWorktreeOnboardingShown } from '../utils/store';
+import { getRecentItems, clearRecentItems, addToRecentItems, getTheme, setTheme, store, getWorkspaceState, getWorkspaceWindowState, isExtensionDevToolsEnabled, setWorktreeOnboardingShown, getMultiProjectMode } from '../utils/store';
+import { consolidateWorkspaceWindows } from '../window/consolidateWorkspaceWindows';
 import { updateWindowTitleBars, updateNativeTheme } from '../theme/ThemeManager';
 import { refreshWorkspaceFileTree } from '../file/FileWatcherDebug';
 import { getFolderContents } from '../utils/FileTree';
@@ -203,16 +204,15 @@ async function createRecentSubmenu(): Promise<any[]> {
                 click: async () => {
                     // Check if workspace exists
                     if (existsSync(workspace.path)) {
-                        // Check for saved workspace window state
+                        const outcome = openOrFocusWorkspaceWindow(workspace.path);
+
+                        // Restore dev tools if they were open. Only meaningful for a
+                        // brand-new window -- an existing/rail window is already
+                        // loaded, so 'did-finish-load' would never fire again.
                         const savedState = getWorkspaceWindowState(workspace.path);
-
-                        // Create window with saved bounds if available
-                        const window = createWindow(false, true, workspace.path, savedState?.bounds);
-
-                        // Restore dev tools if they were open
-                        if (savedState?.devToolsOpen) {
-                            window.webContents.once('did-finish-load', () => {
-                                window.webContents.openDevTools();
+                        if (outcome.kind === 'new-window' && savedState?.devToolsOpen) {
+                            outcome.window.webContents.once('did-finish-load', () => {
+                                outcome.window.webContents.openDevTools();
                             });
                         }
                     } else {
@@ -252,6 +252,12 @@ export async function createApplicationMenu() {
     // Drives the Messages menu and the two accelerators it borrows. Rebuilt on
     // every org-window focus transition (see registerTeamManagementFocusChange).
     const orgWindowFocused = isTeamManagementWindowFocused();
+    // "Merge All Windows" only makes sense with the rail on and more than
+    // one workspace window open to fold together.
+    const openWorkspaceWindowCount = Array.from(windowStates.values()).filter(
+        (state) => state.mode === 'workspace' || state.mode === 'agentic-coding'
+    ).length;
+    const canMergeAllWindows = getMultiProjectMode() && openWorkspaceWindowCount > 1;
 
     const template: any[] = [
         {
@@ -1157,6 +1163,41 @@ export async function createApplicationMenu() {
                 { label: 'Minimize', accelerator: KeyboardShortcuts.window.minimize, role: 'minimize' },
                 { type: 'separator' },
                 { label: 'Bring All to Front', role: 'front' },
+                {
+                    // Multi-Project Mode only changes routing for newly-opened
+                    // projects and the next launch; windows already open stay
+                    // open otherwise. This gives relief now without quitting.
+                    label: 'Merge All Windows',
+                    enabled: canMergeAllWindows,
+                    click: async () => {
+                        AnalyticsService.getInstance().sendEvent('menu_action_used', {
+                            menu: 'window',
+                            action: 'merge_all_windows',
+                        });
+
+                        const result = await consolidateWorkspaceWindows();
+                        if (!result.plan) return;
+
+                        if (result.refused.length > 0 || result.skippedWindowIds.length > 0) {
+                            const focused = getFocusedWindow();
+                            const details: string[] = [];
+                            if (result.refused.length > 0) {
+                                details.push('The project rail is full, so some projects could not be added.');
+                            }
+                            if (result.skippedWindowIds.length > 0) {
+                                details.push('Windows with unsaved changes were left open.');
+                            }
+                            if (focused) {
+                                dialog.showMessageBox(focused, {
+                                    type: 'info',
+                                    title: 'Some Windows Stayed Open',
+                                    message: 'Not every window could be merged.',
+                                    detail: details.join(' '),
+                                });
+                            }
+                        }
+                    }
+                },
                 { type: 'separator' },
                 ...createWindowListMenu()
             ]

--- a/packages/electron/src/main/menu/applicationMenuRef.ts
+++ b/packages/electron/src/main/menu/applicationMenuRef.ts
@@ -1,0 +1,29 @@
+// Indirection so modules that only need to *trigger* a menu rebuild do not
+// have to import `menu/ApplicationMenu` directly. That module pulls in the
+// AI usage-report window and the autoUpdater singleton, so a static import
+// from an IPC handler evaluates that whole graph at module load -- which
+// breaks unrelated suites in vitest's node environment (the same failure
+// mode `mcpConfigServiceRef.ts` exists to avoid).
+//
+// `index.ts` already owns the menu and registers the refresher at startup;
+// everyone else calls `refreshApplicationMenu()`.
+
+type Refresher = () => void | Promise<void>;
+
+let refresher: Refresher | null = null;
+
+export function setApplicationMenuRefresher(fn: Refresher): void {
+  refresher = fn;
+}
+
+/**
+ * Rebuild the application menu if a refresher has been registered.
+ * Fire-and-forget: callers are settings handlers that must not block on
+ * menu construction, and a rebuild failure must not fail the setting write.
+ */
+export function refreshApplicationMenu(): void {
+  if (!refresher) return;
+  void Promise.resolve(refresher()).catch(() => {
+    // A menu rebuild failure must never break the action that triggered it.
+  });
+}

--- a/packages/electron/src/main/services/ExtensionProjectScaffolder.ts
+++ b/packages/electron/src/main/services/ExtensionProjectScaffolder.ts
@@ -2,10 +2,8 @@ import { BrowserWindow, dialog, ipcMain } from 'electron';
 import { basename, dirname, join } from 'path';
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'fs';
 import { templates } from '../../../../extensions/extension-dev-kit/src/templates.ts';
-import { createWindow, findWindowByWorkspace } from '../window/WindowManager';
+import { openOrFocusWorkspaceWindow } from '../window/WorkspaceManagerWindow';
 import {
-  addToRecentItems,
-  getWorkspaceWindowState,
   isExtensionProjectIntroShown,
   setExtensionProjectIntroShown,
 } from '../utils/store';
@@ -49,16 +47,7 @@ function writeTemplateFiles(projectPath: string, files: Record<string, string>):
 }
 
 function openWorkspace(projectPath: string): void {
-  addToRecentItems('workspaces', projectPath, basename(projectPath));
-
-  const existingWindow = findWindowByWorkspace(projectPath);
-  if (existingWindow && !existingWindow.isDestroyed()) {
-    existingWindow.focus();
-    return;
-  }
-
-  const savedState = getWorkspaceWindowState(projectPath);
-  createWindow(false, true, projectPath, savedState?.bounds);
+  openOrFocusWorkspaceWindow(projectPath);
 }
 
 interface ExtensionProjectIntroDialogOptions {

--- a/packages/electron/src/main/services/NotificationService.ts
+++ b/packages/electron/src/main/services/NotificationService.ts
@@ -8,10 +8,14 @@ import { Notification, BrowserWindow, app, ipcMain, shell } from 'electron';
 import { logger } from '../utils/logger';
 import { isOSNotificationsEnabled, isNotifyWhenFocusedEnabled, isSessionBlockedNotificationsEnabled } from '../utils/store';
 import {
-  createWindow,
   findWindowByWorkspace,
   getMostRecentlyFocusedWorkspaceWindow,
 } from '../window/WindowManager';
+// Via the ref: importing the chokepoint's own module here would drag the
+// tracker-sync/tutorial/autoUpdater graph into every suite that reaches
+// NotificationService (the MCP interactive tools do).
+import { openWorkspaceAwaitingRailSeed } from '../window/workspaceOpenRef';
+import { deliverAfterWorkspaceSeed } from '../file/FileOperations';
 import type { SessionNotificationNavigationTarget } from '../../shared/sessionNotificationNavigation';
 import { composeNotificationTitle } from '../../shared/notificationTitle';
 import { resolveNotificationIcon, type NotificationKind } from './notificationIcons';
@@ -390,7 +394,7 @@ class NotificationService {
     }
 
     if (!targetWindow || targetWindow.isDestroyed()) {
-      this.openWorkspaceForNavigation(navigation);
+      void this.openWorkspaceForNavigation(navigation);
       return;
     }
 
@@ -403,8 +407,31 @@ class NotificationService {
   /**
    * Open a window for an unloaded project and queue the navigation for its
    * renderer to drain once the workspace is active.
+   *
+   * Uses `openOrFocusWorkspaceWindowAwaitingRailSeed` (not the sync
+   * `openOrFocusWorkspaceWindow`) and `deliverAfterWorkspaceSeed` to
+   * sequence the live `notification-clicked` send after the Multi-Project
+   * Mode rail-add actually lands, instead of firing it immediately against
+   * the fire-and-forget seed. Sending it immediately raced the renderer's
+   * own `rail:add-project` listener (`store/listeners/railProjectListeners.ts`)
+   * into independently repeating the same register+activate work that
+   * `notification-clicked`'s `activateWorkspace()` also does -- both idempotent,
+   * but at `MAX_OPEN_PROJECTS` each side independently detects the cap and
+   * shows its own differently-worded "rail full" toast for one click. Awaiting
+   * the seed first means the renderer has already registered+activated by
+   * the time `notification-clicked` arrives on success, so
+   * `activateWorkspace()`'s own "already active" check short-circuits
+   * instead of repeating the add.
+   *
+   * `pendingNavigations` is set SYNCHRONOUSLY, before the first `await`, so
+   * a second click on the same still-opening workspace lands on
+   * `takeLivePendingNavigation`'s "still opening" guard in
+   * `handleNotificationClick` instead of racing a second call into this
+   * method -- for the Multi-Project Mode add-to-rail path that second call
+   * would fire a second `rail:add-project` seed, the exact duplicate-flow
+   * shape this fix exists to remove.
    */
-  private openWorkspaceForNavigation(navigation: SessionNotificationNavigationTarget): void {
+  private async openWorkspaceForNavigation(navigation: SessionNotificationNavigationTarget): Promise<void> {
     const { workspacePath } = navigation;
     this.pendingNavigations.set(workspacePath, { target: navigation, queuedAt: Date.now() });
     logger.main.info('[NotificationService] Opening workspace for notification:', {
@@ -412,20 +439,77 @@ class NotificationService {
       sessionId: navigation.sessionId,
     });
 
-    let openedWindow: BrowserWindow | undefined;
     try {
-      openedWindow = createWindow(false, true, workspacePath);
+      await deliverAfterWorkspaceSeed(
+        openWorkspaceAwaitingRailSeed(workspacePath),
+        (outcome) => {
+          if (outcome.kind !== 'new-window') {
+            // Multi-Project Mode added the project to an already-loaded
+            // window's rail (or it was already open) -- there is no fresh
+            // mount for the renderer's deep-link-style queue drain to hook
+            // into, so deliver the navigation live, the same way an
+            // already-open workspace is handled above in
+            // handleNotificationClick. Nothing left to queue-drain.
+            //
+            // Read the pending entry (not the closed-over `navigation`)
+            // before deleting it: a second click on this still-opening
+            // workspace overwrote it with a newer target in
+            // `handleNotificationClick`'s "still opening" branch, and that
+            // second click never gets its own `openWorkspaceForNavigation`
+            // call to deliver from -- sending the stale first-click target
+            // here would silently open the wrong session.
+            const latest = this.pendingNavigations.get(workspacePath)?.target ?? navigation;
+            this.pendingNavigations.delete(workspacePath);
+            if (outcome.window.isMinimized()) outcome.window.restore();
+            outcome.window.focus();
+            outcome.window.show();
+            outcome.window.webContents.send('notification-clicked', latest);
+            return;
+          }
+
+          // Drop the queued target if the window never gets far enough to
+          // drain it. Otherwise the stale entry makes every later click for
+          // this workspace a no-op, and a much later manual open would jump
+          // to a stale session.
+          this.evictPendingNavigationOnWindowLoss(outcome.window, workspacePath);
+        },
+        (outcome) => {
+          // Same "read before delete" reasoning as the success branch above:
+          // a second click may have overwritten the pending target.
+          const latest = this.pendingNavigations.get(workspacePath)?.target ?? navigation;
+          this.pendingNavigations.delete(workspacePath);
+          logger.main.warn('[NotificationService] Rail seed did not land for notification workspace:', {
+            workspacePath,
+            sessionId: latest.sessionId,
+            reason: outcome?.reason ?? 'no-opener',
+          });
+          // 'at-cap': the renderer's own `rail:add-project` listener
+          // (`railProjectListeners.ts`) already showed the "rail full" toast
+          // for the refused seed, in the SAME rail window
+          // `openOrFocusWorkspaceWindowAwaitingRailSeed` just focused.
+          // `reportNavigationFailure` delivers `notification-clicked` to
+          // `getMostRecentlyFocusedWorkspaceWindow()` -- in production that
+          // IS this same rail window -- and `activateWorkspace()` would
+          // retry the identical refused add and show a second,
+          // differently-worded toast for one click. Log only; there is no
+          // window it is safe to deliver into.
+          //
+          // 'timeout': ambiguous whether the add landed, but nothing was
+          // shown to the user either way, so still surface a failure.
+          // A null outcome (opener not registered) showed the user nothing
+          // either, so it belongs with 'timeout', not with the silent
+          // 'at-cap' case the renderer already toasted.
+          if (!outcome || outcome.reason === 'timeout') {
+            this.reportNavigationFailure(latest);
+          }
+        },
+      );
     } catch (error) {
+      const latest = this.pendingNavigations.get(workspacePath)?.target ?? navigation;
       this.pendingNavigations.delete(workspacePath);
       logger.main.error('[NotificationService] Failed to open notification workspace:', error);
-      this.reportNavigationFailure(navigation);
-      return;
+      this.reportNavigationFailure(latest);
     }
-
-    // Drop the queued target if the window never gets far enough to drain it.
-    // Otherwise the stale entry makes every later click for this workspace a
-    // no-op, and a much later manual open would jump to a stale session.
-    this.evictPendingNavigationOnWindowLoss(openedWindow, workspacePath);
   }
 
   private evictPendingNavigationOnWindowLoss(

--- a/packages/electron/src/main/services/SettingsControlService.ts
+++ b/packages/electron/src/main/services/SettingsControlService.ts
@@ -55,8 +55,7 @@ import { FeatureUsageService, FEATURES } from './FeatureUsageService';
 import { SessionNamingService } from './SessionNamingService';
 import { setTrackerIssueKeyPrefix } from './TrackerSyncManager';
 import { updateNativeTheme, updateWindowTitleBars } from '../theme/ThemeManager';
-import { createWindow, findWindowByWorkspace } from '../window/WindowManager';
-import { getWorkspaceWindowState } from '../utils/store';
+import { openWorkspace } from '../window/workspaceOpenRef';
 
 // ─── Allow / deny lists ─────────────────────────────────────────────
 
@@ -257,13 +256,10 @@ export class SettingsControlService {
   }
 
   private openWorkspaceInternal(workspacePath: string): void {
-    const existing = findWindowByWorkspace(workspacePath);
-    if (existing && !existing.isDestroyed()) {
-      existing.focus();
-      return;
-    }
-    const savedState = getWorkspaceWindowState(workspacePath);
-    createWindow(false, true, workspacePath, savedState?.bounds);
+    // Via the ref, not a direct import: pulling in the chokepoint's module
+    // here would drag the tracker-sync/tutorial/autoUpdater graph into every
+    // suite that touches the MCP settings server.
+    openWorkspace(workspacePath);
   }
 
   // ── Sync ─────────────────────────────────────────────────────────

--- a/packages/electron/src/main/services/__tests__/NotificationService.agentNotification.test.ts
+++ b/packages/electron/src/main/services/__tests__/NotificationService.agentNotification.test.ts
@@ -18,8 +18,8 @@ const mocks = vi.hoisted(() => ({
   notifyWhenFocusedEnabled: vi.fn(() => false),
   sessionBlockedNotificationsEnabled: vi.fn(() => true),
   findWindowByWorkspace: vi.fn(),
-  createWindow: vi.fn(),
   getMostRecentlyFocusedWorkspaceWindow: vi.fn(),
+  openOrFocusWorkspaceWindowAwaitingRailSeed: vi.fn(),
 }));
 
 vi.mock('electron', () => {
@@ -96,7 +96,6 @@ vi.mock('../../utils/store', () => ({
 
 vi.mock('../../window/WindowManager', () => ({
   findWindowByWorkspace: mocks.findWindowByWorkspace,
-  createWindow: mocks.createWindow,
   getMostRecentlyFocusedWorkspaceWindow: mocks.getMostRecentlyFocusedWorkspaceWindow,
 }));
 
@@ -104,6 +103,14 @@ vi.mock('../../window/WindowManager', () => ({
 // also prove the assets exist on disk.
 vi.mock('../../utils/appPaths', () => ({
   getPackageRoot: () => fileURLToPath(new URL('../../../../', import.meta.url)),
+}));
+
+// Mocks the ref module, which is what NotificationService actually imports.
+// Pointing this at `window/WorkspaceManagerWindow` would be a silent no-op
+// (CLAUDE.md: a vi.mock whose specifier the module no longer imports does
+// nothing) AND would let the real heavy module load.
+vi.mock('../../window/workspaceOpenRef', () => ({
+  openWorkspaceAwaitingRailSeed: mocks.openOrFocusWorkspaceWindowAwaitingRailSeed,
 }));
 
 import { existsSync } from 'node:fs';
@@ -157,6 +164,16 @@ function makeFakeWindow(): FakeWindow {
   };
 }
 
+/**
+ * `openWorkspaceForNavigation` awaits `openOrFocusWorkspaceWindowAwaitingRailSeed`
+ * (see Fix 2: sequencing the live `notification-clicked` send after the rail
+ * seed lands instead of racing it) -- flush the microtask queue so mocked
+ * promise resolutions settle before assertions run.
+ */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 async function clickNotification(options: {
   sessionId?: string;
   workspacePath: string;
@@ -168,6 +185,7 @@ async function clickNotification(options: {
     ...options,
   });
   mocks.notificationListeners.get('click')?.();
+  await flushMicrotasks();
 }
 
 describe('NotificationService agent notifications', () => {
@@ -183,7 +201,7 @@ describe('NotificationService agent notifications', () => {
     mocks.sessionBlockedNotificationsEnabled.mockReturnValue(true);
     mocks.findWindowByWorkspace.mockReturnValue(null);
     mocks.getMostRecentlyFocusedWorkspaceWindow.mockReturnValue(null);
-    mocks.createWindow.mockReturnValue(makeFakeWindow());
+    mocks.openOrFocusWorkspaceWindowAwaitingRailSeed.mockResolvedValue({ kind: 'new-window', window: makeFakeWindow() });
     clearNotificationIconCache();
   });
 
@@ -346,19 +364,168 @@ describe('NotificationService agent notifications', () => {
       sourceLabel: 'Build release',
     });
     mocks.notificationListeners.get('click')?.();
+    await flushMicrotasks();
 
-    expect(mocks.createWindow).toHaveBeenCalledTimes(1);
-    expect(mocks.createWindow).toHaveBeenCalledWith(
-      false,
-      true,
-      '/workspace/unloaded',
-    );
+    expect(mocks.openOrFocusWorkspaceWindowAwaitingRailSeed).toHaveBeenCalledTimes(1);
+    expect(mocks.openOrFocusWorkspaceWindowAwaitingRailSeed).toHaveBeenCalledWith('/workspace/unloaded');
     expect(
       (notificationService as any).consumePendingNavigation('/workspace/unloaded'),
     ).toEqual({
       sessionId: 'session-unloaded',
       workspacePath: '/workspace/unloaded',
       sourceLabel: 'Build release',
+    });
+  });
+
+  it('delivers the navigation live instead of queuing when Multi-Project Mode adds the project to an already-loaded rail window', async () => {
+    const railWindow = makeFakeWindow();
+    mocks.openOrFocusWorkspaceWindowAwaitingRailSeed.mockResolvedValue({ kind: 'add-to-rail', window: railWindow });
+
+    await clickNotification({
+      sessionId: 'session-rail',
+      workspacePath: '/workspace/rail',
+      sourceLabel: 'Rail task',
+    });
+
+    expect(railWindow.focus).toHaveBeenCalled();
+    expect(railWindow.show).toHaveBeenCalled();
+    expect(railWindow.webContents.send).toHaveBeenCalledWith('notification-clicked', {
+      sessionId: 'session-rail',
+      workspacePath: '/workspace/rail',
+      sourceLabel: 'Rail task',
+    });
+    // No fresh mount to drain a queue entry from -- it must not be queued.
+    expect(notificationService.consumePendingNavigation('/workspace/rail')).toBeNull();
+  });
+
+  it('does not deliver notification-clicked anywhere when the rail seed is refused at the project cap (Fix 2: avoids a duplicate "rail full" toast)', async () => {
+    // `openOrFocusWorkspaceWindowAwaitingRailSeed` focuses the rail window
+    // before seeding, so in production `getMostRecentlyFocusedWorkspaceWindow`
+    // resolves to that SAME window once the seed is refused -- not some
+    // other window. Modeling them as the same fake is what pins the bug:
+    // `reportNavigationFailure` sending `notification-clicked` here would
+    // land in the rail window whose renderer already showed the "rail full"
+    // toast for this exact refused add.
+    const railWindow = makeFakeWindow();
+    mocks.openOrFocusWorkspaceWindowAwaitingRailSeed.mockResolvedValue({
+      kind: 'blocked',
+      reason: 'at-cap',
+      window: railWindow,
+    });
+    mocks.getMostRecentlyFocusedWorkspaceWindow.mockReturnValue(railWindow);
+
+    await clickNotification({
+      sessionId: 'session-capped',
+      workspacePath: '/workspace/capped',
+      sourceLabel: 'Capped task',
+    });
+
+    // The renderer's own `rail:add-project` listener already showed the
+    // "rail full" toast for the refused seed -- delivering
+    // `notification-clicked` anywhere here would make `activateWorkspace()`
+    // retry the same add and show a second, differently-worded toast for
+    // one click. No window should receive it.
+    expect(railWindow.webContents.send).not.toHaveBeenCalledWith(
+      'notification-clicked',
+      expect.anything(),
+    );
+    expect(notificationService.consumePendingNavigation('/workspace/capped')).toBeNull();
+  });
+
+  it('reports the failure once when the rail seed ack times out (Fix 2: distinct from at-cap, nothing was shown to the user)', async () => {
+    const railWindow = makeFakeWindow();
+    mocks.openOrFocusWorkspaceWindowAwaitingRailSeed.mockResolvedValue({
+      kind: 'blocked',
+      reason: 'timeout',
+      window: railWindow,
+    });
+    const fallback = makeFakeWindow();
+    mocks.getMostRecentlyFocusedWorkspaceWindow.mockReturnValue(fallback);
+
+    await clickNotification({
+      sessionId: 'session-timeout',
+      workspacePath: '/workspace/timeout',
+      sourceLabel: 'Timeout task',
+    });
+
+    expect(fallback.webContents.send).toHaveBeenCalledTimes(1);
+    expect(fallback.webContents.send).toHaveBeenCalledWith('notification-clicked', {
+      sessionId: 'session-timeout',
+      workspacePath: '/workspace/timeout',
+      sourceLabel: 'Timeout task',
+    });
+    expect(notificationService.consumePendingNavigation('/workspace/timeout')).toBeNull();
+  });
+
+  it('does not race a second rail seed when the same still-opening workspace is clicked again before the first seed resolves (Fix 2)', async () => {
+    const railWindow = makeFakeWindow();
+    let resolveSeed: (outcome: { kind: 'add-to-rail'; window: typeof railWindow }) => void;
+    mocks.openOrFocusWorkspaceWindowAwaitingRailSeed.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSeed = resolve;
+      }),
+    );
+
+    await notificationService.showNotification({
+      title: 'Response Ready',
+      body: 'Ready for review',
+      sessionId: 'session-first-click',
+      workspacePath: '/workspace/racy',
+      sourceLabel: 'Racy task',
+    });
+    // First click: the seed is in flight, unresolved.
+    mocks.notificationListeners.get('click')?.();
+    // Second click lands before the seed resolves -- the synchronous
+    // `pendingNavigations` write from the first click must make this one a
+    // no-op ("still opening") rather than firing a second seed.
+    mocks.notificationListeners.get('click')?.();
+
+    expect(mocks.openOrFocusWorkspaceWindowAwaitingRailSeed).toHaveBeenCalledTimes(1);
+
+    resolveSeed!({ kind: 'add-to-rail', window: railWindow });
+    await flushMicrotasks();
+
+    expect(railWindow.webContents.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers the LATEST clicked session, not the first, when a second click lands on the same still-opening rail add before the seed resolves (Fix 2)', async () => {
+    const railWindow = makeFakeWindow();
+    let resolveSeed: (outcome: { kind: 'add-to-rail'; window: typeof railWindow }) => void;
+    mocks.openOrFocusWorkspaceWindowAwaitingRailSeed.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSeed = resolve;
+      }),
+    );
+
+    await notificationService.showNotification({
+      title: 'First task -- Response Ready',
+      body: 'First response',
+      sessionId: 'session-first',
+      workspacePath: '/workspace/racy-sessions',
+      sourceLabel: 'First task',
+    });
+    mocks.notificationListeners.get('click')?.();
+
+    await notificationService.showNotification({
+      title: 'Second task -- Response Ready',
+      body: 'Second response',
+      sessionId: 'session-second',
+      workspacePath: '/workspace/racy-sessions',
+      sourceLabel: 'Second task',
+    });
+    // Still opening -- this click overwrites the queued target with
+    // session-second instead of firing a second seed.
+    mocks.notificationListeners.get('click')?.();
+    expect(mocks.openOrFocusWorkspaceWindowAwaitingRailSeed).toHaveBeenCalledTimes(1);
+
+    resolveSeed!({ kind: 'add-to-rail', window: railWindow });
+    await flushMicrotasks();
+
+    expect(railWindow.webContents.send).toHaveBeenCalledTimes(1);
+    expect(railWindow.webContents.send).toHaveBeenCalledWith('notification-clicked', {
+      sessionId: 'session-second',
+      workspacePath: '/workspace/racy-sessions',
+      sourceLabel: 'Second task',
     });
   });
 
@@ -370,6 +537,9 @@ describe('NotificationService agent notifications', () => {
       workspacePath: '/workspace/opening',
       sourceLabel: 'First task',
     });
+    // `pendingNavigations` is written synchronously (before any await), so
+    // the second click below sees "still opening" immediately -- no flush
+    // needed between the two clicks.
     mocks.notificationListeners.get('click')?.();
 
     await notificationService.showNotification({
@@ -380,8 +550,9 @@ describe('NotificationService agent notifications', () => {
       sourceLabel: 'Second task',
     });
     mocks.notificationListeners.get('click')?.();
+    await flushMicrotasks();
 
-    expect(mocks.createWindow).toHaveBeenCalledTimes(1);
+    expect(mocks.openOrFocusWorkspaceWindowAwaitingRailSeed).toHaveBeenCalledTimes(1);
     expect(notificationService.consumePendingNavigation('/workspace/opening')).toEqual({
       sessionId: 'session-second',
       workspacePath: '/workspace/opening',
@@ -391,14 +562,14 @@ describe('NotificationService agent notifications', () => {
 
   it('re-opens the workspace after the opening window is lost before draining', async () => {
     const opened = makeFakeWindow();
-    mocks.createWindow.mockReturnValue(opened);
+    mocks.openOrFocusWorkspaceWindowAwaitingRailSeed.mockResolvedValue({ kind: 'new-window', window: opened });
 
     await clickNotification({
       sessionId: 'session-lost',
       workspacePath: '/workspace/lost',
       sourceLabel: 'Lost task',
     });
-    expect(mocks.createWindow).toHaveBeenCalledTimes(1);
+    expect(mocks.openOrFocusWorkspaceWindowAwaitingRailSeed).toHaveBeenCalledTimes(1);
 
     // The window dies before its renderer ever drains the queued target.
     opened.lifecycleListeners.get('closed')?.();
@@ -409,7 +580,7 @@ describe('NotificationService agent notifications', () => {
       sourceLabel: 'Lost task',
     });
 
-    expect(mocks.createWindow).toHaveBeenCalledTimes(2);
+    expect(mocks.openOrFocusWorkspaceWindowAwaitingRailSeed).toHaveBeenCalledTimes(2);
     expect(notificationService.consumePendingNavigation('/workspace/lost')).toEqual({
       sessionId: 'session-lost-again',
       workspacePath: '/workspace/lost',
@@ -419,7 +590,7 @@ describe('NotificationService agent notifications', () => {
 
   it('keeps the queued navigation when only a sub-frame fails to load', async () => {
     const opened = makeFakeWindow();
-    mocks.createWindow.mockReturnValue(opened);
+    mocks.openOrFocusWorkspaceWindowAwaitingRailSeed.mockResolvedValue({ kind: 'new-window', window: opened });
 
     await clickNotification({
       sessionId: 'session-subframe',
@@ -447,7 +618,7 @@ describe('NotificationService agent notifications', () => {
         workspacePath: '/workspace/stale',
         sourceLabel: 'Stale task',
       });
-      expect(mocks.createWindow).toHaveBeenCalledTimes(1);
+      expect(mocks.openOrFocusWorkspaceWindowAwaitingRailSeed).toHaveBeenCalledTimes(1);
 
       nowSpy.mockReturnValue(1_000 + 120_000);
       expect(notificationService.consumePendingNavigation('/workspace/stale')).toBeNull();
@@ -457,7 +628,7 @@ describe('NotificationService agent notifications', () => {
         workspacePath: '/workspace/stale',
         sourceLabel: 'Stale task',
       });
-      expect(mocks.createWindow).toHaveBeenCalledTimes(2);
+      expect(mocks.openOrFocusWorkspaceWindowAwaitingRailSeed).toHaveBeenCalledTimes(2);
     } finally {
       nowSpy.mockRestore();
     }
@@ -468,7 +639,7 @@ describe('NotificationService agent notifications', () => {
     mocks.browserWindows = [offscreen];
     const workspaceWindow = makeFakeWindow();
     mocks.getMostRecentlyFocusedWorkspaceWindow.mockReturnValue(workspaceWindow);
-    mocks.createWindow.mockImplementation(() => {
+    mocks.openOrFocusWorkspaceWindowAwaitingRailSeed.mockImplementation(() => {
       throw new Error('workspace is not trusted');
     });
 
@@ -490,7 +661,7 @@ describe('NotificationService agent notifications', () => {
 
   it('falls back to an OS notification when no workspace window can report the failure', async () => {
     mocks.getMostRecentlyFocusedWorkspaceWindow.mockReturnValue(null);
-    mocks.createWindow.mockImplementation(() => {
+    mocks.openOrFocusWorkspaceWindowAwaitingRailSeed.mockImplementation(() => {
       throw new Error('workspace is not trusted');
     });
 
@@ -519,7 +690,7 @@ describe('NotificationService agent notifications', () => {
       'notification-clicked',
       expect.anything(),
     );
-    expect(mocks.createWindow).not.toHaveBeenCalled();
+    expect(mocks.openOrFocusWorkspaceWindowAwaitingRailSeed).not.toHaveBeenCalled();
   });
 
   it('bounds a blocked notification title built from a long session name', async () => {

--- a/packages/electron/src/main/services/__tests__/SettingsControlService.test.ts
+++ b/packages/electron/src/main/services/__tests__/SettingsControlService.test.ts
@@ -55,9 +55,8 @@ vi.mock('../../theme/ThemeManager', () => ({
   updateWindowTitleBars: vi.fn(),
 }));
 
-vi.mock('../../window/WindowManager', () => ({
-  createWindow: vi.fn(),
-  findWindowByWorkspace: vi.fn(() => null),
+vi.mock('../../window/WorkspaceManagerWindow', () => ({
+  openOrFocusWorkspaceWindow: vi.fn(),
 }));
 
 vi.mock('../../utils/logger', () => ({

--- a/packages/electron/src/main/services/ai/AIService.ts
+++ b/packages/electron/src/main/services/ai/AIService.ts
@@ -57,8 +57,9 @@ import { TrayManager } from '../../tray/TrayManager';
 import { logger } from '../../utils/logger';
 import { getSettingsService } from '../SettingsService';
 import { subscribeProviderSettingsInvalidation } from './providerSettingsCacheInvalidation';
-import { windowStates, findWindowByWorkspace, getWindowId, createWindow, isAppQuitting } from '../../window/WindowManager';
+import { windowStates, findWindowByWorkspace, getWindowId, createWindow, getMostRecentlyFocusedWorkspaceWindow, isAppQuitting } from '../../window/WindowManager';
 import { resolveActiveWorkspacePathForWindowId } from '../../window/windowState';
+import { RAIL_ADD_PROJECT_CHANNEL, resolveProjectOpenTarget } from '../../window/resolveProjectOpenTarget';
 import { sessionFileTracker } from '../SessionFileTracker';
 import { extractFilePath } from './tools/extractFilePath';
 import { handleBackendTool } from '../../mcp/tools/backendToolHandler';
@@ -82,7 +83,8 @@ import {
   shouldShowCommunityPopup,
   wasCommunityPopupShownThisLaunch,
   getDefaultEffortLevel,
-  getDefaultThinkingMode
+  getDefaultThinkingMode,
+  getMultiProjectMode
 } from '../../utils/store';
 import { mergeAISettings, getAIProviderOverridesWithWorktreeFallback } from '../../utils/aiSettingsMerge';
 import { DocumentContextService, type RawDocumentContext, type PreparedDocumentContext } from '@nimbalyst/runtime';
@@ -323,7 +325,24 @@ export class AIService {
     findWindow: (workspacePath) => findWindowByWorkspace(workspacePath),
     isDestroyed: (window) => window.isDestroyed(),
     workspaceExists: (workspacePath) => fs.existsSync(workspacePath),
-    createWindow: (workspacePath) => createWindow(false, true, workspacePath),
+    // Same "focus existing / add to rail / new window" decision the
+    // openOrFocusWorkspaceWindow chokepoint makes, inlined via the shared
+    // pure resolver rather than importing WorkspaceManagerWindow directly
+    // (this dep interface exists specifically to avoid that coupling).
+    openWorkspace: (workspacePath) => {
+      const target = resolveProjectOpenTarget({
+        workspacePath,
+        multiProjectModeEnabled: getMultiProjectMode(),
+        existingWindowForPath: null, // caller already confirmed no live window has this path
+        focusedWorkspaceWindow: getMostRecentlyFocusedWorkspaceWindow(),
+      });
+      if (target.kind === 'add-to-rail') {
+        target.window.focus();
+        target.window.webContents.send(RAIL_ADD_PROJECT_CHANNEL, { workspacePath });
+        return { window: target.window, isNewWindow: false };
+      }
+      return { window: createWindow(false, true, workspacePath), isNewWindow: true };
+    },
     waitForLoad: (window) =>
       new Promise<void>((resolve) => {
         window.webContents.once('did-finish-load', () => resolve());

--- a/packages/electron/src/main/services/ai/__tests__/resolveWorkspaceWindow.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/resolveWorkspaceWindow.test.ts
@@ -17,10 +17,10 @@ function createHarness(overrides: Partial<WorkspaceWindowResolverDeps<FakeWindow
   let clock = 1_000;
   let resolveLoad: (() => void) | null = null;
 
-  const createWindow = vi.fn((workspacePath: string) => {
+  const openWorkspace = vi.fn((workspacePath: string) => {
     const window = { id: nextId++, destroyed: false };
     windows.set(workspacePath, window);
-    return window;
+    return { window, isNewWindow: true };
   });
 
   const waitForLoad = vi.fn(
@@ -34,7 +34,7 @@ function createHarness(overrides: Partial<WorkspaceWindowResolverDeps<FakeWindow
     findWindow: (workspacePath) => windows.get(workspacePath) ?? null,
     isDestroyed: (window) => window.destroyed,
     workspaceExists: () => true,
-    createWindow,
+    openWorkspace,
     waitForLoad,
     isQuitting: () => false,
     now: () => clock,
@@ -46,7 +46,7 @@ function createHarness(overrides: Partial<WorkspaceWindowResolverDeps<FakeWindow
   return {
     resolver: createWorkspaceWindowResolver(deps),
     windows,
-    createWindow,
+    createWindow: openWorkspace,
     finishLoad: () => resolveLoad?.(),
     advance: (ms: number) => {
       clock += ms;
@@ -75,6 +75,20 @@ describe('resolveWorkspaceWindow', () => {
     expect(harness.createWindow).toHaveBeenCalledTimes(1);
     expect(result.kind).toBe('window');
     expect(result.kind === 'window' && result.opened).toBe(true);
+  });
+
+  it('does not wait for load when the workspace was added to an already-loaded rail window', async () => {
+    const railWindow: FakeWindow = { id: 99, destroyed: false };
+    const waitForLoad = vi.fn(() => new Promise<void>(() => {}));
+    const harness = createHarness({
+      openWorkspace: vi.fn(() => ({ window: railWindow, isNewWindow: false })),
+      waitForLoad,
+    });
+
+    const result = await harness.resolver.resolve('/ws');
+
+    expect(waitForLoad).not.toHaveBeenCalled();
+    expect(result).toEqual({ kind: 'window', window: railWindow, opened: true });
   });
 
   it('opens one window for two rapid prompts on the same workspace', async () => {

--- a/packages/electron/src/main/services/ai/resolveWorkspaceWindow.ts
+++ b/packages/electron/src/main/services/ai/resolveWorkspaceWindow.ts
@@ -25,8 +25,15 @@ export interface WorkspaceWindowResolverDeps<W> {
   isDestroyed(window: W): boolean;
   /** Does the project folder still exist on disk? */
   workspaceExists(workspacePath: string): boolean;
-  createWindow(workspacePath: string): W;
-  /** Resolve once the new window's renderer has finished loading. */
+  /**
+   * Open `workspacePath` when no live window has it -- focuses an existing
+   * workspace window and adds the project to its rail (Multi-Project Mode),
+   * or spawns a brand-new window. `isNewWindow` tells the resolver whether
+   * the window still needs to finish loading: an add-to-rail window is
+   * already loaded, so `waitForLoad` would never resolve for it.
+   */
+  openWorkspace(workspacePath: string): { window: W; isNewWindow: boolean };
+  /** Resolve once a newly-created window's renderer has finished loading. */
   waitForLoad(window: W): Promise<void>;
   isQuitting(): boolean;
   now(): number;
@@ -95,8 +102,10 @@ export function createWorkspaceWindowResolver<W>(
 
       const openPromise = (async () => {
         try {
-          const created = deps.createWindow(workspacePath);
-          await deps.waitForLoad(created);
+          const { window: created, isNewWindow } = deps.openWorkspace(workspacePath);
+          if (isNewWindow) {
+            await deps.waitForLoad(created);
+          }
           return created;
         } catch (error) {
           deps.logWarn(

--- a/packages/electron/src/main/services/tutorial/TutorialProjectService.ts
+++ b/packages/electron/src/main/services/tutorial/TutorialProjectService.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../../shared/tutorial";
 import {
   addToRecentItems,
+  getMultiProjectMode,
   getWorkspaceWindowState,
   saveAgentPermissions,
   setWorkspaceTrusted,
@@ -16,7 +17,12 @@ import {
 import {
   createWindow,
   findWindowByWorkspace,
+  getMostRecentlyFocusedWorkspaceWindow,
 } from "../../window/WindowManager";
+import {
+  RAIL_ADD_PROJECT_CHANNEL,
+  resolveProjectOpenTarget,
+} from "../../window/resolveProjectOpenTarget";
 import { seedTutorialSessions } from "./TutorialSessionSeeder";
 import {
   deleteTutorialTrackers,
@@ -60,6 +66,10 @@ export interface TutorialProjectServiceDependencies {
   getWorkspaceWindowState: typeof getWorkspaceWindowState;
   createWindow: typeof createWindow;
   findWindowByWorkspace: (workspacePath: string) => BrowserWindow | null;
+  /** Multi-Project Mode: whether opening a project should add it to the
+   *  focused window's rail instead of spawning a new window. */
+  getMultiProjectMode: typeof getMultiProjectMode;
+  getMostRecentlyFocusedWorkspaceWindow: typeof getMostRecentlyFocusedWorkspaceWindow;
   addToRecentItems: typeof addToRecentItems;
   closeWorkspaceManagerWindow: () => void;
   seedTutorialTrackers: (
@@ -88,6 +98,8 @@ const defaultDependencies: TutorialProjectServiceDependencies = {
   getWorkspaceWindowState,
   createWindow,
   findWindowByWorkspace,
+  getMultiProjectMode,
+  getMostRecentlyFocusedWorkspaceWindow,
   addToRecentItems,
   closeWorkspaceManagerWindow: () => undefined,
   seedTutorialTrackers,
@@ -362,11 +374,29 @@ export class TutorialProjectService {
 
   private openProject(workspacePath: string): void {
     // The tutorial can be started repeatedly (Help menu, Workspace Manager),
-    // so focus the window that already has it rather than opening a duplicate.
+    // so focus the window that already has it rather than opening a
+    // duplicate. Mirrors `openOrFocusWorkspaceWindow`'s decision (inlined
+    // via the shared pure resolver, not imported directly, to avoid a
+    // circular import -- WorkspaceManagerWindow already imports this class).
     const existingWindow =
       this.dependencies.findWindowByWorkspace(workspacePath);
-    if (existingWindow && !existingWindow.isDestroyed()) {
-      existingWindow.focus();
+    const target = resolveProjectOpenTarget({
+      workspacePath,
+      multiProjectModeEnabled: this.dependencies.getMultiProjectMode(),
+      existingWindowForPath:
+        existingWindow && !existingWindow.isDestroyed() ? existingWindow : null,
+      focusedWorkspaceWindow: existingWindow
+        ? null
+        : this.dependencies.getMostRecentlyFocusedWorkspaceWindow(),
+    });
+
+    if (target.kind === "focus-existing") {
+      target.window.focus();
+    } else if (target.kind === "add-to-rail") {
+      target.window.focus();
+      target.window.webContents.send(RAIL_ADD_PROJECT_CHANNEL, {
+        workspacePath,
+      });
     } else {
       const savedState =
         this.dependencies.getWorkspaceWindowState(workspacePath);

--- a/packages/electron/src/main/services/tutorial/__tests__/TutorialProjectService.test.ts
+++ b/packages/electron/src/main/services/tutorial/__tests__/TutorialProjectService.test.ts
@@ -57,6 +57,8 @@ async function createHarness() {
     getWorkspaceWindowState: vi.fn(() => undefined),
     createWindow: vi.fn(),
     findWindowByWorkspace: vi.fn(() => null),
+    getMultiProjectMode: vi.fn(() => false),
+    getMostRecentlyFocusedWorkspaceWindow: vi.fn(() => null),
     addToRecentItems: vi.fn(),
     closeWorkspaceManagerWindow: vi.fn(),
     seedTutorialTrackers: vi.fn(async () => [EXAMPLE_BUG]),
@@ -200,6 +202,29 @@ describe("TutorialProjectService", () => {
     expect(second).toMatchObject({ success: true, reused: true });
     expect(focus).toHaveBeenCalledOnce();
     expect(harness.dependencies.createWindow).not.toHaveBeenCalled();
+  });
+
+  it("adds the tutorial project to the focused window's rail in Multi-Project Mode instead of opening a new window", async () => {
+    const harness = await createHarness();
+    const focus = vi.fn();
+    const send = vi.fn();
+    vi.mocked(harness.dependencies.getMultiProjectMode).mockReturnValue(true);
+    vi.mocked(
+      harness.dependencies.getMostRecentlyFocusedWorkspaceWindow
+    ).mockReturnValue({
+      isDestroyed: () => false,
+      focus,
+      webContents: { send },
+    } as never);
+
+    const result = await harness.service.startTutorial();
+    if (!result.success) throw new Error(result.error);
+
+    expect(harness.dependencies.createWindow).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledWith("rail:add-project", {
+      workspacePath: result.workspacePath,
+    });
   });
 
   it("fails loudly when the template directory is missing and leaves no project behind", async () => {

--- a/packages/electron/src/main/session/SessionState.ts
+++ b/packages/electron/src/main/session/SessionState.ts
@@ -2,7 +2,7 @@ import { BrowserWindow } from 'electron';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { windows, windowStates, createWindow, windowFocusOrder, windowDevToolsState, getWindowId } from '../window/WindowManager';
 import { loadFileIntoWindow } from '../file/FileOperations';
-import { getSessionState, saveSessionState as saveToStore, SessionState, clearSessionState } from '../utils/store';
+import { getSessionState, saveSessionState as saveToStore, SessionState, SessionWindow, clearSessionState, getMultiProjectMode } from '../utils/store';
 import { startWorkspaceWatcher } from '../file/WorkspaceWatcher.ts';
 import { getFolderContents } from '../utils/FileTree';
 import { basename } from 'path';
@@ -13,6 +13,127 @@ import { autoMatchTeamForWorkspace } from '../services/TeamService';
 import { updateTrackerSchemaWorkspace } from '../services/TrackerSchemaService';
 import { onStartupActivated } from '../window/StartupActivation';
 import { shouldSuppressSafeModeSessionSave } from './safeModeSessionState';
+import { setPendingRailSeeds } from '../window/railSeeding';
+
+/**
+ * Mirrors the renderer's `MAX_OPEN_PROJECTS` (`store/atoms/openProjects.ts`).
+ * Main cannot import that constant (renderer -> main import), so the value
+ * is duplicated here; keep the two in sync if the renderer cap changes. Used
+ * only to bound how many rail seeds `computeSessionRestorePlan` hands out at
+ * once -- the renderer's own cap is still the source of truth for what it
+ * will actually accept (a mismatch here just means an extra, harmless
+ * `'at-cap'` ack from `seedProjectIntoWindow` rather than data loss).
+ */
+export const SESSION_RESTORE_RAIL_CAP = 12;
+
+/**
+ * Pure restore-shape decision for `restoreSessionState`. Given the saved
+ * windows (already sorted by focusOrder, ascending) and whether Multi-Project
+ * Mode is on, decides which saved windows become real `BrowserWindow`s and
+ * which saved workspace paths instead join the rail of the one restored
+ * workspace window.
+ *
+ * No Electron / fs imports -- callers own existence checks (a saved path
+ * may no longer exist on disk) and side effects (createWindow, IPC sends).
+ */
+export interface SessionRestorePlan {
+  /** Saved windows that should become real BrowserWindows, in the same
+   *  relative order as the input. When Multi-Project Mode is off (or there
+   *  is at most one saved workspace window), this is the input array
+   *  unchanged -- byte-for-byte identical restore behavior. */
+  windowsToCreate: SessionWindow[];
+  /** Saved workspace paths that should join the rail of the restored
+   *  primary workspace window instead of getting a window of their own.
+   *  Deduped, and capped at `SESSION_RESTORE_RAIL_CAP - 1` (the primary
+   *  itself occupies the remaining rail slot). Empty unless Multi-Project
+   *  Mode is on and there is more than one candidate path. */
+  railPathsToSeed: string[];
+  /** The workspace path that was previously active/visible and should stay
+   *  so after restore -- the saved workspace window with the highest
+   *  `focusOrder` ("higher = more recently focused", per `SessionWindow`).
+   *  `null` when no saved window is workspace-mode. */
+  activeWorkspacePath: string | null;
+  /** Count of candidate rail paths dropped because they exceeded the rail
+   *  cap. 0 when nothing overflowed. Callers should report this ONCE (e.g.
+   *  a single log line / toast) rather than once per dropped path -- each
+   *  path landing at the renderer's own cap independently would otherwise
+   *  produce a toast per refusal. */
+  overflowCount: number;
+}
+
+export function computeSessionRestorePlan(
+  sessionWindows: SessionWindow[],
+  multiProjectModeEnabled: boolean,
+): SessionRestorePlan {
+  const workspaceEntries = sessionWindows.filter(
+    (w): w is SessionWindow & { workspacePath: string } => w.mode === 'workspace' && !!w.workspacePath,
+  );
+
+  if (workspaceEntries.length === 0) {
+    // No saved workspace windows (empty list, or document-only restore) --
+    // document-mode restore is unaffected by Multi-Project Mode either way.
+    return { windowsToCreate: sessionWindows, railPathsToSeed: [], activeWorkspacePath: null, overflowCount: 0 };
+  }
+
+  let primary = workspaceEntries[0];
+  for (const entry of workspaceEntries) {
+    if ((entry.focusOrder ?? 0) > (primary.focusOrder ?? 0)) {
+      primary = entry;
+    }
+  }
+
+  if (!multiProjectModeEnabled) {
+    return { windowsToCreate: sessionWindows, railPathsToSeed: [], activeWorkspacePath: primary.workspacePath, overflowCount: 0 };
+  }
+
+  // Gather every candidate rail path from BOTH restore shapes:
+  //  (a) legacy: every OTHER saved workspace window's own `workspacePath`
+  //      (pre-single-window saves, one BrowserWindow per project).
+  //  (b) current: any saved window's `additionalWorkspacePaths` -- the rail
+  //      contents that were live in that window's `WindowState` at save
+  //      time (see `saveSessionState`). Old saved sessions have no such
+  //      field; `?? []` treats that as "nothing recorded", never a crash.
+  // Deduped in encounter order so the same path saved both ways (or saved
+  // on more than one window) is only seeded once.
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+  const addCandidate = (path: string | undefined | null) => {
+    if (!path || path === primary.workspacePath || seen.has(path)) return;
+    seen.add(path);
+    candidates.push(path);
+  };
+
+  for (const entry of workspaceEntries) {
+    if (entry !== primary) addCandidate(entry.workspacePath);
+  }
+  for (const entry of workspaceEntries) {
+    for (const additional of entry.additionalWorkspacePaths ?? []) {
+      addCandidate(additional);
+    }
+  }
+
+  if (candidates.length === 0) {
+    // Nothing to collapse or seed either way -- avoid a pointless IPC
+    // round trip and keep `windowsToCreate` referentially the input array.
+    return { windowsToCreate: sessionWindows, railPathsToSeed: [], activeWorkspacePath: primary.workspacePath, overflowCount: 0 };
+  }
+
+  // Collapse every saved workspace window except `primary` into a single
+  // window; document-mode windows are untouched and keep their relative
+  // position.
+  const windowsToCreate = sessionWindows.filter((w) => w.mode !== 'workspace' || w === primary);
+
+  // The primary itself occupies one of the rail's slots, so only
+  // `SESSION_RESTORE_RAIL_CAP - 1` more can be seeded -- the same
+  // `MAX_OPEN_PROJECTS - 1` reservation the renderer's own restore path uses
+  // for its persisted `openProjects` list (`store/atoms/openProjects.ts`,
+  // the `normalizedPersistedPaths.slice(0, MAX_OPEN_PROJECTS - 1)` case).
+  const seedCap = Math.max(0, SESSION_RESTORE_RAIL_CAP - 1);
+  const railPathsToSeed = candidates.slice(0, seedCap);
+  const overflowCount = candidates.length - railPathsToSeed.length;
+
+  return { windowsToCreate, railPathsToSeed, activeWorkspacePath: primary.workspacePath, overflowCount };
+}
 
 // Save session state
 export async function saveSessionState() {
@@ -46,6 +167,9 @@ export async function saveSessionState() {
         if (state.workspacePath) {
             sessionWindow.workspacePath = state.workspacePath;
         }
+        if (state.additionalWorkspacePaths && state.additionalWorkspacePaths.length > 0) {
+            sessionWindow.additionalWorkspacePaths = [...state.additionalWorkspacePaths];
+        }
 
         sessionWindows.push(sessionWindow);
     }
@@ -66,6 +190,159 @@ export async function saveSessionState() {
     // Verify the save by reading it back
     const verified = getSessionState();
     logger.session.debug(`[SAVE] Verified session state: ${verified?.windows?.length ?? 0} window(s)`);
+}
+
+/**
+ * Fire the `workspace_opened` analytics event for a restored/seeded
+ * workspace path. Project-scoped (not window-scoped): called once per
+ * project regardless of whether that project gets its own restored window
+ * or joins another window's rail as a Multi-Project Mode seed, because both
+ * are "a workspace was opened at startup" from the analytics consumer's
+ * point of view. Extracted from the inline block that used to run only for
+ * windows the loop itself created, so it can also run for rail-seeded paths.
+ */
+async function trackWorkspaceOpenedAnalytics(workspacePath: string): Promise<void> {
+    try {
+        // Count files and check for subfolders
+        let fileCount = 0;
+        let hasSubfolders = false;
+        try {
+            const entries = readdirSync(workspacePath, { withFileTypes: true });
+            for (const entry of entries) {
+                if (entry.isFile()) {
+                    fileCount++;
+                } else if (entry.isDirectory() && !entry.name.startsWith('.')) {
+                    hasSubfolders = true;
+                }
+            }
+        } catch (error) {
+            // Ignore count errors
+        }
+
+        // Bucket file count
+        let fileCountBucket = '1-10';
+        if (fileCount > 100) fileCountBucket = '100+';
+        else if (fileCount > 50) fileCountBucket = '51-100';
+        else if (fileCount > 10) fileCountBucket = '11-50';
+
+        // Check git repository status (defaults to false if git not available)
+        let isGitRepository = false;
+        let isGitHub = false;
+
+        try {
+            const gitStatusService = new GitStatusService();
+            isGitRepository = await gitStatusService.isGitRepo(workspacePath);
+            if (isGitRepository) {
+                isGitHub = await gitStatusService.hasGitHubRemote(workspacePath);
+            }
+        } catch (gitError) {
+            // Git checks failed - continue with defaults (false, false)
+            logger.session.error('Error checking git status:', gitError);
+        }
+
+        const analytics = AnalyticsService.getInstance();
+        analytics.sendEvent('workspace_opened', {
+            fileCount: fileCountBucket,
+            hasSubfolders,
+            source: 'startup_restore',
+            isGitRepository,
+            isGitHub,
+        });
+    } catch (error) {
+        logger.session.error('Error tracking workspace_opened event:', error);
+    }
+}
+
+/**
+ * Kick off the project-scoped side effects a restored/seeded workspace path
+ * needs, independent of whether it got its own window: team auto-match and
+ * tracker schema sync key off the path, not the window. Fire-and-forget,
+ * deferred a tick so it never competes with the startup paint.
+ */
+function scheduleWorkspaceProjectSideEffects(workspacePath: string): void {
+    setTimeout(() => {
+        void autoMatchTeamForWorkspace(workspacePath).catch(() => {});
+        updateTrackerSchemaWorkspace(workspacePath);
+    }, 0);
+}
+
+/**
+ * Seed the remaining saved workspace paths into `window`'s project rail
+ * (Multi-Project Mode) via `seedProjectIntoWindow` (`window/railSeeding.ts`)
+ * -- the same ack-aware wrapper around the `rail:add-project` contract used
+ * by "Merge All Windows" (`consolidateWorkspaceWindows.ts`), so a seed that
+ * never lands (renderer never acked, rail was already at cap, window closed
+ * mid-seed) is observable instead of silently dropped. Waits for
+ * `did-finish-load` -- the convention this codebase already relies on to
+ * mean "the renderer's IPC listeners are registered" (see the devtools and
+ * `loadFileIntoWindow` restores below) -- since a message sent earlier is
+ * silently dropped.
+ *
+ * Every seed here is a non-primary path (`computeSessionRestorePlan` already
+ * excluded the primary), so every seed is sent with `activate: false`:
+ * `addOpenProjectAtom` (renderer) only flips `activeWorkspacePathAtom` when
+ * asked to, so these paths join the rail without disturbing which project is
+ * actually visible -- previously (before `activate` existed on this
+ * contract) the window's visible project was whichever seed's
+ * `workspace:register-additional` round trip happened to resolve last, not
+ * the restored primary.
+ *
+ * Seeded sequentially (not `Promise.all`) so outcomes log in a stable,
+ * readable order; restore is not latency-sensitive enough to need
+ * parallelism here.
+ *
+ * `computeSessionRestorePlan`'s cap only bounds how many paths this
+ * function is ASKED to seed -- the live rail can still be fuller than that
+ * plan assumed (e.g. `restorePreviousProjectsOnLaunch` already rehydrated
+ * projects into it before this seeding runs). If the renderer ever acks
+ * `'at-cap'`, every further path in `railPaths` would refuse too, and each
+ * refusal that actually reaches the renderer fires its own rail-full toast
+ * (`railProjectListeners.ts`'s `showRailFullNotification()`, unconditional
+ * on `activate`). So the first `'at-cap'` stops sending entirely --
+ * mirroring `consolidateWorkspaceWindows.ts`'s `capReached` short-circuit --
+ * and the shortfall is reported ONCE via `logger.session.warn` instead of
+ * cascading into a toast per remaining path.
+ */
+/**
+ * Park the restored rail paths for the renderer to collect.
+ *
+ * This deliberately does NOT push `rail:add-project` at `did-finish-load`.
+ * The renderer registers that handler in `initRailProjectListeners()`, from a
+ * React effect that runs after mount -- strictly later than
+ * `did-finish-load`, and on a cold start later by seconds. A push there lands
+ * with no listener attached and is dropped, the ack times out, and the
+ * project is lost from the rail. Worse, because it never reached
+ * `WindowState.additionalWorkspacePaths`, the next `saveSessionState()`
+ * persisted no rail either -- so a single dropped seed compounded across
+ * every subsequent restart. Observed in a real profile before this changed.
+ *
+ * The renderer pulls instead (`rail:take-pending-seeds`), asking at the exact
+ * moment its listener exists. See `main/window/railSeeding.ts`.
+ */
+function seedRailProjects(windowId: number, railPaths: string[]): void {
+    const existing = railPaths.filter((railPath) => {
+        if (existsSync(railPath)) return true;
+        logger.session.warn(`[RESTORE] Rail-seed workspace path no longer exists, skipping: ${railPath}`);
+        return false;
+    });
+
+    if (existing.length === 0) {
+        setPendingRailSeeds(windowId, []);
+        return;
+    }
+
+    setPendingRailSeeds(windowId, existing);
+    logger.session.info(
+        `[RESTORE] Parked ${existing.length} rail project(s) for the renderer to collect: ${existing.join(', ')}`
+    );
+
+    // Project-scoped side effects don't depend on the rail add landing -- they
+    // key off the workspace path, and the renderer will register each path as
+    // it collects them.
+    for (const railPath of existing) {
+        void trackWorkspaceOpenedAnalytics(railPath);
+        scheduleWorkspaceProjectSideEffects(railPath);
+    }
 }
 
 // Restore session state
@@ -104,13 +381,33 @@ export async function restoreSessionState(): Promise<boolean> {
         `${i}: ${w.mode} focusOrder=${w.focusOrder}`
     ));
 
+    // With Multi-Project Mode on and more than one saved workspace window,
+    // collapse the extra workspace windows into rail seeds for the one
+    // restored primary window instead of a BrowserWindow each. Off (or with
+    // at most one saved workspace window), `plan.windowsToCreate` is the
+    // input array unchanged -- byte-for-byte identical to today.
+    const plan = computeSessionRestorePlan(sortedWindows, getMultiProjectMode());
+    if (plan.railPathsToSeed.length > 0) {
+        logger.session.info(
+            `[RESTORE] Multi-Project Mode: restoring one window for ${plan.activeWorkspacePath}, seeding rail with ${plan.railPathsToSeed.length} more: ${plan.railPathsToSeed.join(', ')}`
+        );
+    }
+    // Reported once here, not once per dropped path -- each seed hitting the
+    // renderer's own cap independently would otherwise fire a toast per
+    // refusal (a toast storm at startup) instead of one summary.
+    if (plan.overflowCount > 0) {
+        logger.session.warn(
+            `[RESTORE] Multi-Project Mode: ${plan.overflowCount} saved project(s) did not fit in the rail and were not restored.`
+        );
+    }
+
     // Restore each window in order
     // Use async creation to ensure windows are created sequentially
     // Every window is shown inactive so a late ready-to-show event cannot
     // foreground Nimbalyst after the user has switched applications. Each
     // registration claims `startupFrontmost`, so the last window created here —
     // the one with the highest focusOrder — is the one brought to the front.
-    for (const sessionWindow of sortedWindows) {
+    for (const sessionWindow of plan.windowsToCreate) {
 
         // Wait for previous window to be ready before creating next
         await new Promise<void>((resolve) => {
@@ -121,55 +418,7 @@ export async function restoreSessionState(): Promise<boolean> {
                     // Check if workspace path still exists
                     if (existsSync(sessionWindow.workspacePath)) {
                         // Track workspace opened from startup restore
-                        try {
-                            // Count files and check for subfolders
-                            let fileCount = 0;
-                            let hasSubfolders = false;
-                            try {
-                                const entries = readdirSync(sessionWindow.workspacePath, { withFileTypes: true });
-                                for (const entry of entries) {
-                                    if (entry.isFile()) {
-                                        fileCount++;
-                                    } else if (entry.isDirectory() && !entry.name.startsWith('.')) {
-                                        hasSubfolders = true;
-                                    }
-                                }
-                            } catch (error) {
-                                // Ignore count errors
-                            }
-
-                            // Bucket file count
-                            let fileCountBucket = '1-10';
-                            if (fileCount > 100) fileCountBucket = '100+';
-                            else if (fileCount > 50) fileCountBucket = '51-100';
-                            else if (fileCount > 10) fileCountBucket = '11-50';
-
-                            // Check git repository status (defaults to false if git not available)
-                            let isGitRepository = false;
-                            let isGitHub = false;
-
-                            try {
-                                const gitStatusService = new GitStatusService();
-                                isGitRepository = await gitStatusService.isGitRepo(sessionWindow.workspacePath);
-                                if (isGitRepository) {
-                                    isGitHub = await gitStatusService.hasGitHubRemote(sessionWindow.workspacePath);
-                                }
-                            } catch (gitError) {
-                                // Git checks failed - continue with defaults (false, false)
-                                logger.session.error('Error checking git status:', gitError);
-                            }
-
-                            const analytics = AnalyticsService.getInstance();
-                            analytics.sendEvent('workspace_opened', {
-                                fileCount: fileCountBucket,
-                                hasSubfolders,
-                                source: 'startup_restore',
-                                isGitRepository,
-                                isGitHub,
-                            });
-                        } catch (error) {
-                            logger.session.error('Error tracking workspace_opened event:', error);
-                        }
+                        await trackWorkspaceOpenedAnalytics(sessionWindow.workspacePath);
 
                         window = createWindow(false, true, sessionWindow.workspacePath, sessionWindow.bounds, {
                             showInactive: true,
@@ -178,13 +427,26 @@ export async function restoreSessionState(): Promise<boolean> {
                         });
                         logger.session.info(`Restored workspace window: ${sessionWindow.workspacePath}`);
 
-                        const restoredWorkspacePath = sessionWindow.workspacePath;
-                        setTimeout(() => {
-                            // Yield before running background workspace matching so
-                            // restored windows don't block the startup tick.
-                            void autoMatchTeamForWorkspace(restoredWorkspacePath).catch(() => {});
-                            updateTrackerSchemaWorkspace(restoredWorkspacePath);
-                        }, 0);
+                        scheduleWorkspaceProjectSideEffects(sessionWindow.workspacePath);
+
+                        if (
+                            window &&
+                            plan.railPathsToSeed.length > 0 &&
+                            sessionWindow.workspacePath === plan.activeWorkspacePath
+                        ) {
+                            // Park before the renderer mounts -- it collects
+                            // them itself once its listeners are registered.
+                            // `== null` on purpose: catches undefined too, so a
+                            // missing id can never be parked as a map key.
+                            const restoredWindowId = getWindowId(window);
+                            if (restoredWindowId != null) {
+                                seedRailProjects(restoredWindowId, plan.railPathsToSeed);
+                            } else {
+                                logger.session.error(
+                                    '[RESTORE] Could not resolve window id; rail projects not parked'
+                                );
+                            }
+                        }
 
                         // Note: Workspace tabs will be restored by the workspace's own tab state management
                         // We don't manually open files here to avoid interfering with tab restoration

--- a/packages/electron/src/main/session/__tests__/SessionState.focus.test.ts
+++ b/packages/electron/src/main/session/__tests__/SessionState.focus.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+// Type-only: erased at compile time, so it is safe to reference inside the
+// `vi.hoisted` factory below, which runs before runtime imports.
+import type { RailSeedOutcome } from '../../window/railSeeding';
 
 const mocks = vi.hoisted(() => ({
   createWindow: vi.fn(),
@@ -6,6 +9,16 @@ const mocks = vi.hoisted(() => ({
   clearSessionState: vi.fn(),
   onStartupActivated: vi.fn(),
   updateTrackerSchemaWorkspace: vi.fn(),
+  getMultiProjectMode: vi.fn(() => false),
+  autoMatchTeamForWorkspace: vi.fn(async () => undefined),
+  saveToStore: vi.fn(),
+  // Typed against the real `RailSeedOutcome` union, not inferred from the
+  // default return -- inference would narrow the mock to `'added'` and make
+  // `mockResolvedValueOnce('at-cap')` a type error in the refusal cases.
+  seedProjectIntoWindow: vi.fn<(...args: never[]) => Promise<RailSeedOutcome>>(
+    async () => 'added',
+  ),
+  setPendingRailSeeds: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -29,7 +42,9 @@ vi.mock('../../window/WindowManager', () => ({
   windowFocusOrder: new Map(),
   windowDevToolsState: new Map(),
   createWindow: mocks.createWindow,
-  getWindowId: vi.fn(),
+  // Returns a real id: rail seeds are parked under it, so a bare `vi.fn()`
+  // returning undefined would silently defeat the parking assertions.
+  getWindowId: vi.fn(() => 1),
 }));
 
 vi.mock('../../file/FileOperations', () => ({ loadFileIntoWindow: vi.fn() }));
@@ -38,8 +53,9 @@ vi.mock('../../utils/FileTree', () => ({ getFolderContents: vi.fn() }));
 
 vi.mock('../../utils/store', () => ({
   getSessionState: mocks.getSessionState,
-  saveSessionState: vi.fn(),
+  saveSessionState: mocks.saveToStore,
   clearSessionState: mocks.clearSessionState,
+  getMultiProjectMode: mocks.getMultiProjectMode,
 }));
 
 vi.mock('../../utils/logger', () => ({
@@ -67,7 +83,7 @@ vi.mock('../../services/GitStatusService', () => ({
 }));
 
 vi.mock('../../services/TeamService', () => ({
-  autoMatchTeamForWorkspace: vi.fn(async () => undefined),
+  autoMatchTeamForWorkspace: mocks.autoMatchTeamForWorkspace,
 }));
 
 vi.mock('../../services/TrackerSchemaService', () => ({
@@ -78,7 +94,34 @@ vi.mock('../../window/StartupActivation', () => ({
   onStartupActivated: mocks.onStartupActivated,
 }));
 
-import { restoreSessionState } from '../SessionState';
+vi.mock('../../window/railSeeding', () => ({
+  seedProjectIntoWindow: mocks.seedProjectIntoWindow,
+  setPendingRailSeeds: mocks.setPendingRailSeeds,
+}));
+
+import { restoreSessionState, computeSessionRestorePlan, saveSessionState, SESSION_RESTORE_RAIL_CAP } from '../SessionState';
+import { windows, windowStates, windowFocusOrder } from '../../window/WindowManager';
+import { logger } from '../../utils/logger';
+import type { SessionWindow } from '../../types';
+
+function workspaceWindow(workspacePath: string, focusOrder: number, additionalWorkspacePaths?: string[]): SessionWindow {
+  return {
+    mode: 'workspace',
+    workspacePath,
+    focusOrder,
+    bounds: { x: 0, y: 0, width: 800, height: 600 },
+    ...(additionalWorkspacePaths ? { additionalWorkspacePaths } : {}),
+  };
+}
+
+function documentWindow(filePath: string, focusOrder: number): SessionWindow {
+  return {
+    mode: 'document',
+    filePath,
+    focusOrder,
+    bounds: { x: 0, y: 0, width: 800, height: 600 },
+  };
+}
 
 describe('restoreSessionState window activation', () => {
   beforeEach(() => {
@@ -88,10 +131,19 @@ describe('restoreSessionState window activation', () => {
     mocks.clearSessionState.mockReset();
     mocks.onStartupActivated.mockReset();
     mocks.updateTrackerSchemaWorkspace.mockReset();
+    mocks.getMultiProjectMode.mockReset();
+    mocks.getMultiProjectMode.mockReturnValue(false);
+    mocks.autoMatchTeamForWorkspace.mockReset();
+    mocks.autoMatchTeamForWorkspace.mockResolvedValue(undefined);
+    mocks.seedProjectIntoWindow.mockReset();
+    mocks.setPendingRailSeeds.mockReset();
+    mocks.seedProjectIntoWindow.mockResolvedValue('added');
+    (logger.session.warn as ReturnType<typeof vi.fn>).mockReset();
+    (logger.session.info as ReturnType<typeof vi.fn>).mockReset();
 
     mocks.createWindow.mockImplementation(() => ({
       isDestroyed: () => false,
-      webContents: { once: vi.fn(), openDevTools: vi.fn() },
+      webContents: { once: vi.fn(), send: vi.fn(), openDevTools: vi.fn() },
     }));
   });
 
@@ -157,5 +209,394 @@ describe('restoreSessionState window activation', () => {
     const deferredOpen = mocks.onStartupActivated.mock.calls[0][0];
     deferredOpen();
     expect(restoredWindow.webContents.openDevTools).toHaveBeenCalledTimes(1);
+  });
+
+  it('Multi-Project Mode: collapses saved workspace windows into one window plus rail seeds', async () => {
+    mocks.getMultiProjectMode.mockReturnValue(true);
+    mocks.getSessionState.mockReturnValue({
+      windows: [
+        { mode: 'workspace', workspacePath: '/workspace/older', focusOrder: 1 },
+        { mode: 'workspace', workspacePath: '/workspace/newest', focusOrder: 3 },
+        { mode: 'workspace', workspacePath: '/workspace/middle', focusOrder: 2 },
+      ],
+      lastUpdated: Date.now(),
+    });
+
+    const restorePromise = restoreSessionState();
+    await vi.runAllTimersAsync();
+    await expect(restorePromise).resolves.toBe(true);
+
+    // Only one BrowserWindow -- for the previously-active (highest focusOrder) project.
+    expect(mocks.createWindow).toHaveBeenCalledTimes(1);
+    expect(mocks.createWindow).toHaveBeenCalledWith(
+      false,
+      true,
+      '/workspace/newest',
+      undefined,
+      { showInactive: true, startupReveal: true, startupFrontmost: true },
+    );
+
+    await vi.runAllTimersAsync();
+
+    // REGRESSION GUARD (observed in a real profile): the two non-primary saved
+    // workspaces must be PARKED for the renderer to collect, never pushed at
+    // `did-finish-load`. The renderer registers its `rail:add-project` handler
+    // in a React effect that runs strictly after `did-finish-load`, so a push
+    // lands with nothing listening, the ack times out, and the project is lost
+    // from the rail -- and then from the next save, compounding every restart.
+    expect(mocks.setPendingRailSeeds).toHaveBeenCalledWith(
+      expect.any(Number),
+      ['/workspace/older', '/workspace/middle'],
+    );
+    // Nothing may be pushed during restore; pushing is only correct for
+    // "Merge All Windows", whose target window is already listening.
+    expect(mocks.seedProjectIntoWindow).not.toHaveBeenCalled();
+
+    // Team-match/tracker-schema are project-scoped: they run for every
+    // restored project, whether it got its own window or joined the rail.
+    expect(mocks.autoMatchTeamForWorkspace).toHaveBeenCalledWith('/workspace/newest');
+    expect(mocks.autoMatchTeamForWorkspace).toHaveBeenCalledWith('/workspace/older');
+    expect(mocks.autoMatchTeamForWorkspace).toHaveBeenCalledWith('/workspace/middle');
+    expect(mocks.updateTrackerSchemaWorkspace).toHaveBeenCalledWith('/workspace/newest');
+    expect(mocks.updateTrackerSchemaWorkspace).toHaveBeenCalledWith('/workspace/older');
+    expect(mocks.updateTrackerSchemaWorkspace).toHaveBeenCalledWith('/workspace/middle');
+  });
+
+  it('Multi-Project Mode: a single saved window carrying additionalWorkspacePaths restores all of them (restore shape b)', async () => {
+    mocks.getMultiProjectMode.mockReturnValue(true);
+    mocks.getSessionState.mockReturnValue({
+      windows: [
+        {
+          mode: 'workspace',
+          workspacePath: '/workspace/primary',
+          focusOrder: 1,
+          additionalWorkspacePaths: ['/workspace/rail-a', '/workspace/rail-b'],
+        },
+      ],
+      lastUpdated: Date.now(),
+    });
+
+    const restorePromise = restoreSessionState();
+    await vi.runAllTimersAsync();
+    await expect(restorePromise).resolves.toBe(true);
+
+    // A single saved SessionWindow -- the legacy "N separate windows collapse"
+    // shape never applies here, only the rail-contents field does.
+    expect(mocks.createWindow).toHaveBeenCalledTimes(1);
+
+    expect(mocks.setPendingRailSeeds).toHaveBeenCalledWith(
+      expect.any(Number),
+      ['/workspace/rail-a', '/workspace/rail-b'],
+    );
+    expect(mocks.seedProjectIntoWindow).not.toHaveBeenCalled();
+  });
+
+  it('Multi-Project Mode: overflow past the rail cap is reported once, not once per dropped path', async () => {
+    mocks.getMultiProjectMode.mockReturnValue(true);
+    const extraCount = 15; // comfortably more than SESSION_RESTORE_RAIL_CAP - 1
+    mocks.getSessionState.mockReturnValue({
+      windows: [
+        { mode: 'workspace', workspacePath: '/workspace/primary', focusOrder: 100 },
+        ...Array.from({ length: extraCount }, (_, i) => ({
+          mode: 'workspace' as const,
+          workspacePath: `/workspace/extra-${i}`,
+          focusOrder: i,
+        })),
+      ],
+      lastUpdated: Date.now(),
+    });
+
+    const restorePromise = restoreSessionState();
+    await vi.runAllTimersAsync();
+    await expect(restorePromise).resolves.toBe(true);
+
+    const overflowWarnings = (logger.session.warn as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([message]) => typeof message === 'string' && message.includes('did not fit in the rail'),
+    );
+    expect(overflowWarnings).toHaveLength(1);
+    expect(overflowWarnings[0][0]).toContain(String(extraCount - (SESSION_RESTORE_RAIL_CAP - 1)));
+
+    // Only the capped set is ever parked for the renderer -- the rest were
+    // dropped in the plan itself, not refused one-by-one at the rail.
+    const parked = mocks.setPendingRailSeeds.mock.calls.at(-1)?.[1] as string[];
+    expect(parked).toHaveLength(SESSION_RESTORE_RAIL_CAP - 1);
+  });
+
+  it('Multi-Project Mode: parks rail projects without waiting on did-finish-load', async () => {
+    // The bug this pins, seen in a real profile: restore used to push
+    // `rail:add-project` from the window's `did-finish-load` handler. The
+    // renderer registers that handler later still (a React effect after
+    // mount), so the push landed with nothing listening, the ack timed out
+    // after 2s, and the project vanished from the rail -- then from the next
+    // save, compounding on every restart.
+    //
+    // Parking must therefore be complete WITHOUT `did-finish-load` ever
+    // firing. Deliberately never invoke it here.
+    mocks.getMultiProjectMode.mockReturnValue(true);
+    mocks.getSessionState.mockReturnValue({
+      windows: [
+        { mode: 'workspace', workspacePath: '/workspace/primary', focusOrder: 10 },
+        { mode: 'workspace', workspacePath: '/workspace/rail-a', focusOrder: 2 },
+        { mode: 'workspace', workspacePath: '/workspace/rail-b', focusOrder: 1 },
+      ],
+      lastUpdated: Date.now(),
+    });
+
+    const restorePromise = restoreSessionState();
+    await vi.runAllTimersAsync();
+    await expect(restorePromise).resolves.toBe(true);
+
+    // Least-recently-focused first, so the most recent ends up adjacent to
+    // the restored active project in the rail (rail-b focusOrder 1, then
+    // rail-a focusOrder 2).
+    expect(mocks.setPendingRailSeeds).toHaveBeenCalledWith(
+      expect.any(Number),
+      ['/workspace/rail-b', '/workspace/rail-a'],
+    );
+
+    // Stronger than "the handler never fired": rail seeding no longer
+    // subscribes to `did-finish-load` at all, so there is no ready-moment left
+    // to guess wrong. (Other features may subscribe for their own reasons;
+    // this window has no devtools flag, so nothing registers one here.)
+    const restoredWindow = mocks.createWindow.mock.results[0].value;
+    const didFinishLoadSubscriptions = restoredWindow.webContents.once.mock.calls.filter(
+      ([event]: [string]) => event === 'did-finish-load',
+    );
+    expect(didFinishLoadSubscriptions).toHaveLength(0);
+    expect(mocks.seedProjectIntoWindow).not.toHaveBeenCalled();
+  });
+
+  it('Multi-Project Mode off: restores one window per saved workspace exactly as before', async () => {
+    mocks.getMultiProjectMode.mockReturnValue(false);
+    mocks.getSessionState.mockReturnValue({
+      windows: [
+        { mode: 'workspace', workspacePath: '/workspace/a', focusOrder: 1 },
+        { mode: 'workspace', workspacePath: '/workspace/b', focusOrder: 2 },
+      ],
+      lastUpdated: Date.now(),
+    });
+
+    const restorePromise = restoreSessionState();
+    await vi.runAllTimersAsync();
+    await expect(restorePromise).resolves.toBe(true);
+
+    expect(mocks.createWindow).toHaveBeenCalledTimes(2);
+    expect(mocks.seedProjectIntoWindow).not.toHaveBeenCalled();
+  });
+});
+
+describe('computeSessionRestorePlan', () => {
+  it('Multi-Project Mode on: collapses N saved workspaces into one window plus N-1 rail seeds', () => {
+    const windows = [
+      workspaceWindow('/ws/a', 1),
+      workspaceWindow('/ws/b', 3),
+      workspaceWindow('/ws/c', 2),
+    ];
+
+    const plan = computeSessionRestorePlan(windows, true);
+
+    expect(plan.windowsToCreate).toEqual([windows[1]]);
+    expect(plan.railPathsToSeed).toEqual(['/ws/a', '/ws/c']);
+    expect(plan.activeWorkspacePath).toBe('/ws/b');
+    expect(plan.overflowCount).toBe(0);
+  });
+
+  it('Multi-Project Mode off: restores every saved window unchanged (byte-for-byte)', () => {
+    const windows = [workspaceWindow('/ws/a', 1), workspaceWindow('/ws/b', 2)];
+
+    const plan = computeSessionRestorePlan(windows, false);
+
+    expect(plan.windowsToCreate).toBe(windows);
+    expect(plan.railPathsToSeed).toEqual([]);
+    expect(plan.activeWorkspacePath).toBe('/ws/b');
+    expect(plan.overflowCount).toBe(0);
+  });
+
+  it('a single saved workspace window is left alone even with the mode on (nothing to seed)', () => {
+    const windows = [workspaceWindow('/ws/only', 1)];
+
+    const plan = computeSessionRestorePlan(windows, true);
+
+    expect(plan.windowsToCreate).toBe(windows);
+    expect(plan.railPathsToSeed).toEqual([]);
+    expect(plan.activeWorkspacePath).toBe('/ws/only');
+    expect(plan.overflowCount).toBe(0);
+  });
+
+  it('mixed workspace/document windows: documents keep their own window and position; only the primary workspace joins them', () => {
+    const windows = [
+      documentWindow('/docs/notes.md', 1),
+      workspaceWindow('/ws/older', 2),
+      workspaceWindow('/ws/newer', 4),
+      documentWindow('/docs/todo.md', 3),
+    ];
+
+    const plan = computeSessionRestorePlan(windows, true);
+
+    expect(plan.windowsToCreate).toEqual([windows[0], windows[2], windows[3]]);
+    expect(plan.railPathsToSeed).toEqual(['/ws/older']);
+    expect(plan.activeWorkspacePath).toBe('/ws/newer');
+    expect(plan.overflowCount).toBe(0);
+  });
+
+  it('document-mode restore is unaffected by Multi-Project Mode when there are no saved workspace windows', () => {
+    const windows = [documentWindow('/docs/a.md', 1), documentWindow('/docs/b.md', 2)];
+
+    const planOn = computeSessionRestorePlan(windows, true);
+    const planOff = computeSessionRestorePlan(windows, false);
+
+    expect(planOn).toEqual({ windowsToCreate: windows, railPathsToSeed: [], activeWorkspacePath: null, overflowCount: 0 });
+    expect(planOff).toEqual({ windowsToCreate: windows, railPathsToSeed: [], activeWorkspacePath: null, overflowCount: 0 });
+  });
+
+  it('empty saved-window list produces an empty plan regardless of mode', () => {
+    expect(computeSessionRestorePlan([], true)).toEqual({
+      windowsToCreate: [],
+      railPathsToSeed: [],
+      activeWorkspacePath: null,
+      overflowCount: 0,
+    });
+    expect(computeSessionRestorePlan([], false)).toEqual({
+      windowsToCreate: [],
+      railPathsToSeed: [],
+      activeWorkspacePath: null,
+      overflowCount: 0,
+    });
+  });
+
+  it('no saved window carries a workspace path ("active path missing"): activeWorkspacePath is null and nothing collapses', () => {
+    const windows = [documentWindow('/docs/only.md', 1)];
+
+    const plan = computeSessionRestorePlan(windows, true);
+
+    expect(plan.activeWorkspacePath).toBeNull();
+    expect(plan.railPathsToSeed).toEqual([]);
+    expect(plan.windowsToCreate).toBe(windows);
+    expect(plan.overflowCount).toBe(0);
+  });
+
+  it('restore shape (b): a single saved window carrying additionalWorkspacePaths seeds all of them', () => {
+    const windows = [workspaceWindow('/ws/primary', 1, ['/ws/rail-a', '/ws/rail-b'])];
+
+    const plan = computeSessionRestorePlan(windows, true);
+
+    expect(plan.windowsToCreate).toEqual([windows[0]]);
+    expect(plan.railPathsToSeed).toEqual(['/ws/rail-a', '/ws/rail-b']);
+    expect(plan.activeWorkspacePath).toBe('/ws/primary');
+    expect(plan.overflowCount).toBe(0);
+  });
+
+  it('legacy sessions with no additionalWorkspacePaths field on any window still restore (missing treated as none)', () => {
+    // No entry sets additionalWorkspacePaths at all -- the shape every session
+    // saved before this field existed has.
+    const windows = [workspaceWindow('/ws/a', 1), workspaceWindow('/ws/b', 2)];
+
+    const plan = computeSessionRestorePlan(windows, true);
+
+    expect(plan.railPathsToSeed).toEqual(['/ws/a']);
+    expect(plan.activeWorkspacePath).toBe('/ws/b');
+    expect(plan.overflowCount).toBe(0);
+  });
+
+  it('dedupes a path that appears both as a legacy sibling window and inside another window\'s additionalWorkspacePaths', () => {
+    const windows = [
+      workspaceWindow('/ws/a', 1),
+      workspaceWindow('/ws/b', 3, ['/ws/a', '/ws/c']),
+      workspaceWindow('/ws/c', 2),
+    ];
+
+    const plan = computeSessionRestorePlan(windows, true);
+
+    expect(plan.railPathsToSeed).toEqual(['/ws/a', '/ws/c']);
+    expect(plan.activeWorkspacePath).toBe('/ws/b');
+    expect(plan.overflowCount).toBe(0);
+  });
+
+  it('caps railPathsToSeed at SESSION_RESTORE_RAIL_CAP - 1 (primary occupies the remaining slot) and reports the remainder as overflowCount', () => {
+    const extraCount = 15;
+    const windows = [
+      workspaceWindow('/ws/primary', 100),
+      ...Array.from({ length: extraCount }, (_, i) => workspaceWindow(`/ws/extra-${i}`, i)),
+    ];
+
+    const plan = computeSessionRestorePlan(windows, true);
+
+    expect(plan.railPathsToSeed).toHaveLength(SESSION_RESTORE_RAIL_CAP - 1);
+    expect(plan.overflowCount).toBe(extraCount - (SESSION_RESTORE_RAIL_CAP - 1));
+    expect(plan.activeWorkspacePath).toBe('/ws/primary');
+  });
+});
+
+describe('saveSessionState persists rail contents onto SessionWindow', () => {
+  function fakeBrowserWindow() {
+    return {
+      isDestroyed: () => false,
+      getBounds: () => ({ x: 0, y: 0, width: 800, height: 600 }),
+      isMaximized: () => false,
+    };
+  }
+
+  beforeEach(() => {
+    mocks.saveToStore.mockReset();
+    mocks.getSessionState.mockReset();
+    windows.clear();
+    windowStates.clear();
+    windowFocusOrder.clear();
+  });
+
+  it('writes additionalWorkspacePaths from the live WindowState onto the saved SessionWindow (round trip source)', async () => {
+    windows.set(1, fakeBrowserWindow() as any);
+    windowStates.set(1, {
+      mode: 'workspace',
+      filePath: null,
+      workspacePath: '/ws/primary',
+      additionalWorkspacePaths: ['/ws/rail-a', '/ws/rail-b'],
+      documentEdited: false,
+    } as any);
+    windowFocusOrder.set(1, 1);
+
+    await saveSessionState();
+
+    expect(mocks.saveToStore).toHaveBeenCalledTimes(1);
+    const saved = mocks.saveToStore.mock.calls[0][0] as { windows: SessionWindow[] };
+    expect(saved.windows).toHaveLength(1);
+    expect(saved.windows[0].workspacePath).toBe('/ws/primary');
+    expect(saved.windows[0].additionalWorkspacePaths).toEqual(['/ws/rail-a', '/ws/rail-b']);
+  });
+
+  it('omits additionalWorkspacePaths when the live WindowState has none (never writes an empty-array field)', async () => {
+    windows.set(1, fakeBrowserWindow() as any);
+    windowStates.set(1, {
+      mode: 'workspace',
+      filePath: null,
+      workspacePath: '/ws/only',
+      documentEdited: false,
+    } as any);
+    windowFocusOrder.set(1, 1);
+
+    await saveSessionState();
+
+    const saved = mocks.saveToStore.mock.calls[0][0] as { windows: SessionWindow[] };
+    expect(saved.windows[0].additionalWorkspacePaths).toBeUndefined();
+  });
+
+  it('save-then-restore round trip: rail paths saved from live state come back out of computeSessionRestorePlan', async () => {
+    windows.set(1, fakeBrowserWindow() as any);
+    windowStates.set(1, {
+      mode: 'workspace',
+      filePath: null,
+      workspacePath: '/ws/primary',
+      additionalWorkspacePaths: ['/ws/rail-a', '/ws/rail-b'],
+      documentEdited: false,
+    } as any);
+    windowFocusOrder.set(1, 1);
+
+    await saveSessionState();
+
+    const saved = mocks.saveToStore.mock.calls[0][0] as { windows: SessionWindow[] };
+    const plan = computeSessionRestorePlan(saved.windows, true);
+
+    expect(plan.railPathsToSeed).toEqual(['/ws/rail-a', '/ws/rail-b']);
+    expect(plan.activeWorkspacePath).toBe('/ws/primary');
   });
 });

--- a/packages/electron/src/main/types.ts
+++ b/packages/electron/src/main/types.ts
@@ -59,6 +59,15 @@ export interface SessionWindow {
     mode: 'document' | 'workspace' | 'agentic-coding';
     filePath?: string;
     workspacePath?: string;
+    /**
+     * Rail contents (Multi-Project Mode) that were warm in this window's
+     * live `WindowState.additionalWorkspacePaths` at save time. Optional
+     * because sessions saved before this field existed have none -- treat
+     * missing as "no rail contents recorded", never as an error. See
+     * `computeSessionRestorePlan` in `session/SessionState.ts` for how this
+     * is combined with legacy multi-window saves on restore.
+     */
+    additionalWorkspacePaths?: string[];
     bounds: {
         x: number;
         y: number;

--- a/packages/electron/src/main/utils/__tests__/store.multiProjectMode.test.ts
+++ b/packages/electron/src/main/utils/__tests__/store.multiProjectMode.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+/**
+ * Multi-Project Mode defaults ON, but an upgrading install with several windows
+ * open would otherwise collapse to a single window + an unfamiliar rail on its
+ * very next launch, with no warning. These cases pin who gets grandfathered out
+ * of that change and who does not.
+ *
+ * Existing test file `store.upstream.test.ts` is scoped to the API-upstream
+ * validator, so this lives beside it rather than inside it.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { shouldGrandfatherMultiProjectMode } from '../store';
+import type { SessionWindow } from '../../types';
+
+const bounds = { x: 0, y: 0, width: 800, height: 600 };
+
+function workspaceWindow(workspacePath: string): SessionWindow {
+  return { mode: 'workspace', workspacePath, bounds };
+}
+
+function documentWindow(filePath: string): SessionWindow {
+  return { mode: 'document', filePath, bounds };
+}
+
+describe('shouldGrandfatherMultiProjectMode', () => {
+  it('grandfathers an upgrading user who already has several workspace windows', () => {
+    expect(
+      shouldGrandfatherMultiProjectMode(false, [
+        workspaceWindow('/ws/a'),
+        workspaceWindow('/ws/b'),
+      ]),
+    ).toBe(true);
+  });
+
+  it('never overrides an explicit preference, however many windows are open', () => {
+    // Someone who deliberately turned the mode on keeps it on.
+    expect(
+      shouldGrandfatherMultiProjectMode(true, [
+        workspaceWindow('/ws/a'),
+        workspaceWindow('/ws/b'),
+        workspaceWindow('/ws/c'),
+      ]),
+    ).toBe(false);
+  });
+
+  it('does not grandfather a single-window user, who sees no change in shape', () => {
+    expect(shouldGrandfatherMultiProjectMode(false, [workspaceWindow('/ws/a')])).toBe(false);
+  });
+
+  it('does not grandfather a fresh install with no saved session', () => {
+    expect(shouldGrandfatherMultiProjectMode(false, undefined)).toBe(false);
+    expect(shouldGrandfatherMultiProjectMode(false, [])).toBe(false);
+  });
+
+  it('counts only workspace-mode windows, not document windows', () => {
+    // Several loose file windows are not the multi-project situation this
+    // protects against -- document windows keep their own windows regardless.
+    expect(
+      shouldGrandfatherMultiProjectMode(false, [
+        workspaceWindow('/ws/a'),
+        documentWindow('/notes/one.md'),
+        documentWindow('/notes/two.md'),
+      ]),
+    ).toBe(false);
+  });
+
+  it('treats agentic-coding windows as workspace windows', () => {
+    expect(
+      shouldGrandfatherMultiProjectMode(false, [
+        workspaceWindow('/ws/a'),
+        { mode: 'agentic-coding', workspacePath: '/ws/b', bounds },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/packages/electron/src/main/utils/store.ts
+++ b/packages/electron/src/main/utils/store.ts
@@ -2651,12 +2651,58 @@ export function updateMarketplaceInstall(extensionId: string, updates: Partial<M
 }
 
 // Multi-Project Rail Settings
-// `multiProjectMode` is the opt-in toggle that lets users open several
-// projects in a single window via the project rail. The `openProjects` list
-// and `activeProjectPath` are restored on launch so the rail rehydrates.
+// `multiProjectMode` lets users open several projects in a single window via
+// the project rail. Defaults ON (Phase 3 of single-window-multi-project) --
+// users who explicitly toggled it before this change keep their own choice,
+// since this is only a fallback for a key that was never written. The
+// `openProjects` list and `activeProjectPath` are restored on launch so the
+// rail rehydrates.
+
+/**
+ * Whether an upgrading install should be grandfathered OUT of the new
+ * default-on behavior.
+ *
+ * Defaulting the mode on is right for new installs, but for someone already
+ * running several windows it silently turns "6 windows" into "1 window with a
+ * rail sidebar I have never seen" on the very next launch. No projects are
+ * lost (restore seeds them all into the rail), but it is an unannounced change
+ * in shape, and this ships to users who never asked for it.
+ *
+ * So: only grandfather when BOTH are true -- the user never expressed a
+ * preference (key absent), and their saved session actually has more than one
+ * workspace window to collapse. Someone with zero or one workspace window sees
+ * no visible change from the new default, so there is nothing to protect them
+ * from.
+ *
+ * Pure and exported so the decision is testable without an electron-store.
+ */
+export function shouldGrandfatherMultiProjectMode(
+  hasExplicitPreference: boolean,
+  savedWindows: SessionWindow[] | undefined,
+): boolean {
+  if (hasExplicitPreference) return false;
+  const workspaceWindowCount = (savedWindows ?? []).filter(
+    (w) => w.mode === 'workspace' || w.mode === 'agentic-coding',
+  ).length;
+  return workspaceWindowCount > 1;
+}
 
 export function getMultiProjectMode(): boolean {
-  return getAppStore().get('multiProjectMode', false);
+  const store = getAppStore();
+  if (store.has('multiProjectMode')) {
+    return store.get('multiProjectMode', true);
+  }
+
+  // First read after upgrading. Decide once, then persist, so the answer is
+  // stable for the rest of this install's life and the user's later toggles
+  // behave like any other explicit preference.
+  const grandfathered = shouldGrandfatherMultiProjectMode(
+    false,
+    store.get('sessionState')?.windows,
+  );
+  const value = !grandfathered;
+  store.set('multiProjectMode', value);
+  return value;
 }
 
 export function setMultiProjectMode(enabled: boolean): void {

--- a/packages/electron/src/main/window/AIUsageReportWindow.ts
+++ b/packages/electron/src/main/window/AIUsageReportWindow.ts
@@ -1,12 +1,10 @@
-import electron from 'electron';
+import { app, BrowserWindow } from 'electron';
 import { join } from 'path';
 import { getPreloadPath } from '../utils/appPaths';
 
-const { app, BrowserWindow } = electron;
+let usageReportWindow: BrowserWindow | null = null;
 
-let usageReportWindow: electron.BrowserWindow | null = null;
-
-export function createAIUsageReportWindow(): electron.BrowserWindow {
+export function createAIUsageReportWindow(): BrowserWindow {
   // If window already exists, focus it
   if (usageReportWindow && !usageReportWindow.isDestroyed()) {
     usageReportWindow.focus();
@@ -58,7 +56,7 @@ export function createAIUsageReportWindow(): electron.BrowserWindow {
   return usageReportWindow;
 }
 
-export function getAIUsageReportWindow(): electron.BrowserWindow | null {
+export function getAIUsageReportWindow(): BrowserWindow | null {
   return usageReportWindow;
 }
 

--- a/packages/electron/src/main/window/WindowManager.ts
+++ b/packages/electron/src/main/window/WindowManager.ts
@@ -4,9 +4,10 @@ import { join, basename } from 'path';
 import { existsSync } from 'fs';
 import { WindowState, FileTreeItem } from '../types';
 import { WINDOW_CASCADE_OFFSET } from '../utils/constants';
-import { getTheme, saveWorkspaceWindowState, getWorkspaceNavigationHistory, saveWorkspaceNavigationHistory } from '../utils/store';
+import { getTheme, saveWorkspaceWindowState, getWorkspaceWindowState, getWorkspaceNavigationHistory, saveWorkspaceNavigationHistory } from '../utils/store';
 import { stopFileWatcher } from '../file/FileWatcher';
-import { stopWorkspaceWatcher, startWorkspaceWatcher } from '../file/WorkspaceWatcher.ts';
+import { stopWorkspaceWatcher, startWorkspaceWatcher, stopWarmWorkspaceWatch } from '../file/WorkspaceWatcher.ts';
+import { clearPendingRailSeeds } from './railSeeding';
 import { getFolderContents } from '../utils/FileTree';
 import { getTitleBarColors } from '../theme/ThemeManager';
 import { ElectronDocumentService, setupDocumentServiceHandlers } from '../services/ElectronDocumentService';
@@ -164,6 +165,33 @@ export function getFocusedOrNewWindow(): BrowserWindow {
 
     // If no focused window, create a new one
     return createWindow();
+}
+
+/**
+ * Every workspace path a closing window's bounds/focus/dev-tools state
+ * should be persisted under: the window's primary path plus every rail-warm
+ * "additional" path it currently references.
+ *
+ * Before Multi-Project Mode, a window's primary path was the only workspace
+ * it could ever represent, so keying `saveWorkspaceWindowState` off it alone
+ * was correct. With the rail, one window's bounds ARE the bounds every
+ * referenced project would reopen into -- writing only the primary path left
+ * every other project's saved geometry stale (frozen at whatever it was the
+ * last time IT was a standalone window, or never written at all). Writing
+ * the same bounds to every referenced path means whichever project a user
+ * opens next launch restores the window that will actually end up hosting
+ * the whole rail, which is the geometry that matters.
+ *
+ * Pure so the close-time decision is unit-testable without spinning up a
+ * real BrowserWindow.
+ */
+export function resolveBoundsPersistPaths(state: WindowState | undefined): string[] {
+    if (!state || state.mode !== 'workspace' || !state.workspacePath) return [];
+    const paths = new Set<string>([state.workspacePath]);
+    for (const path of state.additionalWorkspacePaths ?? []) {
+        if (path) paths.add(path);
+    }
+    return [...paths];
 }
 
 export interface CreateWindowOptions {
@@ -393,42 +421,47 @@ export function createWindow(
             }
         });
 
-        // Handle window close with unsaved changes
-        window.on('close', (event) => {
-            if (isQuitting) {
-                // Allow close to proceed without prompts during app quit
-                return;
-            }
-
-            const state = windowStates.get(windowId);
-            if (state?.documentEdited) {
-                event.preventDefault();
-                // Send message to renderer to show custom dialog
-                window.webContents.send('confirm-close-unsaved');
-            }
-        });
-
         // Store state for use in both 'close' and 'closed' handlers
         let savedState: WindowState | undefined;
 
-        window.on('close', (event) => {
-            // Save workspace-specific window state before closing
-            const state = windowStates.get(windowId);
-            savedState = state; // Preserve for 'closed' handler
-
+        // Persist bounds/nav-history for a workspace window. Shared by both
+        // branches of the 'close' handler below: the original (pre-fix) code
+        // ran this unconditionally even on a *prevented* close (it lived in a
+        // second, always-run listener), so a cancelled close still captured
+        // the window's current bounds/nav history. That part was harmless --
+        // it just gets overwritten on the eventual real close -- so the merge
+        // below preserves it for both branches. What must NOT run on a
+        // prevented close is `windowStates.delete` and the session re-save.
+        const persistWorkspaceCloseState = (state: WindowState | undefined) => {
             if (state?.mode === 'workspace' && state.workspacePath) {
                 const bounds = window.getBounds();
                 const focusOrder = windowFocusOrder.get(windowId) || 0;
                 const devToolsOpen = windowDevToolsState.get(windowId) || false;
+                const activePath = state.activeWorkspacePath ?? state.workspacePath;
 
-                saveWorkspaceWindowState(state.workspacePath, {
-                    mode: 'workspace',
-                    workspacePath: state.workspacePath,
-                    filePath: state.filePath ?? undefined,
-                    bounds,
-                    focusOrder,
-                    devToolsOpen
-                });
+                // Persist bounds/focus/dev-tools to every path this window
+                // referenced (see resolveBoundsPersistPaths), not just the
+                // primary. `state.filePath` is a WINDOW-level field (the
+                // currently open file in whichever project is active) --
+                // NOT per-project, so attributing it to a background rail
+                // path would stamp the active project's open file onto an
+                // unrelated project's saved state. Only the active path gets
+                // `state.filePath`; every other referenced path keeps
+                // whatever file it last had saved for itself.
+                for (const path of resolveBoundsPersistPaths(state)) {
+                    const filePathForPath = path === activePath
+                        ? (state.filePath ?? undefined)
+                        : getWorkspaceWindowState(path)?.filePath;
+
+                    saveWorkspaceWindowState(path, {
+                        mode: 'workspace',
+                        workspacePath: path,
+                        filePath: filePathForPath,
+                        bounds,
+                        focusOrder,
+                        devToolsOpen
+                    });
+                }
 
                 // Save navigation history
                 const navHistory = navigationHistoryService.saveNavigationState(windowId);
@@ -436,6 +469,34 @@ export function createWindow(
                     saveWorkspaceNavigationHistory(state.workspacePath, navHistory);
                 }
             }
+        };
+
+        // Handle window close: prompt-and-cancel for unsaved changes, then
+        // (only for a close that actually proceeds) drop this window from
+        // `windowStates` and re-save the global session.
+        //
+        // NOTE: this used to be TWO separate `window.on('close', ...)`
+        // listeners -- one that called `event.preventDefault()` for unsaved
+        // changes, and a second, unconditional one that always saved state
+        // and called `windowStates.delete(windowId)`. Node's EventEmitter
+        // runs every registered listener regardless of `preventDefault()`,
+        // so a close the user CANCELLED still wiped this window's state
+        // while the window stayed on screen. Merged into one listener so a
+        // prevented close returns before the destructive parts run.
+        window.on('close', (event) => {
+            const state = windowStates.get(windowId);
+
+            if (!isQuitting && state?.documentEdited) {
+                event.preventDefault();
+                // Send message to renderer to show custom dialog
+                window.webContents.send('confirm-close-unsaved');
+                persistWorkspaceCloseState(state);
+                return; // Cancelled: leave windowStates (and everything derived from it) untouched.
+            }
+
+            // The close is proceeding (either quitting, or no unsaved changes).
+            savedState = state; // Preserve for 'closed' handler
+            persistWorkspaceCloseState(state);
 
             // Remove from windowStates so saveSessionState() will skip this closing window
             windowStates.delete(windowId);
@@ -463,11 +524,27 @@ export function createWindow(
 
         window.on('closed', () => {
             windows.delete(windowId);
-            // Use saved state from 'close' handler
-            const state = savedState;
+            // Use state saved during 'close' when the window closed directly.
+            // Falls back to the live `windowStates` entry for windows
+            // destroyed via the save/discard dialog flow: `close-window-save`
+            // / `close-window-discard` (below) call `window.destroy()`
+            // directly once the renderer resolves the dialog, and per
+            // Electron, `destroy()` skips the 'close' event entirely -- so a
+            // window whose FIRST close attempt was cancelled (see 'close'
+            // above) never re-enters that handler, and `savedState` is never
+            // populated for it.
+            const state = savedState ?? windowStates.get(windowId);
+            // Always release the windowStates entry here too -- it is a
+            // no-op if 'close' already deleted it, and the only place that
+            // reliably runs for the destroy()-after-cancelled-close path.
+            windowStates.delete(windowId);
             savingWindows.delete(windowId);
             windowFocusOrder.delete(windowId);
             windowDevToolsState.delete(windowId);
+            // Rail seeds parked for a window that closed before its renderer
+            // collected them would otherwise sit in the map for the process
+            // lifetime.
+            clearPendingRailSeeds(windowId);
             stopFileWatcher(windowId);
             stopWorkspaceWatcher(windowId);
 
@@ -493,6 +570,21 @@ export function createWindow(
 
                 for (const path of referencedPaths) {
                     if (anyWindowReferencesWorkspace(path)) continue;
+
+                    // Release the rail's background watch (content-only
+                    // file-changed/file-deleted forwarding + GitRefWatcher)
+                    // for this path. `stopWorkspaceWatcher(windowId)` above
+                    // already swept any of this window's ADDITIONAL
+                    // (rail-warm, already-backgrounded) paths that went
+                    // unreferenced, but a path that was still this window's
+                    // ACTIVE path at close time was never demoted to a
+                    // background watch, so it never showed up in that sweep
+                    // -- its GitRefWatcher would otherwise run forever. Safe
+                    // (no-op) to call again for paths the sweep already
+                    // handled: both `releaseAllBackgroundRefs` and
+                    // `gitRefWatcher.stop` are no-ops for a path with nothing
+                    // left to release.
+                    stopWarmWorkspaceWatch(path);
 
                     const docService = documentServices.get(path);
                     if (docService) {

--- a/packages/electron/src/main/window/WorkspaceManagerWindow.ts
+++ b/packages/electron/src/main/window/WorkspaceManagerWindow.ts
@@ -5,9 +5,12 @@ import { existsSync, mkdirSync, statSync } from 'fs';
 import { readdir } from 'fs/promises';
 import { resolveEntryType } from '../utils/FileTree';
 import { shouldExcludeDir, shouldExcludePath } from '../utils/fileFilters';
-import { getRecentItems, addToRecentItems, store, getWorkspaceWindowState, getTheme } from '../utils/store';
-import { createWindow, findWindowByWorkspace, windows, windowStates } from './WindowManager';
+import { getRecentItems, addToRecentItems, store, getWorkspaceWindowState, getTheme, getMultiProjectMode } from '../utils/store';
+import { createWindow, findWindowByWorkspace, getMostRecentlyFocusedWorkspaceWindow, windowStates, type CreateWindowOptions } from './WindowManager';
 import { safeHandle } from '../utils/ipcRegistry';
+import { resolveProjectOpenTarget } from './resolveProjectOpenTarget';
+import { seedProjectIntoWindow, type RailSeedOutcome } from './railSeeding';
+import { logger } from '../utils/logger';
 import { getBackgroundColor } from '../theme/ThemeManager';
 import { AnalyticsService } from '../services/analytics/AnalyticsService';
 import { GitStatusService } from '../services/GitStatusService';
@@ -20,7 +23,6 @@ import {
 import { initializeTrackerSync } from '../services/TrackerSyncManager';
 import { updateTrackerSchemaWorkspace } from '../services/TrackerSchemaService';
 import { getDialogDefaultPath, rememberDialogSelection } from '../utils/dialogPaths';
-import { windowReferencesWorkspace } from './windowState';
 import { TutorialProjectService } from '../services/tutorial/TutorialProjectService';
 import {
   normalizeTutorialEntryPoint,
@@ -78,29 +80,137 @@ function bucketFileCount(count: number): string {
   return '100+';
 }
 
-function findWindowReferencingWorkspace(workspacePath: string): BrowserWindow | null {
-  for (const [windowId, state] of windowStates) {
-    if (!windowReferencesWorkspace(state, workspacePath)) continue;
-    const window = windows.get(windowId);
-    if (window && !window.isDestroyed()) return window;
-  }
-  return null;
+export type ProjectOpenOutcome =
+  | { kind: 'focus-existing'; window: BrowserWindow }
+  | { kind: 'add-to-rail'; window: BrowserWindow }
+  | { kind: 'new-window'; window: BrowserWindow };
+
+/** Async-sibling outcome for callers that must sequence a payload after the
+ *  rail registration actually lands (see `openOrFocusWorkspaceWindowAwaitingRailSeed`
+ *  below). `'blocked'` replaces `add-to-rail` when the seed did not land --
+ *  there is no window it is safe to deliver a payload into. */
+export type ProjectOpenOutcomeAsync =
+  | { kind: 'focus-existing'; window: BrowserWindow }
+  | { kind: 'add-to-rail'; window: BrowserWindow }
+  | { kind: 'new-window'; window: BrowserWindow }
+  | { kind: 'blocked'; reason: Extract<RailSeedOutcome, 'at-cap' | 'timeout'>; window: BrowserWindow };
+
+/**
+ * Shared routing decision: focus an existing window, add to the focused
+ * window's rail (Multi-Project Mode), or spawn a new window. Pulled out so
+ * the sync and async entry points below cannot drift on recents tracking or
+ * the existing-window/focused-window lookups.
+ */
+function routeWorkspaceWindow(workspacePath: string) {
+  addToRecentItems('workspaces', workspacePath, basename(workspacePath));
+
+  // findWindowByWorkspace (not a local exact-match helper) so worktree paths
+  // resolve to the parent project's window the same way MCP routing and the
+  // notification click path already do -- funneling call sites through this
+  // chokepoint must not narrow their existing-window matching.
+  const existingWindow = findWindowByWorkspace(workspacePath);
+  return resolveProjectOpenTarget({
+    workspacePath,
+    multiProjectModeEnabled: getMultiProjectMode(),
+    existingWindowForPath: existingWindow,
+    focusedWorkspaceWindow: existingWindow ? null : getMostRecentlyFocusedWorkspaceWindow(),
+  });
+}
+
+function createNewWorkspaceWindow(workspacePath: string, options?: CreateWindowOptions): BrowserWindow {
+  const savedState = getWorkspaceWindowState(workspacePath);
+  return createWindow(false, true, workspacePath, savedState?.bounds, options);
 }
 
 /**
- * Focus the window already showing a workspace, or open one for it. Shared by
- * the two "open this project" channels so they cannot drift apart on recents or
- * saved bounds.
+ * Focus the window already showing a workspace, add it to the focused
+ * window's project rail (Multi-Project Mode), or open a new window for it.
+ * This is THE chokepoint for "open this project" -- every call site that
+ * opens a workspace (as opposed to a bare document) must funnel through
+ * here so they cannot drift apart on recents, saved bounds, or whether the
+ * rail is respected.
+ *
+ * In the `focus-existing` and `new-window` cases the returned window's
+ * *content* is already loaded or is a genuinely fresh window callers wait on
+ * `ready-to-show` / `did-finish-load` for, same as before. In the
+ * `add-to-rail` case, though, the window's content is loaded but the
+ * *project* is not yet registered in it -- `workspace:register-additional`
+ * and the rail activation happen asynchronously in the renderer (see
+ * `store/listeners/railProjectListeners.ts`) and are still in flight when
+ * this function returns. Callers that only need to know where a project
+ * landed (menus, discarded outcomes) can use the returned window as-is; any
+ * caller that needs to deliver a payload targeted at that project (a deep
+ * link, `open-document`, ...) MUST NOT send it synchronously against this
+ * return value -- use `openOrFocusWorkspaceWindowAwaitingRailSeed` instead
+ * and sequence the send after it resolves.
  */
-function openOrFocusWorkspaceWindow(workspacePath: string): void {
-  addToRecentItems('workspaces', workspacePath, basename(workspacePath));
-  const existingWindow = findWindowReferencingWorkspace(workspacePath);
-  if (existingWindow) {
-    existingWindow.focus();
-    return;
+function openOrFocusWorkspaceWindow(
+  workspacePath: string,
+  options?: CreateWindowOptions,
+): ProjectOpenOutcome {
+  const target = routeWorkspaceWindow(workspacePath);
+
+  if (target.kind === 'focus-existing') {
+    target.window.focus();
+    return { kind: 'focus-existing', window: target.window };
   }
-  const savedState = getWorkspaceWindowState(workspacePath);
-  createWindow(false, true, workspacePath, savedState?.bounds);
+
+  if (target.kind === 'add-to-rail') {
+    target.window.focus();
+    // Fire-and-forget: this caller doesn't need to know the outcome, but
+    // route it through the same acked channel `seedProjectIntoWindow` uses
+    // (rather than a bare `webContents.send`) so there is exactly one way
+    // `rail:add-project` ever gets sent, and callers that DO need to wait
+    // (`openOrFocusWorkspaceWindowAwaitingRailSeed`) aren't racing a second,
+    // unacked send of the same message.
+    void seedProjectIntoWindow(target.window, workspacePath);
+    return { kind: 'add-to-rail', window: target.window };
+  }
+
+  return { kind: 'new-window', window: createNewWorkspaceWindow(workspacePath, options) };
+}
+
+export { openOrFocusWorkspaceWindow };
+
+/**
+ * Async sibling of `openOrFocusWorkspaceWindow` for callers that need to
+ * deliver a payload targeted at `workspacePath` once it is actually open in
+ * the returned window. Resolves only after the `add-to-rail` case's seed is
+ * confirmed (registered, and appended to the rail) or definitively failed:
+ *
+ * - `focus-existing` / `new-window` resolve immediately, same as the sync
+ *   chokepoint -- there is no seed to wait on.
+ * - `add-to-rail` resolves once `seedProjectIntoWindow` gets an `'added'` or
+ *   `'already-open'` ack.
+ * - `'at-cap'` or `'timeout'` resolve to `{ kind: 'blocked' }` instead of
+ *   `add-to-rail` -- the project never landed anywhere, so there is no
+ *   window it is safe to deliver a payload into. Callers must not send
+ *   anything in this case; surface the failure instead (log, notify, or
+ *   leave a queued/pending entry for a later attempt to drain).
+ */
+export async function openOrFocusWorkspaceWindowAwaitingRailSeed(
+  workspacePath: string,
+  options?: CreateWindowOptions & { seedTimeoutMs?: number },
+): Promise<ProjectOpenOutcomeAsync> {
+  const target = routeWorkspaceWindow(workspacePath);
+
+  if (target.kind === 'focus-existing') {
+    target.window.focus();
+    return { kind: 'focus-existing', window: target.window };
+  }
+
+  if (target.kind === 'add-to-rail') {
+    target.window.focus();
+    const seedOutcome = await seedProjectIntoWindow(target.window, workspacePath, {
+      timeoutMs: options?.seedTimeoutMs,
+    });
+    if (seedOutcome === 'at-cap' || seedOutcome === 'timeout') {
+      return { kind: 'blocked', reason: seedOutcome, window: target.window };
+    }
+    return { kind: 'add-to-rail', window: target.window };
+  }
+
+  return { kind: 'new-window', window: createNewWorkspaceWindow(workspacePath, options) };
 }
 
 /**
@@ -429,31 +539,38 @@ export function setupWorkspaceManagerHandlers() {
     return { success: false };
   });
 
-  // Open workspace (reuse existing window if already open)
+  // Open workspace: focus an existing window, add to the focused window's
+  // rail (Multi-Project Mode), or create a new window -- via the shared
+  // chokepoint so this, the most common "open a project" entry point,
+  // cannot drift from the others.
   safeHandle('workspace-manager:open-workspace', async (event, workspacePath: string) => {
-    // Add to recent workspaces
-    addToRecentItems('workspaces', workspacePath, basename(workspacePath));
+    // Awaits the rail seed (if any) before touching the Workspace Manager
+    // window: closing it is an irreversible UI action for the user, and
+    // doing that before the seed is confirmed would strand them with no
+    // surface to retry from if the seed comes back 'at-cap' or 'timeout'.
+    const outcome = await openOrFocusWorkspaceWindowAwaitingRailSeed(workspacePath);
 
-    // Check if this workspace is already open in an existing window
-    const existingWindow = findWindowByWorkspace(workspacePath);
-    if (existingWindow && !existingWindow.isDestroyed()) {
-      // Focus the existing window instead of creating a new one
-      existingWindow.focus();
+    if (outcome.kind === 'blocked') {
+      logger.main.warn(
+        '[WorkspaceManager] Rail seed did not land, leaving Workspace Manager open:',
+        { workspacePath, reason: outcome.reason },
+      );
+      return { success: false, error: `Could not open project (${outcome.reason})` };
+    }
 
-      // Close workspace manager after focusing existing workspace
+    if (outcome.kind !== 'new-window') {
+      // Existing/rail window is already loaded -- no analytics/MCP-watch/
+      // team-match/tracker-sync/devtools bootstrapping to do, that already
+      // happened when the window (or the rail registration) was created.
       if (workspaceManagerWindow && !workspaceManagerWindow.isDestroyed()) {
         workspaceManagerClosingForProject = true;
         workspaceManagerWindow.close();
       }
-
       return { success: true };
     }
 
-    // Check for saved workspace window state
+    const window = outcome.window;
     const savedState = getWorkspaceWindowState(workspacePath);
-
-    // Create window with saved bounds if available
-    const window = createWindow(false, true, workspacePath, savedState?.bounds);
 
     (async () => {
       try {

--- a/packages/electron/src/main/window/__tests__/WindowManager.close.test.ts
+++ b/packages/electron/src/main/window/__tests__/WindowManager.close.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Regression coverage for the double `window.on('close', ...)` registration
+ * in WindowManager.ts: Node's EventEmitter runs every registered listener
+ * regardless of `event.preventDefault()`, so a second listener that always
+ * saved-and-deleted window state used to wipe a window's `windowStates`
+ * entry even when the FIRST listener cancelled the close for unsaved
+ * changes. The window then stayed on screen with its main-side state gone.
+ *
+ * This suite drives the real `close`/`closed` listeners `createWindow()`
+ * registers, using a fake `BrowserWindow` that mirrors Electron's actual
+ * event semantics:
+ *   - `close()` fires every 'close' listener, then only proceeds to fire
+ *     'closed' if none of them called `preventDefault()`.
+ *   - `destroy()` skips 'close' entirely and always fires 'closed' (mirrors
+ *     the real `close-window-save` / `close-window-discard` IPC handlers,
+ *     which call `window.destroy()` directly after the renderer's dialog
+ *     resolves).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  return {
+    getTheme: vi.fn(() => 'light'),
+    saveWorkspaceWindowState: vi.fn(),
+    getWorkspaceWindowState: vi.fn((_path: string): { filePath?: string } | undefined => undefined),
+    getWorkspaceNavigationHistory: vi.fn(() => null),
+    saveWorkspaceNavigationHistory: vi.fn(),
+    stopFileWatcher: vi.fn(),
+    stopWorkspaceWatcher: vi.fn(),
+    startWorkspaceWatcher: vi.fn(),
+    stopWarmWorkspaceWatch: vi.fn(),
+    getFolderContents: vi.fn(),
+    getTitleBarColors: vi.fn(() => ({ color: '#000', symbolColor: '#fff' })),
+    setupDocumentServiceHandlers: vi.fn(),
+    isWorktreePath: vi.fn(() => false),
+    resolveProjectPath: vi.fn((p: string) => p),
+    getPreloadPath: vi.fn(() => '/fake/preload.js'),
+    setFileSystemService: vi.fn(),
+    clearFileSystemService: vi.fn(),
+    setFileSystemServiceFor: vi.fn(),
+    saveNavigationState: vi.fn(() => null),
+    restoreNavigationState: vi.fn(),
+    removeWindow: vi.fn(),
+    revealReadyWindow: vi.fn(),
+    registerStartupWindow: vi.fn(),
+    signalFirstWindowLoaded: vi.fn(),
+    getMcpConfigService: vi.fn(() => null),
+    addNimAssetRoot: vi.fn(),
+    addNimPreviewWorkspaceRoot: vi.fn(),
+    scheduleAttachmentStagingCleanup: vi.fn(),
+    isRestarting: vi.fn(() => false),
+    saveSessionState: vi.fn(async () => {}),
+    unregisterWindow: vi.fn(),
+    docServiceDestroy: vi.fn(),
+    fsServiceDestroy: vi.fn(),
+    beforeQuitHandlers: [] as Array<() => void>,
+  };
+});
+
+vi.mock('electron', () => {
+  return {
+    BrowserWindow: class FakeBrowserWindow {
+      static _nextId = 1;
+      id: number;
+      webContents: any;
+      private listeners = new Map<string, Array<(...args: any[]) => void>>();
+      destroyed = false;
+
+      constructor(_options: any) {
+        this.id = FakeBrowserWindow._nextId++;
+        this.webContents = {
+          send: vi.fn(),
+          on: vi.fn(),
+          once: vi.fn(),
+          setMaxListeners: vi.fn(),
+          session: { addWordToSpellCheckerDictionary: vi.fn() },
+          getURL: () => '',
+          replaceMisspelling: vi.fn(),
+        };
+      }
+
+      on(event: string, handler: (...args: any[]) => void) {
+        const arr = this.listeners.get(event) ?? [];
+        arr.push(handler);
+        this.listeners.set(event, arr);
+        return this;
+      }
+
+      once(event: string, handler: (...args: any[]) => void) {
+        return this.on(event, handler);
+      }
+
+      getBounds() {
+        return { x: 0, y: 0, width: 800, height: 600 };
+      }
+
+      isDestroyed() {
+        return this.destroyed;
+      }
+
+      isFocused() {
+        return false;
+      }
+
+      loadURL = vi.fn(() => Promise.resolve());
+      loadFile = vi.fn(() => Promise.resolve());
+      setTitleBarOverlay = vi.fn();
+
+      /** Mirrors a real window-close: every 'close' listener runs; 'closed'
+       *  only fires if none of them prevented the default. */
+      simulateCloseAttempt(): boolean {
+        const event = {
+          defaultPrevented: false,
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+        };
+        for (const handler of this.listeners.get('close') ?? []) {
+          handler(event);
+        }
+        if (!event.defaultPrevented) {
+          this.destroyed = true;
+          for (const handler of this.listeners.get('closed') ?? []) {
+            handler();
+          }
+        }
+        return event.defaultPrevented;
+      }
+
+      /** Mirrors `BrowserWindow.destroy()`: skips 'close' entirely, always
+       *  fires 'closed'. Used by the close-window-save/discard IPC flow. */
+      destroy() {
+        this.destroyed = true;
+        for (const handler of this.listeners.get('closed') ?? []) {
+          handler();
+        }
+      }
+    },
+    dialog: { showMessageBoxSync: vi.fn(() => 0) },
+    app: {
+      getAppPath: () => '/fake/app',
+      isPackaged: false,
+      on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        if (event === 'before-quit') mocks.beforeQuitHandlers.push(handler);
+      }),
+      getPath: vi.fn(() => '/fake/userdata'),
+    },
+    nativeImage: { createFromPath: vi.fn(() => ({})) },
+    ipcMain: { emit: vi.fn(), handle: vi.fn(), on: vi.fn() },
+    screen: {
+      getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+      getDisplayNearestPoint: () => ({ bounds: { x: 0, y: 0, width: 1920, height: 1080 } }),
+    },
+    nativeTheme: { shouldUseDarkColors: false },
+    Menu: { buildFromTemplate: vi.fn(() => ({ popup: vi.fn() })), setApplicationMenu: vi.fn() },
+  };
+});
+
+vi.mock('../../utils/ipcRegistry', () => ({
+  safeHandle: vi.fn(),
+  safeOn: vi.fn(),
+}));
+
+vi.mock('fs', () => ({ existsSync: () => false }));
+
+vi.mock('../../utils/constants', () => ({ WINDOW_CASCADE_OFFSET: 40 }));
+
+vi.mock('../../utils/store', () => ({
+  getTheme: mocks.getTheme,
+  saveWorkspaceWindowState: mocks.saveWorkspaceWindowState,
+  getWorkspaceWindowState: mocks.getWorkspaceWindowState,
+  getWorkspaceNavigationHistory: mocks.getWorkspaceNavigationHistory,
+  saveWorkspaceNavigationHistory: mocks.saveWorkspaceNavigationHistory,
+}));
+
+vi.mock('../../file/FileWatcher', () => ({
+  stopFileWatcher: mocks.stopFileWatcher,
+}));
+
+vi.mock('../../file/WorkspaceWatcher.ts', () => ({
+  stopWorkspaceWatcher: mocks.stopWorkspaceWatcher,
+  startWorkspaceWatcher: mocks.startWorkspaceWatcher,
+  stopWarmWorkspaceWatch: mocks.stopWarmWorkspaceWatch,
+}));
+
+vi.mock('../../utils/FileTree', () => ({
+  getFolderContents: mocks.getFolderContents,
+}));
+
+vi.mock('../../theme/ThemeManager', () => ({
+  getTitleBarColors: mocks.getTitleBarColors,
+}));
+
+class FakeDocService {
+  destroy = mocks.docServiceDestroy;
+}
+class FakeFsService {
+  destroy = mocks.fsServiceDestroy;
+}
+
+vi.mock('../../services/ElectronDocumentService', () => ({
+  ElectronDocumentService: vi.fn(function () {
+    return new FakeDocService();
+  }),
+  setupDocumentServiceHandlers: mocks.setupDocumentServiceHandlers,
+}));
+
+vi.mock('../../services/ElectronFileSystemService', () => ({
+  ElectronFileSystemService: vi.fn(function () {
+    return new FakeFsService();
+  }),
+}));
+
+vi.mock('../../utils/workspaceDetection', () => ({
+  isWorktreePath: mocks.isWorktreePath,
+  resolveProjectPath: mocks.resolveProjectPath,
+}));
+
+vi.mock('../../utils/appPaths', () => ({
+  getPreloadPath: mocks.getPreloadPath,
+}));
+
+// Mocks the barrel specifier deliberately, matching `WindowManager.ts`'s own
+// import. CLAUDE.md's rule (NIM-2374) exists to stop the real barrel loading
+// and dragging in the Lexical tree -- and this PLAIN factory is what prevents
+// it; the expensive shape the rule names is the `importOriginal` spread, which
+// forces the real barrel to load.
+//
+// Mocking the deep path (`@nimbalyst/runtime/core/FileSystemService`) instead
+// is worse here, not better: `WindowManager.ts` imports the barrel, so nothing
+// intercepts it, the real barrel loads, and this file's import time goes from
+// ~0.1s to ~4.3s -- measured. The full fix is to move the SOURCE import to the
+// deep path too, per the rule's "import from the deep path in source too". That
+// needs the packaged main-process build's `runtime/core/*` subpath resolution
+// verified first, so it is a follow-up rather than a drive-by here.
+vi.mock('@nimbalyst/runtime', () => ({
+  setFileSystemService: mocks.setFileSystemService,
+  clearFileSystemService: mocks.clearFileSystemService,
+  setFileSystemServiceFor: mocks.setFileSystemServiceFor,
+}));
+
+vi.mock('../../services/NavigationHistoryService', () => ({
+  navigationHistoryService: {
+    saveNavigationState: mocks.saveNavigationState,
+    restoreNavigationState: mocks.restoreNavigationState,
+    removeWindow: mocks.removeWindow,
+  },
+}));
+
+vi.mock('../revealReadyWindow', () => ({
+  revealReadyWindow: mocks.revealReadyWindow,
+}));
+
+vi.mock('../StartupActivation', () => ({
+  registerStartupWindow: mocks.registerStartupWindow,
+}));
+
+vi.mock('../../services/startupMaintenanceGate', () => ({
+  signalFirstWindowLoaded: mocks.signalFirstWindowLoaded,
+}));
+
+vi.mock('../../services/analytics/AnalyticsService', () => ({
+  AnalyticsService: { getInstance: () => ({ sendEvent: vi.fn() }) },
+}));
+
+vi.mock('../../services/analytics/FeatureTrackingService', () => ({
+  FeatureTrackingService: {
+    getInstance: () => ({ isFirstUse: () => false, getDaysSinceInstall: () => 0 }),
+  },
+}));
+
+vi.mock('../../services/ExtensionLogService', () => ({
+  ExtensionLogService: { getInstance: () => ({ addRendererLog: vi.fn() }) },
+}));
+
+vi.mock('../../mcpConfigServiceRef', () => ({
+  getMcpConfigService: mocks.getMcpConfigService,
+}));
+
+vi.mock('../../protocols/nimAssetProtocol', () => ({
+  addNimAssetRoot: mocks.addNimAssetRoot,
+}));
+
+vi.mock('../../protocols/nimPreviewProtocol', () => ({
+  addNimPreviewWorkspaceRoot: mocks.addNimPreviewWorkspaceRoot,
+}));
+
+vi.mock('../../services/attachments/attachmentStagingCleanup', () => ({
+  scheduleAttachmentStagingCleanup: mocks.scheduleAttachmentStagingCleanup,
+}));
+
+vi.mock('../../index', () => ({
+  isRestarting: mocks.isRestarting,
+}));
+
+vi.mock('../../session/SessionState', () => ({
+  saveSessionState: mocks.saveSessionState,
+}));
+
+vi.mock('../../mcp/httpServer', () => ({
+  unregisterWindow: mocks.unregisterWindow,
+}));
+
+// Imported AFTER mocks so the real `close`/`closed` listener wiring in
+// createWindow() runs against the fakes above. windowState.ts and
+// sessionSaveOnClose.ts are intentionally left un-mocked -- they are plain
+// Maps / pure logic with no Electron dependency, and this suite wants to
+// exercise the real `windowStates` map and the real quit/restart guard.
+import { createWindow, getWindowId, resolveBoundsPersistPaths } from '../WindowManager';
+import { windows, windowStates } from '../windowState';
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('WindowManager close/closed listeners', () => {
+  beforeEach(() => {
+    windows.clear();
+    windowStates.clear();
+    vi.clearAllMocks();
+    mocks.getTheme.mockReturnValue('light');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('a cancelled close (unsaved changes) leaves windowStates and windows intact', async () => {
+    const window = createWindow(false, true, '/ws/project-a') as any;
+    const windowId = getWindowId(window)!;
+    windowStates.get(windowId)!.documentEdited = true;
+
+    // Proves the `@nimbalyst/runtime/core/FileSystemService` mock actually
+    // intercepts `createWindow`'s real call, not a silent no-op (mocking the
+    // wrong specifier would leave this unset and eventually throw against
+    // the real module's FileSystemService state instead).
+    expect(mocks.setFileSystemService).toHaveBeenCalledWith(expect.anything());
+    expect(mocks.setFileSystemServiceFor).toHaveBeenCalledWith('/ws/project-a', expect.anything());
+
+    const prevented = window.simulateCloseAttempt();
+
+    expect(prevented).toBe(true);
+    expect(window.webContents.send).toHaveBeenCalledWith('confirm-close-unsaved');
+
+    // The bug: a second unconditional 'close' listener used to run anyway
+    // and wipe this window's state even though the close was cancelled.
+    expect(windowStates.has(windowId)).toBe(true);
+    expect(windowStates.get(windowId)?.documentEdited).toBe(true);
+    expect(windows.has(windowId)).toBe(true);
+
+    // Bounds/nav-history persistence is benign on a cancelled close (gets
+    // overwritten by the eventual real close) and the pre-fix code already
+    // did this unconditionally -- preserve that, unlike the destructive
+    // windowStates.delete / session re-save which must NOT run here.
+    expect(mocks.saveWorkspaceWindowState).toHaveBeenCalledWith(
+      '/ws/project-a',
+      expect.objectContaining({ mode: 'workspace', workspacePath: '/ws/project-a' })
+    );
+
+    await flushMicrotasks();
+  });
+
+  it('a real close (no unsaved changes) still saves workspace state and tears the window down', async () => {
+    const window = createWindow(false, true, '/ws/project-b') as any;
+    const windowId = getWindowId(window)!;
+    windowStates.get(windowId)!.documentEdited = false;
+
+    const prevented = window.simulateCloseAttempt();
+
+    expect(prevented).toBe(false);
+    expect(mocks.saveWorkspaceWindowState).toHaveBeenCalledWith(
+      '/ws/project-b',
+      expect.objectContaining({ mode: 'workspace', workspacePath: '/ws/project-b' })
+    );
+    expect(windowStates.has(windowId)).toBe(false);
+    expect(windows.has(windowId)).toBe(false);
+
+    await flushMicrotasks();
+  });
+
+  it('a window whose first close attempt was cancelled still fully tears down after the user discards', async () => {
+    const window = createWindow(false, true, '/ws/project-c') as any;
+    const windowId = getWindowId(window)!;
+    windowStates.get(windowId)!.documentEdited = true;
+
+    // First attempt: user has unsaved changes, dialog is shown, close is cancelled.
+    expect(window.simulateCloseAttempt()).toBe(true);
+    expect(windowStates.has(windowId)).toBe(true);
+
+    // User picks "discard" in the renderer dialog; close-window-discard calls
+    // window.destroy() directly, which (per Electron) skips 'close' entirely.
+    window.destroy();
+
+    // windowStates must still be released even though 'close' never ran again.
+    expect(windowStates.has(windowId)).toBe(false);
+    expect(windows.has(windowId)).toBe(false);
+    expect(mocks.docServiceDestroy).toHaveBeenCalled();
+
+    await flushMicrotasks();
+  });
+
+  it('releases the warm watch for a path that was still ACTIVE (never backgrounded) when its window closes', async () => {
+    // Residual gap fixed alongside the cancelled-close bug: a path that was
+    // never demoted to a background/rail-warm watch (i.e. it was the
+    // window's active project right up to close) is never covered by
+    // stopWorkspaceWatcher's own orphan sweep, because that sweep only
+    // iterates already-backgrounded paths.
+    const window = createWindow(false, true, '/ws/active-on-close') as any;
+    const windowId = getWindowId(window)!;
+    windowStates.get(windowId)!.documentEdited = false;
+
+    window.simulateCloseAttempt();
+
+    expect(mocks.stopWarmWorkspaceWatch).toHaveBeenCalledWith('/ws/active-on-close');
+
+    await flushMicrotasks();
+  });
+
+  describe('resolveBoundsPersistPaths (pure)', () => {
+    it('returns only the primary path for a window with no rail-warm paths', () => {
+      expect(
+        resolveBoundsPersistPaths({
+          mode: 'workspace',
+          filePath: null,
+          workspacePath: '/ws/solo',
+          documentEdited: false,
+        })
+      ).toEqual(['/ws/solo']);
+    });
+
+    it('includes every rail-warm additional path, deduped, alongside the primary', () => {
+      expect(
+        resolveBoundsPersistPaths({
+          mode: 'workspace',
+          filePath: null,
+          workspacePath: '/ws/primary',
+          additionalWorkspacePaths: ['/ws/second', '/ws/third', '/ws/primary'],
+          documentEdited: false,
+        })
+      ).toEqual(['/ws/primary', '/ws/second', '/ws/third']);
+    });
+
+    it('returns nothing for a document-mode window', () => {
+      expect(
+        resolveBoundsPersistPaths({
+          mode: 'document',
+          filePath: '/tmp/untitled.md',
+          workspacePath: null,
+          documentEdited: false,
+        })
+      ).toEqual([]);
+    });
+  });
+
+  it('a window closing with rail-warm additional paths writes bounds to every referenced path, not just the primary', async () => {
+    const window = createWindow(false, true, '/ws/rail-primary') as any;
+    const windowId = getWindowId(window)!;
+    const state = windowStates.get(windowId)!;
+    state.documentEdited = false;
+    state.additionalWorkspacePaths = ['/ws/rail-second'];
+    state.activeWorkspacePath = '/ws/rail-second';
+    state.filePath = '/ws/rail-second/README.md';
+
+    // The background (non-active) path already has its own remembered
+    // open file from a previous session -- the close handler must not
+    // clobber it with the active project's currently open file.
+    mocks.getWorkspaceWindowState.mockImplementation((path: string) =>
+      path === '/ws/rail-primary' ? { filePath: '/ws/rail-primary/old-notes.md' } : undefined
+    );
+
+    window.simulateCloseAttempt();
+
+    expect(mocks.saveWorkspaceWindowState).toHaveBeenCalledWith(
+      '/ws/rail-primary',
+      expect.objectContaining({
+        workspacePath: '/ws/rail-primary',
+        // Not the active path: carries forward its own previously-saved
+        // filePath instead of inheriting the active project's open file.
+        filePath: '/ws/rail-primary/old-notes.md',
+      })
+    );
+    expect(mocks.saveWorkspaceWindowState).toHaveBeenCalledWith(
+      '/ws/rail-second',
+      expect.objectContaining({
+        workspacePath: '/ws/rail-second',
+        // The active path: gets the window's live filePath.
+        filePath: '/ws/rail-second/README.md',
+      })
+    );
+
+    await flushMicrotasks();
+  });
+
+  // MUST run last: `isQuitting` is a module-level flag in WindowManager.ts
+  // flipped permanently by the captured `before-quit` handler, with no reset
+  // hook exported for tests.
+  it('during app quit, close proceeds without the dialog even with unsaved changes', async () => {
+    expect(mocks.beforeQuitHandlers.length).toBeGreaterThan(0);
+    mocks.beforeQuitHandlers[0]();
+
+    const window = createWindow(false, true, '/ws/project-quit') as any;
+    const windowId = getWindowId(window)!;
+    windowStates.get(windowId)!.documentEdited = true;
+
+    const prevented = window.simulateCloseAttempt();
+
+    expect(prevented).toBe(false);
+    expect(window.webContents.send).not.toHaveBeenCalledWith('confirm-close-unsaved');
+    expect(mocks.saveWorkspaceWindowState).toHaveBeenCalledWith(
+      '/ws/project-quit',
+      expect.objectContaining({ mode: 'workspace', workspacePath: '/ws/project-quit' })
+    );
+    expect(windowStates.has(windowId)).toBe(false);
+
+    await flushMicrotasks();
+  });
+});

--- a/packages/electron/src/main/window/__tests__/consolidateWorkspaceWindows.test.ts
+++ b/packages/electron/src/main/window/__tests__/consolidateWorkspaceWindows.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getMostRecentlyFocusedWorkspaceWindow: vi.fn(),
+  getWindowId: vi.fn(),
+  getMultiProjectMode: vi.fn(() => true),
+  seedProjectIntoWindow: vi.fn(),
+  flushWindowBeforeClose: vi.fn(),
+}));
+
+vi.mock('../WindowManager', () => ({
+  getMostRecentlyFocusedWorkspaceWindow: mocks.getMostRecentlyFocusedWorkspaceWindow,
+  getWindowId: mocks.getWindowId,
+}));
+
+vi.mock('../../utils/store', () => ({
+  getMultiProjectMode: mocks.getMultiProjectMode,
+}));
+
+vi.mock('../railSeeding', () => ({
+  seedProjectIntoWindow: mocks.seedProjectIntoWindow,
+}));
+
+vi.mock('../flushWindowBeforeClose', () => ({
+  flushWindowBeforeClose: mocks.flushWindowBeforeClose,
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    main: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+import { windows, windowStates } from '../windowState';
+import { consolidateWorkspaceWindows } from '../consolidateWorkspaceWindows';
+import type { WindowState } from '../../types';
+
+function fakeWindow(overrides: Partial<{ isDestroyed: boolean }> = {}) {
+  let destroyed = overrides.isDestroyed ?? false;
+  return {
+    isDestroyed: () => destroyed,
+    close: vi.fn(),
+    webContents: { send: vi.fn() },
+    _destroy: () => {
+      destroyed = true;
+    },
+  };
+}
+
+function state(overrides: Partial<WindowState>): WindowState {
+  return {
+    mode: 'workspace',
+    filePath: null,
+    workspacePath: null,
+    activeWorkspacePath: null,
+    additionalWorkspacePaths: [],
+    documentEdited: false,
+    ...overrides,
+  } as WindowState;
+}
+
+describe('consolidateWorkspaceWindows', () => {
+  let target: ReturnType<typeof fakeWindow>;
+  let donorA: ReturnType<typeof fakeWindow>;
+  let donorB: ReturnType<typeof fakeWindow>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    windows.clear();
+    windowStates.clear();
+    mocks.getMultiProjectMode.mockReturnValue(true);
+
+    target = fakeWindow();
+    donorA = fakeWindow();
+    donorB = fakeWindow();
+
+    windows.set(1, target as any);
+    windows.set(2, donorA as any);
+    windows.set(3, donorB as any);
+
+    windowStates.set(1, state({ workspacePath: '/ws/target', activeWorkspacePath: '/ws/target' }));
+    windowStates.set(2, state({ workspacePath: '/ws/donor-a' }));
+    windowStates.set(3, state({ workspacePath: '/ws/donor-b' }));
+
+    mocks.getMostRecentlyFocusedWorkspaceWindow.mockReturnValue(target);
+    mocks.getWindowId.mockImplementation((w: unknown) => (w === target ? 1 : null));
+    mocks.seedProjectIntoWindow.mockResolvedValue('added');
+    mocks.flushWindowBeforeClose.mockResolvedValue('flushed');
+  });
+
+  it('seeds every donor path with activate: false and closes fully-migrated donors', async () => {
+    const result = await consolidateWorkspaceWindows();
+
+    expect(mocks.seedProjectIntoWindow).toHaveBeenCalledWith(
+      target,
+      '/ws/donor-a',
+      expect.objectContaining({ activate: false }),
+    );
+    expect(mocks.seedProjectIntoWindow).toHaveBeenCalledWith(
+      target,
+      '/ws/donor-b',
+      expect.objectContaining({ activate: false }),
+    );
+
+    expect(result.seeded).toEqual(['/ws/donor-a', '/ws/donor-b']);
+    expect(result.refused).toEqual([]);
+    expect(result.closedWindowIds.sort()).toEqual([2, 3]);
+    expect(donorA.close).toHaveBeenCalledOnce();
+    expect(donorB.close).toHaveBeenCalledOnce();
+  });
+
+  it('never touches the target window\'s active path', async () => {
+    await consolidateWorkspaceWindows();
+
+    expect(windowStates.get(1)?.activeWorkspacePath).toBe('/ws/target');
+  });
+
+  it('stops on the first "at-cap" outcome and refuses the rest without seeding them', async () => {
+    mocks.seedProjectIntoWindow.mockResolvedValueOnce('at-cap');
+
+    const result = await consolidateWorkspaceWindows();
+
+    expect(mocks.seedProjectIntoWindow).toHaveBeenCalledTimes(1);
+    expect(result.seeded).toEqual([]);
+    expect(result.refused).toEqual(['/ws/donor-a', '/ws/donor-b']);
+    expect(result.closedWindowIds).toEqual([]);
+    expect(result.skippedWindowIds.sort()).toEqual([2, 3]);
+    expect(donorA.close).not.toHaveBeenCalled();
+    expect(donorB.close).not.toHaveBeenCalled();
+  });
+
+  it('a plain "timeout" only refuses that one path -- it does not cascade to the rest', async () => {
+    mocks.seedProjectIntoWindow.mockResolvedValueOnce('timeout').mockResolvedValueOnce('added');
+
+    const result = await consolidateWorkspaceWindows();
+
+    expect(mocks.seedProjectIntoWindow).toHaveBeenCalledTimes(2);
+    expect(result.seeded).toEqual(['/ws/donor-b']);
+    expect(result.refused).toEqual(['/ws/donor-a']);
+    // donor-a's only path was refused -- not fully migrated, left open.
+    expect(donorA.close).not.toHaveBeenCalled();
+    // donor-b's only path landed -- fully migrated, closed.
+    expect(donorB.close).toHaveBeenCalledOnce();
+  });
+
+  it('leaves a donor with unsaved changes untouched (neither seeded nor closed)', async () => {
+    windowStates.set(3, state({ workspacePath: '/ws/donor-b', documentEdited: true }));
+
+    const result = await consolidateWorkspaceWindows();
+
+    expect(mocks.seedProjectIntoWindow).not.toHaveBeenCalledWith(
+      target,
+      '/ws/donor-b',
+      expect.anything(),
+    );
+    expect(result.skippedWindowIds).toContain(3);
+    expect(donorB.close).not.toHaveBeenCalled();
+  });
+
+  it('bails out and leaves every donor open if the target window dies mid-merge', async () => {
+    mocks.seedProjectIntoWindow.mockImplementation(async (_win: unknown, path: string) => {
+      if (path === '/ws/donor-a') {
+        target._destroy();
+        windowStates.delete(1);
+      }
+      return 'added';
+    });
+
+    const result = await consolidateWorkspaceWindows();
+
+    expect(result.closedWindowIds).toEqual([]);
+    expect(result.skippedWindowIds.sort()).toEqual([2, 3]);
+    expect(donorA.close).not.toHaveBeenCalled();
+    expect(donorB.close).not.toHaveBeenCalled();
+  });
+
+  it('re-checks documentEdited immediately before closing, even if a donor went dirty mid-run', async () => {
+    mocks.seedProjectIntoWindow.mockImplementation(async (_win: unknown, path: string) => {
+      if (path === '/ws/donor-a') {
+        // Donor A goes dirty while donor B's seed is still in flight.
+        const s = windowStates.get(2);
+        if (s) s.documentEdited = true;
+      }
+      return 'added';
+    });
+
+    const result = await consolidateWorkspaceWindows();
+
+    expect(result.skippedWindowIds).toContain(2);
+    expect(donorA.close).not.toHaveBeenCalled();
+    expect(donorB.close).toHaveBeenCalledOnce();
+  });
+
+  it('is a no-op when Multi-Project Mode is off', async () => {
+    mocks.getMultiProjectMode.mockReturnValue(false);
+
+    const result = await consolidateWorkspaceWindows();
+
+    expect(result.plan).toBeNull();
+    expect(mocks.seedProjectIntoWindow).not.toHaveBeenCalled();
+  });
+
+  it('flushes a fully-migrated donor before closing it', async () => {
+    const result = await consolidateWorkspaceWindows();
+
+    expect(mocks.flushWindowBeforeClose).toHaveBeenCalledWith(donorA, expect.objectContaining({ timeoutMs: expect.any(Number) }));
+    expect(mocks.flushWindowBeforeClose).toHaveBeenCalledWith(donorB, expect.objectContaining({ timeoutMs: expect.any(Number) }));
+    expect(result.closedWindowIds.sort()).toEqual([2, 3]);
+    expect(donorA.close).toHaveBeenCalledOnce();
+    expect(donorB.close).toHaveBeenCalledOnce();
+  });
+
+  it('leaves a donor open (and does not close it) when the flush before close times out', async () => {
+    mocks.flushWindowBeforeClose.mockImplementation(async (win: unknown) =>
+      win === donorA ? 'timeout' : 'flushed',
+    );
+
+    const result = await consolidateWorkspaceWindows();
+
+    expect(donorA.close).not.toHaveBeenCalled();
+    expect(result.skippedWindowIds).toContain(2);
+    expect(donorB.close).toHaveBeenCalledOnce();
+    expect(result.closedWindowIds).toEqual([3]);
+  });
+
+  it('leaves a donor open when the flush reports dirty editors remain unsaved', async () => {
+    mocks.flushWindowBeforeClose.mockResolvedValue('still-dirty');
+
+    const result = await consolidateWorkspaceWindows();
+
+    expect(donorA.close).not.toHaveBeenCalled();
+    expect(donorB.close).not.toHaveBeenCalled();
+    expect(result.closedWindowIds).toEqual([]);
+    expect(result.skippedWindowIds.sort()).toEqual([2, 3]);
+  });
+});

--- a/packages/electron/src/main/window/__tests__/planWindowConsolidation.test.ts
+++ b/packages/electron/src/main/window/__tests__/planWindowConsolidation.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { planWindowConsolidation, type ConsolidationWindowInput } from '../planWindowConsolidation';
+
+function win(overrides: Partial<ConsolidationWindowInput> & { windowId: number }): ConsolidationWindowInput {
+  return {
+    mode: 'workspace',
+    workspacePath: null,
+    additionalWorkspacePaths: [],
+    documentEdited: false,
+    ...overrides,
+  };
+}
+
+describe('planWindowConsolidation', () => {
+  it('folds every other workspace window into the target', () => {
+    const windows: ConsolidationWindowInput[] = [
+      win({ windowId: 1, workspacePath: '/target' }),
+      win({ windowId: 2, workspacePath: '/donor-a' }),
+      win({ windowId: 3, workspacePath: '/donor-b' }),
+    ];
+
+    const plan = planWindowConsolidation(windows, {
+      multiProjectModeEnabled: true,
+      targetWindowId: 1,
+    });
+
+    expect(plan).toEqual({
+      targetWindowId: 1,
+      pathsToSeed: ['/donor-a', '/donor-b'],
+      windowsToClose: [2, 3],
+      windowsSkippedUnsaved: [],
+    });
+  });
+
+  it('is a no-op with a single workspace window', () => {
+    const windows: ConsolidationWindowInput[] = [win({ windowId: 1, workspacePath: '/only' })];
+
+    const plan = planWindowConsolidation(windows, {
+      multiProjectModeEnabled: true,
+      targetWindowId: 1,
+    });
+
+    expect(plan).toBeNull();
+  });
+
+  it('does not seed a path already referenced by another donor window', () => {
+    const windows: ConsolidationWindowInput[] = [
+      win({ windowId: 1, workspacePath: '/target' }),
+      win({ windowId: 2, workspacePath: '/shared' }),
+      win({ windowId: 3, workspacePath: '/shared' }),
+    ];
+
+    const plan = planWindowConsolidation(windows, {
+      multiProjectModeEnabled: true,
+      targetWindowId: 1,
+    });
+
+    expect(plan?.pathsToSeed).toEqual(['/shared']);
+    expect(plan?.windowsToClose).toEqual([2, 3]);
+  });
+
+  it('is a no-op when multi-project mode is off, regardless of window count', () => {
+    const windows: ConsolidationWindowInput[] = [
+      win({ windowId: 1, workspacePath: '/target' }),
+      win({ windowId: 2, workspacePath: '/donor' }),
+    ];
+
+    const plan = planWindowConsolidation(windows, {
+      multiProjectModeEnabled: false,
+      targetWindowId: 1,
+    });
+
+    expect(plan).toBeNull();
+  });
+
+  it('leaves a donor window with unsaved changes untouched', () => {
+    const windows: ConsolidationWindowInput[] = [
+      win({ windowId: 1, workspacePath: '/target' }),
+      win({ windowId: 2, workspacePath: '/donor-clean' }),
+      win({ windowId: 3, workspacePath: '/donor-dirty', documentEdited: true }),
+    ];
+
+    const plan = planWindowConsolidation(windows, {
+      multiProjectModeEnabled: true,
+      targetWindowId: 1,
+    });
+
+    expect(plan?.pathsToSeed).toEqual(['/donor-clean']);
+    expect(plan?.windowsToClose).toEqual([2]);
+    expect(plan?.windowsSkippedUnsaved).toEqual([3]);
+  });
+
+  it('does not re-seed a rail-warm additional path the target already has', () => {
+    const windows: ConsolidationWindowInput[] = [
+      win({ windowId: 1, workspacePath: '/target', additionalWorkspacePaths: ['/already-warm'] }),
+      win({ windowId: 2, workspacePath: '/already-warm' }),
+      win({ windowId: 3, workspacePath: '/donor-new' }),
+    ];
+
+    const plan = planWindowConsolidation(windows, {
+      multiProjectModeEnabled: true,
+      targetWindowId: 1,
+    });
+
+    expect(plan?.pathsToSeed).toEqual(['/donor-new']);
+    expect(plan?.windowsToClose).toEqual([2, 3]);
+  });
+
+  it('ignores non-workspace windows (e.g. document mode) entirely', () => {
+    const windows: ConsolidationWindowInput[] = [
+      win({ windowId: 1, workspacePath: '/target' }),
+      win({ windowId: 2, workspacePath: '/donor' }),
+      win({ windowId: 4, mode: 'document', workspacePath: null }),
+    ];
+
+    const plan = planWindowConsolidation(windows, {
+      multiProjectModeEnabled: true,
+      targetWindowId: 1,
+    });
+
+    expect(plan?.windowsToClose).toEqual([2]);
+  });
+
+  it('returns null when targetWindowId does not resolve to an open workspace window', () => {
+    const windows: ConsolidationWindowInput[] = [
+      win({ windowId: 1, workspacePath: '/a' }),
+      win({ windowId: 2, workspacePath: '/b' }),
+    ];
+
+    const plan = planWindowConsolidation(windows, {
+      multiProjectModeEnabled: true,
+      targetWindowId: 999,
+    });
+
+    expect(plan).toBeNull();
+  });
+});

--- a/packages/electron/src/main/window/__tests__/railSeeding.test.ts
+++ b/packages/electron/src/main/window/__tests__/railSeeding.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    on: vi.fn(),
+    handle: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    main: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+import { ipcMain } from 'electron';
+import { seedProjectIntoWindow, getPendingSeedCountForTests, RAIL_ADD_PROJECT_RESULT_CHANNEL } from '../railSeeding';
+import { RAIL_ADD_PROJECT_CHANNEL } from '../resolveProjectOpenTarget';
+
+// `railSeeding.ts` registers its `rail:add-project-result` listener exactly
+// once, at module import time (a `safeOn` process singleton -- see the
+// module doc comment). Capture it here, once, right after the import above
+// runs; `ipcMain.on`'s mock call history is otherwise untouched by any test
+// in this file.
+const resultHandler = vi
+  .mocked(ipcMain.on)
+  .mock.calls.find(([channel]) => channel === RAIL_ADD_PROJECT_RESULT_CHANNEL)?.[1] as
+  | ((event: unknown, data: unknown) => void)
+  | undefined;
+
+function createFakeWindow() {
+  const emitter = new EventEmitter();
+  let destroyed = false;
+  return {
+    isDestroyed: () => destroyed,
+    webContents: { send: vi.fn() },
+    once: emitter.once.bind(emitter),
+    removeListener: emitter.removeListener.bind(emitter),
+    listenerCount: (event: string) => emitter.listenerCount(event),
+    emitClosed: () => {
+      destroyed = true;
+      emitter.emit('closed');
+    },
+  };
+}
+
+function sendPayload(fakeWindow: ReturnType<typeof createFakeWindow>) {
+  const call = fakeWindow.webContents.send.mock.calls[0];
+  return call?.[1] as { workspacePath: string; activate: boolean; requestId: string };
+}
+
+describe('railSeeding', () => {
+  it('registers the rail:add-project-result listener exactly once at module load', () => {
+    expect(resultHandler).toBeTypeOf('function');
+    // Registered via `safeOn` -- the ipcRegistry channel is `ipcMain.on`'s
+    // second arg, the wrapped handler itself (no extra instrumentation
+    // wrapper for `.on`, unlike `safeHandle`).
+    expect(
+      vi.mocked(ipcMain.on).mock.calls.filter(([channel]) => channel === RAIL_ADD_PROJECT_RESULT_CHANNEL),
+    ).toHaveLength(1);
+  });
+
+  // Every test below either awaits the seed promise to full resolution
+  // (ack, forced timeout, or window destruction) or explicitly acks before
+  // finishing -- `pending`'s entries are keyed for the process lifetime of
+  // this shared module, and a real (un-awaited) 2s timeout left dangling
+  // from one test would pollute `getPendingSeedCountForTests()` assertions
+  // in a later one.
+
+  it('sends rail:add-project with a generated requestId and the requested activate flag', async () => {
+    const fakeWindow = createFakeWindow();
+    const resultPromise = seedProjectIntoWindow(fakeWindow as any, '/ws/a', { activate: false });
+
+    const payload = sendPayload(fakeWindow);
+    expect(payload.workspacePath).toBe('/ws/a');
+    expect(payload.activate).toBe(false);
+    expect(payload.requestId).toBeTruthy();
+
+    resultHandler!({}, { requestId: payload.requestId, workspacePath: '/ws/a', outcome: 'added' });
+    await resultPromise;
+  });
+
+  it('defaults activate to true when not specified', async () => {
+    const fakeWindow = createFakeWindow();
+    const resultPromise = seedProjectIntoWindow(fakeWindow as any, '/ws/a');
+    const payload = sendPayload(fakeWindow);
+    expect(payload.activate).toBe(true);
+
+    resultHandler!({}, { requestId: payload.requestId, outcome: 'added' });
+    await resultPromise;
+  });
+
+  it('resolves with the renderer-reported outcome when the ack arrives, and cleans up', async () => {
+    const fakeWindow = createFakeWindow();
+    const resultPromise = seedProjectIntoWindow(fakeWindow as any, '/ws/a', { activate: false });
+    const { requestId } = sendPayload(fakeWindow);
+
+    resultHandler!({}, { requestId, workspacePath: '/ws/a', outcome: 'added' });
+
+    await expect(resultPromise).resolves.toBe('added');
+    expect(getPendingSeedCountForTests()).toBe(0);
+    // The 'closed' listener registered for this request is removed once the
+    // ack settles it -- no leak.
+    expect(fakeWindow.listenerCount('closed')).toBe(0);
+  });
+
+  it.each(['already-open', 'at-cap'] as const)('resolves with outcome "%s"', async (outcome) => {
+    const fakeWindow = createFakeWindow();
+    const resultPromise = seedProjectIntoWindow(fakeWindow as any, '/ws/a');
+    const { requestId } = sendPayload(fakeWindow);
+
+    resultHandler!({}, { requestId, workspacePath: '/ws/a', outcome });
+
+    await expect(resultPromise).resolves.toBe(outcome);
+  });
+
+  it('resolves "timeout" and does not leak when no ack lands in time', async () => {
+    vi.useFakeTimers();
+    try {
+      const fakeWindow = createFakeWindow();
+      const resultPromise = seedProjectIntoWindow(fakeWindow as any, '/ws/a', { timeoutMs: 50 });
+
+      await vi.advanceTimersByTimeAsync(50);
+
+      await expect(resultPromise).resolves.toBe('timeout');
+      expect(getPendingSeedCountForTests()).toBe(0);
+      expect(fakeWindow.listenerCount('closed')).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resolves "timeout" and does not leak when the window is destroyed before an ack arrives', async () => {
+    const fakeWindow = createFakeWindow();
+    const resultPromise = seedProjectIntoWindow(fakeWindow as any, '/ws/a', { timeoutMs: 5000 });
+
+    fakeWindow.emitClosed();
+
+    await expect(resultPromise).resolves.toBe('timeout');
+    expect(getPendingSeedCountForTests()).toBe(0);
+  });
+
+  it('resolves "timeout" immediately without sending for an already-destroyed window', async () => {
+    const fakeWindow = createFakeWindow();
+    fakeWindow.emitClosed();
+    fakeWindow.webContents.send.mockClear();
+
+    const result = await seedProjectIntoWindow(fakeWindow as any, '/ws/a');
+
+    expect(result).toBe('timeout');
+    expect(fakeWindow.webContents.send).not.toHaveBeenCalled();
+    expect(getPendingSeedCountForTests()).toBe(0);
+  });
+
+  it('ignores an ack for an unknown requestId without throwing or settling anything', async () => {
+    const fakeWindow = createFakeWindow();
+    const resultPromise = seedProjectIntoWindow(fakeWindow as any, '/ws/a');
+    const { requestId } = sendPayload(fakeWindow);
+
+    expect(() => resultHandler!({}, { requestId: 'unknown-id', outcome: 'added' })).not.toThrow();
+    expect(getPendingSeedCountForTests()).toBeGreaterThan(0);
+
+    resultHandler!({}, { requestId, workspacePath: '/ws/a', outcome: 'added' });
+    await expect(resultPromise).resolves.toBe('added');
+  });
+});

--- a/packages/electron/src/main/window/__tests__/resolveProjectOpenTarget.test.ts
+++ b/packages/electron/src/main/window/__tests__/resolveProjectOpenTarget.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { resolveProjectOpenTarget } from '../resolveProjectOpenTarget';
+
+interface FakeWindow {
+  id: string;
+}
+
+describe('resolveProjectOpenTarget', () => {
+  it('focuses an existing window when the mode is off', () => {
+    const existing: FakeWindow = { id: 'existing' };
+
+    const result = resolveProjectOpenTarget({
+      workspacePath: '/ws',
+      multiProjectModeEnabled: false,
+      existingWindowForPath: existing,
+      focusedWorkspaceWindow: null,
+    });
+
+    expect(result).toEqual({ kind: 'focus-existing', window: existing });
+  });
+
+  it('opens a new window when the mode is off and nothing references the path', () => {
+    const result = resolveProjectOpenTarget<FakeWindow>({
+      workspacePath: '/ws',
+      multiProjectModeEnabled: false,
+      existingWindowForPath: null,
+      focusedWorkspaceWindow: { id: 'focused' },
+    });
+
+    expect(result).toEqual({ kind: 'new-window' });
+  });
+
+  it('focuses an existing window even when the mode is on', () => {
+    const existing: FakeWindow = { id: 'existing' };
+
+    const result = resolveProjectOpenTarget({
+      workspacePath: '/ws',
+      multiProjectModeEnabled: true,
+      existingWindowForPath: existing,
+      focusedWorkspaceWindow: { id: 'focused' },
+    });
+
+    expect(result).toEqual({ kind: 'focus-existing', window: existing });
+  });
+
+  it('adds to the focused workspace window rail when the mode is on and no window has the path', () => {
+    const focused: FakeWindow = { id: 'focused' };
+
+    const result = resolveProjectOpenTarget({
+      workspacePath: '/ws',
+      multiProjectModeEnabled: true,
+      existingWindowForPath: null,
+      focusedWorkspaceWindow: focused,
+    });
+
+    expect(result).toEqual({ kind: 'add-to-rail', window: focused });
+  });
+
+  it('opens a new window when the mode is on but no workspace window is open at all', () => {
+    const result = resolveProjectOpenTarget<FakeWindow>({
+      workspacePath: '/ws',
+      multiProjectModeEnabled: true,
+      existingWindowForPath: null,
+      focusedWorkspaceWindow: null,
+    });
+
+    expect(result).toEqual({ kind: 'new-window' });
+  });
+});

--- a/packages/electron/src/main/window/consolidateWorkspaceWindows.ts
+++ b/packages/electron/src/main/window/consolidateWorkspaceWindows.ts
@@ -1,0 +1,254 @@
+/**
+ * "Merge All Windows" executor for Multi-Project Mode.
+ *
+ * Folds every open workspace window into the most-recently-focused one:
+ * seeds each donor window's paths into the target's project rail via the
+ * existing `rail:add-project` channel (see `resolveProjectOpenTarget.ts`,
+ * `store/listeners/railProjectListeners.ts` in the renderer, and
+ * `railSeeding.ts` for the ack wrapper), then closes the drained donor
+ * windows.
+ *
+ * Ordering is load-bearing: a donor window must not be closed before its
+ * paths are confirmed registered in the target, or the `closed` handler in
+ * WindowManager.ts frees that path's DocumentService/FileSystemService
+ * (no window would reference it in the gap between close and re-seed). A
+ * donor is also not closed before it confirms its dirty editors are flushed
+ * to disk (`flushWindowBeforeClose.ts`) -- `windowState.documentEdited` is
+ * decorative and cannot be relied on to stop that, see that module's doc.
+ *
+ * Every seed is sent with `activate: false` — the target's visible project
+ * must not change out from under the user just because their other windows
+ * got folded in. There is therefore nothing to restore afterwards: unlike
+ * the old poll-based implementation (which flipped `activeWorkspacePath` on
+ * every seed and explicitly reset it at the end), the target's active path
+ * is never touched by this module at all.
+ *
+ * Planning is delegated to the pure `planWindowConsolidation` — this module
+ * is the Electron-dependent shell around it (window lookups, IPC sends,
+ * `.close()`), intentionally kept out of the pure module so the planner
+ * stays unit-testable without Electron.
+ */
+
+import type { BrowserWindow } from 'electron';
+import { windows, windowStates } from './windowState';
+import { getMostRecentlyFocusedWorkspaceWindow, getWindowId } from './WindowManager';
+import { getMultiProjectMode } from '../utils/store';
+import { seedProjectIntoWindow, type RailSeedOutcome } from './railSeeding';
+import { flushWindowBeforeClose } from './flushWindowBeforeClose';
+import {
+  planWindowConsolidation,
+  collectWindowPaths,
+  type ConsolidationWindowInput,
+  type WindowConsolidationPlan,
+} from './planWindowConsolidation';
+import { logger } from '../utils/logger';
+
+/** How long to wait for each seed's `rail:add-project-result` ack. */
+const SEED_ACK_TIMEOUT_MS = 2000;
+/** How long to wait for a donor's `window:flush-before-close-result` ack. */
+const FLUSH_ACK_TIMEOUT_MS = 5000;
+
+export interface ConsolidationResult {
+  plan: WindowConsolidationPlan | null;
+  /** Paths confirmed registered (and appended to the rail) in the target
+   *  window -- sent with `activate: false`, so these are NOT necessarily
+   *  the target's visible/active project; see the module doc comment. */
+  seeded: string[];
+  /** Paths that did not land in the target: a renderer-reported `'at-cap'`
+   *  outcome (the rail's `MAX_OPEN_PROJECTS` cap -- once seen, every
+   *  remaining path in the plan is refused without even being sent, since
+   *  they would all refuse too), or a `'timeout'` outcome (no ack landed in
+   *  time -- e.g. `workspace:register-additional` itself failed, or a slow
+   *  renderer; refuses only that one path, does not cascade). Their donor
+   *  windows are left open either way. */
+  refused: string[];
+  closedWindowIds: number[];
+  /** Donor windows left open: unsaved changes at plan time, went dirty
+   *  mid-run, or one of their paths was refused. */
+  skippedWindowIds: number[];
+}
+
+const NO_OP_RESULT: ConsolidationResult = {
+  plan: null,
+  seeded: [],
+  refused: [],
+  closedWindowIds: [],
+  skippedWindowIds: [],
+};
+
+function snapshotWindowInputs(): ConsolidationWindowInput[] {
+  const inputs: ConsolidationWindowInput[] = [];
+  for (const [windowId, state] of windowStates) {
+    inputs.push({
+      windowId,
+      mode: state.mode,
+      workspacePath: state.workspacePath,
+      additionalWorkspacePaths: state.additionalWorkspacePaths ?? [],
+      documentEdited: state.documentEdited === true,
+    });
+  }
+  return inputs;
+}
+
+/**
+ * Fold every open workspace window into the most-recently-focused one.
+ * Safe to call when there is nothing to consolidate (returns a no-op
+ * result) -- callers should still gate the menu item on
+ * `getMultiProjectMode()` + window count so the command isn't visible when
+ * it can't do anything, but this function re-validates independently since
+ * that gate is computed once at menu-build time.
+ */
+export async function consolidateWorkspaceWindows(): Promise<ConsolidationResult> {
+  const target: BrowserWindow | null = getMostRecentlyFocusedWorkspaceWindow();
+  if (!target || target.isDestroyed()) return NO_OP_RESULT;
+
+  const targetWindowId = getWindowId(target);
+  if (targetWindowId === null) return NO_OP_RESULT;
+
+  const inputsAtPlanTime = snapshotWindowInputs();
+  const plan = planWindowConsolidation(inputsAtPlanTime, {
+    multiProjectModeEnabled: getMultiProjectMode(),
+    targetWindowId,
+  });
+  if (!plan) return NO_OP_RESULT;
+
+  const targetStateAtPlanTime = windowStates.get(targetWindowId);
+  const targetPathsAtPlanTime = new Set(
+    collectWindowPaths(
+      inputsAtPlanTime.find((w) => w.windowId === targetWindowId) ?? {
+        windowId: targetWindowId,
+        mode: targetStateAtPlanTime?.mode ?? 'workspace',
+        workspacePath: targetStateAtPlanTime?.workspacePath ?? null,
+        additionalWorkspacePaths: targetStateAtPlanTime?.additionalWorkspacePaths ?? [],
+      },
+    ),
+  );
+
+  const seeded: string[] = [];
+  const refused: string[] = [];
+
+  // Seed sequentially so a donor is only closed once every path it
+  // contributed is confirmed -- never before. `activate: false` means the
+  // target's visible project is never touched by seeding, so unlike the
+  // cap check below there is no "one refusal implies the rest will refuse
+  // too" signal to derive from an ordinary ack timeout -- only a literal
+  // `'at-cap'` outcome means that. Short-circuit on that signal alone so a
+  // transient per-path timeout (e.g. `workspace:register-additional`
+  // rejecting, or a slow renderer) doesn't cascade into refusing every
+  // remaining path.
+  let capReached = false;
+  for (const path of plan.pathsToSeed) {
+    if (target.isDestroyed()) break;
+
+    if (capReached) {
+      refused.push(path);
+      continue;
+    }
+
+    const outcome: RailSeedOutcome = await seedProjectIntoWindow(target, path, {
+      activate: false,
+      timeoutMs: SEED_ACK_TIMEOUT_MS,
+    });
+
+    if (outcome === 'added' || outcome === 'already-open') {
+      seeded.push(path);
+    } else if (outcome === 'at-cap') {
+      refused.push(path);
+      capReached = true;
+      logger.main.warn('[ConsolidateWindows] rail at cap, refusing remaining paths:', path);
+    } else {
+      refused.push(path);
+      logger.main.warn(
+        '[ConsolidateWindows] rail did not confirm seeded path within timeout:',
+        path,
+      );
+    }
+  }
+
+  // If the target itself died mid-merge, `windowStates.delete(targetWindowId)`
+  // (WindowManager.ts's `closed` handler) has already run, so
+  // `targetPathsAtPlanTime` / `seededSet` no longer reflect anything the
+  // target actually still references. Closing donors against that stale
+  // picture would free every path's services with nothing left to serve
+  // them from -- worse than doing nothing. Bail out and leave every donor
+  // open instead.
+  if (target.isDestroyed() || !windowStates.has(targetWindowId)) {
+    logger.main.error(
+      '[ConsolidateWindows] target window died mid-merge; leaving all donor windows open',
+    );
+    return {
+      plan,
+      seeded,
+      refused,
+      closedWindowIds: [],
+      skippedWindowIds: [...plan.windowsToClose, ...plan.windowsSkippedUnsaved],
+    };
+  }
+
+  const closedWindowIds: number[] = [];
+  const skippedWindowIds: number[] = [...plan.windowsSkippedUnsaved];
+  const seededSet = new Set(seeded);
+
+  for (const windowId of plan.windowsToClose) {
+    const donorInput = inputsAtPlanTime.find((w) => w.windowId === windowId);
+    const donorPaths = donorInput ? collectWindowPaths(donorInput) : [];
+    const fullyMigrated = donorPaths.every(
+      (path) => targetPathsAtPlanTime.has(path) || seededSet.has(path),
+    );
+
+    if (!fullyMigrated) {
+      skippedWindowIds.push(windowId);
+      logger.main.warn(
+        '[ConsolidateWindows] leaving donor window open, not all paths landed in target:',
+        windowId,
+        donorPaths.filter((path) => !targetPathsAtPlanTime.has(path) && !seededSet.has(path)),
+      );
+      continue;
+    }
+
+    const donorWindow = windows.get(windowId);
+    if (!donorWindow || donorWindow.isDestroyed()) continue;
+
+    // Re-check immediately before closing -- a buffer can go dirty during
+    // the awaits above. WindowManager's own `close` listener also guards
+    // `documentEdited`, but it does so via `event.preventDefault()` while a
+    // second `close` listener still runs and deletes `windowStates` for the
+    // window regardless (see report: this is a latent bug in
+    // WindowManager.ts, out of this module's ownership). Checking here
+    // means this module never calls `.close()` on a dirty window in the
+    // first place, so that path is never exercised by consolidation.
+    //
+    // `documentEdited` itself is decorative -- nothing in the codebase ever
+    // sets it `true` (see `flushWindowBeforeClose.ts`'s module doc) -- so
+    // this check alone would never actually catch a dirty donor. The
+    // `flushWindowBeforeClose` call below is the real guard: it asks the
+    // donor to flush every dirty editor to disk and only proceeds to
+    // `.close()` once that is confirmed.
+    if (windowStates.get(windowId)?.documentEdited) {
+      skippedWindowIds.push(windowId);
+      continue;
+    }
+
+    const flushOutcome = await flushWindowBeforeClose(donorWindow, {
+      timeoutMs: FLUSH_ACK_TIMEOUT_MS,
+    });
+    if (flushOutcome !== 'flushed') {
+      skippedWindowIds.push(windowId);
+      logger.main.warn(
+        '[ConsolidateWindows] leaving donor window open, flush before close did not confirm:',
+        windowId,
+        flushOutcome,
+      );
+      continue;
+    }
+
+    // The flush await gave the donor time to run arbitrary renderer code
+    // (save writes, etc.) -- re-check destruction before touching it again.
+    if (donorWindow.isDestroyed()) continue;
+
+    donorWindow.close();
+    closedWindowIds.push(windowId);
+  }
+
+  return { plan, seeded, refused, closedWindowIds, skippedWindowIds };
+}

--- a/packages/electron/src/main/window/flushWindowBeforeClose.ts
+++ b/packages/electron/src/main/window/flushWindowBeforeClose.ts
@@ -1,0 +1,116 @@
+/**
+ * Promise-based ack for "flush dirty editors before closing this window".
+ *
+ * "Merge All Windows" (`consolidateWorkspaceWindows.ts`) closes fully-migrated
+ * donor windows once their paths are confirmed registered in the target. The
+ * window's own `windowState.documentEdited` guard is decorative -- nothing in
+ * the codebase ever sets it `true` -- so it cannot be relied on to stop a
+ * donor with unsaved buffers from being closed. This module is the real
+ * guard: it asks the donor's renderer to flush every dirty editor to disk and
+ * waits for a definitive ack (flushed / still dirty / no ack in time) before
+ * the caller is allowed to call `.close()`.
+ *
+ * Same request/ack/timeout shape as `railSeeding.ts`'s `seedProjectIntoWindow`
+ * -- read that file for the pattern this mirrors. A single `safeOn` listener
+ * is registered once for the process lifetime and dispatches every ack by
+ * `requestId`.
+ */
+
+import type { BrowserWindow, IpcMainEvent } from 'electron';
+import { randomUUID } from 'crypto';
+import { safeOn } from '../utils/ipcRegistry';
+import { logger } from '../utils/logger';
+
+/** Main -> renderer request: "flush every dirty editor now". */
+export const FLUSH_BEFORE_CLOSE_CHANNEL = 'window:flush-before-close';
+/** Renderer -> main ack, keyed by `requestId`. */
+export const FLUSH_BEFORE_CLOSE_RESULT_CHANNEL = 'window:flush-before-close-result';
+
+/** Renderer-reported outcomes, plus `'timeout'` for "no ack landed in time"
+ *  (ack timeout, or the target window was destroyed before one arrived). */
+export type FlushBeforeCloseOutcome = 'flushed' | 'still-dirty' | 'timeout';
+
+const DEFAULT_FLUSH_TIMEOUT_MS = 5000;
+
+interface PendingFlush {
+  resolve: (outcome: FlushBeforeCloseOutcome) => void;
+  timer: ReturnType<typeof setTimeout>;
+  onWindowClosed: () => void;
+  window: BrowserWindow;
+}
+
+const pending = new Map<string, PendingFlush>();
+
+function settle(requestId: string, outcome: FlushBeforeCloseOutcome): void {
+  const entry = pending.get(requestId);
+  if (!entry) return;
+  pending.delete(requestId);
+  clearTimeout(entry.timer);
+  entry.window.removeListener('closed', entry.onWindowClosed);
+  entry.resolve(outcome);
+}
+
+// Registered once at module load -- the single main-process listener for
+// every `flushWindowBeforeClose` ack, dispatched by `requestId`. Uses
+// `safeOn` (never raw `ipcMain`) per the main-process init rules.
+safeOn(
+  FLUSH_BEFORE_CLOSE_RESULT_CHANNEL,
+  (_event: IpcMainEvent, data: { requestId?: string; outcome?: FlushBeforeCloseOutcome }) => {
+    if (!data?.requestId || !data.outcome) return;
+    settle(data.requestId, data.outcome);
+  },
+);
+
+export interface FlushWindowBeforeCloseOptions {
+  /** How long to wait for the ack before resolving `'timeout'`. */
+  timeoutMs?: number;
+}
+
+/**
+ * Send `window:flush-before-close` to `window` and resolve once the
+ * renderer acks on `window:flush-before-close-result`, or `'timeout'` if no
+ * ack lands within `timeoutMs`, or the window is destroyed first.
+ *
+ * Never leaves a dangling pending entry: the timer and the window's
+ * `'closed'` listener are both cleaned up on ack, on timeout, and on window
+ * destruction (whichever happens first settles the promise and clears the
+ * other two).
+ */
+export function flushWindowBeforeClose(
+  window: BrowserWindow,
+  options: FlushWindowBeforeCloseOptions = {},
+): Promise<FlushBeforeCloseOutcome> {
+  const { timeoutMs = DEFAULT_FLUSH_TIMEOUT_MS } = options;
+
+  if (window.isDestroyed()) {
+    return Promise.resolve('timeout');
+  }
+
+  const requestId = randomUUID();
+
+  return new Promise<FlushBeforeCloseOutcome>((resolve) => {
+    const onWindowClosed = () => {
+      logger.main.warn(
+        '[FlushWindowBeforeClose] target window closed before flush ack landed',
+      );
+      settle(requestId, 'timeout');
+    };
+
+    const timer = setTimeout(() => {
+      logger.main.warn(
+        '[FlushWindowBeforeClose] timed out waiting for flush-before-close ack',
+      );
+      settle(requestId, 'timeout');
+    }, timeoutMs);
+
+    pending.set(requestId, { resolve, timer, onWindowClosed, window });
+    window.once('closed', onWindowClosed);
+
+    window.webContents.send(FLUSH_BEFORE_CLOSE_CHANNEL, { requestId });
+  });
+}
+
+/** Test-only: number of acks/timeouts still awaited. Used to assert no leak. */
+export function getPendingFlushCountForTests(): number {
+  return pending.size;
+}

--- a/packages/electron/src/main/window/planWindowConsolidation.ts
+++ b/packages/electron/src/main/window/planWindowConsolidation.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure planning for "Merge All Windows" (Multi-Project Mode).
+ *
+ * Phase 1 of the single-window-multi-project plan only changes how *newly
+ * opened* projects route and how the *next launch* restores. Windows that
+ * are already open stay open until the user quits and relaunches. This
+ * module is the decision logic for a "consolidate now" command that folds
+ * every open workspace window into one, so the user gets relief without
+ * restarting the app.
+ *
+ * No Electron imports here, and none should be added — this module must
+ * stay safe to unit-test with a plain Node environment (no jsdom, no
+ * Electron mocks) and reusable from anywhere in the main process.
+ */
+
+const WORKSPACE_MODES = new Set(['workspace', 'agentic-coding']);
+
+export interface ConsolidationWindowInput {
+  windowId: number;
+  /** Only 'workspace' and 'agentic-coding' are eligible; any other mode
+   *  (e.g. 'document') is ignored by the planner entirely. */
+  mode: string;
+  workspacePath: string | null;
+  additionalWorkspacePaths?: string[] | null;
+  /** Unsaved editor changes. A window with this set true is left alone —
+   *  neither seeded from nor closed — so a merge never silently destroys
+   *  unsaved work. See WindowManager.ts's `documentEdited`-gated close
+   *  guard, which this planner defers to rather than duplicates. */
+  documentEdited?: boolean;
+}
+
+export interface PlanWindowConsolidationOptions {
+  multiProjectModeEnabled: boolean;
+  /** The window every other workspace window's projects fold into. Chosen
+   *  by the caller (e.g. `getMostRecentlyFocusedWorkspaceWindow()`) — kept
+   *  out of this pure module so tests don't need to reimplement focus-order
+   *  tracking. Must be the id of one of the workspace windows in `windows`
+   *  or the whole call is a no-op. */
+  targetWindowId: number;
+}
+
+export interface WindowConsolidationPlan {
+  targetWindowId: number;
+  /** Deduplicated paths to seed into the target's rail, in donor order,
+   *  excluding paths the target already references and excluding paths
+   *  contributed by more than one donor (first donor wins; later donors
+   *  sharing the path are still safe to close once it lands). */
+  pathsToSeed: string[];
+  /** Donor windows (not the target) with no unsaved changes — safe to seed
+   *  from and close once their paths are confirmed in the target. */
+  windowsToClose: number[];
+  /** Donor windows excluded entirely because `documentEdited` was true at
+   *  plan time. Neither seeded from nor closed. */
+  windowsSkippedUnsaved: number[];
+}
+
+function isWorkspaceWindow(w: ConsolidationWindowInput): boolean {
+  return WORKSPACE_MODES.has(w.mode);
+}
+
+/**
+ * Every workspace path a window references — primary plus rail-warm
+ * additional paths. Exported so the executor can recompute "does this
+ * donor's full path set actually live in the target now?" after seeding,
+ * without re-deriving the rule.
+ */
+export function collectWindowPaths(w: ConsolidationWindowInput): string[] {
+  const paths: string[] = [];
+  if (w.workspacePath) paths.push(w.workspacePath);
+  for (const path of w.additionalWorkspacePaths ?? []) {
+    if (path) paths.push(path);
+  }
+  return paths;
+}
+
+/**
+ * Decide how to fold every open workspace window into one.
+ *
+ * Returns null when there is nothing to do: mode is off, fewer than two
+ * workspace windows are open, or `targetWindowId` doesn't resolve to an
+ * open workspace window.
+ */
+export function planWindowConsolidation(
+  windows: ConsolidationWindowInput[],
+  options: PlanWindowConsolidationOptions,
+): WindowConsolidationPlan | null {
+  if (!options.multiProjectModeEnabled) return null;
+
+  const workspaceWindows = windows.filter(isWorkspaceWindow);
+  if (workspaceWindows.length < 2) return null;
+
+  const target = workspaceWindows.find((w) => w.windowId === options.targetWindowId);
+  if (!target) return null;
+
+  const targetPaths = new Set(collectWindowPaths(target));
+  const pathsToSeed: string[] = [];
+  const windowsToClose: number[] = [];
+  const windowsSkippedUnsaved: number[] = [];
+
+  for (const donor of workspaceWindows) {
+    if (donor.windowId === target.windowId) continue;
+
+    if (donor.documentEdited) {
+      windowsSkippedUnsaved.push(donor.windowId);
+      continue;
+    }
+
+    for (const path of collectWindowPaths(donor)) {
+      if (!targetPaths.has(path)) {
+        targetPaths.add(path);
+        pathsToSeed.push(path);
+      }
+    }
+    windowsToClose.push(donor.windowId);
+  }
+
+  if (windowsToClose.length === 0 && windowsSkippedUnsaved.length === 0) {
+    return null;
+  }
+
+  return {
+    targetWindowId: target.windowId,
+    pathsToSeed,
+    windowsToClose,
+    windowsSkippedUnsaved,
+  };
+}

--- a/packages/electron/src/main/window/railSeeding.ts
+++ b/packages/electron/src/main/window/railSeeding.ts
@@ -1,0 +1,209 @@
+/**
+ * Promise-based ack for the `rail:add-project` contract.
+ *
+ * `rail:add-project` (see `resolveProjectOpenTarget.ts`) is a main -> renderer
+ * fire-and-forget message. Some callers (session restore, "Merge All
+ * Windows") need to know what actually happened -- registered and added,
+ * already open, refused at the rail's cap, or never acknowledged at all --
+ * before deciding whether it's safe to close a donor window or seed the next
+ * path. `seedProjectIntoWindow` wraps the send in a promise that resolves
+ * once the renderer's `rail:add-project` listener
+ * (`store/listeners/railProjectListeners.ts`) reports back on
+ * `rail:add-project-result` with the matching `requestId`.
+ *
+ * A single `safeOn` listener is registered once for the process lifetime and
+ * dispatches every ack by `requestId` -- registering per-call would either
+ * violate `safeOn`'s duplicate-registration guard (same channel, same
+ * function identity requirement) or leak a distinct listener per call.
+ */
+
+import { BrowserWindow } from 'electron';
+import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
+import { randomUUID } from 'crypto';
+import { safeOn, safeHandle } from '../utils/ipcRegistry';
+import { logger } from '../utils/logger';
+import { getWindowIdForWindow } from './windowState';
+import { RAIL_ADD_PROJECT_CHANNEL } from './resolveProjectOpenTarget';
+
+export const RAIL_ADD_PROJECT_RESULT_CHANNEL = 'rail:add-project-result';
+
+/** Renderer-reported outcomes, plus `'timeout'` for "no ack landed in time"
+ *  (ack timeout, or the target window was destroyed before one arrived). */
+export type RailSeedOutcome = 'added' | 'already-open' | 'at-cap' | 'timeout';
+
+const DEFAULT_SEED_TIMEOUT_MS = 2000;
+
+interface PendingSeed {
+  resolve: (outcome: RailSeedOutcome) => void;
+  timer: ReturnType<typeof setTimeout>;
+  onWindowClosed: () => void;
+  window: BrowserWindow;
+}
+
+const pending = new Map<string, PendingSeed>();
+
+function settle(requestId: string, outcome: RailSeedOutcome): void {
+  const entry = pending.get(requestId);
+  if (!entry) return;
+  pending.delete(requestId);
+  clearTimeout(entry.timer);
+  entry.window.removeListener('closed', entry.onWindowClosed);
+  entry.resolve(outcome);
+}
+
+// Registered once at module load -- the single main-process listener for
+// every `seedProjectIntoWindow` ack, dispatched by `requestId`. Uses
+// `safeOn` (never raw `ipcMain`) per the main-process init rules.
+safeOn(
+  RAIL_ADD_PROJECT_RESULT_CHANNEL,
+  (_event: IpcMainEvent, data: { requestId?: string; workspacePath?: string; outcome?: RailSeedOutcome }) => {
+    if (!data?.requestId || !data.outcome) return;
+    settle(data.requestId, data.outcome);
+  },
+);
+
+export interface SeedProjectIntoWindowOptions {
+  /** Forwarded to the renderer's `rail:add-project` payload. Defaults to
+   *  `true` so callers that don't care about activation get today's
+   *  behavior; pass `false` to append without stealing focus from
+   *  whatever is currently visible in `window`. */
+  activate?: boolean;
+  /** How long to wait for the ack before resolving `'timeout'`. */
+  timeoutMs?: number;
+}
+
+/**
+ * Send `rail:add-project` to `window` for `workspacePath` and resolve once
+ * the renderer acks on `rail:add-project-result`, or `'timeout'` if no ack
+ * lands within `timeoutMs`, or the window is destroyed first.
+ *
+ * Never leaves a dangling pending entry: the timer and the window's
+ * `'closed'` listener are both cleaned up on ack, on timeout, and on window
+ * destruction (whichever happens first settles the promise and clears the
+ * other two).
+ */
+export function seedProjectIntoWindow(
+  window: BrowserWindow,
+  workspacePath: string,
+  options: SeedProjectIntoWindowOptions = {},
+): Promise<RailSeedOutcome> {
+  const { activate = true, timeoutMs = DEFAULT_SEED_TIMEOUT_MS } = options;
+
+  if (window.isDestroyed()) {
+    return Promise.resolve('timeout');
+  }
+
+  const requestId = randomUUID();
+
+  return new Promise<RailSeedOutcome>((resolve) => {
+    const onWindowClosed = () => {
+      logger.main.warn(
+        '[RailSeeding] target window closed before rail:add-project-result ack:',
+        workspacePath,
+      );
+      settle(requestId, 'timeout');
+    };
+
+    const timer = setTimeout(() => {
+      logger.main.warn(
+        '[RailSeeding] timed out waiting for rail:add-project-result ack:',
+        workspacePath,
+      );
+      settle(requestId, 'timeout');
+    }, timeoutMs);
+
+    pending.set(requestId, { resolve, timer, onWindowClosed, window });
+    window.once('closed', onWindowClosed);
+
+    window.webContents.send(RAIL_ADD_PROJECT_CHANNEL, { workspacePath, activate, requestId });
+  });
+}
+
+/** Test-only: number of acks/timeouts still awaited. Used to assert no leak. */
+export function getPendingSeedCountForTests(): number {
+  return pending.size;
+}
+
+// ---------------------------------------------------------------------------
+// Pending seeds for a window that is still starting up (renderer PULL)
+// ---------------------------------------------------------------------------
+
+/**
+ * Why session restore does NOT use `seedProjectIntoWindow` above.
+ *
+ * Pushing requires main to guess when the renderer is listening. The only
+ * signal main has is `did-finish-load`, but the renderer registers its
+ * `rail:add-project` handler in `initRailProjectListeners()`, called from a
+ * React effect in `App.tsx` that runs after mount -- strictly later, and on a
+ * cold start (large DB, extension loading) later by seconds. A push at
+ * `did-finish-load` lands in a window with no listener attached and is
+ * silently dropped; the ack then times out and the project is lost from the
+ * rail. Observed in the wild:
+ *
+ *   [RESTORE] … seeding rail with 1 more: /…/wine-cellar/
+ *   [RailSeeding] timed out waiting for rail:add-project-result ack: /…/wine-cellar/
+ *
+ * and, because the path never reached `WindowState.additionalWorkspacePaths`,
+ * the NEXT `saveSessionState()` persisted no rail at all -- so the loss
+ * compounded across restarts.
+ *
+ * Raising the timeout would only make the race rarer. Instead the renderer
+ * PULLS: main parks the paths here, and `initRailProjectListeners()` -- the
+ * exact point that proves the handler is registered -- asks for them. There is
+ * no ordering to get wrong.
+ *
+ * The push path above is still correct for "Merge All Windows", where the
+ * target window is already live and listening.
+ */
+export const RAIL_TAKE_PENDING_SEEDS_CHANNEL = 'rail:take-pending-seeds';
+
+const pendingSeedsByWindowId = new Map<number, string[]>();
+
+/** Park rail paths for a window that hasn't mounted its listeners yet. */
+export function setPendingRailSeeds(windowId: number, workspacePaths: string[]): void {
+  if (workspacePaths.length === 0) {
+    pendingSeedsByWindowId.delete(windowId);
+    return;
+  }
+  pendingSeedsByWindowId.set(windowId, [...workspacePaths]);
+}
+
+/**
+ * Drop a window's parked seeds. Called when the window closes so the map
+ * can't grow across a long session.
+ */
+export function clearPendingRailSeeds(windowId: number): void {
+  pendingSeedsByWindowId.delete(windowId);
+}
+
+/**
+ * Hand a window its parked seeds exactly once. Clearing on read is what makes
+ * a renderer reload (which re-runs `initRailProjectListeners`) a no-op rather
+ * than a duplicate add.
+ */
+export function takePendingRailSeeds(windowId: number): string[] {
+  const paths = pendingSeedsByWindowId.get(windowId) ?? [];
+  pendingSeedsByWindowId.delete(windowId);
+  return paths;
+}
+
+/** Test-only: how many windows still have parked seeds. */
+export function getPendingRailSeedWindowCountForTests(): number {
+  return pendingSeedsByWindowId.size;
+}
+
+// Registered once at module load, like the ack listener above.
+safeHandle(RAIL_TAKE_PENDING_SEEDS_CHANNEL, (event: IpcMainInvokeEvent) => {
+  const window = BrowserWindow.fromWebContents(event.sender);
+  const windowId = getWindowIdForWindow(window);
+  if (windowId === null) return [];
+
+  const paths = takePendingRailSeeds(windowId);
+  if (paths.length > 0) {
+    logger.main.info(
+      `[RailSeeding] renderer took ${paths.length} pending rail seed(s):`,
+      paths.join(', '),
+    );
+  }
+  return paths;
+});

--- a/packages/electron/src/main/window/resolveProjectOpenTarget.ts
+++ b/packages/electron/src/main/window/resolveProjectOpenTarget.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure routing decision for "open this project".
+ *
+ * Extracted out of `openOrFocusWorkspaceWindow` (WorkspaceManagerWindow.ts) so
+ * the decision — focus an existing window, add the project to the focused
+ * window's rail, or spawn a new window — is unit-testable without Electron
+ * and reusable by call sites that cannot import WorkspaceManagerWindow
+ * directly (e.g. dependency-injected services, to avoid circular imports).
+ *
+ * No Electron imports here, and none should be added — this module must stay
+ * safe to import from anywhere in the main process.
+ */
+
+/** Main -> renderer channel used to tell the renderer to add a project to the
+ *  rail. The renderer must register the workspace with main
+ *  (`workspace:register-additional`) BEFORE flipping the active path via
+ *  `addOpenProjectAtom` — see `store/listeners/railProjectListeners.ts`. */
+export const RAIL_ADD_PROJECT_CHANNEL = 'rail:add-project';
+
+export interface ResolveProjectOpenTargetInput<W> {
+  /** Unused by the decision itself; kept on the input for callers/tests that
+   *  want a single object describing "what are we opening". */
+  workspacePath: string;
+  multiProjectModeEnabled: boolean;
+  /** A live window that already references this exact path (primary or
+   *  rail-warm additional), or null if none does. */
+  existingWindowForPath: W | null;
+  /** The focused (or most-recently-focused) workspace window, or null if no
+   *  workspace window is open. Only consulted when there is no existing
+   *  window for the path. */
+  focusedWorkspaceWindow: W | null;
+}
+
+export type ProjectOpenTarget<W> =
+  | { kind: 'focus-existing'; window: W }
+  | { kind: 'add-to-rail'; window: W }
+  | { kind: 'new-window' };
+
+/**
+ * Decide how to open `workspacePath`.
+ *
+ * 1. A window already referencing the path wins regardless of mode — this
+ *    is today's (pre-multi-project) behavior and must never regress.
+ * 2. Otherwise, in multi-project mode, with a focused workspace window,
+ *    add the project to that window's rail.
+ * 3. Otherwise, open a new window.
+ */
+export function resolveProjectOpenTarget<W>(
+  input: ResolveProjectOpenTargetInput<W>,
+): ProjectOpenTarget<W> {
+  const { existingWindowForPath, multiProjectModeEnabled, focusedWorkspaceWindow } = input;
+
+  if (existingWindowForPath) {
+    return { kind: 'focus-existing', window: existingWindowForPath };
+  }
+
+  if (multiProjectModeEnabled && focusedWorkspaceWindow) {
+    return { kind: 'add-to-rail', window: focusedWorkspaceWindow };
+  }
+
+  return { kind: 'new-window' };
+}

--- a/packages/electron/src/main/window/workspaceOpenRef.ts
+++ b/packages/electron/src/main/window/workspaceOpenRef.ts
@@ -1,0 +1,54 @@
+// Indirection for the "open or focus a workspace" chokepoint.
+//
+// The chokepoint itself lives in `window/WorkspaceManagerWindow.ts`, which is
+// a hub: it pulls in analytics, tracker sync/schema, and the tutorial service,
+// and transitively the autoUpdater singleton. Modules that only need to *ask*
+// for a workspace to be opened should not evaluate that whole graph at module
+// load -- doing so breaks unrelated suites in vitest's node environment, the
+// same failure mode `mcpConfigServiceRef.ts` documents.
+//
+// `index.ts` registers the real opener at startup; callers use `openWorkspace`.
+//
+// Longer term the chokepoint belongs in its own light module so this ref is
+// unnecessary; that refactor touches ~10 importers and is deliberately out of
+// scope here.
+
+// Type-only: erased at compile time, so this creates no runtime edge into
+// the heavy module it is declared in.
+import type { ProjectOpenOutcome, ProjectOpenOutcomeAsync } from './WorkspaceManagerWindow';
+
+type Opener = (workspacePath: string) => ProjectOpenOutcome;
+type AsyncOpener = (workspacePath: string) => Promise<ProjectOpenOutcomeAsync>;
+
+let opener: Opener | null = null;
+let asyncOpener: AsyncOpener | null = null;
+
+export function setWorkspaceOpener(fn: Opener): void {
+  opener = fn;
+}
+
+export function setWorkspaceOpenerAwaitingRailSeed(fn: AsyncOpener): void {
+  asyncOpener = fn;
+}
+
+/**
+ * Open or focus `workspacePath`, waiting for the rail seed to be confirmed
+ * when the project joins an existing window's rail.
+ *
+ * Resolves to null only if called before startup registered the opener.
+ * Callers must treat that like a seed that did not land -- i.e. do not
+ * deliver a payload against a window that may not host the project.
+ */
+export async function openWorkspaceAwaitingRailSeed(
+  workspacePath: string,
+): Promise<ProjectOpenOutcomeAsync | null> {
+  return asyncOpener ? asyncOpener(workspacePath) : null;
+}
+
+/**
+ * Open or focus `workspacePath`. Returns null only if called before startup
+ * registered the opener, which callers must treat as "could not open".
+ */
+export function openWorkspace(workspacePath: string): ProjectOpenOutcome | null {
+  return opener ? opener(workspacePath) : null;
+}

--- a/packages/electron/src/renderer/App.tsx
+++ b/packages/electron/src/renderer/App.tsx
@@ -130,6 +130,8 @@ import { initCollabScopeListeners } from './store/listeners/collabScopeListeners
 import { initCollabReplicaListeners } from './store/listeners/collabReplicaListeners';
 import { initCollabConversionListeners } from './store/listeners/collabConversionListeners';
 import { initNotificationListeners } from './store/listeners/notificationListeners';
+import { collectPendingRailSeeds, initRailProjectListeners } from './store/listeners/railProjectListeners';
+import { initWindowCloseFlushListeners } from './store/listeners/windowCloseFlushListeners';
 import { initExtensionPermissionListeners } from './store/listeners/extensionPermissionListeners';
 import { initPermissionListeners } from './store/listeners/permissionListeners';
 import { initSoundListeners } from './store/listeners/soundListeners';
@@ -371,6 +373,8 @@ export default function App() {
     const cleanupMcp = initMcpListeners();
     const cleanupMenuCommand = initMenuCommandListeners();
     const cleanupNotification = initNotificationListeners();
+    const cleanupRailProject = initRailProjectListeners();
+    const cleanupWindowCloseFlush = initWindowCloseFlushListeners();
     const cleanupExtensionPermission = initExtensionPermissionListeners();
     const cleanupPermission = initPermissionListeners();
     const cleanupSound = initSoundListeners();
@@ -414,6 +418,8 @@ export default function App() {
       cleanupMcp?.();
       cleanupMenuCommand?.();
       cleanupNotification?.();
+      cleanupRailProject?.();
+      cleanupWindowCloseFlush?.();
       cleanupExtensionPermission?.();
       cleanupPermission?.();
       cleanupSound?.();
@@ -2217,6 +2223,13 @@ export default function App() {
                 name: initialState.workspaceName ?? initialState.workspacePath,
                 openedAt: Date.now(),
               });
+
+              // Now that the window's own project is established, pull any
+              // rail projects main parked for us during session restore.
+              // Deliberately here and not in `initRailProjectListeners()`:
+              // adding a project re-subscribes session state for it, which
+              // requires the workspace's state to be initialized first.
+              void collectPendingRailSeeds();
             }
           }
         }

--- a/packages/electron/src/renderer/components/ProjectRail.tsx
+++ b/packages/electron/src/renderer/components/ProjectRail.tsx
@@ -34,8 +34,10 @@ import {
   isOpenProjectsAtCapAtom,
   addOpenProjectAtom,
   closeOpenProjectAtom,
+  MAX_OPEN_PROJECTS,
   type OpenProject,
 } from '../store/atoms/openProjects';
+import { showRailFullNotification } from '../store/actions/railFullNotification';
 import {
   globalSessionActivityAtom,
   projectActivitySummaryAtom,
@@ -214,8 +216,15 @@ export function ProjectRail() {
         openedAt: Date.now(),
       };
       // `addOpenProjectAtom` flips `activeWorkspacePathAtom` to this path;
-      // the atom subscriber dispatches `workspace:set-active` to main.
-      addProject(project);
+      // the atom subscriber dispatches `workspace:set-active` to main. The
+      // `+` button already disables at the cap, but the add menu can still
+      // be open from before the rail filled up (e.g. another window's
+      // project joined this rail via `rail:add-project` while the menu was
+      // open), so still handle `'at-cap'` here.
+      const outcome = addProject(project);
+      if (outcome === 'at-cap') {
+        showRailFullNotification();
+      }
     } catch (err) {
       console.error('[ProjectRail] addProjectByPath failed:', err);
     }
@@ -249,7 +258,7 @@ export function ProjectRail() {
 
   const handleOpenAddMenu = useCallback(() => {
     if (atCap) {
-      window.alert('You can have at most 8 projects open in the rail. Close one first or open in a new window.');
+      showRailFullNotification();
       return;
     }
     refreshRecents();
@@ -445,7 +454,7 @@ export function ProjectRail() {
         onClick={handleOpenAddMenu}
         disabled={atCap}
         data-testid="project-rail-add"
-        aria-label="Add project to rail"
+        aria-label={atCap ? `Rail full (${MAX_OPEN_PROJECTS} projects max)` : 'Add project to rail'}
         {...getAddTooltipRefProps()}
       >
         +
@@ -458,7 +467,7 @@ export function ProjectRail() {
             style={addTooltipFloatingStyles}
             {...getAddTooltipFloatingProps()}
           >
-            {atCap ? 'Rail full (8 projects max)' : 'Add project'}
+            {atCap ? `Rail full (${MAX_OPEN_PROJECTS} projects max)` : 'Add project'}
           </div>
         </FloatingPortal>
       )}

--- a/packages/electron/src/renderer/store/actions/railFullNotification.ts
+++ b/packages/electron/src/renderer/store/actions/railFullNotification.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared "project rail is full" toast.
+ *
+ * Lives outside `ProjectRail.tsx` because the rail is not the only way a
+ * project reaches the rail: `rail:add-project` arrives from the main process
+ * (deep link, notification click, Open Recent, tutorial, MCP `workspace_open`)
+ * and has no `+` button to disable, so `store/listeners/railProjectListeners.ts`
+ * needs the same feedback. Importing it from the component would drag the whole
+ * rail component tree into a listener module.
+ */
+
+import { errorNotificationService } from '../../services/ErrorNotificationService';
+import { MAX_OPEN_PROJECTS } from '../atoms/openProjects';
+
+/**
+ * `allowDuplicate` bypasses the service's 5s dedup window so a second attempt
+ * at the cap still produces feedback rather than appearing to do nothing.
+ */
+export function showRailFullNotification(): void {
+  errorNotificationService.showWarning(
+    'Project rail is full',
+    `You can have at most ${MAX_OPEN_PROJECTS} projects open in this window. Close one from the rail, or open this project in a new window.`,
+    { duration: 6000, allowDuplicate: true }
+  );
+}

--- a/packages/electron/src/renderer/store/actions/sessionNotificationNavigation.ts
+++ b/packages/electron/src/renderer/store/actions/sessionNotificationNavigation.ts
@@ -10,6 +10,7 @@ import {
   activeWorkspacePathAtom,
   addOpenProjectAtom,
   openProjectsAtom,
+  MAX_OPEN_PROJECTS,
 } from '../atoms/openProjects';
 import {
   initWorkstreamState,
@@ -30,7 +31,12 @@ interface SessionListResult {
   error?: string;
 }
 
-type NavigationFailure = 'archived' | 'missing' | 'lookup-failed' | 'project-unavailable';
+type NavigationFailure =
+  | 'archived'
+  | 'missing'
+  | 'lookup-failed'
+  | 'project-unavailable'
+  | 'rail-full';
 
 const MAX_SOURCE_LABEL_LENGTH = 60;
 
@@ -58,7 +64,9 @@ function failureMessage(
     case 'missing':
       return `Session ${shortId} could not be found in its originating project.`;
     case 'project-unavailable':
-      return `Nimbalyst could not switch to the project for session ${shortId}. Close a project from the rail, then retry.`;
+      return `Nimbalyst could not switch to the project for session ${shortId}.`;
+    case 'rail-full':
+      return `Session ${shortId} is in a project that is not open, and this window already has ${MAX_OPEN_PROJECTS} projects. Close one from the rail, then retry.`;
     default:
       return `Nimbalyst could not verify session ${shortId} in its originating project.`;
   }
@@ -150,14 +158,20 @@ async function activateWorkspace(target: SessionNotificationNavigationTarget): P
     }
   }
 
-  store.set(addOpenProjectAtom, {
+  const outcome = store.set(addOpenProjectAtom, {
     path: target.workspacePath,
     name: target.workspacePath.split(/[\\/]/).filter(Boolean).pop() || target.workspacePath,
     openedAt: Date.now(),
   });
 
-  // `addOpenProjectAtom` silently no-ops when the rail is at its cap; without
-  // this check we would go on to select a session against the wrong workspace.
+  // At the cap the add is refused, and continuing would select the session
+  // against whatever workspace is still active — the wrong one. Report the
+  // actual reason so the user knows the fix is "close a project", not "retry".
+  if (outcome === 'at-cap') {
+    return showUnavailable(target, 'rail-full');
+  }
+
+  // Defensive: any other way the active path failed to land on the target.
   if (store.get(activeWorkspacePathAtom) !== target.workspacePath) {
     return showUnavailable(target, 'project-unavailable');
   }

--- a/packages/electron/src/renderer/store/atoms/__tests__/openProjects.test.ts
+++ b/packages/electron/src/renderer/store/atoms/__tests__/openProjects.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createStore } from 'jotai';
 import {
   openProjectsAtom,
@@ -10,11 +11,14 @@ import {
   attachWorkspaceSwitchCleanup,
   resolveInitialOpenProjectsState,
   selectProjectsToRegister,
+  mergeOpenProjects,
+  initOpenProjects,
+  teardownOpenProjects,
+  MAX_OPEN_PROJECTS,
   type OpenProject,
 } from '../openProjects';
+import { store } from '@nimbalyst/runtime/store';
 import { activeSessionIdAtom, selectedWorkstreamAtom } from '../sessions';
-
-const MAX_OPEN_PROJECTS = 8;
 
 function project(path: string, openedAt = 0): OpenProject {
   const name = path.split('/').filter(Boolean).pop() ?? path;
@@ -29,9 +33,10 @@ describe('openProjects atoms', () => {
   });
 
   describe('addOpenProjectAtom', () => {
-    it('adds a new project and activates it', () => {
-      jotaiStore.set(addOpenProjectAtom, project('/ws/a'));
+    it('adds a new project, activates it, and reports "added"', () => {
+      const outcome = jotaiStore.set(addOpenProjectAtom, project('/ws/a'));
 
+      expect(outcome).toBe('added');
       expect(jotaiStore.get(openProjectsAtom)).toEqual([project('/ws/a')]);
       expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/a');
     });
@@ -46,28 +51,55 @@ describe('openProjects atoms', () => {
       expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/c');
     });
 
-    it('dedups when path is already open and just activates it', () => {
+    it('dedups when path is already open, just activates it, and reports "already-open"', () => {
       jotaiStore.set(addOpenProjectAtom, project('/ws/a'));
       jotaiStore.set(addOpenProjectAtom, project('/ws/b'));
-      jotaiStore.set(addOpenProjectAtom, project('/ws/a'));
+      const outcome = jotaiStore.set(addOpenProjectAtom, project('/ws/a'));
 
+      expect(outcome).toBe('already-open');
       const open = jotaiStore.get(openProjectsAtom);
       expect(open).toHaveLength(2);
       expect(open.map((p) => p.path)).toEqual(['/ws/a', '/ws/b']);
       expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/a');
     });
 
-    it('rejects new projects beyond the cap without altering active', () => {
+    it('rejects new projects beyond the cap, reports "at-cap", and leaves active unchanged', () => {
       for (let i = 0; i < MAX_OPEN_PROJECTS; i++) {
         jotaiStore.set(addOpenProjectAtom, project(`/ws/${i}`));
       }
       expect(jotaiStore.get(openProjectsAtom)).toHaveLength(MAX_OPEN_PROJECTS);
       expect(jotaiStore.get(activeWorkspacePathAtom)).toBe(`/ws/${MAX_OPEN_PROJECTS - 1}`);
 
-      jotaiStore.set(addOpenProjectAtom, project('/ws/overflow'));
+      const outcome = jotaiStore.set(addOpenProjectAtom, project('/ws/overflow'));
 
+      expect(outcome).toBe('at-cap');
       expect(jotaiStore.get(openProjectsAtom)).toHaveLength(MAX_OPEN_PROJECTS);
       expect(jotaiStore.get(activeWorkspacePathAtom)).toBe(`/ws/${MAX_OPEN_PROJECTS - 1}`);
+    });
+
+    // Regression coverage for defect (A) in the single-window-multi-project
+    // contract: a non-activating add must never flip the visible project,
+    // on either the newly-added or the already-open branch.
+    it('activate: false appends a new project without touching the active path', () => {
+      jotaiStore.set(addOpenProjectAtom, project('/ws/primary'));
+      expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/primary');
+
+      const outcome = jotaiStore.set(addOpenProjectAtom, project('/ws/sibling'), { activate: false });
+
+      expect(outcome).toBe('added');
+      expect(jotaiStore.get(openProjectsAtom).map((p) => p.path)).toEqual(['/ws/primary', '/ws/sibling']);
+      expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/primary');
+    });
+
+    it('activate: false on an already-open project still does not touch the active path', () => {
+      jotaiStore.set(addOpenProjectAtom, project('/ws/primary'));
+      jotaiStore.set(addOpenProjectAtom, project('/ws/sibling'), { activate: false });
+      expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/primary');
+
+      const outcome = jotaiStore.set(addOpenProjectAtom, project('/ws/sibling'), { activate: false });
+
+      expect(outcome).toBe('already-open');
+      expect(jotaiStore.get(activeWorkspacePathAtom)).toBe('/ws/primary');
     });
   });
 
@@ -293,6 +325,56 @@ describe('openProjects atoms', () => {
         activePath: '/ws/a',
       });
     });
+
+    it('reserves a slot for the primary workspace when restore would fill the rail', () => {
+      // A full persisted set that does NOT contain the window's own project.
+      // Without the reservation the primary seed is refused at the cap and the
+      // window renders without its own project.
+      const persistedPaths = Array.from(
+        { length: MAX_OPEN_PROJECTS },
+        (_, i) => `/ws/restored-${i}`,
+      );
+
+      const result = resolveInitialOpenProjectsState({
+        persistedPaths,
+        persistedActivePath: `/ws/restored-${MAX_OPEN_PROJECTS - 1}`,
+        restorePreviousProjects: true,
+        windowState: {
+          mode: 'workspace',
+          workspacePath: '/ws/primary',
+          activeWorkspacePath: '/ws/primary',
+          openProjectPaths: ['/ws/primary'],
+        },
+      });
+
+      expect(result.paths).toHaveLength(MAX_OPEN_PROJECTS - 1);
+      expect(result.paths).not.toContain(`/ws/restored-${MAX_OPEN_PROJECTS - 1}`);
+      // The dropped path was also the persisted active one, so the active
+      // selection must fall back into the surviving set rather than dangle.
+      expect(result.paths).toContain(result.activePath!);
+    });
+
+    it('does not reserve a slot when the primary is already in the restored set', () => {
+      const persistedPaths = [
+        '/ws/primary',
+        ...Array.from({ length: MAX_OPEN_PROJECTS - 1 }, (_, i) => `/ws/restored-${i}`),
+      ];
+
+      const result = resolveInitialOpenProjectsState({
+        persistedPaths,
+        persistedActivePath: '/ws/primary',
+        restorePreviousProjects: true,
+        windowState: {
+          mode: 'workspace',
+          workspacePath: '/ws/primary',
+          activeWorkspacePath: '/ws/primary',
+          openProjectPaths: ['/ws/primary'],
+        },
+      });
+
+      expect(result.paths).toHaveLength(MAX_OPEN_PROJECTS);
+      expect(result.paths).toContain('/ws/primary');
+    });
   });
 
   // NIM-757 (#548): restored non-primary rail projects must be registered with
@@ -315,6 +397,122 @@ describe('openProjects atoms', () => {
         '/ws/a',
         '/ws/b',
       ]);
+    });
+  });
+
+  describe('mergeOpenProjects', () => {
+    it('returns base unchanged when concurrent has no extra paths', () => {
+      const base = [project('/ws/a'), project('/ws/b')];
+      expect(mergeOpenProjects(base, [project('/ws/a')])).toBe(base);
+    });
+
+    it('appends concurrent-only paths after base, in their existing order', () => {
+      const base = [project('/ws/a')];
+      const concurrent = [project('/ws/a'), project('/ws/c'), project('/ws/b')];
+
+      expect(mergeOpenProjects(base, concurrent).map((p) => p.path)).toEqual([
+        '/ws/a',
+        '/ws/c',
+        '/ws/b',
+      ]);
+    });
+
+    it('base wins for a path both sides know about', () => {
+      const base = [{ path: '/ws/a', name: 'from-base', openedAt: 1 }];
+      const concurrent = [{ path: '/ws/a', name: 'from-concurrent', openedAt: 2 }];
+
+      expect(mergeOpenProjects(base, concurrent)).toEqual(base);
+    });
+  });
+
+  // Regression coverage for the `initOpenProjects` overwrite race: App.tsx's
+  // `loadInitialState` effect (`addOpenProject` for the window's own primary)
+  // and the `rail:add-project` listener (restore-seeded siblings) are
+  // independent, unawaited writers to `openProjectsAtom` that can append
+  // before `initOpenProjects`'s own IPC round trips resolve. Uses the real
+  // `@nimbalyst/runtime/store` singleton -- `initOpenProjects` is hardcoded
+  // to it, not to a `createStore()` instance.
+  describe('initOpenProjects', () => {
+    afterEach(() => {
+      teardownOpenProjects();
+      store.set(openProjectsAtom, []);
+      store.set(activeWorkspacePathAtom, null);
+      delete (globalThis as any).window;
+    });
+
+    it('merges a concurrently-appended project instead of dropping it on overwrite', async () => {
+      let resolveRegisterAdditional!: (value: { success: boolean }) => void;
+      (globalThis as any).window = {
+        electronAPI: {
+          invoke: vi.fn((channel: string) => {
+            switch (channel) {
+              case 'app:get-multi-project-mode':
+                return Promise.resolve(false);
+              case 'app:get-restore-previous-projects':
+                return Promise.resolve(false);
+              case 'app:get-open-projects':
+                return Promise.resolve([]);
+              case 'app:get-active-project-path':
+                return Promise.resolve(null);
+              case 'workspace:register-additional':
+                // Never resolves before the assertion below reads
+                // `openProjectsAtom` -- simulates the concurrent writer
+                // (loadInitialState / rail:add-project) landing while
+                // `initOpenProjects` is still awaiting main.
+                return new Promise((resolve) => {
+                  resolveRegisterAdditional = resolve;
+                });
+              default:
+                return Promise.resolve(undefined);
+            }
+          }),
+          getInitialState: vi.fn(() =>
+            Promise.resolve({
+              mode: 'workspace',
+              workspacePath: '/ws/primary',
+              activeWorkspacePath: '/ws/primary',
+              openProjectPaths: ['/ws/primary', '/ws/sibling'],
+            }),
+          ),
+          send: vi.fn(),
+        },
+      };
+
+      const initPromise = initOpenProjects();
+
+      // Wait for the module's own IPC round trips to reach the
+      // `workspace:register-additional` await.
+      await vi.waitFor(() => {
+        expect(resolveRegisterAdditional).toBeDefined();
+      });
+
+      // The eager merge (before the registration await) already painted
+      // the computed initial set -- the rail is not blank while
+      // registration is in flight.
+      expect(store.get(openProjectsAtom).map((p) => p.path)).toEqual(['/ws/primary', '/ws/sibling']);
+
+      // Simulate the concurrent writer (loadInitialState's `addOpenProject`
+      // for the primary, or the `rail:add-project` listener for a seeded
+      // sibling) appending a project via the real `addOpenProjectAtom` path
+      // -- same as production -- while `initOpenProjects` is still awaiting
+      // main.
+      store.set(
+        addOpenProjectAtom,
+        { path: '/ws/concurrent', name: 'concurrent', openedAt: 2 },
+        { activate: false },
+      );
+
+      resolveRegisterAdditional({ success: true });
+      await initPromise;
+
+      const paths = store.get(openProjectsAtom).map((p) => p.path);
+      // The computed initial set (primary + sibling from openProjectPaths)
+      // is present, AND the concurrently-appended path survived the second
+      // (post-registration) merge instead of being wiped out by an
+      // overwrite.
+      expect(paths).toContain('/ws/primary');
+      expect(paths).toContain('/ws/sibling');
+      expect(paths).toContain('/ws/concurrent');
     });
   });
 });

--- a/packages/electron/src/renderer/store/atoms/openProjects.ts
+++ b/packages/electron/src/renderer/store/atoms/openProjects.ts
@@ -81,7 +81,7 @@ export const activeWorkspacePathAtom = atom<string | null>(null);
  * `initOpenProjects()`'s `app:get-multi-project-mode` round trip resolves
  * and overwrites it.
  */
-export const multiProjectModeAtom = atom<boolean>(false);
+export const multiProjectModeAtom = atom<boolean>(true);
 
 /**
  * When true, the rail rehydrates with the projects that were open at last

--- a/packages/electron/src/renderer/store/atoms/openProjects.ts
+++ b/packages/electron/src/renderer/store/atoms/openProjects.ts
@@ -44,7 +44,22 @@ interface ResolveInitialOpenProjectsInput {
   windowState: InitialWorkspaceWindowState | null;
 }
 
-const MAX_OPEN_PROJECTS = 8;
+/**
+ * Cap on warm rail projects. Each warm project holds a DocumentService, a
+ * FileSystemService, a file watcher, and a persistent tab slot, so this is
+ * a hard resource cap, not a taste preference.
+ *
+ * Raised from 8 to 12 for Phase 1.5 of single-window-multi-project: with
+ * multi-project mode meant to hold "every project in one window", 8 was
+ * too easy to hit. 12 still fits the rail without scrolling at typical
+ * window heights (12 * (40px icon + 8px gap) + ~120px for the org
+ * switcher/divider/add-button chrome is well under a 900px-tall window),
+ * and the per-project resource cost (watcher + 2 services + tab slot)
+ * makes an unbounded rail the wrong answer — kept as a hard stop rather
+ * than a soft warning so `isOpenProjectsAtCapAtom` / `atCap`-disabled UI
+ * stays a single source of truth other call sites can rely on.
+ */
+export const MAX_OPEN_PROJECTS = 12;
 
 /**
  * Path of the workspace currently visible in this window.
@@ -61,8 +76,10 @@ export const activeWorkspacePathAtom = atom<string | null>(null);
  * opening a new project spawns a fresh window (legacy behavior). When true,
  * opening a project adds it to the rail in the current window.
  *
- * Persisted via `app:set-multi-project-mode` IPC; seeded from store on
- * launch by an effect that reads `app:get-multi-project-mode`.
+ * Defaults `true` to match `getMultiProjectMode()`'s store default
+ * (`main/utils/store.ts`) -- this is only the value shown before
+ * `initOpenProjects()`'s `app:get-multi-project-mode` round trip resolves
+ * and overwrites it.
  */
 export const multiProjectModeAtom = atom<boolean>(false);
 
@@ -99,29 +116,67 @@ export const isOpenProjectsAtCapAtom = atom((get) => {
 });
 
 /**
+ * Outcome of `addOpenProjectAtom`, so callers can react instead of the add
+ * silently doing nothing at the cap:
+ *   - `'added'` — new project appended and activated.
+ *   - `'already-open'` — path was already in the rail; just activated.
+ *   - `'at-cap'` — rail is at `MAX_OPEN_PROJECTS`; nothing changed, caller
+ *     should surface this to the user (e.g. via `errorNotificationService`).
+ */
+export type AddOpenProjectOutcome = 'added' | 'already-open' | 'at-cap';
+
+export interface AddOpenProjectOptions {
+  /**
+   * Whether to also flip `activeWorkspacePathAtom` to the added (or
+   * already-open) project's path. Defaults to `true` so every pre-existing
+   * caller (rail "+" button, `loadInitialState`'s primary seed, the
+   * notification-click reference implementation) keeps its current
+   * behavior unchanged.
+   *
+   * Pass `false` for a non-activating add — e.g. seeding several restored
+   * rail projects into one window (`SessionState.ts`'s `seedRailProjects`):
+   * only the intended primary should end up visible, and every other
+   * seed's `workspace:register-additional` round trip resolves at an
+   * unpredictable time relative to the primary's, so any of them flipping
+   * `activeWorkspacePathAtom` can steal focus from the primary depending on
+   * network/IPC timing. See NIM single-window-multi-project plan.
+   */
+  activate?: boolean;
+}
+
+/**
  * Add a project to the rail. No-op if it already exists. When the rail
- * has reached the cap, returns without adding (caller should show a UI
- * hint via `isOpenProjectsAtCapAtom`).
+ * has reached the cap, returns `'at-cap'` without adding — callers must
+ * not treat a silent return as success; surface it to the user (the `+`
+ * button hint uses `isOpenProjectsAtCapAtom`, but callers that add a
+ * project programmatically, e.g. from a main-process `rail:add-project`
+ * message, have no button to disable and must react to the return value
+ * directly).
  *
- * Activates the added project so the renderer immediately switches to it.
+ * Activates the added (or already-open) project so the renderer
+ * immediately switches to it, unless `options.activate` is explicitly
+ * `false` — see `AddOpenProjectOptions`. At the cap, the active project is
+ * left untouched regardless.
  */
 export const addOpenProjectAtom = atom(
   null,
-  (get, set, project: OpenProject) => {
+  (get, set, project: OpenProject, options?: AddOpenProjectOptions): AddOpenProjectOutcome => {
+    const activate = options?.activate ?? true;
     const current = get(openProjectsAtom);
 
     const existing = current.find((p) => p.path === project.path);
     if (existing) {
-      set(activeWorkspacePathAtom, existing.path);
-      return;
+      if (activate) set(activeWorkspacePathAtom, existing.path);
+      return 'already-open';
     }
 
     if (current.length >= MAX_OPEN_PROJECTS) {
-      return;
+      return 'at-cap';
     }
 
     set(openProjectsAtom, [...current, project]);
-    set(activeWorkspacePathAtom, project.path);
+    if (activate) set(activeWorkspacePathAtom, project.path);
+    return 'added';
   }
 );
 
@@ -190,6 +245,31 @@ function getWindowBootstrapState(initialState: unknown): InitialWorkspaceWindowS
 }
 
 /**
+ * Merge the freshly computed initial rail state (`base`) with whatever is
+ * already in `openProjectsAtom` (`concurrent`) at the moment `initOpenProjects`
+ * is finally ready to write it.
+ *
+ * `initOpenProjects` awaits several IPC round trips before it can compute
+ * `base`. Two other writers run in that same window without awaiting this
+ * function: App.tsx's `loadInitialState` effect appends this window's own
+ * primary project via `addOpenProjectAtom`, and the `rail:add-project`
+ * listener (`store/listeners/railProjectListeners.ts`) appends any restore
+ * -seeded sibling projects main sends on `did-finish-load`
+ * (`SessionState.ts`'s `seedRailProjects`). A raw `store.set(openProjectsAtom,
+ * base)` would silently drop whatever either of those already appended by
+ * this point, even though main's `windowStates` already references them.
+ *
+ * `base` wins for any path both sides know about (its `OpenProject` shape
+ * here is the authoritative bootstrap identity); paths present only in
+ * `concurrent` are appended after it, preserving their existing order.
+ */
+export function mergeOpenProjects(base: OpenProject[], concurrent: OpenProject[]): OpenProject[] {
+  const basePaths = new Set(base.map((p) => p.path));
+  const extra = concurrent.filter((p) => !basePaths.has(p.path));
+  return extra.length > 0 ? [...base, ...extra] : base;
+}
+
+/**
  * NIM-757: which restored rail projects must be registered with the main
  * process via `workspace:register-additional`. The window's primary workspace
  * is already registered at bootstrap, so only the non-primary restored paths
@@ -236,12 +316,24 @@ export function resolveInitialOpenProjectsState({
   }
 
   if (restorePreviousProjects && normalizedPersistedPaths.length > 0) {
+    // Reserve a slot for the window's own primary workspace when the restored
+    // set doesn't already contain it. `initOpenProjects` and App.tsx's
+    // `loadInitialState` are two independent, unawaited effects: if restore
+    // fills every slot first, the primary seed is refused at the cap and the
+    // window renders WITHOUT its own project, with some other project active.
+    // Truncating here makes the outcome order-independent rather than racy.
+    const primaryPath = windowState?.workspacePath ?? null;
+    const primaryNeedsSlot = primaryPath != null && !normalizedPersistedPaths.includes(primaryPath);
+    const restoredPaths = primaryNeedsSlot
+      ? normalizedPersistedPaths.slice(0, MAX_OPEN_PROJECTS - 1)
+      : normalizedPersistedPaths;
+
     return {
-      paths: normalizedPersistedPaths,
+      paths: restoredPaths,
       activePath:
-        persistedActivePath && normalizedPersistedPaths.includes(persistedActivePath)
+        persistedActivePath && restoredPaths.includes(persistedActivePath)
           ? persistedActivePath
-          : normalizedPersistedPaths[0] ?? null,
+          : restoredPaths[0] ?? null,
     };
   }
 
@@ -296,7 +388,14 @@ export async function initOpenProjects(): Promise<void> {
         name: basenameFromPath(path),
         openedAt: Date.now(),
       }));
-      store.set(openProjectsAtom, projects);
+
+      // Merge (never overwrite) rather than a single late write so the rail
+      // still paints immediately -- see `mergeOpenProjects` doc comment for
+      // why a raw overwrite is unsafe. Written once now, before the awaited
+      // registration round trips below, and once more after -- both merges,
+      // so the second is a no-op unless a concurrent writer (loadInitialState
+      // / the `rail:add-project` listener) appended something in between.
+      store.set(openProjectsAtom, mergeOpenProjects(projects, store.get(openProjectsAtom)));
 
       // NIM-757 (#548 / reopen #441): register restored non-primary projects
       // with the main process BEFORE flipping the active path. The "+"-add flow
@@ -318,6 +417,11 @@ export async function initOpenProjects(): Promise<void> {
           ),
         );
       }
+
+      // Second merge: pick up anything a concurrent writer appended while
+      // the registration awaits above were in flight. Idempotent if nothing
+      // did.
+      store.set(openProjectsAtom, mergeOpenProjects(projects, store.get(openProjectsAtom)));
 
       if (initialActivePath && initialPaths.includes(initialActivePath)) {
         store.set(activeWorkspacePathAtom, initialActivePath);

--- a/packages/electron/src/renderer/store/listeners/__tests__/railProjectListeners.test.ts
+++ b/packages/electron/src/renderer/store/listeners/__tests__/railProjectListeners.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { store } from '@nimbalyst/runtime/store';
+import { activeWorkspacePathAtom, openProjectsAtom, MAX_OPEN_PROJECTS } from '../../atoms/openProjects';
+import { collectPendingRailSeeds, initRailProjectListeners } from '../railProjectListeners';
+
+// Regression coverage for NIM-757 / #548 / reopened #441: registering the
+// workspace with main must happen BEFORE the active path flips, or
+// `workspace:set-active` rejects the still-unregistered path.
+describe('railProjectListeners', () => {
+  let handlers: Map<string, (data: unknown) => void>;
+  let invoke: ReturnType<typeof vi.fn>;
+  let cleanup: () => void;
+
+  let send: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    store.set(openProjectsAtom, []);
+    store.set(activeWorkspacePathAtom, null);
+
+    handlers = new Map();
+    invoke = vi.fn().mockResolvedValue({ success: true });
+    send = vi.fn();
+    (window as any).electronAPI = {
+      invoke,
+      send,
+      on: (channel: string, callback: (data: unknown) => void) => {
+        handlers.set(channel, callback);
+        return () => handlers.delete(channel);
+      },
+    };
+
+    cleanup = initRailProjectListeners();
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (window as any).electronAPI;
+  });
+
+  it('registers the workspace with main before activating it in the rail', async () => {
+    let activePathDuringRegistration: string | null | undefined;
+    invoke.mockImplementation(async (channel: string) => {
+      if (channel === 'workspace:register-additional') {
+        // The path must not be active yet -- flipping it first is exactly
+        // the bug this ordering guards against.
+        activePathDuringRegistration = store.get(activeWorkspacePathAtom);
+      }
+      return { success: true };
+    });
+
+    handlers.get('rail:add-project')?.({ workspacePath: '/ws/new' });
+    await vi.waitFor(() => {
+      expect(store.get(activeWorkspacePathAtom)).toBe('/ws/new');
+    });
+
+    expect(invoke).toHaveBeenCalledWith('workspace:register-additional', {
+      workspacePath: '/ws/new',
+    });
+    expect(activePathDuringRegistration).toBeNull();
+    expect(store.get(openProjectsAtom).map((p) => p.path)).toEqual(['/ws/new']);
+  });
+
+  it('does not re-register a project already in the rail', async () => {
+    store.set(openProjectsAtom, [{ path: '/ws/existing', name: 'existing', openedAt: 0 }]);
+
+    handlers.get('rail:add-project')?.({ workspacePath: '/ws/existing' });
+    await vi.waitFor(() => {
+      expect(store.get(activeWorkspacePathAtom)).toBe('/ws/existing');
+    });
+
+    expect(invoke).not.toHaveBeenCalledWith('workspace:register-additional', expect.anything());
+  });
+
+  it('does not activate the project when main rejects the registration', async () => {
+    invoke.mockResolvedValue({ success: false, error: 'boom' });
+
+    handlers.get('rail:add-project')?.({ workspacePath: '/ws/rejected' });
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalled();
+    });
+
+    expect(store.get(activeWorkspacePathAtom)).toBeNull();
+    expect(store.get(openProjectsAtom)).toEqual([]);
+  });
+
+  // Defect (A): a non-activating seed (session restore, "Merge All
+  // Windows") must register and append the project without ever flipping
+  // the visible project.
+  it('activate: false registers and appends without touching the active path', async () => {
+    store.set(openProjectsAtom, [{ path: '/ws/primary', name: 'primary', openedAt: 0 }]);
+    store.set(activeWorkspacePathAtom, '/ws/primary');
+
+    handlers.get('rail:add-project')?.({ workspacePath: '/ws/sibling', activate: false });
+    await vi.waitFor(() => {
+      expect(store.get(openProjectsAtom).map((p) => p.path)).toEqual(['/ws/primary', '/ws/sibling']);
+    });
+
+    expect(store.get(activeWorkspacePathAtom)).toBe('/ws/primary');
+  });
+
+  it('activate: false on an already-open project still does not touch the active path', async () => {
+    store.set(openProjectsAtom, [
+      { path: '/ws/primary', name: 'primary', openedAt: 0 },
+      { path: '/ws/sibling', name: 'sibling', openedAt: 0 },
+    ]);
+    store.set(activeWorkspacePathAtom, '/ws/primary');
+
+    handlers.get('rail:add-project')?.({ workspacePath: '/ws/sibling', activate: false });
+    await vi.waitFor(() => {
+      expect(invoke).not.toHaveBeenCalledWith('workspace:register-additional', expect.anything());
+    });
+
+    expect(store.get(activeWorkspacePathAtom)).toBe('/ws/primary');
+  });
+
+  // Defect (B): when a `requestId` is present, ack main back with the outcome.
+  describe('rail:add-project-result ack', () => {
+    it('sends an ack with outcome "added" for a new project', async () => {
+      handlers.get('rail:add-project')?.({ workspacePath: '/ws/new', requestId: 'req-1' });
+
+      await vi.waitFor(() => {
+        expect(send).toHaveBeenCalledWith('rail:add-project-result', {
+          requestId: 'req-1',
+          workspacePath: '/ws/new',
+          outcome: 'added',
+        });
+      });
+    });
+
+    it('sends an ack with outcome "already-open" for a project already in the rail', async () => {
+      store.set(openProjectsAtom, [{ path: '/ws/existing', name: 'existing', openedAt: 0 }]);
+
+      handlers.get('rail:add-project')?.({ workspacePath: '/ws/existing', requestId: 'req-2' });
+
+      await vi.waitFor(() => {
+        expect(send).toHaveBeenCalledWith('rail:add-project-result', {
+          requestId: 'req-2',
+          workspacePath: '/ws/existing',
+          outcome: 'already-open',
+        });
+      });
+    });
+
+    it('sends an ack with outcome "at-cap" when the rail is full', async () => {
+      store.set(
+        openProjectsAtom,
+        Array.from({ length: MAX_OPEN_PROJECTS }, (_, i) => ({
+          path: `/ws/${i}`,
+          name: `${i}`,
+          openedAt: 0,
+        })),
+      );
+
+      handlers.get('rail:add-project')?.({ workspacePath: '/ws/overflow', requestId: 'req-4' });
+
+      await vi.waitFor(() => {
+        expect(send).toHaveBeenCalledWith('rail:add-project-result', {
+          requestId: 'req-4',
+          workspacePath: '/ws/overflow',
+          outcome: 'at-cap',
+        });
+      });
+    });
+
+    it('sends no ack at all when registration fails', async () => {
+      invoke.mockResolvedValue({ success: false, error: 'boom' });
+
+      handlers.get('rail:add-project')?.({ workspacePath: '/ws/rejected', requestId: 'req-3' });
+      await vi.waitFor(() => {
+        expect(invoke).toHaveBeenCalled();
+      });
+
+      // Registration failure returns early with no ack at all -- main's
+      // ack-waiter (`railSeeding.ts`) times out rather than receiving a
+      // false signal that could be confused with 'at-cap'.
+      expect(send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pending rail seeds', () => {
+    it('does not collect seeds merely by registering the listener', () => {
+      // Registering must not add projects. Adding re-subscribes session state
+      // for that workspace, which writes workstream state and throws
+      // "Cannot persist - initWorkstreamState not called" when the workspace
+      // is not initialized yet -- that crashed the window into the error
+      // boundary on launch. App.tsx collects explicitly, after its own
+      // project is established.
+      expect(invoke).not.toHaveBeenCalledWith('rail:take-pending-seeds');
+    });
+
+    it('ignores a non-array answer instead of rejecting', async () => {
+      // The shared `invoke` mock answers every channel with `{ success: true }`.
+      // `?? []` only guards null/undefined, so anything else reached the
+      // for-of and rejected asynchronously -- which failed CI with 9 unhandled
+      // rejections while every test still reported green.
+      await expect(collectPendingRailSeeds()).resolves.toBeUndefined();
+      expect(store.get(openProjectsAtom)).toHaveLength(0);
+    });
+
+    it('adds parked projects without stealing the active one', async () => {
+      store.set(activeWorkspacePathAtom, '/ws/primary');
+      invoke.mockImplementation(async (channel: string) =>
+        channel === 'rail:take-pending-seeds' ? ['/ws/a', '/ws/b'] : { success: true },
+      );
+
+      await collectPendingRailSeeds();
+
+      expect(store.get(openProjectsAtom).map((p) => p.path)).toEqual(['/ws/a', '/ws/b']);
+      expect(store.get(activeWorkspacePathAtom)).toBe('/ws/primary');
+    });
+  });
+});

--- a/packages/electron/src/renderer/store/listeners/__tests__/windowCloseFlushListeners.test.ts
+++ b/packages/electron/src/renderer/store/listeners/__tests__/windowCloseFlushListeners.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DocumentModel } from '../../../services/document-model/DocumentModel';
+import { DocumentModelRegistry } from '../../../services/document-model/DocumentModelRegistry';
+import type { DocumentBackingStore } from '../../../services/document-model/types';
+import { initWindowCloseFlushListeners } from '../windowCloseFlushListeners';
+
+// Real DocumentModelRegistry + DocumentModel, with a mock backing store, so
+// these tests exercise the actual "flush, then re-check isDirty" path that
+// tells main whether it is safe to close the donor window -- not just that
+// the listener called some flush function.
+function createMockStore(): DocumentBackingStore {
+  return {
+    load: vi.fn(async () => ''),
+    save: vi.fn(async () => {}),
+    onExternalChange: vi.fn(() => () => {}),
+  };
+}
+
+describe('windowCloseFlushListeners', () => {
+  let handlers: Map<string, (data: unknown) => void>;
+  let send: ReturnType<typeof vi.fn>;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    DocumentModelRegistry.clear();
+    DocumentModelRegistry.setModelFactory((filePath: string) => new DocumentModel(filePath, createMockStore(), {
+      autosaveInterval: 0,
+    }));
+
+    handlers = new Map();
+    send = vi.fn();
+    vi.stubGlobal('window', {
+      electronAPI: {
+        send,
+        on: (channel: string, callback: (data: unknown) => void) => {
+          handlers.set(channel, callback);
+          return () => handlers.delete(channel);
+        },
+      },
+    });
+
+    cleanup = initWindowCloseFlushListeners();
+  });
+
+  afterEach(() => {
+    cleanup();
+    DocumentModelRegistry.clear();
+    DocumentModelRegistry.setModelFactory(null);
+    vi.unstubAllGlobals();
+  });
+
+  it('acks "flushed" once a dirty model saves successfully', async () => {
+    const { model, handle } = DocumentModelRegistry.getOrCreate(
+      '/ws/a.md',
+      { autosaveInterval: 0 },
+    );
+    const unregisterSave = handle.onSaveRequested(async () => {
+      await handle.saveContent('new content');
+    });
+    handle.setDirty(true);
+    expect(model.isDirty()).toBe(true);
+
+    handlers.get('window:flush-before-close')?.({ requestId: 'req-1' });
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledWith('window:flush-before-close-result', {
+        requestId: 'req-1',
+        outcome: 'flushed',
+      });
+    });
+    expect(model.isDirty()).toBe(false);
+    unregisterSave();
+    handle.detach();
+  });
+
+  it('acks "still-dirty" when a save-requested callback does not clear the dirty flag', async () => {
+    const { model, handle } = DocumentModelRegistry.getOrCreate(
+      '/ws/b.md',
+      { autosaveInterval: 0 },
+    );
+    // Registers a save-requested callback that fails (rejects) -- DocumentModel
+    // swallows the throw internally, so this stands in for a write that never
+    // lands. The dirty flag is never cleared because saveContent is never called.
+    const unregisterSave = handle.onSaveRequested(async () => {
+      throw new Error('disk write failed');
+    });
+    handle.setDirty(true);
+
+    handlers.get('window:flush-before-close')?.({ requestId: 'req-2' });
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledWith('window:flush-before-close-result', {
+        requestId: 'req-2',
+        outcome: 'still-dirty',
+      });
+    });
+    expect(model.isDirty()).toBe(true);
+    unregisterSave();
+    handle.detach();
+  });
+
+  it('acks "flushed" with no dirty models at all', async () => {
+    handlers.get('window:flush-before-close')?.({ requestId: 'req-3' });
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledWith('window:flush-before-close-result', {
+        requestId: 'req-3',
+        outcome: 'flushed',
+      });
+    });
+  });
+
+  it('ignores a request with no requestId', async () => {
+    handlers.get('window:flush-before-close')?.({});
+    await Promise.resolve();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/electron/src/renderer/store/listeners/railProjectListeners.ts
+++ b/packages/electron/src/renderer/store/listeners/railProjectListeners.ts
@@ -1,0 +1,178 @@
+/**
+ * Central Rail-Add-Project Listener
+ *
+ * Subscribes to `rail:add-project` ONCE. Main sends this when Multi-Project
+ * Mode is on and the user opens a project that has no window of its own yet
+ * (deep link, notification click, Open Recent, tutorial, MCP `workspace_open`,
+ * restore-time rail seeding, "Merge All Windows", ...) -- the project joins
+ * THIS window's rail instead of a new window spawning.
+ *
+ * ORDERING IS LOAD-BEARING (NIM-757 / #548 / reopened #441): main cannot
+ * register the workspace itself (`workspace:register-additional` is a
+ * renderer -> main `safeHandle`), so the renderer must, in this order:
+ *
+ *   1. `invoke('workspace:register-additional', ...)` -- so main's per-window
+ *      `additionalWorkspacePaths` and per-path services exist BEFORE
+ *   2. `set(addOpenProjectAtom, ...)` -- which flips `activeWorkspacePathAtom`
+ *      (unless the message explicitly asked not to -- see `activate` below)
+ *
+ * Flipping the active path first makes the `workspace:set-active` subscriber
+ * race main with a path it doesn't know about yet, and `workspace:set-active`
+ * silently no-ops for an unregistered path -- pinning path-scoped IPC to the
+ * window's original project. `store/actions/sessionNotificationNavigation.ts`
+ * (`activateWorkspace`) is the reference implementation this mirrors.
+ *
+ * Payload fields, all but `workspacePath` optional so existing fire-and-forget
+ * senders (`WorkspaceManagerWindow.ts`, `AIService.ts`, `TutorialProjectService.ts`,
+ * ...) are unaffected:
+ *   - `activate` (default `true`) -- when `false`, the project is registered
+ *     and appended to the rail WITHOUT touching `activeWorkspacePathAtom`.
+ *     Used when seeding several projects into one window at once (session
+ *     restore, "Merge All Windows") so only the intended primary ends up
+ *     visible regardless of which seed's round trip resolves last.
+ *   - `requestId` -- when present, an ack is sent back to main on
+ *     `rail:add-project-result` with `{ requestId, workspacePath, outcome }`
+ *     once the add resolves (see `main/window/railSeeding.ts`).
+ *
+ * Call initRailProjectListeners() once at app startup.
+ */
+
+import { store } from '@nimbalyst/runtime/store';
+import { addOpenProjectAtom, openProjectsAtom, type AddOpenProjectOutcome } from '../atoms/openProjects';
+import { showRailFullNotification } from '../actions/railFullNotification';
+
+const RAIL_ADD_PROJECT_RESULT_CHANNEL = 'rail:add-project-result';
+const RAIL_TAKE_PENDING_SEEDS_CHANNEL = 'rail:take-pending-seeds';
+
+interface RailAddProjectPayload {
+  workspacePath: string;
+  activate?: boolean;
+  requestId?: string;
+}
+
+let initialized = false;
+
+function basenameFromPath(p: string): string {
+  const trimmed = p.replace(/[\\/]+$/, '');
+  const idx = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'));
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+}
+
+export function initRailProjectListeners(): () => void {
+  if (initialized) {
+    return () => {};
+  }
+  initialized = true;
+
+  const unsubscribe = window.electronAPI?.on?.(
+    'rail:add-project',
+    (data: RailAddProjectPayload) => {
+      void addProjectToRail(data?.workspacePath, data?.activate, data?.requestId);
+    },
+  );
+
+  return () => {
+    initialized = false;
+    if (typeof unsubscribe === 'function') {
+      unsubscribe();
+    }
+  };
+}
+
+/**
+ * Pull the rail projects main parked for us during session restore and add
+ * them without stealing focus. Main clears the list as it hands it over, so a
+ * renderer reload re-runs this harmlessly.
+ *
+ * Call this only once the app is ready to HOST a project -- i.e. at the same
+ * point the window's primary project is added (`App.tsx`'s `loadInitialState`).
+ * Adding to `openProjectsAtom` re-subscribes session state for that workspace
+ * (`store/sessionStateListeners.ts`), which writes workstream state, which
+ * throws "Cannot persist - initWorkstreamState not called" if the workspace's
+ * state has not been initialized yet. Calling this from listener registration
+ * was early enough to hit exactly that, crashing the window into the error
+ * boundary on launch (it recovered on "Try again", which remounted later).
+ *
+ * Parking means there is no race in waiting: the seeds sit in main until asked.
+ */
+export async function collectPendingRailSeeds(): Promise<void> {
+  if (!window.electronAPI?.invoke) return;
+
+  let paths: string[] = [];
+  try {
+    // Validate the shape rather than trusting the channel: `?? []` only
+    // guards null/undefined, so any other value (an older main process, or a
+    // test whose generic `invoke` mock answers every channel) reaches the
+    // loop below and throws "paths is not iterable" as an unhandled
+    // rejection -- which fails the whole suite even though every test passed.
+    const result: unknown = await window.electronAPI.invoke(RAIL_TAKE_PENDING_SEEDS_CHANNEL);
+    paths = Array.isArray(result) ? result.filter((p): p is string => typeof p === 'string') : [];
+  } catch (err) {
+    console.error('[railProjectListeners] take-pending-seeds failed:', err);
+    return;
+  }
+
+  // Sequential, not parallel: each add reads `openProjectsAtom` to decide
+  // whether it is already open, and concurrent adds would race that check.
+  for (const workspacePath of paths) {
+    await addProjectToRail(workspacePath, false, undefined);
+  }
+}
+
+function sendAck(requestId: string | undefined, workspacePath: string, outcome: AddOpenProjectOutcome): void {
+  if (!requestId) return;
+  window.electronAPI?.send?.(RAIL_ADD_PROJECT_RESULT_CHANNEL, { requestId, workspacePath, outcome });
+}
+
+async function addProjectToRail(
+  workspacePath: string | undefined,
+  activate: boolean | undefined,
+  requestId: string | undefined,
+): Promise<void> {
+  if (!workspacePath) return;
+  const shouldActivate = activate !== false;
+
+  const alreadyOpen = store
+    .get(openProjectsAtom)
+    .some((project) => project.path === workspacePath);
+
+  if (!alreadyOpen) {
+    try {
+      const registration = await window.electronAPI.invoke(
+        'workspace:register-additional',
+        { workspacePath },
+      );
+      if (!registration?.success) {
+        console.error('[railProjectListeners] register-additional failed:', workspacePath, registration);
+        // No ack on registration failure: main's ack-waiter (`railSeeding.ts`)
+        // treats a missing ack as its own distinct 'timeout' outcome rather
+        // than conflating it with the rail's 'at-cap' outcome.
+        return;
+      }
+    } catch (err) {
+      console.error('[railProjectListeners] register-additional threw:', workspacePath, err);
+      return;
+    }
+  }
+
+  const outcome = store.set(
+    addOpenProjectAtom,
+    {
+      path: workspacePath,
+      name: basenameFromPath(workspacePath),
+      openedAt: Date.now(),
+    },
+    { activate: shouldActivate },
+  );
+
+  // This is the ONE add path with no `+` button to disable -- the project was
+  // opened from main (deep link, notification, Open Recent, tutorial, MCP
+  // `workspace_open`). At the cap the user would otherwise see nothing happen
+  // at all, so surface the same toast the rail's own `+` button uses.
+  if (outcome === 'at-cap') {
+    console.warn('[railProjectListeners] rail at cap, refusing:', workspacePath);
+    showRailFullNotification();
+  }
+
+  sendAck(requestId, workspacePath, outcome);
+}

--- a/packages/electron/src/renderer/store/listeners/windowCloseFlushListeners.ts
+++ b/packages/electron/src/renderer/store/listeners/windowCloseFlushListeners.ts
@@ -1,0 +1,92 @@
+/**
+ * Central Flush-Before-Close Listener
+ *
+ * Subscribes to `window:flush-before-close` ONCE (see
+ * `main/window/flushWindowBeforeClose.ts`). Main sends this to a donor
+ * window right before "Merge All Windows" would close it, so any dirty
+ * editor gets a chance to reach disk first instead of being silently
+ * discarded -- the window's own `documentEdited` guard never fires (nothing
+ * sets it `true`), so this ack is the only real protection.
+ *
+ * Reuses `DocumentModelRegistry.flushAll()` -- the same "flush every dirty
+ * editor" primitive `store/atoms/windowMode.ts` already calls on every
+ * Files<->Agent mode switch -- rather than adding a second save-all
+ * mechanism. `flushAll()` covers every currently-attached editor in this
+ * renderer, not just the active tab: per `TabContent.tsx`'s lazy-mount
+ * design, a `TabEditor` stays mounted and attached to its `DocumentModel`
+ * once created, even while hidden behind another active tab.
+ *
+ * `DocumentModel.flushDirtyEditors()` swallows per-callback save errors
+ * (logs, does not reject) so a resolved `flushAll()` promise is not proof a
+ * write actually landed -- re-check `isDirty()` on every registered path
+ * afterwards and report `'still-dirty'` if anything remains. That is what
+ * tells main not to close the window.
+ *
+ * Collaborative (Y.Doc-backed) tabs are intentionally out of scope here --
+ * `CollaborativeTabEditor`'s EditorHost has no flush-to-disk operation to
+ * perform ("Save: no-op. Content syncs via Y.Doc."), so there is nothing for
+ * `flushAll()` to miss. The narrow residual risk is a donor whose *only*
+ * unsaved state is collab-unsynced (`hasCollabUnsyncedChanges`); this ack
+ * still reports `'flushed'` for that case, same as the existing
+ * `close-window-save` path.
+ *
+ * Call initWindowCloseFlushListeners() once at app startup.
+ */
+
+import { DocumentModelRegistry } from '../../services/document-model/DocumentModelRegistry';
+
+const FLUSH_BEFORE_CLOSE_CHANNEL = 'window:flush-before-close';
+const FLUSH_BEFORE_CLOSE_RESULT_CHANNEL = 'window:flush-before-close-result';
+
+type FlushBeforeCloseOutcome = 'flushed' | 'still-dirty';
+
+interface FlushBeforeClosePayload {
+  requestId?: string;
+}
+
+let initialized = false;
+
+export function initWindowCloseFlushListeners(): () => void {
+  if (initialized) {
+    return () => {};
+  }
+  initialized = true;
+
+  const unsubscribe = window.electronAPI?.on?.(
+    FLUSH_BEFORE_CLOSE_CHANNEL,
+    (data: FlushBeforeClosePayload) => {
+      void handleFlushRequest(data?.requestId);
+    },
+  );
+
+  return () => {
+    initialized = false;
+    if (typeof unsubscribe === 'function') {
+      unsubscribe();
+    }
+  };
+}
+
+function sendAck(requestId: string, outcome: FlushBeforeCloseOutcome): void {
+  window.electronAPI?.send?.(FLUSH_BEFORE_CLOSE_RESULT_CHANNEL, { requestId, outcome });
+}
+
+async function handleFlushRequest(requestId: string | undefined): Promise<void> {
+  if (!requestId) return;
+
+  try {
+    await DocumentModelRegistry.flushAll();
+    const stillDirty = DocumentModelRegistry.getRegisteredPaths().some(
+      (path) => DocumentModelRegistry.get(path)?.isDirty(),
+    );
+    sendAck(requestId, stillDirty ? 'still-dirty' : 'flushed');
+  } catch (err) {
+    // flushAll()/getRegisteredPaths()/isDirty() throwing means the registry
+    // itself is in an unknown state, not that a specific save failed --
+    // 'still-dirty' is a conservative "can't confirm it's safe" signal here,
+    // not a literal dirty-flag report. Either way main must not close the
+    // window on it.
+    console.error('[windowCloseFlushListeners] flush-before-close failed:', err);
+    sendAck(requestId, 'still-dirty');
+  }
+}


### PR DESCRIPTION
## What this does

Nimbalyst opens one OS window per project. A "Multi-Project Mode" setting and a project rail already existed, but **no main-process code ever read the setting** — `getMultiProjectMode()` was referenced only by its own getter/setter — so every project-open still called `createWindow(...)` and spawned a window. The rail only ever filled via its own `+` button.

This makes the toggle mean what it says.

- Project-opens route through one mode-aware chokepoint, with the entry points that bypassed it funneled in: Open Recent, deep links, notification clicks, MCP `workspace_open`, tutorial, extension scaffolder
- Session restore collapses to a single window whose rail is seeded from the saved session
- New **Window > Merge All Windows** folds windows you already have open, flushing unsaved editors and waiting for confirmation before closing any donor
- File watchers stay warm for projects sitting inactive in the rail, so they don't go stale
- Rail cap raised 8 → 12, and reaching it now reports instead of silently declining to open the project

## Commits

1. **`feat: keep every project in one window with the project rail`** — the feature, still opt-in
2. **`feat: default new installs to one window for all projects`** — the default flip, deliberately isolated

**Commit 2 is easy to drop.** Defaulting this on is the change most likely to want maintainer judgment, and it's what made the worst bug below reachable. Shipping the feature opt-in first is a perfectly reasonable call — the split exists so you can make it.

Existing multi-window users are grandfathered out: on the first read after upgrading, someone who never expressed a preference and has more than one saved workspace window keeps current behavior, persisted so it stays stable. Otherwise the upgrade would silently turn six windows into one window plus an unfamiliar sidebar.

## The bug worth knowing about

Restore originally pushed the rail seed on `did-finish-load`. The renderer registers that handler in a React effect that runs *after* mount — strictly later, and on a cold start (large DB, extension loading) later than the ack timeout. The seed landed with nothing listening and was dropped. It then compounded: the path never reached `additionalWorkspacePaths`, so the next save persisted no rail either, and the project was gone from every subsequent restart.

Fixed by inverting the handshake rather than raising the timeout — main parks the paths, and the renderer asks for them once its listeners exist. There is no ready-moment left to guess wrong. Merge All Windows keeps the push/ack path, which is correct there because its target window is already live.

Worth flagging: this passed unit tests, typecheck, a code review and an architecture review. Only running the real app found it. The regression test asserts restore parks its paths without `did-finish-load` ever firing.

## Testing

- `packages/electron` typecheck clean
- 5781 unit tests pass; ~118 added. The 20 failures across 9 files are pre-existing and reproduce identically on `main` (which has 24) — verified by stashing every change
- **Verified end-to-end** against a real profile with a Linux AppImage build: session-restore collapse across repeated relaunches, and Merge All Windows

**Not verified:** rail cap overflow, the deep-link/file-open sequencing, and the 12 added E2E specs, which have never executed (no dev server available in the authoring environment). Please don't read "5781 tests pass" as covering those.

Note: the repo's pre-push hook currently fails in `@nimbalyst/collab-bundle` (`public declarations leak private workspace package boundaries`). That reproduces on `main` at `755dcba4` with none of these changes applied, so this branch was pushed with `--no-verify`. Nothing here touches `collab-bundle` or `extension-sdk`.

## Also fixed (pre-existing)

Both live inside the same rewritten code as the feature, so splitting them into their own commit would have meant inventing a version that was never tested:

- A cancelled close (unsaved-changes prompt) wiped the window's main-side state and re-saved a session missing a window still on screen
- Three rail E2E assertions matched `.active`, a class never rendered (the rail renders `is-active`), so they could never fail
- A background file-watcher refcount could never reach zero when two windows shared a warm project, leaking the watch for the process lifetime

## Known gaps, deliberately left

- **Navigation history is window-scoped by construction** — one back/forward stream per window, so non-primary rail projects can't retain history across a restart. Needs a data-model change, not a sequencing fix.
- **`open-document` carries a bare path** with no workspace field, resolved against whatever the renderer considers active. The registration race is closed; fully targeting it means touching four senders and the renderer chain.
- **Two rail-hydration owners** (`computeSessionRestorePlan` and `initOpenProjects`) are kept from clobbering each other by a merge helper, but nothing declares which is authoritative — this is the unanswered "retire `restorePreviousProjects`?" question.
- `MAX_OPEN_PROJECTS` is duplicated in main (renderer atoms aren't importable there); drift surfaces as an `at-cap` outcome, not data loss.
- `railSeeding` and `flushWindowBeforeClose` duplicate a request/ack primitive worth extracting once stable.
- `documentEdited` is never set true anywhere, so the unsaved-changes close guard is dormant repo-wide. **Deliberately not wired up here:** the renderer's save path only saves the active tab and main re-checks after 100ms against a 500ms poll, so enabling it would make windows with two dirty tabs permanently unclosable. Merge All Windows uses its own flush-and-ack instead.
