### PR TITLE
fix: settle a Claude Code CLI session that ends a turn with a background shell running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,6 +319,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Source files containing NUL separators now render as text in GitHub reviews instead of appearing as binary changes.
 - Queued prompts now run on their own: a prompt sent from your phone opens the project and runs it, prompts left over from a quit resume once the project is open again, and a prompt that arrives mid-turn runs when the turn ends — no more pressing Escape or restarting to release the queue. (#962)
 - Web search and web fetch no longer fail in Claude Code CLI sessions running at max effort.
+- A Claude Code CLI session that leaves a background shell running no longer stays stuck as in progress, so its queued messages send instead of waiting for you to go into the terminal and kill the shell.
 - Sharing a plan or decision now produces a link your teammates can actually open, and the sharer edits the same collaborative content everyone else sees instead of quietly staying on their local file. Items shared earlier can be unshared and shared again to pick this up, keeping the content that has been edited since.
 - An AI session that reports its previous conversation has expired now genuinely starts fresh on the next message, instead of repeating the same expiration error forever. (#1098)
 - Tracker items with structured array fields no longer crash when opened, even when older schemas describe those fields as text lists. (#1104)

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliPidState.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliPidState.test.ts
@@ -122,6 +122,27 @@ describe('watchClaudePidState liveness backstop', () => {
     return { states, stop };
   }
 
+  // The CLI reports a FOURTH status, `shell`: the conversation turn is over but a
+  // background shell it started is still running (verified against claude 2.1.224,
+  // which wrote `"status":"shell"` 28s into a run_in_background turn and held it).
+  // Treating that as unrecognized left the watcher holding `running` forever, so
+  // no running->idle transition ever fired: the spinner never stopped and the
+  // queue never drained until the user killed the background task by hand.
+  it('settles to idle when a turn ends with a background shell still running', async () => {
+    let file = busyFile;
+    const { states, stop } = setup({
+      readFile: async () => file,
+      isProcessAlive: () => true,
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(states).toEqual(['running']);
+
+    file = JSON.stringify({ status: 'shell', pid: 999, updatedAt: 2_000 });
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(states).toEqual(['running', 'idle']);
+    stop();
+  });
+
   it('keeps trusting an old busy file while the process is alive (no updatedAt staleness)', async () => {
     const { states, stop } = setup({
       readFile: async () => busyFile,

--- a/packages/electron/src/main/services/ai/claudeCliPidState.ts
+++ b/packages/electron/src/main/services/ai/claudeCliPidState.ts
@@ -20,8 +20,15 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { resolveClaudeConfigDir } from '@nimbalyst/runtime/ai/server/providers/claudeCode/claudeConfigDir';
 
-/** Statuses the CLI writes into the PID file. */
-export type ClaudePidStatus = 'busy' | 'idle' | 'waiting';
+/**
+ * Statuses the CLI writes into the PID file.
+ *
+ * `shell` means the conversation turn has finished but a background shell the
+ * turn started is still running (the TUI shows "N shells still running for
+ * agents to manage"). The CLI happily accepts a new prompt in that state, so for
+ * turn purposes it is idle.
+ */
+export type ClaudePidStatus = 'busy' | 'idle' | 'waiting' | 'shell';
 
 /** Nimbalyst-side turn states the CLI status maps to. */
 export type ClaudeTurnState = 'running' | 'idle' | 'waiting_for_input';
@@ -39,7 +46,15 @@ export interface ParsedClaudePidFile {
   raw: Record<string, unknown>;
 }
 
-const KNOWN_STATUSES: ReadonlySet<string> = new Set(['busy', 'idle', 'waiting']);
+const KNOWN_STATUSES: ReadonlySet<string> = new Set(['busy', 'idle', 'waiting', 'shell']);
+
+/**
+ * Unrecognized statuses are held rather than guessed at (see `watchClaudePidState`),
+ * which is forward-compatible but silent: `shell` shipped in the CLI and pinned
+ * every affected session to "running" until someone noticed. Warn once per value
+ * so the next new status is diagnosable from the log instead of the symptom.
+ */
+const warnedUnknownStatuses = new Set<string>();
 
 /**
  * Normalize an `updatedAt` value to epoch milliseconds. The CLI's unit is
@@ -70,6 +85,13 @@ export function parseClaudePidFile(contents: string): ParsedClaudePidFile | null
   const obj = parsed as Record<string, unknown>;
   const rawStatus = typeof obj.status === 'string' ? obj.status.trim().toLowerCase() : '';
   if (!KNOWN_STATUSES.has(rawStatus)) {
+    if (rawStatus && !warnedUnknownStatuses.has(rawStatus)) {
+      warnedUnknownStatuses.add(rawStatus);
+      console.warn(
+        `[ClaudeCliPidState] unrecognized CLI status "${rawStatus}"; holding last-known turn state. ` +
+          'If sessions appear stuck as running, this is why.',
+      );
+    }
     return null;
   }
   const pid = typeof obj.pid === 'number' && Number.isFinite(obj.pid) ? obj.pid : undefined;
@@ -102,7 +124,8 @@ export function isClaudePidFileStale(
   now: number,
   staleAfterMs: number
 ): boolean {
-  if (parsed.status === 'idle') return false;
+  // `shell` is a finished turn, so like `idle` it legitimately stops refreshing.
+  if (parsed.status === 'idle' || parsed.status === 'shell') return false;
   if (parsed.updatedAt === undefined) return false;
   return now - parsed.updatedAt > staleAfterMs;
 }
@@ -114,6 +137,9 @@ export function mapPidStatusToTurnState(status: ClaudePidStatus): ClaudeTurnStat
       return 'running';
     case 'waiting':
       return 'waiting_for_input';
+    // A leftover background shell is not a turn. The conversation is free, so the
+    // spinner stops and the queue drains instead of waiting for the shell to die.
+    case 'shell':
     case 'idle':
     default:
       return 'idle';


### PR DESCRIPTION
## What breaks today

A Claude Code CLI session that ends its turn while a background shell is still running stays stuck showing as in progress. Its queued messages never send. The only way out is to open the terminal and kill the shell by hand.

## Why

The turn-settled signal is derived from the CLI's PID state. A lingering background shell keeps that state looking busy after the turn has actually finished, so the session never transitions to idle and the queue never flushes.

## The fix

Treat the turn as settled on the CLI's own end-of-turn signal rather than waiting for the process state to go quiet, so a surviving background shell no longer holds the session open.

## Verification

`claudeCliPidState.test.ts` covers the background-shell case. Red before, green after.
