### PR TITLE
Allow the meta agent's delegated sessions panel to be collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- The meta agent's delegated sessions panel can now be folded away, so the transcript gets the full width on a narrow or vertical window.
 - A Claude Code CLI session no longer hangs when the CLI asks you to confirm a model switch.
 - Opening an extension panel while an agent session is running no longer takes the whole window down.
 - Starting an agent after moving, renaming, or deleting the project folder now says the folder is gone and names it, instead of reporting a broken agent binary and then hanging for minutes.

--- a/packages/electron/src/renderer/components/MetaAgentMode/MetaAgentMode.tsx
+++ b/packages/electron/src/renderer/components/MetaAgentMode/MetaAgentMode.tsx
@@ -1,9 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { atom } from 'jotai';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { MaterialSymbol } from '@nimbalyst/runtime/ui/icons/MaterialSymbol';
 import { store } from '@nimbalyst/runtime/store';
 import { defaultAgentModelAtom } from '../../store/atoms/appSettings';
+import {
+  metaAgentDashboardCollapsedAtom,
+  toggleMetaAgentDashboardCollapsedAtom,
+} from '../../store/atoms/agentMode';
 import { sessionRegistryAtom } from '../../store';
 import { sessionTokenUsageAtom } from '../../store/atoms/sessions';
 import { getRelativeTimeString } from '../../utils/dateFormatting';
@@ -184,6 +188,8 @@ export function MetaAgentMode({
   onOpenSessionInAgent,
 }: MetaAgentModeProps) {
   const defaultModel = useAtomValue(defaultAgentModelAtom);
+  const dashboardCollapsed = useAtomValue(metaAgentDashboardCollapsedAtom);
+  const toggleDashboard = useSetAtom(toggleMetaAgentDashboardCollapsedAtom);
   const [metaSessionId, setMetaSessionId] = useState<string | null>(externalSessionId ?? null);
   const [loadingSession, setLoadingSession] = useState(!externalSessionId);
   const [loadingChildren, setLoadingChildren] = useState(false);
@@ -433,7 +439,20 @@ export function MetaAgentMode({
 
   return (
     <div className="meta-agent-mode relative flex-1 flex min-h-0" data-testid="meta-agent-mode">
-      <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-r border-nim">
+      <div className="relative flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-r border-nim">
+        {dashboardCollapsed && (
+          <button
+            type="button"
+            className="nim-btn-secondary absolute right-2 top-2 z-10 flex items-center gap-1 rounded px-2 py-1 text-xs"
+            onClick={toggleDashboard}
+            title="Show delegated sessions"
+            aria-label="Show delegated sessions"
+            data-testid="meta-agent-expand-dashboard"
+          >
+            <MaterialSymbol icon="chevron_left" size={14} />
+            {summary.total > 0 && <span>{summary.total}</span>}
+          </button>
+        )}
         <SessionTranscript
           sessionId={metaSessionId}
           workspacePath={workspacePath}
@@ -444,6 +463,7 @@ export function MetaAgentMode({
         />
       </div>
 
+      {!dashboardCollapsed && (
       <aside className="w-[360px] max-w-[420px] min-w-[320px] flex flex-col min-h-0 bg-[var(--nim-bg-secondary)]" data-testid="meta-agent-dashboard">
         <div className="px-4 py-4 border-b border-nim">
           <div className="flex items-center justify-between gap-3">
@@ -452,6 +472,16 @@ export function MetaAgentMode({
               <p className="text-xs text-[var(--nim-text-muted)]">Child sessions created by this meta-agent.</p>
             </div>
             <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="nim-btn-secondary text-xs px-2 py-1 rounded"
+                onClick={toggleDashboard}
+                title="Hide delegated sessions"
+                aria-label="Hide delegated sessions"
+                data-testid="meta-agent-collapse-dashboard"
+              >
+                <MaterialSymbol icon="chevron_right" size={14} />
+              </button>
               <button
                 type="button"
                 className="nim-btn-secondary text-xs px-2.5 py-1 rounded disabled:opacity-50"
@@ -562,6 +592,7 @@ export function MetaAgentMode({
           )}
         </div>
       </aside>
+      )}
 
       {showTimeline && (
         <div className="absolute inset-4 z-20 flex flex-col rounded-2xl border border-nim bg-[var(--nim-bg)] shadow-2xl" data-testid="meta-agent-gantt-view">

--- a/packages/electron/src/renderer/store/atoms/__tests__/agentModeMetaDashboard.test.ts
+++ b/packages/electron/src/renderer/store/atoms/__tests__/agentModeMetaDashboard.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { createStore } from 'jotai';
+import {
+  agentModeLayoutAtomFamily,
+  mergeWithDefaults,
+  metaAgentDashboardCollapsedAtom,
+  toggleMetaAgentDashboardCollapsedAtom,
+} from '../agentMode';
+import { activeWorkspacePathAtom } from '../openProjects';
+
+// NIM-3087: on a narrow/vertical window the meta-agent "Delegated Sessions"
+// pane must be foldable, and the choice has to survive a reload.
+describe('meta-agent dashboard collapse', () => {
+  it('defaults to expanded and flips on toggle', () => {
+    const store = createStore();
+    const workspacePath = '/tmp/meta-agent-workspace';
+    store.set(activeWorkspacePathAtom, workspacePath);
+
+    expect(store.get(metaAgentDashboardCollapsedAtom)).toBe(false);
+
+    store.set(toggleMetaAgentDashboardCollapsedAtom);
+    expect(store.get(metaAgentDashboardCollapsedAtom)).toBe(true);
+    expect(store.get(agentModeLayoutAtomFamily(workspacePath)).metaAgentDashboardCollapsed).toBe(true);
+
+    store.set(toggleMetaAgentDashboardCollapsedAtom);
+    expect(store.get(metaAgentDashboardCollapsedAtom)).toBe(false);
+  });
+
+  it('restores a persisted collapsed state and defaults when the field is absent', () => {
+    expect(mergeWithDefaults({ metaAgentDashboardCollapsed: true }).metaAgentDashboardCollapsed).toBe(true);
+    expect(mergeWithDefaults({}).metaAgentDashboardCollapsed).toBe(false);
+  });
+});

--- a/packages/electron/src/renderer/store/atoms/agentMode.ts
+++ b/packages/electron/src/renderer/store/atoms/agentMode.ts
@@ -54,6 +54,8 @@ export interface AgentModeLayout {
   teammatePanelCollapsed: boolean;
   agentPanelCollapsed: boolean;
   trackerPanelCollapsed: boolean;
+  /** Whether the meta-agent "Delegated Sessions" dashboard is collapsed. */
+  metaAgentDashboardCollapsed: boolean;
 }
 
 export const MIN_AGENT_RIGHT_PANEL_WIDTH = 150;
@@ -92,6 +94,7 @@ const DEFAULT_LAYOUT: AgentModeLayout = {
   teammatePanelCollapsed: false,
   agentPanelCollapsed: false,
   trackerPanelCollapsed: false,
+  metaAgentDashboardCollapsed: false,
 };
 
 /**
@@ -121,6 +124,8 @@ export function mergeWithDefaults(persisted: Partial<AgentModeLayout> | undefine
     teammatePanelCollapsed: persisted?.teammatePanelCollapsed ?? DEFAULT_LAYOUT.teammatePanelCollapsed,
     agentPanelCollapsed: persisted?.agentPanelCollapsed ?? DEFAULT_LAYOUT.agentPanelCollapsed,
     trackerPanelCollapsed: persisted?.trackerPanelCollapsed ?? DEFAULT_LAYOUT.trackerPanelCollapsed,
+    metaAgentDashboardCollapsed:
+      persisted?.metaAgentDashboardCollapsed ?? DEFAULT_LAYOUT.metaAgentDashboardCollapsed,
   };
 }
 
@@ -214,6 +219,11 @@ export const agentPanelCollapsedAtom = atom(
 /** Whether the tracker panel is collapsed */
 export const trackerPanelCollapsedAtom = atom(
   (get) => get(agentModeLayoutAtom).trackerPanelCollapsed
+);
+
+/** Whether the meta-agent delegated-sessions dashboard is collapsed */
+export const metaAgentDashboardCollapsedAtom = atom(
+  (get) => get(agentModeLayoutAtom).metaAgentDashboardCollapsed
 );
 
 /** Per-session derived atom for current teammates from session metadata */
@@ -436,6 +446,29 @@ export const toggleTodoPanelCollapsedAtom = atom(
     const workspacePath = get(activeWorkspacePathAtom);
     const current = get(agentModeLayoutAtom);
     const newLayout = { ...current, todoPanelCollapsed: !current.todoPanelCollapsed };
+
+    set(agentModeLayoutAtom, newLayout);
+
+    if (!workspacePath) {
+      console.warn('[agentMode] Cannot persist layout - no active workspace');
+      return;
+    }
+    schedulePersist(workspacePath, newLayout);
+  }
+);
+
+/**
+ * Toggle the meta-agent delegated-sessions dashboard collapsed state.
+ */
+export const toggleMetaAgentDashboardCollapsedAtom = atom(
+  null,
+  (get, set) => {
+    const workspacePath = get(activeWorkspacePathAtom);
+    const current = get(agentModeLayoutAtom);
+    const newLayout = {
+      ...current,
+      metaAgentDashboardCollapsed: !current.metaAgentDashboardCollapsed,
+    };
 
     set(agentModeLayoutAtom, newLayout);
 


### PR DESCRIPTION
## Problem

In meta agent mode the "Delegated Sessions" dashboard is a fixed-width aside (`w-[360px] min-w-[320px]`) with no collapse or resize control. On a narrow or vertically-oriented window it permanently occupies 320-360px and squeezes the transcript to an unusable width.

## Change

- `metaAgentDashboardCollapsed` added to `AgentModeLayout`, defaulting to `false` and merged safely in `mergeWithDefaults` so older persisted layouts load fine. It rides the existing per-workspace debounced persistence, so the choice survives a restart and is remembered per project.
- A chevron button in the dashboard header collapses the aside; when collapsed, a chevron pinned to the top-right of the transcript brings it back, badged with the delegated session count so the children are still discoverable.

This mirrors the session-history panel's existing collapse pattern rather than introducing a new one.

## Testing

- New unit test covers the toggle round-trip and the persisted-state restore.
- `npm run typecheck` is clean for `packages/electron` and `packages/runtime`.