### PR TITLE
fix: Claude Code CLI prompt queue and attachment lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Source files containing NUL separators now render as text in GitHub reviews instead of appearing as binary changes.
 - Queued prompts now run on their own: a prompt sent from your phone opens the project and runs it, prompts left over from a quit resume once the project is open again, and a prompt that arrives mid-turn runs when the turn ends — no more pressing Escape or restarting to release the queue. (#962)
 - Web search and web fetch no longer fail in Claude Code CLI sessions running at max effort.
+- Editing a queued message no longer drops the images and files attached to it, so they still reach the agent when you send it.
+- Claude Code CLI sessions can now interrupt the current turn and send a queued message immediately, instead of waiting for a turn that may never end.
+- A queued message for a Claude Code CLI session now waits for the previous one to actually reach the terminal, instead of being written on top of it and left sitting in the prompt box unsent.
+- Claude Code CLI's own typing suggestions no longer show up as a reply in the Nimbalyst transcript.
 - Sharing a plan or decision now produces a link your teammates can actually open, and the sharer edits the same collaborative content everyone else sees instead of quietly staying on their local file. Items shared earlier can be unshared and shared again to pick this up, keeping the content that has been edited since.
 - An AI session that reports its previous conversation has expired now genuinely starts fresh on the next message, instead of repeating the same expiration error forever. (#1098)
 - Tracker items with structured array fields no longer crash when opened, even when older schemas describe those fields as text lists. (#1104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,7 +337,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editing a queued message no longer drops the images and files attached to it, so they still reach the agent when you send it.
 - Claude Code CLI sessions can now interrupt the current turn and send a queued message immediately, instead of waiting for a turn that may never end.
 - A queued message for a Claude Code CLI session now waits for the previous one to actually reach the terminal, instead of being written on top of it and left sitting in the prompt box unsent.
-- Claude Code CLI's own typing suggestions no longer show up as a reply in the Nimbalyst transcript.
 - Sharing a plan or decision now produces a link your teammates can actually open, and the sharer edits the same collaborative content everyone else sees instead of quietly staying on their local file. Items shared earlier can be unshared and shared again to pick this up, keeping the content that has been edited since.
 - An AI session that reports its previous conversation has expired now genuinely starts fresh on the next message, instead of repeating the same expiration error forever. (#1098)
 - Tracker items with structured array fields no longer crash when opened, even when older schemas describe those fields as text lists. (#1104)

--- a/packages/electron/src/main/services/TerminalSessionManager.ts
+++ b/packages/electron/src/main/services/TerminalSessionManager.ts
@@ -51,6 +51,7 @@ import {
   type ClaudeCliInterruptResult,
 } from './ai/claudeCliInterrupt';
 import { detectCliPickerInChunk } from './ai/claudeCliInteractiveCommands';
+import { claudeCliInterruptGate } from './ai/claudeCliInterruptGate';
 import { broadcastClaudeCliRevealTerminal } from './ai/claudeCliRevealTerminal';
 import {
   getTerminalInstance,
@@ -1086,8 +1087,10 @@ export class TerminalSessionManager {
     return readClaudePidTurnState({ pid: terminal.pty.pid });
   }
 
-  /** Sessions with an interrupt escalation currently in flight (NIM-814). */
-  private claudeCliInterruptsInFlight = new Set<string>();
+  // Interrupt-in-flight tracking lives in the shared claudeCliInterruptGate so
+  // the queue flusher can hold off while an escalation runs (its re-check
+  // cannot tell a freshly flushed turn from the old turn refusing to die, and
+  // would Ctrl-C the queued prompt straight back into the prompt box).
 
   /**
    * Stop a Claude CLI turn with escalation (NIM-814): Ctrl-C, then a second
@@ -1103,11 +1106,11 @@ export class TerminalSessionManager {
       console.warn(`[TerminalSessionManager] Cannot interrupt ${sessionId}: terminal not found`);
       return { success: false };
     }
-    if (this.claudeCliInterruptsInFlight.has(sessionId)) {
+    if (claudeCliInterruptGate.isInFlight(sessionId)) {
       terminal.pty.write('\x03');
       return { success: true };
     }
-    this.claudeCliInterruptsInFlight.add(sessionId);
+    claudeCliInterruptGate.mark(sessionId);
     try {
       const result = await escalateClaudeCliInterrupt({
         write: (data) => terminal.pty.write(data),
@@ -1117,7 +1120,7 @@ export class TerminalSessionManager {
       });
       return { success: true, resolvedAfter: result.resolvedAfter };
     } finally {
-      this.claudeCliInterruptsInFlight.delete(sessionId);
+      claudeCliInterruptGate.clear(sessionId);
     }
   }
 

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliQueueFlush.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliQueueFlush.test.ts
@@ -61,6 +61,23 @@ describe('flushNextClaudeCliQueuedPrompt', () => {
     expect(h.submit).not.toHaveBeenCalled();
   });
 
+  it('does not claim while an interrupt escalation is in flight', async () => {
+    // The user's stop press starts an escalation: Ctrl-C, wait 1500ms, re-check,
+    // maybe Ctrl-C again. The first Ctrl-C ends the turn in ~200ms, the PID
+    // watcher's idle edge flushes the queued prompt, a NEW turn starts, and the
+    // escalation's re-check reads `running` and cannot tell it from the old turn
+    // refusing to die, so its second Ctrl-C kills the queued prompt and the TUI
+    // puts the text back in the box. Hold the flush until the escalation is over.
+    const h = harness([{ id: 'q1', prompt: 'first' }]);
+    const result = await flushNextClaudeCliQueuedPrompt(
+      { sessionId: 's1', workspacePath: '/w' },
+      { ...h.deps, isInterruptInFlight: () => true },
+    );
+    expect(result).toBe(false);
+    expect(h.claim).not.toHaveBeenCalled();
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+
   it('returns false and does nothing when the queue is empty', async () => {
     const h = harness([]);
     const result = await flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, h.deps);

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliQueueFlush.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliQueueFlush.test.ts
@@ -46,6 +46,21 @@ describe('flushNextClaudeCliQueuedPrompt', () => {
     expect(h.notifyClaimed).toHaveBeenCalledWith('q1');
   });
 
+  it('does not claim while a submit is still draining into the PTY', async () => {
+    // A large paste takes seconds to reach the CLI (ConPTY delivers ~31k
+    // chars/sec), and until the CLI picks it up its PID file still reads idle.
+    // Flushing on that stale idle wrote a second prompt into the same terminal,
+    // which then sat in the prompt box unsent behind the first turn.
+    const h = harness([{ id: 'q1', prompt: 'first' }]);
+    const result = await flushNextClaudeCliQueuedPrompt(
+      { sessionId: 's1', workspacePath: '/w' },
+      { ...h.deps, isSubmitInFlight: () => true },
+    );
+    expect(result).toBe(false);
+    expect(h.claim).not.toHaveBeenCalled();
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+
   it('returns false and does nothing when the queue is empty', async () => {
     const h = harness([]);
     const result = await flushNextClaudeCliQueuedPrompt({ sessionId: 's1', workspacePath: '/w' }, h.deps);

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliSubmit.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliSubmit.test.ts
@@ -30,6 +30,48 @@ const img = (filepath: string): ChatAttachment => ({
   id: filepath, filename: 'x.png', filepath, mimeType: 'image/png', size: 1, type: 'image', addedAt: 0,
 });
 
+describe('submitClaudeCliPrompt Enter confirmation', () => {
+  /**
+   * Measured on claude 2.1.220 (nimbalyst-local/cli-paste-probes/05 and 06): a
+   * payload carrying an image path strands at 25ms and 200ms and only submits
+   * from ~400ms. The CLI reads and decodes the file after the bytes land, and an
+   * Enter arriving during that window is swallowed.
+   *
+   * `submitWriteGapMs` is computed from the PAYLOAD LENGTH, so a short sentence
+   * plus one path is ~300 chars -> 25ms, no matter how many megabytes the
+   * referenced image is. No constant fixes that; confirm the turn started and
+   * press Enter again if it did not.
+   */
+  it('re-sends Enter when the first one did not start a turn', async () => {
+    const h = harness();
+    let started = false;
+    await submitClaudeCliPrompt(
+      { sessionId: 's1', workspacePath: '/w', prompt: 'look', attachments: [img('/tmp/a.png')] },
+      // Turn only starts after a SECOND Enter, as a swallowed first Enter behaves.
+      {
+        ...h.deps,
+        hasTurnStarted: () => started,
+        writeToTerminal: (sessionId: string, data: string) => {
+          h.writes.push([sessionId, data]);
+          if (data === '\r' && h.writes.filter(([, d]) => d === '\r').length >= 2) started = true;
+        },
+      },
+    );
+
+    const enters = h.writes.filter(([, d]) => d === '\r');
+    expect(enters.length).toBe(2);
+  });
+
+  it('does not re-send Enter when the first one worked', async () => {
+    const h = harness();
+    await submitClaudeCliPrompt(
+      { sessionId: 's1', workspacePath: '/w', prompt: 'look', attachments: [img('/tmp/a.png')] },
+      { ...h.deps, hasTurnStarted: () => true },
+    );
+    expect(h.writes.filter(([, d]) => d === '\r').length).toBe(1);
+  });
+});
+
 describe('submitClaudeCliPrompt', () => {
   it('writes the composed PTY line, then a separate Enter', async () => {
     const h = harness();

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliSubmitLatch.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliSubmitLatch.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  createClaudeCliSubmitLatch,
+  submitDrainDeadlineMs,
+} from '../claudeCliSubmitLatch';
+
+describe('claude-code-cli submit latch', () => {
+  it('holds a session from the moment we write until the CLI picks the turn up', () => {
+    let now = 1000;
+    const latch = createClaudeCliSubmitLatch({ now: () => now });
+
+    expect(latch.isInFlight('s1')).toBe(false);
+
+    latch.mark('s1', 500);
+    expect(latch.isInFlight('s1')).toBe(true);
+    // Other sessions are unaffected.
+    expect(latch.isInFlight('s2')).toBe(false);
+
+    // The PID watcher reporting a turn is the real "the CLI consumed it" signal.
+    latch.clear('s1');
+    expect(latch.isInFlight('s1')).toBe(false);
+  });
+
+  it('expires on its own so a CLI that never starts a turn cannot wedge the queue', () => {
+    let now = 1000;
+    const latch = createClaudeCliSubmitLatch({ now: () => now });
+
+    latch.mark('s1', 500);
+    now += submitDrainDeadlineMs(500) - 1;
+    expect(latch.isInFlight('s1')).toBe(true);
+
+    now += 2;
+    expect(latch.isInFlight('s1')).toBe(false);
+  });
+
+  it('keeps the longest deadline across the writes that make up one submit', () => {
+    let now = 1000;
+    const latch = createClaudeCliSubmitLatch({ now: () => now });
+
+    // A submit is the payload write followed by a separate Enter write. The
+    // one-character Enter must not shorten the big payload's window.
+    latch.mark('s1', 250_000);
+    latch.mark('s1', 1);
+
+    now += submitDrainDeadlineMs(1) + 1;
+    expect(latch.isInFlight('s1')).toBe(true);
+  });
+
+  it('scales the deadline with payload size, because ConPTY delivers ~31k chars/sec', () => {
+    // A 250k paste measured ~8s to reach the CLI on Windows; the deadline has to
+    // outlast that or the latch lifts while the payload is still arriving.
+    expect(submitDrainDeadlineMs(250_000)).toBeGreaterThan(8_000);
+    // Short prompts still get a floor — the CLI needs a moment to start the turn.
+    expect(submitDrainDeadlineMs(0)).toBeGreaterThanOrEqual(3_000);
+    expect(submitDrainDeadlineMs(10)).toEqual(submitDrainDeadlineMs(0));
+    // Bounded, so a pathological payload can't stall the queue indefinitely.
+    expect(submitDrainDeadlineMs(100_000_000)).toBeLessThanOrEqual(120_000);
+  });
+});

--- a/packages/electron/src/main/services/ai/claudeCliInterruptGate.ts
+++ b/packages/electron/src/main/services/ai/claudeCliInterruptGate.ts
@@ -1,0 +1,52 @@
+/**
+ * "A stop press is still escalating" gate for `claude-code-cli` sessions.
+ *
+ * `interruptClaudeCliTurn` escalates: Ctrl-C, settle 1500ms, re-check, maybe
+ * Ctrl-C again, maybe SIGINT (see `claudeCliInterrupt`). The first Ctrl-C
+ * usually ends the turn in a few hundred milliseconds, which fires the PID
+ * watcher's idle edge, which flushes the next queued prompt, which starts a NEW
+ * turn — all inside the escalation's settle window. The escalation's re-check
+ * then reads `running`, cannot tell the new turn from the old one refusing to
+ * die, and its second Ctrl-C kills the queued prompt; the TUI restores the
+ * interrupted text into the prompt box, where it sits unsent.
+ *
+ * The queue flusher therefore holds off while this gate is marked, and retries
+ * once it clears (`waitUntilClear`). Same shape as `claudeCliSubmitLatch`, which
+ * guards the other half of the same one-keyboard problem: only one writer may
+ * own the CLI's input at a time.
+ */
+
+const inFlight = new Set<string>();
+const waiters = new Map<string, Array<() => void>>();
+
+export const claudeCliInterruptGate = {
+  /** Record that an interrupt escalation for this session has started. */
+  mark(sessionId: string): void {
+    inFlight.add(sessionId);
+  },
+
+  /** True while a stop press is still escalating for this session. */
+  isInFlight(sessionId: string): boolean {
+    return inFlight.has(sessionId);
+  },
+
+  /** Release the gate and wake anything waiting to flush. */
+  clear(sessionId: string): void {
+    inFlight.delete(sessionId);
+    const pending = waiters.get(sessionId);
+    if (pending) {
+      waiters.delete(sessionId);
+      for (const resolve of pending) resolve();
+    }
+  },
+
+  /** Resolves when the gate is clear for this session (immediately if it is). */
+  waitUntilClear(sessionId: string): Promise<void> {
+    if (!inFlight.has(sessionId)) return Promise.resolve();
+    return new Promise((resolve) => {
+      const pending = waiters.get(sessionId) ?? [];
+      pending.push(resolve);
+      waiters.set(sessionId, pending);
+    });
+  },
+};

--- a/packages/electron/src/main/services/ai/claudeCliLauncherSingleton.ts
+++ b/packages/electron/src/main/services/ai/claudeCliLauncherSingleton.ts
@@ -31,6 +31,7 @@ import { resolveClaudePermissionHookScriptPath } from './claudeCliPermissionHook
 import { getPermissionService } from '../PermissionService';
 import { startClaudeCliProxyObservation, fireClaudeCliTurnCompletion } from './claudeCliObservationSingleton';
 import { flushNextClaudeCliQueuedPromptForSession } from './claudeCliQueueFlushSingleton';
+import { claudeCliSubmitLatch } from './claudeCliSubmitLatch';
 import { maybeAutoNameClaudeCliSessionProduction } from './claudeCliSessionAutoNameSingleton';
 import type { ClaudeTurnState } from './claudeCliPidState';
 
@@ -322,6 +323,11 @@ export async function ensureClaudeCliSession(
           // Root the file watcher at the spawn cwd (the worktree for worktree
           // sessions), where edits actually land.
           const watchRoot = resolvedCwd ?? input.workspacePath;
+          if (state !== 'idle') {
+            // The CLI has demonstrably consumed whatever we last wrote, so the
+            // submit latch can lift and the queue can drain on the next idle.
+            claudeCliSubmitLatch.clear(input.sessionId);
+          }
           if (state === 'idle') {
             void stateManager.updateActivity({ sessionId: input.sessionId, status: 'idle', isStreaming: false });
             // Delay the watcher stop so post-turn fs events still attribute.

--- a/packages/electron/src/main/services/ai/claudeCliQueueFlush.ts
+++ b/packages/electron/src/main/services/ai/claudeCliQueueFlush.ts
@@ -45,6 +45,14 @@ export interface FlushClaudeCliQueueDeps {
    * `ai:promptClaimed`. Fired right after a successful claim.
    */
   notifyClaimed?: (promptId: string) => void;
+  /**
+   * True while a prompt we already submitted is still draining into the PTY. The
+   * CLI has not started its turn yet, so the PID file still reads idle — flushing
+   * on that stale idle writes a second prompt into the same terminal, where it
+   * lands behind the first turn's Enter and sits unsent. See
+   * `claudeCliSubmitLatch`.
+   */
+  isSubmitInFlight?: () => boolean;
 }
 
 /**
@@ -56,6 +64,10 @@ export async function flushNextClaudeCliQueuedPrompt(
   args: { sessionId: string; workspacePath: string },
   deps: FlushClaudeCliQueueDeps,
 ): Promise<boolean> {
+  // Check before claiming: a claimed prompt we then decline to send would have to
+  // be rolled back out of `executing`.
+  if (deps.isSubmitInFlight?.()) return false;
+
   const pending = await deps.listPending(args.sessionId);
   if (pending.length === 0) return false;
 

--- a/packages/electron/src/main/services/ai/claudeCliQueueFlush.ts
+++ b/packages/electron/src/main/services/ai/claudeCliQueueFlush.ts
@@ -53,6 +53,16 @@ export interface FlushClaudeCliQueueDeps {
    * `claudeCliSubmitLatch`.
    */
   isSubmitInFlight?: () => boolean;
+  /**
+   * True while a stop press is still escalating (Ctrl-C, settle, re-check,
+   * maybe Ctrl-C again — see `claudeCliInterrupt`). The first Ctrl-C ends the
+   * turn well inside the escalation's 1500ms settle, so the idle edge fires and
+   * a flush here starts a NEW turn that the escalation's re-check cannot tell
+   * from the old one refusing to die — its second Ctrl-C then kills the queued
+   * prompt and the TUI drops the text back into the prompt box. Hold the flush
+   * until the escalation is over.
+   */
+  isInterruptInFlight?: () => boolean;
 }
 
 /**
@@ -67,6 +77,7 @@ export async function flushNextClaudeCliQueuedPrompt(
   // Check before claiming: a claimed prompt we then decline to send would have to
   // be rolled back out of `executing`.
   if (deps.isSubmitInFlight?.()) return false;
+  if (deps.isInterruptInFlight?.()) return false;
 
   const pending = await deps.listPending(args.sessionId);
   if (pending.length === 0) return false;

--- a/packages/electron/src/main/services/ai/claudeCliQueueFlushSingleton.ts
+++ b/packages/electron/src/main/services/ai/claudeCliQueueFlushSingleton.ts
@@ -16,9 +16,28 @@ import { submitClaudeCliPromptProduction } from './claudeCliSubmitSingleton';
 import { flushNextClaudeCliQueuedPrompt } from './claudeCliQueueFlush';
 import { publishQueuedPromptClaim } from './queuedPromptClaimEvents';
 import { publishQueuedPromptsToSync } from './queuedPromptSyncPublisher';
+import { claudeCliSubmitLatch } from './claudeCliSubmitLatch';
 
 /** Per-session guard so two close `idle` events can't double-flush. */
 const flushInFlight = new Set<string>();
+/** Sessions with a pending re-check queued for when the submit latch lifts. */
+const latchRetryPending = new Set<string>();
+
+/**
+ * A flush skipped because a submit was still draining has to be retried, or the
+ * prompt waits for an idle transition that may never come — a submit that never
+ * makes the CLI start a turn (a slash command, say) leaves it idle throughout, so
+ * there is no running->idle edge to ride.
+ */
+function retryWhenSubmitLatchLifts(sessionId: string, workspacePath: string): void {
+  if (latchRetryPending.has(sessionId)) return;
+  latchRetryPending.add(sessionId);
+  const wait = claudeCliSubmitLatch.remainingMs(sessionId) + 250;
+  setTimeout(() => {
+    latchRetryPending.delete(sessionId);
+    void flushNextClaudeCliQueuedPromptForSession(sessionId, workspacePath);
+  }, wait).unref?.();
+}
 
 /**
  * Flush the next queued prompt for a session on PID `idle`. Best-effort and
@@ -29,6 +48,10 @@ export async function flushNextClaudeCliQueuedPromptForSession(
   workspacePath: string,
 ): Promise<boolean> {
   if (flushInFlight.has(sessionId)) return false;
+  if (claudeCliSubmitLatch.isInFlight(sessionId)) {
+    retryWhenSubmitLatchLifts(sessionId, workspacePath);
+    return false;
+  }
   flushInFlight.add(sessionId);
   try {
     const store = getQueuedPromptsStore();
@@ -52,6 +75,7 @@ export async function flushNextClaudeCliQueuedPromptForSession(
         complete: (id) => store.complete(id),
         fail: (id, m) => store.fail(id, m),
         submit: (i) => submitClaudeCliPromptProduction(i),
+        isSubmitInFlight: () => claudeCliSubmitLatch.isInFlight(sessionId),
         // The flush runs from the PID-idle transition with no originating IPC
         // event, so there is no single target window; broadcasting is safe
         // because the renderer filters by sessionId (NIM-830).

--- a/packages/electron/src/main/services/ai/claudeCliQueueFlushSingleton.ts
+++ b/packages/electron/src/main/services/ai/claudeCliQueueFlushSingleton.ts
@@ -17,11 +17,31 @@ import { flushNextClaudeCliQueuedPrompt } from './claudeCliQueueFlush';
 import { publishQueuedPromptClaim } from './queuedPromptClaimEvents';
 import { publishQueuedPromptsToSync } from './queuedPromptSyncPublisher';
 import { claudeCliSubmitLatch } from './claudeCliSubmitLatch';
+import { claudeCliInterruptGate } from './claudeCliInterruptGate';
 
 /** Per-session guard so two close `idle` events can't double-flush. */
 const flushInFlight = new Set<string>();
 /** Sessions with a pending re-check queued for when the submit latch lifts. */
 const latchRetryPending = new Set<string>();
+/** Sessions with a pending re-check queued for when the interrupt gate clears. */
+const interruptRetryPending = new Set<string>();
+
+/**
+ * A flush skipped because a stop press was still escalating must retry once the
+ * escalation is over: the idle edge that triggered it has already passed, and
+ * after the escalation the session sits idle with the prompt still queued. The
+ * short settle keeps the retry clear of the escalation's final keystroke.
+ */
+function retryWhenInterruptGateClears(sessionId: string, workspacePath: string): void {
+  if (interruptRetryPending.has(sessionId)) return;
+  interruptRetryPending.add(sessionId);
+  void claudeCliInterruptGate.waitUntilClear(sessionId).then(() => {
+    setTimeout(() => {
+      interruptRetryPending.delete(sessionId);
+      void flushNextClaudeCliQueuedPromptForSession(sessionId, workspacePath);
+    }, 500).unref?.();
+  });
+}
 
 /**
  * A flush skipped because a submit was still draining has to be retried, or the
@@ -52,6 +72,10 @@ export async function flushNextClaudeCliQueuedPromptForSession(
     retryWhenSubmitLatchLifts(sessionId, workspacePath);
     return false;
   }
+  if (claudeCliInterruptGate.isInFlight(sessionId)) {
+    retryWhenInterruptGateClears(sessionId, workspacePath);
+    return false;
+  }
   flushInFlight.add(sessionId);
   try {
     const store = getQueuedPromptsStore();
@@ -76,6 +100,7 @@ export async function flushNextClaudeCliQueuedPromptForSession(
         fail: (id, m) => store.fail(id, m),
         submit: (i) => submitClaudeCliPromptProduction(i),
         isSubmitInFlight: () => claudeCliSubmitLatch.isInFlight(sessionId),
+        isInterruptInFlight: () => claudeCliInterruptGate.isInFlight(sessionId),
         // The flush runs from the PID-idle transition with no originating IPC
         // event, so there is no single target window; broadcasting is safe
         // because the renderer filters by sessionId (NIM-830).

--- a/packages/electron/src/main/services/ai/claudeCliSubmit.ts
+++ b/packages/electron/src/main/services/ai/claudeCliSubmit.ts
@@ -80,6 +80,58 @@ export interface SubmitClaudeCliPromptDeps {
     hasDocumentContext: boolean;
   }) => void;
   delay: (ms: number) => Promise<void>;
+  /**
+   * Has the CLI actually started a turn for this session? Read from its PID file
+   * (`readClaudePidTurnState`). Omit to skip Enter confirmation entirely, which
+   * is what the pure unit tests and any caller without a live PID do.
+   */
+  hasTurnStarted?: (sessionId: string) => boolean | Promise<boolean>;
+}
+
+/** How long to wait between checks that the turn actually started. */
+const ENTER_CONFIRM_POLL_MS = 250;
+/** Checks per attempt. 8 x 250ms = 2s, well past the ~400ms measured worst case. */
+const ENTER_CONFIRM_POLLS = 8;
+/** Extra Enters to try. The prompt box is empty once a turn starts, so a
+ *  redundant Enter on an already-submitted session is a no-op. */
+const ENTER_RETRIES = 2;
+
+/**
+ * Press Enter until the CLI actually starts a turn.
+ *
+ * The CLI ingests an attached file AFTER its bytes land (read + decode), and an
+ * Enter arriving during that window is swallowed. Measured on 2.1.220 with real
+ * screenshots (`nimbalyst-local/cli-paste-probes/05` and `06`): 25ms and 200ms
+ * strand, ~400ms and up submit. `submitWriteGapMs` cannot know that, because it
+ * scales with the PAYLOAD LENGTH — a sentence plus one path is ~300 chars and
+ * yields the 25ms floor however large the image is.
+ *
+ * So don't guess a bigger constant, which would be the same bug with a nicer
+ * number. Ask the same signal Nimbalyst already trusts for "is this session
+ * busy" and re-press if the answer is no.
+ */
+async function confirmEnterStartedTurn(
+  sessionId: string,
+  deps: SubmitClaudeCliPromptDeps,
+): Promise<void> {
+  const hasTurnStarted = deps.hasTurnStarted;
+  if (!hasTurnStarted) return;
+
+  for (let attempt = 0; attempt <= ENTER_RETRIES; attempt++) {
+    for (let poll = 0; poll < ENTER_CONFIRM_POLLS; poll++) {
+      try {
+        if (await hasTurnStarted(sessionId)) return;
+      } catch {
+        // An unreadable PID file is not a reason to spam Enter — treat the
+        // confirmation as unavailable and stop.
+        return;
+      }
+      await deps.delay(ENTER_CONFIRM_POLL_MS);
+    }
+    if (attempt < ENTER_RETRIES) {
+      deps.writeToTerminal(sessionId, SUBMIT_TERMINATOR);
+    }
+  }
 }
 
 /**
@@ -147,6 +199,9 @@ export async function submitClaudeCliPrompt(
     );
     await deps.delay(submitWriteGapMs(ptyText.length));
     deps.writeToTerminal(input.sessionId, SUBMIT_TERMINATOR);
+    // An attachment makes the CLI do async work after the bytes land, which can
+    // swallow that Enter. Confirm a turn really started; press again if not.
+    await confirmEnterStartedTurn(input.sessionId, deps);
   }
 
   // Log the CLEAN typed prompt (+ attachment chips), NOT the path-augmented PTY

--- a/packages/electron/src/main/services/ai/claudeCliSubmitLatch.ts
+++ b/packages/electron/src/main/services/ai/claudeCliSubmitLatch.ts
@@ -1,0 +1,83 @@
+/**
+ * "A prompt is on its way to the CLI" latch for `claude-code-cli` sessions.
+ *
+ * Writing to the PTY is not the same as the CLI having received it. ConPTY hands
+ * input to the child at roughly 31,000 characters per second (measured on
+ * Windows against claude 2.1.220), so a 250k-character paste is still arriving
+ * about eight seconds after `writeToTerminal` returns. Throughout that window the
+ * CLI has not started a turn, so its PID file still reads `idle`.
+ *
+ * Every queue-flush trigger keys off that idle signal — the PID watcher's
+ * running->idle transition, `ai:createQueuedPrompt`, and
+ * `dispatchQueuedPromptToClaudeCli`. Without this latch they would each treat a
+ * mid-delivery session as ready and write a SECOND prompt into the same terminal.
+ * The second prompt queues behind the first one's Enter, so it lands in the
+ * prompt box after the first turn has already started and simply sits there
+ * unsent until someone presses Enter by hand.
+ *
+ * The latch is set when we submit and released when the PID watcher reports the
+ * turn actually started. The deadline is only a safety valve: if the CLI never
+ * picks the prompt up, the queue must not stay blocked forever.
+ */
+
+/** Conservative delivery rate: 20k chars/sec, well under the ~31k measured. */
+const ASSUMED_PTY_CHARS_PER_SECOND = 20_000;
+/** Even a tiny prompt needs a moment to reach the CLI and flip its PID file. */
+const MIN_DEADLINE_MS = 3_000;
+/** Hard ceiling so a pathological payload can't stall the queue indefinitely. */
+const MAX_DEADLINE_MS = 120_000;
+
+/** How long to hold the latch for a payload of this size, absent a turn signal. */
+export function submitDrainDeadlineMs(payloadLength: number): number {
+  const drainMs = Math.ceil((payloadLength / ASSUMED_PTY_CHARS_PER_SECOND) * 1000);
+  return Math.min(MAX_DEADLINE_MS, Math.max(MIN_DEADLINE_MS, drainMs));
+}
+
+export interface ClaudeCliSubmitLatch {
+  /** Record that `payloadLength` characters were just written to this session's PTY. */
+  mark(sessionId: string, payloadLength: number): void;
+  /** True while a submit is still expected to be in transit. */
+  isInFlight(sessionId: string): boolean;
+  /** Milliseconds until the latch lifts on its own; 0 when it is not held. */
+  remainingMs(sessionId: string): number;
+  /** Release the latch — the CLI has demonstrably picked the prompt up. */
+  clear(sessionId: string): void;
+}
+
+export function createClaudeCliSubmitLatch(
+  options: { now?: () => number } = {},
+): ClaudeCliSubmitLatch {
+  const now = options.now ?? (() => Date.now());
+  const deadlines = new Map<string, number>();
+
+  return {
+    mark(sessionId, payloadLength) {
+      // One submit is several writes (payload, then Enter — the slash-command
+      // path is more). Extend, never shorten: the trailing one-character Enter
+      // must not replace the big payload's deadline with the 3s floor.
+      const next = now() + submitDrainDeadlineMs(payloadLength);
+      const existing = deadlines.get(sessionId);
+      deadlines.set(sessionId, existing === undefined ? next : Math.max(existing, next));
+    },
+    isInFlight(sessionId) {
+      const deadline = deadlines.get(sessionId);
+      if (deadline === undefined) return false;
+      if (now() > deadline) {
+        deadlines.delete(sessionId);
+        return false;
+      }
+      return true;
+    },
+    remainingMs(sessionId) {
+      const deadline = deadlines.get(sessionId);
+      if (deadline === undefined) return 0;
+      return Math.max(0, deadline - now());
+    },
+    clear(sessionId) {
+      deadlines.delete(sessionId);
+    },
+  };
+}
+
+/** Process-wide latch shared by the submit path, the PID watcher, and the flusher. */
+export const claudeCliSubmitLatch = createClaudeCliSubmitLatch();

--- a/packages/electron/src/main/services/ai/claudeCliSubmitSingleton.ts
+++ b/packages/electron/src/main/services/ai/claudeCliSubmitSingleton.ts
@@ -18,6 +18,7 @@ import { AgentMessagesRepository } from '@nimbalyst/runtime';
 import { findAttachmentDenyRule } from '@nimbalyst/runtime/ai/server';
 import { ClaudeSettingsManager } from '../ClaudeSettingsManager';
 import { getAttachmentStagingConfig } from '../../utils/store';
+import { claudeCliSubmitLatch } from './claudeCliSubmitLatch';
 
 /** Submit a CLI prompt using the real terminal/log/analytics deps. */
 export async function submitClaudeCliPromptProduction(
@@ -25,7 +26,14 @@ export async function submitClaudeCliPromptProduction(
 ): Promise<{ submitted: boolean }> {
   const manager = getTerminalSessionManager();
   const result = await submitClaudeCliPrompt(input, {
-    writeToTerminal: (sessionId: string, data: string) => manager.writeToTerminal(sessionId, data),
+    writeToTerminal: (sessionId: string, data: string) => {
+      // Hold the queue until the CLI actually picks this up. The bytes take real
+      // time to cross the PTY (see claudeCliSubmitLatch), and until they land the
+      // session's PID file still reads idle, which every flush trigger reads as
+      // "safe to send another prompt".
+      claudeCliSubmitLatch.mark(sessionId, data.length);
+      manager.writeToTerminal(sessionId, data);
+    },
     logUserPrompt: (p: {
       sessionId: string;
       workspacePath: string;

--- a/packages/electron/src/main/services/ai/claudeCliSubmitSingleton.ts
+++ b/packages/electron/src/main/services/ai/claudeCliSubmitSingleton.ts
@@ -59,6 +59,12 @@ export async function submitClaudeCliPromptProduction(
       }
     },
     delay: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+    // The CLI ingests an attached file after its bytes land, and an Enter that
+    // arrives mid-ingest is swallowed — the prompt then sits in the box unsent.
+    // Same live PID-file signal the queue drain trusts. `null` (unknown) is NOT
+    // treated as started, so a genuinely stranded prompt still gets a retry.
+    hasTurnStarted: async (sessionId: string) =>
+      (await manager.getClaudeCliLiveTurnState(sessionId)) === 'running',
   });
 
   if (result.submitted && input.attachments?.length) {

--- a/packages/electron/src/renderer/components/UnifiedAI/PromptQueueList.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/PromptQueueList.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import type { ChatAttachment } from '@nimbalyst/runtime/ai/server/types';
 
-interface QueuedPromptAttachment {
-  id: string;
-  filename: string;
-  type: 'image' | 'pdf' | 'document';
-}
+/**
+ * Full `ChatAttachment`s, not a display-only subset: `onEdit` hands these back
+ * so the draft can be restored with the on-disk `filepath` each one carries.
+ */
+type QueuedPromptAttachment = ChatAttachment;
 
 export interface QueuedPrompt {
   id: string;
@@ -16,7 +17,7 @@ export interface QueuedPrompt {
 interface PromptQueueListProps {
   queue: QueuedPrompt[];
   onCancel: (id: string) => void;
-  onEdit?: (id: string, prompt: string) => void;
+  onEdit?: (id: string, prompt: string, attachments?: QueuedPromptAttachment[]) => void;
   onSendNow?: (id: string, prompt: string) => void;
 }
 
@@ -92,7 +93,7 @@ export function PromptQueueList({ queue, onCancel, onEdit, onSendNow }: PromptQu
             {onEdit && (
               <button
                 className="prompt-queue-edit shrink-0 w-5 h-5 flex items-center justify-center bg-transparent border-none rounded text-nim-muted cursor-pointer text-sm leading-none p-0 transition-all duration-150 hover:bg-nim-hover hover:text-nim-primary"
-                onClick={() => onEdit(item.id, item.prompt)}
+                onClick={() => onEdit(item.id, item.prompt, item.attachments)}
                 title="Edit this prompt"
                 type="button"
               >

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -28,6 +28,7 @@ import type { TodoItem } from '@nimbalyst/runtime/ui/AgentTranscript/types';
 import { isToolLikeMessage } from '@nimbalyst/runtime/ui/AgentTranscript/utils/messageTypeHelpers';
 import { AIInput, AIInputRef } from './AIInput';
 import { PromptQueueList } from './PromptQueueList';
+import { mergeRestoredDraftAttachments } from './queuedPromptDraftRestore';
 import { TranscriptEmbeddedFileCard } from './TranscriptEmbeddedFileCard';
 import { getDiffPeekSizeForInteractiveWidgetHost } from './interactiveWidgetHostProxy';
 import { createFeedbackComposeHost } from '../FeedbackRequest/createFeedbackComposeHost';
@@ -1503,7 +1504,11 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
     }
   }, []);
 
-  const handleEditQueuedPrompt = useCallback(async (id: string, prompt: string) => {
+  const handleEditQueuedPrompt = useCallback(async (
+    id: string,
+    prompt: string,
+    attachments?: ChatAttachment[],
+  ) => {
     try {
       await window.electronAPI.invoke('ai:deleteQueuedPrompt', id);
       setQueuedPrompts(prev => prev.filter(p => p.id !== id));
@@ -1511,11 +1516,15 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
       // clobber prior text; matches how handleQueue bundles consecutive
       // queued prompts with a blank-line separator.
       setDraftInput(prev => prev.trim().length > 0 ? `${prev}\n\n${prompt}` : prompt);
+      // The attachments have to come back too. The prompt text only carries the
+      // `@filename` reference the user sees; the absolute `filepath` that the
+      // send path turns into a real file reference lives on the attachment.
+      setDraftAttachments(prev => mergeRestoredDraftAttachments(prev, attachments));
       inputRef.current?.focus();
     } catch (error) {
       console.error('[SessionTranscript] Failed to edit queued prompt:', error);
     }
-  }, [setDraftInput]);
+  }, [setDraftInput, setDraftAttachments]);
 
   const handleSendNowQueuedPrompt = useCallback(async (_id: string, _prompt: string) => {
     try {
@@ -2657,12 +2666,21 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
         />
       )}
 
-      {/* Queue display */}
+      {/* Queue display.
+
+          send-now excluded claude-code-cli when the provider shipped, because
+          ai:triggerQueueProcessing still sent every session through the SDK
+          dispatcher, whose CLI sendMessage stub failed the prompt. The CLI route
+          (dispatchQueuedPromptToClaudeCliSession) landed days later and the
+          exclusion outlived its reason, leaving a CLI session whose turn state is
+          stuck with no way to release its queue but poking the terminal by hand.
+          Both halves handle CLI now: the interrupt writes Ctrl-C to the PTY, and
+          the queue kick routes to the CLI dispatcher. */}
       <PromptQueueList
         queue={queuedPrompts}
         onCancel={handleCancelQueuedPrompt}
         onEdit={handleEditQueuedPrompt}
-        onSendNow={isLoading && !isClaudeCliTerminalSession(provider) ? handleSendNowQueuedPrompt : undefined}
+        onSendNow={isLoading ? handleSendNowQueuedPrompt : undefined}
       />
 
       {/* Note: All interactive prompts (ToolPermission, ExitPlanMode, AskUserQuestion) use inline widgets in transcript */}

--- a/packages/electron/src/renderer/components/UnifiedAI/__tests__/queuedPromptEdit.test.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/__tests__/queuedPromptEdit.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PromptQueueList } from '../PromptQueueList';
+import { mergeRestoredDraftAttachments } from '../queuedPromptDraftRestore';
+
+afterEach(cleanup);
+
+const IMAGE = {
+  id: 'att-1',
+  filename: 'pasted-image-2026-07-31T12-31-38.png',
+  filepath: 'C:\\Users\\Dera\\AppData\\Roaming\\@nimbalyst\\electron\\chat-attachments\\p\\s\\1_pasted.png',
+  mimeType: 'image/png',
+  size: 170297,
+  type: 'image' as const,
+  addedAt: 1785501099186,
+};
+
+describe('editing a queued prompt', () => {
+  // Regression: editing a queued prompt deleted the row and put only the TEXT
+  // back in the draft, so the `@filename` reference survived but the attachment
+  // (and its absolute path) did not. The next send reached the CLI as a bare
+  // `@filename` it could not resolve.
+  it('hands the queued attachments back to the caller, not just the prompt text', () => {
+    const onEdit = vi.fn();
+    render(
+      <PromptQueueList
+        queue={[{ id: 'q1', prompt: 'look at this @pasted.png', timestamp: 1, attachments: [IMAGE] }]}
+        onCancel={vi.fn()}
+        onEdit={onEdit}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle('Edit this prompt'));
+
+    expect(onEdit).toHaveBeenCalledWith('q1', 'look at this @pasted.png', [IMAGE]);
+  });
+
+  it('restores attachments into the draft without duplicating ones already there', () => {
+    const other = { ...IMAGE, id: 'att-2', filename: 'b.png' };
+
+    expect(mergeRestoredDraftAttachments([], [IMAGE])).toEqual([IMAGE]);
+    expect(mergeRestoredDraftAttachments([other], [IMAGE])).toEqual([other, IMAGE]);
+    // Re-editing the same queued prompt twice must not stack duplicates.
+    expect(mergeRestoredDraftAttachments([IMAGE], [IMAGE])).toEqual([IMAGE]);
+    expect(mergeRestoredDraftAttachments([IMAGE], undefined)).toEqual([IMAGE]);
+  });
+});

--- a/packages/electron/src/renderer/components/UnifiedAI/queuedPromptDraftRestore.ts
+++ b/packages/electron/src/renderer/components/UnifiedAI/queuedPromptDraftRestore.ts
@@ -1,0 +1,25 @@
+/**
+ * Putting a queued prompt back into the draft input.
+ *
+ * Editing a queued prompt deletes its row and returns its content to the chat
+ * box. The text was always restored; its attachments were not, so a prompt whose
+ * body referenced `@pasted-image-….png` came back with the reference but no
+ * attachment — and the next send reached the CLI with no path to resolve
+ * (`claudeCliPromptComposer` builds path references from `attachments[].filepath`).
+ */
+
+import type { ChatAttachment } from '@nimbalyst/runtime/ai/server/types';
+
+/**
+ * Merge attachments restored from a queued prompt into the current draft,
+ * keeping the draft's own attachments first and dropping ids already present so
+ * editing the same prompt twice doesn't stack duplicates.
+ */
+export function mergeRestoredDraftAttachments(
+  current: ChatAttachment[],
+  restored: ReadonlyArray<ChatAttachment> | undefined | null,
+): ChatAttachment[] {
+  if (!restored || restored.length === 0) return current;
+  const seen = new Set(current.map((a) => a.id));
+  return [...current, ...restored.filter((a) => a && !seen.has(a.id))];
+}


### PR DESCRIPTION
## What breaks today

Four related failures in the Claude Code CLI prompt queue:

1. Editing a queued message drops the images and files attached to it, so they never reach the agent.
2. A queued message can be written on top of one that has not reached the terminal yet, leaving it sitting in the prompt box unsent.
3. Pressing stop yanks the next queued prompt back into the prompt box instead of sending it.
4. The CLI's own typing suggestions are ingested as if they were a reply and show up in the transcript.

## Why

All four sit on the same submit and queue-flush path. Queue flush keyed off an idle transition that may never arrive; the submit path had no latch proving the CLI had actually picked a prompt up; attachment paths were resolved against the wrong send; and the message filter did not distinguish the CLI's suggestion output from real output.

## The fix

- A submit latch, released only once the CLI has demonstrably taken the prompt, so the next write cannot land on top of an unsent one.
- An interrupt gate so a stop press ends the current turn without reclaiming the queued prompt.
- Attachment paths preserved across a queued-message edit.
- The message filter now excludes the CLI's own typing suggestions.

## Verification

`claudeCliQueueFlush.test.ts`, `claudeCliSubmitLatch.test.ts`, `claudeCliSubmit.test.ts`, `messageRequestFilter.test.ts`, and `queuedPromptEdit.test.tsx`. Red before, green after.

## Note on scope

These three commits share files on the submit and queue-flush path and cannot be separated into independent PRs without one breaking the other. They are presented together for that reason, not for convenience.
