### PR TITLE
feat: switch the interactive CLI path to --effort so effort can change mid-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- The effort level for a Claude Code CLI session can now be changed mid-session instead of only at launch.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/main/ipc/TerminalHandlers.ts
+++ b/packages/electron/src/main/ipc/TerminalHandlers.ts
@@ -9,6 +9,7 @@ import { getTerminalSessionManager } from '../services/TerminalSessionManager';
 import { ensureClaudeCliSession, isClaudeCliInstalled } from '../services/ai/claudeCliLauncherSingleton';
 import { submitClaudeCliPromptProduction } from '../services/ai/claudeCliSubmitSingleton';
 import { switchClaudeCliModel } from '../services/ai/claudeCliModelSwitch';
+import { switchClaudeCliEffort } from '../services/ai/claudeCliEffortSwitch';
 import type { ClaudeCliDocumentContext } from '../services/ai/claudeCliPromptComposer';
 import type { ChatAttachment } from '@nimbalyst/runtime/ai/server/types';
 import { ShellDetector } from '../services/ShellDetector';
@@ -391,6 +392,35 @@ export function registerTerminalHandlers(): void {
         throw new Error(`Model "${payload.model}" cannot be applied to a Claude Code CLI session`);
       }
       return { success: true, cliArg: result.cliArg };
+    }
+  );
+
+  /**
+   * Retune a RUNNING claude-code-cli session's effort via `/effort <level>`.
+   *
+   * `--effort` is fixed for the life of the process, so without this the
+   * composer's effort selector had to be hidden once a session had spawned.
+   * Only works because the launch path no longer exports
+   * CLAUDE_CODE_EFFORT_LEVEL, which would outrank the slash command.
+   */
+  safeHandle(
+    'claude-cli:set-effort',
+    async (_event, payload: { sessionId: string; effortLevel: string }) => {
+      if (!payload?.sessionId || typeof payload.sessionId !== 'string') {
+        throw new Error('sessionId is required and must be a string');
+      }
+      if (!payload?.effortLevel || typeof payload.effortLevel !== 'string') {
+        throw new Error('effortLevel is required and must be a string');
+      }
+      const result = await switchClaudeCliEffort(payload, {
+        writeToTerminal: (sessionId: string, data: string) =>
+          manager.writeToTerminal(sessionId, data),
+        delay: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      });
+      if (!result.switched) {
+        throw new Error(`Effort "${payload.effortLevel}" is not a valid level`);
+      }
+      return { success: true, level: result.level };
     }
   );
 

--- a/packages/electron/src/main/services/ai/ClaudeCliSessionLauncher.ts
+++ b/packages/electron/src/main/services/ai/ClaudeCliSessionLauncher.ts
@@ -130,6 +130,11 @@ export interface LaunchClaudeCliSessionInput {
   cwd?: string;
   /** Resolved CLI model value (`--model`), e.g. `opus`. Omit to let the CLI default. */
   model?: string;
+  /**
+   * Resolved effort level for this session, passed to the CLI as `--effort`.
+   * Omit to leave the CLI on whatever the user already configured.
+   */
+  effortLevel?: string;
   /** Resume an existing CLI session id (`--resume <id>`). */
   resumeSessionId?: string;
   /**
@@ -320,6 +325,7 @@ export class ClaudeCliSessionLauncher {
       cwd,
       mcpConfigPath,
       model: input.model,
+      effortLevel: input.effortLevel,
       sessionId,
       resumeSessionId,
       baseEnv: this.deps.baseEnv ?? process.env,

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliEffortSwitch.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliEffortSwitch.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildClaudeCliEffortSwitchCommand,
+  switchClaudeCliEffort,
+} from '../claudeCliEffortSwitch';
+
+describe('buildClaudeCliEffortSwitchCommand', () => {
+  it('builds the slash command for every valid level', () => {
+    for (const level of ['low', 'medium', 'high', 'xhigh', 'max']) {
+      expect(buildClaudeCliEffortSwitchCommand(level)).toBe(`/effort ${level}`);
+    }
+  });
+
+  it('refuses anything that is not a known level', () => {
+    // Never type an unvalidated string into a live PTY.
+    expect(buildClaudeCliEffortSwitchCommand('')).toBeNull();
+    expect(buildClaudeCliEffortSwitchCommand(undefined)).toBeNull();
+    expect(buildClaudeCliEffortSwitchCommand('ludicrous')).toBeNull();
+    expect(buildClaudeCliEffortSwitchCommand('high; rm -rf /')).toBeNull();
+  });
+});
+
+describe('switchClaudeCliEffort', () => {
+  it('writes the command and Enter as two separate writes', () => {
+    // A single `text + \r` write can leave the Ink TUI showing the text without
+    // consuming Enter, which is the same reason the model switch is two-step.
+    const writeToTerminal = vi.fn();
+    const delay = vi.fn(async () => {});
+
+    return switchClaudeCliEffort({ sessionId: 's1', effortLevel: 'high' }, {
+      writeToTerminal,
+      delay,
+    }).then((result) => {
+      expect(result).toEqual({ switched: true, level: 'high' });
+      expect(writeToTerminal).toHaveBeenNthCalledWith(1, 's1', '/effort high');
+      expect(writeToTerminal).toHaveBeenNthCalledWith(2, 's1', '\r');
+      expect(delay).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('writes nothing at all for an invalid level', async () => {
+    const writeToTerminal = vi.fn();
+    const result = await switchClaudeCliEffort(
+      { sessionId: 's1', effortLevel: 'nonsense' },
+      { writeToTerminal, delay: async () => {} },
+    );
+    expect(result).toEqual({ switched: false });
+    expect(writeToTerminal).not.toHaveBeenCalled();
+  });
+});

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliSpawnConfig.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliSpawnConfig.test.ts
@@ -132,27 +132,29 @@ describe('buildClaudeCliSpawnConfig', () => {
    * whatever the CLI defaults to.
    */
   describe('effort level', () => {
-    it('forwards the resolved effort to the CLI', () => {
+    it('forwards the resolved effort to the CLI as --effort', () => {
       const cfg = buildClaudeCliSpawnConfig({ ...base, effortLevel: 'max' });
-      expect(cfg.env.CLAUDE_CODE_EFFORT_LEVEL).toBe('max');
+      expect(cfg.args).toContain('--effort');
+      expect(cfg.args[cfg.args.indexOf('--effort') + 1]).toBe('max');
     });
 
     it('forwards "high" too, so the selector matches the request (#844)', () => {
       const cfg = buildClaudeCliSpawnConfig({ ...base, effortLevel: 'high' });
-      expect(cfg.env.CLAUDE_CODE_EFFORT_LEVEL).toBe('high');
+      expect(cfg.args[cfg.args.indexOf('--effort') + 1]).toBe('high');
     });
 
     it('leaves the variable unset when no effort is resolved', () => {
       expect(buildClaudeCliSpawnConfig(base).env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
     });
 
-    it('does not let an inherited env value override the resolved selection', () => {
+    it('clears an inherited env value so --effort is the thing in charge', () => {
       const cfg = buildClaudeCliSpawnConfig({
         ...base,
         baseEnv: { CLAUDE_CODE_EFFORT_LEVEL: 'low' },
         effortLevel: 'max',
       });
-      expect(cfg.env.CLAUDE_CODE_EFFORT_LEVEL).toBe('max');
+      expect(cfg.env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
+      expect(cfg.args[cfg.args.indexOf('--effort') + 1]).toBe('max');
     });
 
     it('leaves an inherited value alone when nothing is selected', () => {
@@ -542,5 +544,60 @@ describe('buildClaudeCliSpawnConfig Windows .cmd newline handling (#684)', () =>
       expect(i).toBeGreaterThan(-1);
       expect(/[\r\n]/.test(cfg.args[i + 1])).toBe(true);
     }
+  });
+});
+
+/**
+ * Effort is passed as `--effort`, the CLI's own documented session flag, rather
+ * than by exporting CLAUDE_CODE_EFFORT_LEVEL into the process environment.
+ *
+ * Measured against claude 2.1.220 with `-p`, which is why the inherited-value
+ * case below matters:
+ *
+ *   env unset  + --effort high  -> runs at high
+ *   env = max  + --effort high  -> runs at MAX; the error names 'max'
+ *
+ * The environment variable outranks the flag, so setting the flag without also
+ * clearing an inherited value would leave the selector inert for anyone who has
+ * CLAUDE_CODE_EFFORT_LEVEL exported in their shell -- which is exactly the bug
+ * reported in #996.
+ *
+ * An env var is also the wrong shape for this: it is inherited by every process
+ * the CLI spawns, including all of its MCP servers. The flag is scoped to the
+ * session it was passed to.
+ */
+describe('buildClaudeCliSpawnConfig effort', () => {
+  const base = { cwd: '/work/proj', baseEnv: {} as Record<string, string | undefined> };
+
+  it('passes the selected level as --effort', () => {
+    const cfg = buildClaudeCliSpawnConfig({ ...base, effortLevel: 'high' });
+    expect(cfg.args).toContain('--effort');
+    expect(cfg.args[cfg.args.indexOf('--effort') + 1]).toBe('high');
+  });
+
+  it('does NOT export CLAUDE_CODE_EFFORT_LEVEL', () => {
+    const cfg = buildClaudeCliSpawnConfig({ ...base, effortLevel: 'high' });
+    expect(cfg.env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
+  });
+
+  it('clears an inherited CLAUDE_CODE_EFFORT_LEVEL so the flag actually wins', () => {
+    const cfg = buildClaudeCliSpawnConfig({
+      ...base,
+      baseEnv: { CLAUDE_CODE_EFFORT_LEVEL: 'max' },
+      effortLevel: 'high',
+    });
+    expect(cfg.args[cfg.args.indexOf('--effort') + 1]).toBe('high');
+    expect(cfg.env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
+  });
+
+  it('leaves an inherited value alone when nothing is selected', () => {
+    // No selection means "whatever the user configured stands" -- their shell
+    // export, or the CLI's own default. We do not override it with a guess.
+    const cfg = buildClaudeCliSpawnConfig({
+      ...base,
+      baseEnv: { CLAUDE_CODE_EFFORT_LEVEL: 'max' },
+    });
+    expect(cfg.args).not.toContain('--effort');
+    expect(cfg.env.CLAUDE_CODE_EFFORT_LEVEL).toBe('max');
   });
 });

--- a/packages/electron/src/main/services/ai/claudeCliEffortSwitch.ts
+++ b/packages/electron/src/main/services/ai/claudeCliEffortSwitch.ts
@@ -1,0 +1,67 @@
+/**
+ * Mid-session effort switching for `claude-code-cli` sessions.
+ *
+ * `--effort` fixes the level for the life of the process, so the composer's
+ * effort selector was hidden once a CLI session had spawned: the control existed
+ * but could not do anything. The CLI's own `/effort <level>` slash command is a
+ * direct setter, so a running session can be retuned by typing it into the PTY,
+ * exactly as `claudeCliModelSwitch` already does for `/model`.
+ *
+ * This only works because the launch path passes `--effort` instead of exporting
+ * CLAUDE_CODE_EFFORT_LEVEL. An exported value outranks both the flag and the
+ * slash command, and the CLI says so itself:
+ *
+ *   "CLAUDE_CODE_EFFORT_LEVEL=max overrides this session - clear it and high
+ *    takes over"
+ *
+ * The write is two-step (text, gap, then Enter) mirroring `claudeCliSubmit` and
+ * `claudeCliModelSwitch`: a single `text + \r` write can leave the Ink TUI
+ * showing the text without consuming Enter.
+ */
+
+/** Gap between the command write and the Enter write (same as the model switch). */
+export const EFFORT_SWITCH_WRITE_GAP_MS = 25;
+
+/**
+ * Levels the CLI accepts. Kept as a local literal rather than imported from the
+ * runtime's EffortLevel so an unvalidated string can never be typed into a live
+ * PTY; the union is checked at the boundary instead of trusted from the caller.
+ */
+const VALID_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+
+export interface SwitchClaudeCliEffortInput {
+  sessionId: string;
+  effortLevel: string | undefined;
+}
+
+export interface SwitchClaudeCliEffortDeps {
+  writeToTerminal: (sessionId: string, data: string) => void;
+  delay: (ms: number) => Promise<void>;
+}
+
+export type SwitchClaudeCliEffortResult =
+  | { switched: true; level: string }
+  | { switched: false };
+
+/** Build the `/effort <level>` line, or null when the level is not recognised. */
+export function buildClaudeCliEffortSwitchCommand(
+  effortLevel: string | undefined,
+): string | null {
+  if (!effortLevel || !VALID_LEVELS.has(effortLevel)) return null;
+  return `/effort ${effortLevel}`;
+}
+
+/** Type the `/effort` command into the session's PTY. */
+export async function switchClaudeCliEffort(
+  input: SwitchClaudeCliEffortInput,
+  deps: SwitchClaudeCliEffortDeps,
+): Promise<SwitchClaudeCliEffortResult> {
+  const command = buildClaudeCliEffortSwitchCommand(input.effortLevel);
+  if (!command) return { switched: false };
+
+  deps.writeToTerminal(input.sessionId, command);
+  await deps.delay(EFFORT_SWITCH_WRITE_GAP_MS);
+  deps.writeToTerminal(input.sessionId, '\r');
+
+  return { switched: true, level: command.slice('/effort '.length) };
+}

--- a/packages/electron/src/main/services/ai/claudeCliSpawnConfig.ts
+++ b/packages/electron/src/main/services/ai/claudeCliSpawnConfig.ts
@@ -74,6 +74,12 @@ export interface ClaudeCliSpawnInput {
   sessionId?: string;
   /** Resolved Claude model variant (e.g. `opus`, `sonnet`). */
   model?: string;
+  /**
+   * Effort level for the session (`--effort`). Omit to leave the CLI on whatever
+   * the user already configured, via their own `CLAUDE_CODE_EFFORT_LEVEL` export
+   * or its built-in default.
+   */
+  effortLevel?: string;
   /** Resume an existing CLI session id (`--resume <id>`). */
   resumeSessionId?: string;
   /** Resume the most recent CLI session (`--continue`). Ignored if `resumeSessionId` is set. */
@@ -264,6 +270,14 @@ export function buildClaudeCliSpawnConfig(input: ClaudeCliSpawnInput): ClaudeCli
   if (modelArg) {
     args.push('--model', modelArg);
   }
+  // `--effort`, not a CLAUDE_CODE_EFFORT_LEVEL export. The env var is inherited
+  // by every process the CLI spawns (including all of its MCP servers), and it
+  // OUTRANKS the flag — measured on 2.1.220, `env=max` + `--effort high` runs at
+  // max and the API error names 'max'. The inherited value is cleared below so
+  // the flag is actually the thing in charge.
+  if (input.effortLevel) {
+    args.push('--effort', input.effortLevel);
+  }
   if (input.mcpConfigPath) {
     // NIM-2372: additive only. We deliberately do NOT pair this with
     // `--strict-mcp-config` any more — that made the binary ignore its own
@@ -376,11 +390,12 @@ export function buildClaudeCliSpawnConfig(input: ClaudeCliSpawnInput): ClaudeCli
   if (merged.ENABLE_TOOL_SEARCH == null) {
     merged.ENABLE_TOOL_SEARCH = 'true';
   }
-  // Mirrors the Agent SDK path. Set after baseEnv so an explicit selection wins
-  // over an inherited value; when nothing is selected the inherited value (or
-  // the CLI's own default) stands.
+  // An inherited CLAUDE_CODE_EFFORT_LEVEL beats `--effort`, so a user who has it
+  // exported would see the selector do nothing — which is the bug #996 reported.
+  // Only cleared when we actually pass the flag; with no selection their export
+  // is theirs to keep.
   if (input.effortLevel) {
-    merged.CLAUDE_CODE_EFFORT_LEVEL = input.effortLevel;
+    delete merged.CLAUDE_CODE_EFFORT_LEVEL;
   }
   if (input.extraEnv) {
     Object.assign(merged, input.extraEnv);

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -2157,6 +2157,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // Switch a running claude-code-cli session's model via `/model` (NIM-806).
     setClaudeCliModel: (sessionId: string, model: string) =>
       ipcRenderer.invoke('claude-cli:set-model', { sessionId, model }),
+    // Retune a running claude-code-cli session's effort via `/effort`.
+    setClaudeCliEffort: (sessionId: string, effortLevel: string) =>
+      ipcRenderer.invoke('claude-cli:set-effort', { sessionId, effortLevel }),
     // Stop a claude-code-cli turn with escalation (NIM-814): Ctrl-C → Ctrl-C →
     // SIGINT, re-checking the PID turn state between steps.
     interruptClaudeCli: (sessionId: string) =>

--- a/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/SessionTranscript.tsx
@@ -1589,13 +1589,26 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
 
   const handleEffortLevelChange = useCallback(async (level: EffortLevel) => {
     const previousLevel = effortLevel;
+    // A running CLI session retunes via the genuine CLI's `/effort` slash
+    // command typed into its PTY, the same way the model picker uses `/model`.
+    // `--effort` is fixed at spawn, so without this the selector could only
+    // apply to the NEXT session. Mirrors handleModelChange: PTY first, so a
+    // failed switch leaves the persisted value untouched.
+    if (isClaudeCliTerminalSession(provider) && cliSessionCommitted) {
+      try {
+        await window.electronAPI.terminal.setClaudeCliEffort(sessionId, level);
+      } catch (error) {
+        console.error('[SessionTranscript] Failed to switch CLI effort:', error);
+        return;
+      }
+    }
     await updateSessionMetadataField(sessionId, 'effortLevel', level, null, updateSessionStore);
     setAgentModeSettings({ defaultEffortLevel: level });
     posthog?.capture('ai_effort_level_changed', {
       effort_level: level,
       previous_level: previousLevel,
     });
-  }, [sessionId, updateSessionStore, setAgentModeSettings, effortLevel, posthog]);
+  }, [sessionId, updateSessionStore, setAgentModeSettings, effortLevel, posthog, provider, cliSessionCommitted]);
 
   const handleThinkingModeChange = useCallback(async (mode: ThinkingMode) => {
     const previousMode = thinkingMode;
@@ -2711,7 +2724,7 @@ export const SessionTranscript = forwardRef<SessionTranscriptRef, SessionTranscr
         currentProvider={provider ?? null}
         effortLevel={effortLevel}
         onEffortLevelChange={handleEffortLevelChange}
-        showEffortLevel={isClaudeCliTerminalSession(provider) && cliSessionCommitted ? false : showEffortLevel}
+        showEffortLevel={showEffortLevel}
         thinkingMode={thinkingMode}
         onThinkingModeChange={handleThinkingModeChange}
         showThinkingToggle={isClaudeCliTerminalSession(provider) && cliSessionCommitted ? false : showThinkingToggle}

--- a/packages/electron/src/renderer/electron.d.ts
+++ b/packages/electron/src/renderer/electron.d.ts
@@ -1096,6 +1096,7 @@ interface ElectronAPI {
     isClaudeCliInstalled: () => Promise<boolean>;
     submitClaudeCliPrompt: (payload: { sessionId: string; workspacePath: string; prompt: string; attachments?: unknown[]; documentContext?: unknown }) => Promise<{ success: boolean }>;
     setClaudeCliModel: (sessionId: string, model: string) => Promise<{ success: boolean; cliArg: string }>;
+    setClaudeCliEffort: (sessionId: string, effortLevel: string) => Promise<{ success: boolean; level: string }>;
     interruptClaudeCli: (sessionId: string) => Promise<{ success: boolean; resolvedAfter?: 'first-interrupt' | 'second-interrupt' | 'sigint' | 'unresolved' }>;
     isActive: (terminalId: string) => Promise<boolean>;
     write: (terminalId: string, data: string) => Promise<void>;


### PR DESCRIPTION
Rebased onto v0.74.0. This now carries two commits, and the first one revisits a decision made in #997. That is deliberate, and the evidence is below.

## What #997 shipped, and the limit it creates

#997 forwards effort by setting `CLAUDE_CODE_EFFORT_LEVEL` in the spawned environment, for parity with the Agent SDK path. That is the right call for the SDK path and it fixes the launch case.

It does not work for the interactive CLI path, because that session is long-lived and the user can change effort while it runs. The CLI ranks an exported `CLAUDE_CODE_EFFORT_LEVEL` above both the `--effort` flag and its own `/effort` command. These strings are in the shipped `claude` 2.1.237 binary:

```
apply_flag_settings: CLAUDE_CODE_EFFORT_LEVEL overrides effort for this session
Not applied: CLAUDE_CODE_EFFORT_LEVEL=<x> overrides effort this session
CLAUDE_CODE_EFFORT_LEVEL=<x> overrides this session - clear it and <y> takes over
Effort set to auto for this session, but CLAUDE_CODE_EFFORT_LEVEL=<x> still controls this session
```

The last three come from the `/effort` command handler. So on current main, once a user has selected an effort, mid-session switching cannot work: the CLI refuses it and tells the user to clear a variable Nimbalyst set on their behalf and which they have no way to reach.

## What this PR does

Splits the two paths rather than choosing between them:

- **Agent SDK path** (`sdkOptionsBuilder`): unchanged. Still sets `CLAUDE_CODE_EFFORT_LEVEL`. Cross-provider parity is preserved, and this PR does not touch that file.
- **Interactive CLI path** (`claudeCliSpawnConfig`): passes `--effort`, and clears an inherited `CLAUDE_CODE_EFFORT_LEVEL` only when it actually passes the flag. With no selection, the user's own export is left alone.

On top of that, the second commit adds the mid-session switch: changing the selector types `/effort <level>` into the session, the same mechanism `claudeCliModelSwitch` already uses for `/model`.

The rationale is that the two paths have different session models. The SDK path configures a process per turn, so an environment variable is a natural fit. The interactive path configures a process that outlives many turns, so it needs a channel that stays open.

## Tests

`claudeCliSpawnConfig.test.ts`, `claudeCliEffort.test.ts`, `claudeCliEffortSwitch.test.ts`, 71 passing. The three spawn-config cases that asserted the environment variable now assert the flag, including that an inherited value is cleared so the flag is in charge.

## If you would rather keep the environment variable

Then mid-session switching is not achievable and I will close this. It would be worth documenting the limitation, since the CLI's own "clear it and X takes over" message points the user at something they cannot clear from inside Nimbalyst.
