### PR TITLE
fix: load project-scoped Claude Code MCP servers on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,6 +325,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Claude Code sessions now use your existing MCP setup instead of overriding it, so account connectors load again and sessions no longer fail to start on machines with an organization-managed MCP policy. (#1051)
 - HTTP MCP servers that authenticate with a static key now connect directly on Claude Code sessions instead of being routed through an extra helper process.
 - Unified Quick Open tabs now show compact platform keyboard glyphs without shortcut labels overflowing into neighboring tabs.
+- MCP servers configured for a specific project in Claude Code now load in Nimbalyst on Windows instead of being silently ignored.
 - Desktop AI notifications now lead with the originating session name and open that exact session and project, including child sessions, instead of following whichever project is currently visible.
 - Dropdown menus no longer open underneath the macOS window controls — the project rail's "+" menu now opens beside the button instead of jumping to the top corner. (#1096)
 - File reveal menus now name Finder on macOS, Explorer on Windows, and the containing folder on Linux.

--- a/packages/electron/src/main/services/MCPConfigService.ts
+++ b/packages/electron/src/main/services/MCPConfigService.ts
@@ -25,6 +25,7 @@ import {
   resolveMcpRemoteRequirementOptions,
   type McpRemoteRequirementOptions,
 } from './mcpRemoteRequirement';
+import { normalizeProjectPathKey, resolveProjectConfigKey } from './mcpProjectKey';
 
 /**
  * Service for managing MCP server configurations.
@@ -333,8 +334,12 @@ export class MCPConfigService {
         projects?: Record<string, { mcpServers?: Record<string, MCPServerConfig> }>;
       };
 
-      if (claudeConfig.projects && claudeConfig.projects[workspacePath]) {
-        claudeJsonServers = claudeConfig.projects[workspacePath].mcpServers || {};
+      // Match on the normalized path: Claude Code writes forward-slash keys,
+      // Nimbalyst passes native Windows paths, and an exact comparison never
+      // matched the two.
+      const projectKey = resolveProjectConfigKey(claudeConfig.projects, workspacePath);
+      if (projectKey && claudeConfig.projects) {
+        claudeJsonServers = claudeConfig.projects[projectKey].mcpServers || {};
       }
     } catch (error: any) {
       if (error.code !== 'ENOENT') {
@@ -411,13 +416,19 @@ export class MCPConfigService {
           claudeConfig.projects = {};
         }
 
-        // Initialize this project's entry if it doesn't exist
-        if (!claudeConfig.projects[workspacePath]) {
-          claudeConfig.projects[workspacePath] = {};
+        // Write into the entry Claude Code already owns when there is one, and
+        // otherwise create it in the forward-slash form Claude Code reads.
+        // Writing the native Windows path here forked a second entry that
+        // Claude Code could never see.
+        const existingKey = resolveProjectConfigKey(claudeConfig.projects, workspacePath);
+        const projectKey = existingKey ?? normalizeProjectPathKey(workspacePath);
+
+        if (!claudeConfig.projects[projectKey]) {
+          claudeConfig.projects[projectKey] = {};
         }
 
         // Update the mcpServers for this project
-        claudeConfig.projects[workspacePath].mcpServers = config.mcpServers;
+        claudeConfig.projects[projectKey].mcpServers = config.mcpServers;
 
         // Write back to ~/.claude.json
         const claudeContent = JSON.stringify(claudeConfig, null, 2);

--- a/packages/electron/src/main/services/__tests__/mcpProjectKey.test.ts
+++ b/packages/electron/src/main/services/__tests__/mcpProjectKey.test.ts
@@ -62,6 +62,28 @@ describe('resolveProjectConfigKey', () => {
     expect(resolveProjectConfigKey(projects, 'C:\\work\\locallead')).toBe('c:/work/locallead');
   });
 
+  it('picks the populated entry when a duplicate empty key shadows it', () => {
+    // Real config seen in the wild: Claude Code wrote the drive letter both ways
+    // for the same folder, leaving the servers on one and an empty entry on the
+    // other. Picking the empty one would hide every server.
+    const projects = {
+      'C:/industrylens': {
+        mcpServers: { notion: {}, 'n8n-mcp': {}, vercel: {}, industrylens: {} },
+      },
+      'c:/industrylens': { mcpServers: {} },
+    };
+    expect(resolveProjectConfigKey(projects, 'C:\\industrylens')).toBe('C:/industrylens');
+    // and the same answer whichever spelling the caller happens to pass
+    expect(resolveProjectConfigKey(projects, 'c:/industrylens/')).toBe('C:/industrylens');
+  });
+
+  it('is deterministic when duplicates are all empty', () => {
+    const projects = { 'C:/x': { mcpServers: {} }, 'c:/x': {} };
+    const first = resolveProjectConfigKey(projects, 'C:\\x');
+    expect(first).toBeDefined();
+    expect(resolveProjectConfigKey(projects, 'C:\\x')).toBe(first);
+  });
+
   it('does not match a different project that shares a prefix', () => {
     const projects = { 'C:/work/inforoot': { mcpServers: {} } };
     expect(resolveProjectConfigKey(projects, 'C:/work/inforoot-whatsapp')).toBeUndefined();

--- a/packages/electron/src/main/services/__tests__/mcpProjectKey.test.ts
+++ b/packages/electron/src/main/services/__tests__/mcpProjectKey.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeProjectPathKey, resolveProjectConfigKey } from '../mcpProjectKey';
+
+describe('normalizeProjectPathKey', () => {
+  it('unifies separators', () => {
+    expect(normalizeProjectPathKey('C:\\work\\industrylens')).toBe(
+      normalizeProjectPathKey('C:/work/industrylens'),
+    );
+  });
+
+  it('case-folds the drive letter but not the rest of the path', () => {
+    expect(normalizeProjectPathKey('c:/work/IndustryLens')).toBe(
+      normalizeProjectPathKey('C:/work/IndustryLens'),
+    );
+    expect(normalizeProjectPathKey('C:/work/industrylens')).not.toBe(
+      normalizeProjectPathKey('C:/work/IndustryLens'),
+    );
+  });
+
+  it('ignores a trailing separator', () => {
+    expect(normalizeProjectPathKey('C:/work/inforoot/')).toBe(
+      normalizeProjectPathKey('C:/work/inforoot'),
+    );
+  });
+});
+
+describe('resolveProjectConfigKey', () => {
+  it('finds a forward-slash key when given a backslash path (#the real bug)', () => {
+    // Nimbalyst passes backslashes; Claude Code writes forward slashes. Before
+    // this, the exact-string lookup could never hit and every project-scoped
+    // server was invisible.
+    const projects = {
+      'C:/work/industrylens': { mcpServers: { supabase: {} } },
+    };
+    expect(resolveProjectConfigKey(projects, 'C:\\work\\industrylens')).toBe(
+      'C:/work/industrylens',
+    );
+  });
+
+  it('finds a backslash key when given a forward-slash path', () => {
+    const projects = {
+      'C:\\rzpl-android\\inforoot.ai': { mcpServers: {} },
+    };
+    expect(resolveProjectConfigKey(projects, 'C:/rzpl-android/inforoot.ai')).toBe(
+      'C:\\rzpl-android\\inforoot.ai',
+    );
+  });
+
+  it('prefers an exact match over a normalized one', () => {
+    // Both forms can exist simultaneously (they do on real machines). An exact
+    // hit must win so behaviour does not change for anyone already working.
+    const projects = {
+      'C:/work/inforoot': { mcpServers: { a: {} } },
+      'C:\\work\\inforoot': { mcpServers: { b: {} } },
+    };
+    expect(resolveProjectConfigKey(projects, 'C:\\work\\inforoot')).toBe('C:\\work\\inforoot');
+    expect(resolveProjectConfigKey(projects, 'C:/work/inforoot')).toBe('C:/work/inforoot');
+  });
+
+  it('matches a differing drive-letter case', () => {
+    const projects = { 'c:/work/locallead': { mcpServers: {} } };
+    expect(resolveProjectConfigKey(projects, 'C:\\work\\locallead')).toBe('c:/work/locallead');
+  });
+
+  it('does not match a different project that shares a prefix', () => {
+    const projects = { 'C:/work/inforoot': { mcpServers: {} } };
+    expect(resolveProjectConfigKey(projects, 'C:/work/inforoot-whatsapp')).toBeUndefined();
+  });
+
+  it('returns undefined when there is no match, and tolerates no projects at all', () => {
+    expect(resolveProjectConfigKey({ 'C:/other': {} }, 'C:/work/x')).toBeUndefined();
+    expect(resolveProjectConfigKey(undefined, 'C:/work/x')).toBeUndefined();
+    expect(resolveProjectConfigKey({}, 'C:/work/x')).toBeUndefined();
+  });
+
+  it('is separator-agnostic on POSIX paths too', () => {
+    const projects = { '/home/dera/work/app': { mcpServers: {} } };
+    expect(resolveProjectConfigKey(projects, '/home/dera/work/app/')).toBe(
+      '/home/dera/work/app',
+    );
+  });
+});

--- a/packages/electron/src/main/services/mcpProjectKey.ts
+++ b/packages/electron/src/main/services/mcpProjectKey.ts
@@ -19,6 +19,11 @@
  * case-folded: Windows drive letters vary by who wrote the string, but the rest
  * of the path is left alone so this stays correct on case-sensitive filesystems.
  */
+/** Shape of one entry in the `projects` map that this module cares about. */
+export interface ProjectEntry {
+  mcpServers?: Record<string, unknown>;
+}
+
 export function normalizeProjectPathKey(projectPath: string): string {
   const unified = projectPath.replace(/\\/g, '/').replace(/\/+$/, '');
   return unified.replace(/^([a-zA-Z]):/, (_m, drive: string) => `${drive.toLowerCase()}:`);
@@ -31,7 +36,7 @@ export function normalizeProjectPathKey(projectPath: string): string {
  * the other tool already owns instead of forking a second one.
  */
 export function resolveProjectConfigKey(
-  projects: Record<string, unknown> | undefined,
+  projects: Record<string, ProjectEntry | undefined> | undefined,
   workspacePath: string,
 ): string | undefined {
   if (!projects || !workspacePath) return undefined;
@@ -42,11 +47,20 @@ export function resolveProjectConfigKey(
   }
 
   const target = normalizeProjectPathKey(workspacePath);
-  const matches = Object.keys(projects).filter(
-    (key) => normalizeProjectPathKey(key) === target,
-  );
+  const matches = Object.keys(projects)
+    .filter((key) => normalizeProjectPathKey(key) === target)
+    .sort(); // deterministic, so the same config always resolves the same way
 
-  // Exactly one normalized match is unambiguous. If several keys normalize to
-  // the same path and none matched exactly, prefer none over guessing.
-  return matches.length === 1 ? matches[0] : undefined;
+  if (matches.length <= 1) return matches[0];
+
+  // Several keys refer to the same folder. This happens for real: Claude Code
+  // writes the drive letter inconsistently, leaving e.g. `C:/industrylens`
+  // holding the servers and `c:/industrylens` empty. Prefer whichever entry
+  // actually has servers, so a duplicate empty key cannot hide a populated one.
+  const populated = matches.filter((key) => hasServers(projects[key]));
+  return populated[0] ?? matches[0];
+}
+
+function hasServers(entry: ProjectEntry | undefined): boolean {
+  return Object.keys(entry?.mcpServers ?? {}).length > 0;
 }

--- a/packages/electron/src/main/services/mcpProjectKey.ts
+++ b/packages/electron/src/main/services/mcpProjectKey.ts
@@ -1,0 +1,52 @@
+/**
+ * Project-key matching for the `projects` map in `~/.claude.json`.
+ *
+ * Nimbalyst and Claude Code write that map with different path separators.
+ * Nimbalyst passes native Windows paths (`C:\work\industrylens`); Claude Code
+ * writes forward slashes (`C:/work/industrylens`). The lookup was an exact
+ * string comparison, so on Windows the two never matched: every project-scoped
+ * MCP server was invisible to Nimbalyst, and writes created a second entry
+ * Claude Code could not read.
+ *
+ * One project can legitimately be present under both forms already, so an exact
+ * hit always wins and only an unambiguous normalized hit is used as a fallback.
+ */
+
+/**
+ * Canonical form for comparing two project keys.
+ *
+ * Separators are unified and a trailing one dropped. Only the drive letter is
+ * case-folded: Windows drive letters vary by who wrote the string, but the rest
+ * of the path is left alone so this stays correct on case-sensitive filesystems.
+ */
+export function normalizeProjectPathKey(projectPath: string): string {
+  const unified = projectPath.replace(/\\/g, '/').replace(/\/+$/, '');
+  return unified.replace(/^([a-zA-Z]):/, (_m, drive: string) => `${drive.toLowerCase()}:`);
+}
+
+/**
+ * Find the key in `projects` that refers to `workspacePath`, or undefined.
+ *
+ * Returns the key as it is actually stored, so callers read and write the entry
+ * the other tool already owns instead of forking a second one.
+ */
+export function resolveProjectConfigKey(
+  projects: Record<string, unknown> | undefined,
+  workspacePath: string,
+): string | undefined {
+  if (!projects || !workspacePath) return undefined;
+
+  // Exact match wins: never change behaviour for a config that already worked.
+  if (Object.prototype.hasOwnProperty.call(projects, workspacePath)) {
+    return workspacePath;
+  }
+
+  const target = normalizeProjectPathKey(workspacePath);
+  const matches = Object.keys(projects).filter(
+    (key) => normalizeProjectPathKey(key) === target,
+  );
+
+  // Exactly one normalized match is unambiguous. If several keys normalize to
+  // the same path and none matched exactly, prefer none over guessing.
+  return matches.length === 1 ? matches[0] : undefined;
+}


### PR DESCRIPTION
## What breaks today

MCP servers that Claude Code has configured for a specific project do not load in Nimbalyst on Windows. They are silently skipped.

## Why

Claude Code keys project entries by filesystem path. On Windows the same folder legitimately appears under more than one separator form, so an exact string match misses, and where duplicate keys refer to one folder the empty entry can win over the populated one.

## The fix

- Normalize project path keys before matching, so separator form no longer decides whether a server is found.
- When duplicate keys refer to the same folder, prefer the entry that actually has servers in it.

## Verification

`mcpProjectKey.test.ts` covers both, including the duplicate-key preference. Red before, green after.
