### PR TITLE
feat: nimbalyst://open deep link — open a file at an optional line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- A `nimbalyst://open` link can open a specific file — optionally at a line — landing in the workspace that contains it, so external tools can link straight into your notes and code.
 - OpenCode's model picker now lists the models you are actually signed in for, discovered live instead of a fixed built-in list, with per-model hiding and a refresh control in settings.
 - OpenCode sessions support slash commands and Compact, and can run as one of your configured agent roles.
 

--- a/packages/electron/src/main/file/FileOperations.ts
+++ b/packages/electron/src/main/file/FileOperations.ts
@@ -5,8 +5,10 @@ import { windowStates, getWindowId } from '../window/WindowManager';
 import { addToRecentItems } from '../utils/store';
 
 // Function to open a file in a window - sends open-document event to renderer
-// which triggers handleWorkspaceFileSelect to load content and create tab
-export function loadFileIntoWindow(window: BrowserWindow, filePath: string) {
+// which triggers handleWorkspaceFileSelect to load content and create tab.
+// `reveal` (1-based line) rides along for deep links; the renderer's pending-
+// reveal registry handles editors that are still mounting.
+export function loadFileIntoWindow(window: BrowserWindow, filePath: string, reveal?: { line: number }) {
     try {
         const windowId = getWindowId(window);
         if (windowId === null) {
@@ -23,7 +25,7 @@ export function loadFileIntoWindow(window: BrowserWindow, filePath: string) {
         }
 
         // Send open-document event - renderer handles content loading via switchWorkspaceFile
-        window.webContents.send('open-document', { path: filePath });
+        window.webContents.send('open-document', { path: filePath, ...(reveal ?? {}) });
 
         // Set represented filename for macOS
         if (process.platform === 'darwin') {

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -4,6 +4,11 @@ import {
     type TrackerDeepLinkTarget,
     type TrackerDeepLinkView,
 } from '../shared/trackerDeepLinks';
+import {
+    OPEN_FILE_DEEP_LINK_HOST,
+    parseOpenFileDeepLink,
+    type OpenFileDeepLinkTarget,
+} from './utils/openFileLinks';
 import { parseInviteDeepLink, type InviteDeepLinkTarget } from '../shared/inviteDeepLinks';
 import { resolveOrgMessagingDestination } from '../shared/orgMessagingRouting';
 import { safeHandle, safeOn } from './utils/ipcRegistry';
@@ -1117,6 +1122,15 @@ async function handleDeepLink(url: string): Promise<void> {
                 trackerLink.orgId,
                 trackerLink.view,
             );
+        } else if (parsed.host === OPEN_FILE_DEEP_LINK_HOST || parsed.pathname === `/${OPEN_FILE_DEEP_LINK_HOST}`) {
+            // Open a local file, optionally at a line:
+            // nimbalyst://open?path=/abs/file[&line=N][&workspace=/abs/ws]
+            const target = parseOpenFileDeepLink(url);
+            if (!target) {
+                logger.main.warn('[DeepLink] Invalid open-file link:', summarizeDeepLink(url));
+                return;
+            }
+            await openFileFromDeepLink(target);
         } else {
             logger.main.warn('[DeepLink] Unknown deep link:', summarizeDeepLink(url));
         }
@@ -1501,6 +1515,48 @@ async function openTrackerFromDeepLink(
     return true;
 }
 
+/**
+ * Deep-link twin of the OS open-file path. Deliberately stricter than
+ * openFileWithWorkspaceDetection's fallbacks: a link any web page can mint
+ * must not enroll new workspaces or land arbitrary files in the frontmost
+ * window. The target must exist, be a regular file, and resolve (post-symlink)
+ * into a known workspace — or into the hinted workspace when that workspace is
+ * already open — else we warn and stop.
+ */
+async function openFileFromDeepLink(target: OpenFileDeepLinkTarget): Promise<boolean> {
+    let realPath: string;
+    try {
+        realPath = fs.realpathSync(target.path);
+    } catch {
+        logger.main.warn('[DeepLink] Open-file target does not exist:', { path: target.path });
+        return false;
+    }
+    let stats: fs.Stats;
+    try {
+        stats = fs.statSync(realPath);
+    } catch {
+        logger.main.warn('[DeepLink] Open-file target is not readable:', { path: realPath });
+        return false;
+    }
+    if (!stats.isFile()) {
+        logger.main.warn('[DeepLink] Open-file target is not a regular file:', { path: realPath });
+        return false;
+    }
+
+    const detectedWorkspace = detectFileWorkspace(realPath);
+    const hintedWindow = target.workspacePath ? findWindowByWorkspace(target.workspacePath) : null;
+    const hintContains = target.workspacePath
+        ? realPath.startsWith(path.normalize(target.workspacePath) + path.sep)
+        : false;
+    if (!detectedWorkspace && !(hintedWindow && !hintedWindow.isDestroyed() && hintContains)) {
+        logger.main.warn('[DeepLink] Open-file target is outside known workspaces:', { path: realPath });
+        return false;
+    }
+
+    await openFileWithWorkspaceDetection(realPath, target.line ? { line: target.line } : undefined);
+    return true;
+}
+
 // Handle file open from OS (macOS)
 app.on('open-file', (event, path) => {
     event.preventDefault();
@@ -1515,11 +1571,16 @@ app.on('open-file', (event, path) => {
 });
 
 // Helper function to open a file with workspace detection
-async function openFileWithWorkspaceDetection(filePath: string): Promise<void> {
+async function openFileWithWorkspaceDetection(filePath: string, reveal?: { line: number }): Promise<void> {
     // Check if file is already open in a window
     const existingWindow = findWindowByFilePath(filePath);
     if (existingWindow) {
-        // Window is already open - no need to focus, let macOS handle window ordering
+        // Window is already open - no need to focus, let macOS handle window
+        // ordering. A requested line still travels: re-sending open-document
+        // switches to the tab and scrolls without reloading anything.
+        if (reveal) {
+            await loadFileIntoWindow(existingWindow, filePath, reveal);
+        }
         return;
     }
 
@@ -1535,7 +1596,7 @@ async function openFileWithWorkspaceDetection(filePath: string): Promise<void> {
 
         if (workspaceWindow) {
             // Workspace window exists, use it - no need to focus, let macOS handle window ordering
-            await loadFileIntoWindow(workspaceWindow, filePath);
+            await loadFileIntoWindow(workspaceWindow, filePath, reveal);
         } else {
             // Create new workspace window for this workspace
             workspaceWindow = createWindow(false, true, workspacePath, undefined, {
@@ -1548,7 +1609,7 @@ async function openFileWithWorkspaceDetection(filePath: string): Promise<void> {
             workspaceWindow.once('ready-to-show', async () => {
                 // Window state is already set by createWindow with workspace path
                 // Just load the file
-                await loadFileIntoWindow(workspaceWindow!, filePath);
+                await loadFileIntoWindow(workspaceWindow!, filePath, reveal);
             });
         }
     } else {
@@ -1557,7 +1618,7 @@ async function openFileWithWorkspaceDetection(filePath: string): Promise<void> {
 
         const frontmostWindow = getMostRecentlyFocusedWorkspaceWindow();
         if (frontmostWindow) {
-            await loadFileIntoWindow(frontmostWindow, filePath);
+            await loadFileIntoWindow(frontmostWindow, filePath, reveal);
         } else {
             // No workspace windows open - try to detect a project root and open it
             const suggestedWorkspace = suggestWorkspaceForFile(filePath);
@@ -1570,7 +1631,7 @@ async function openFileWithWorkspaceDetection(filePath: string): Promise<void> {
                 });
                 updateTrackerSchemaWorkspace(suggestedWorkspace);
                 newWindow.once('ready-to-show', async () => {
-                    await loadFileIntoWindow(newWindow, filePath);
+                    await loadFileIntoWindow(newWindow, filePath, reveal);
                 });
             } else {
                 // No project root detected - use the file's directory as workspace
@@ -1583,7 +1644,7 @@ async function openFileWithWorkspaceDetection(filePath: string): Promise<void> {
                 });
                 updateTrackerSchemaWorkspace(fileDir);
                 newWindow.once('ready-to-show', async () => {
-                    await loadFileIntoWindow(newWindow, filePath);
+                    await loadFileIntoWindow(newWindow, filePath, reveal);
                 });
             }
         }

--- a/packages/electron/src/main/utils/__tests__/openFileLinks.test.ts
+++ b/packages/electron/src/main/utils/__tests__/openFileLinks.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { parseOpenFileDeepLink } from '../openFileLinks';
+
+describe('open-file deep links', () => {
+  it('parses the host form with an absolute path', () => {
+    expect(
+      parseOpenFileDeepLink('nimbalyst://open?path=%2FUsers%2Fme%2Fnotes%2Fplan.md'),
+    ).toEqual({ path: '/Users/me/notes/plan.md' });
+  });
+
+  it('parses the empty-host form and preserves spaces and unicode', () => {
+    expect(
+      parseOpenFileDeepLink(
+        'nimbalyst:///open?path=' +
+          encodeURIComponent('/Users/me/Мои заметки/план недели.md'),
+      ),
+    ).toEqual({ path: '/Users/me/Мои заметки/план недели.md' });
+  });
+
+  it('accepts a positive integer line and an absolute workspace hint', () => {
+    expect(
+      parseOpenFileDeepLink(
+        'nimbalyst://open?path=%2Fws%2Fsrc%2Fmain.ts&line=42&workspace=%2Fws',
+      ),
+    ).toEqual({ path: '/ws/src/main.ts', line: 42, workspacePath: '/ws' });
+  });
+
+  it('rejects invalid line values outright instead of degrading', () => {
+    for (const line of ['0', '-1', 'abc', '1.5', '']) {
+      expect(
+        parseOpenFileDeepLink(`nimbalyst://open?path=%2Fws%2Fa.md&line=${line}`),
+      ).toBeNull();
+    }
+  });
+
+  it('requires an absolute, NUL-free path', () => {
+    expect(parseOpenFileDeepLink('nimbalyst://open')).toBeNull();
+    expect(parseOpenFileDeepLink('nimbalyst://open?path=relative%2Fa.md')).toBeNull();
+    expect(parseOpenFileDeepLink('nimbalyst://open?path=%2Fws%2Fa%00.md')).toBeNull();
+  });
+
+  it('rejects a relative workspace hint', () => {
+    expect(
+      parseOpenFileDeepLink('nimbalyst://open?path=%2Fws%2Fa.md&workspace=ws'),
+    ).toBeNull();
+  });
+
+  it('rejects foreign protocols, other hosts, extra segments, and fragments', () => {
+    expect(parseOpenFileDeepLink('https://open?path=%2Fws%2Fa.md')).toBeNull();
+    expect(parseOpenFileDeepLink('nimbalyst://opened?path=%2Fws%2Fa.md')).toBeNull();
+    expect(parseOpenFileDeepLink('nimbalyst://open/extra?path=%2Fws%2Fa.md')).toBeNull();
+    expect(parseOpenFileDeepLink('nimbalyst://open?path=%2Fws%2Fa.md#frag')).toBeNull();
+    expect(parseOpenFileDeepLink('not a url')).toBeNull();
+  });
+});

--- a/packages/electron/src/main/utils/openFileLinks.ts
+++ b/packages/electron/src/main/utils/openFileLinks.ts
@@ -1,0 +1,67 @@
+import * as path from 'path';
+
+export const OPEN_FILE_DEEP_LINK_HOST = 'open';
+
+export interface OpenFileDeepLinkTarget {
+  path: string;
+  line?: number;
+  workspacePath?: string;
+}
+
+const LINE_RE = /^[1-9]\d*$/;
+
+/**
+ * Parse `nimbalyst://open?path=/abs/file[&line=N][&workspace=/abs/ws]`.
+ *
+ * Null-returning like parseFeedbackRequestDeepLink — main logs one warning per
+ * invalid link. Strict by design: this host is mintable by any web page, so
+ * anything short of an absolute, NUL-free path (and a positive integer line /
+ * absolute workspace, when given) rejects the whole link instead of degrading.
+ * Filesystem checks (exists, regular file, known workspace) stay with the
+ * caller in main — this module is pure URL grammar.
+ */
+export function parseOpenFileDeepLink(rawUrl: string): OpenFileDeepLinkTarget | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  // `nimbalyst://open?…` parses as host 'open' with an empty pathname;
+  // `nimbalyst:///open?…` as an empty host with pathname '/open'. Accept both,
+  // reject anything with extra path segments or a fragment.
+  const hostForm =
+    parsed.host === OPEN_FILE_DEEP_LINK_HOST &&
+    (parsed.pathname === '' || parsed.pathname === '/');
+  const pathnameForm =
+    parsed.host === '' && parsed.pathname === `/${OPEN_FILE_DEEP_LINK_HOST}`;
+  if (parsed.protocol !== 'nimbalyst:' || (!hostForm && !pathnameForm) || parsed.hash) {
+    return null;
+  }
+
+  const filePath = parsed.searchParams.get('path');
+  if (!filePath || filePath.includes('\0') || !path.isAbsolute(filePath)) {
+    return null;
+  }
+
+  const target: OpenFileDeepLinkTarget = { path: filePath };
+
+  const line = parsed.searchParams.get('line');
+  if (line !== null) {
+    if (!LINE_RE.test(line)) {
+      return null;
+    }
+    target.line = Number(line);
+  }
+
+  const workspace = parsed.searchParams.get('workspace');
+  if (workspace !== null) {
+    if (workspace.includes('\0') || !path.isAbsolute(workspace)) {
+      return null;
+    }
+    target.workspacePath = workspace;
+  }
+
+  return target;
+}

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -148,8 +148,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('open-workspace-file', handler);
     return () => ipcRenderer.removeListener('open-workspace-file', handler);
   },
-  onOpenDocument: (callback: (data: { path: string }) => void) => {
-    const handler = (_event: any, data: { path: string }) => callback(data);
+  onOpenDocument: (callback: (data: { path: string; line?: number }) => void) => {
+    const handler = (_event: any, data: { path: string; line?: number }) => callback(data);
     ipcRenderer.on('open-document', handler);
     return () => ipcRenderer.removeListener('open-document', handler);
   },

--- a/packages/electron/src/renderer/electron.d.ts
+++ b/packages/electron/src/renderer/electron.d.ts
@@ -266,7 +266,7 @@ interface ElectronAPI {
   // Workspace callbacks
   onWorkspaceOpened: (callback: (data: { workspacePath: string; workspaceName: string; fileTree: FileTreeItem[] }) => void) => () => void;
   onOpenWorkspaceFile: (callback: (filePath: string) => void) => () => void;
-  onOpenDocument: (callback: (data: { path: string }) => void) => () => void;
+  onOpenDocument: (callback: (data: { path: string; line?: number }) => void) => () => void;
   onOpenWorkspaceFromCLI: (callback: (workspacePath: string) => void) => () => void;
   onWorkspaceFileTreeUpdated: (callback: (data: { fileTree: FileTreeItem[]; addedPath?: string; removedPath?: string }) => void) => () => void;
 

--- a/packages/electron/src/renderer/hooks/useIPCHandlers.ts
+++ b/packages/electron/src/renderer/hooks/useIPCHandlers.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useAtomValue } from 'jotai';
+import type { EditorRevealPosition } from '../components/TabEditor/editorRevealCommand';
 import type { LexicalCommand, TextReplacement } from '@nimbalyst/runtime';
 import {
   APPROVE_DIFF_COMMAND,
@@ -129,7 +130,7 @@ interface UseIPCHandlersProps {
   handleOpen: () => Promise<void>;
   handleSave: () => Promise<void>;
   handleSaveAs: () => Promise<void>;
-  handleWorkspaceFileSelect: (filePath: string) => Promise<void>;
+  handleWorkspaceFileSelect: (filePath: string, location?: EditorRevealPosition) => Promise<void>;
   openWelcomeTab: () => Promise<void>;
   openFeedback: () => void;
   // State setters
@@ -360,10 +361,10 @@ export function useIPCHandlers(props: UseIPCHandlersProps) {
     }
 
     if (window.electronAPI.onOpenDocument) {
-      cleanupFns.push(window.electronAPI.onOpenDocument(async ({ path }) => {
+      cleanupFns.push(window.electronAPI.onOpenDocument(async ({ path, line }) => {
         // console.log('[DOCUMENT_LINK] Renderer received open-document for path:', path);
         try {
-          await handlersRef.current.handleWorkspaceFileSelect(path);
+          await handlersRef.current.handleWorkspaceFileSelect(path, line ? { line } : undefined);
         } catch (error) {
           console.error('[DOCUMENT_LINK] Failed to open document reference:', error);
         }


### PR DESCRIPTION
Closes #1352.

## What

New `open` deep-link host: `nimbalyst://open?path=/abs/file[&line=N][&workspace=/abs/ws]` opens the file in the workspace that contains it, optionally scrolling to a 1-based line.

## How

- Pure URL-grammar parser in `main/utils/openFileLinks.ts` (null-returning, `feedbackRequestLinks`/`appActionLinks` style) with unit tests (`@vitest-environment node`): absolute NUL-free `path`, `line` must be a positive integer, `workspace` hint must be absolute; both `nimbalyst://open?…` and `nimbalyst:///open?…` forms; extra segments and fragments reject.
- A `handleDeepLink` branch → `openFileFromDeepLink`: `realpath` → regular-file → known-workspace gate, then delegates to the existing `openFileWithWorkspaceDetection`.
- Deliberately **stricter than the OS open-file path**: a link any web page can mint must not enroll new workspaces and must not land arbitrary files in the frontmost window — the three unknown-workspace fallbacks are refused with a warn. The `workspace` hint is honored only when that workspace is already open and (post-symlink) contains the file.
- `line=N` threads additively through the existing `EditorRevealPosition` plumbing (`loadFileIntoWindow` → `open-document` → `handleWorkspaceFileSelect`); the pending-reveal registry already covers editors that are still mounting. An already-open file with a line re-sends `open-document` (tab switch + scroll, no reload); without a line the OS path is behavior-unchanged.

## Reviewer flags

1. "Known workspace" = `detectFileWorkspace` (the recent-workspaces list), consistent with the app's own routing; open-windows-only would be stricter — happy to tighten if preferred.
2. The `path` param is logged verbatim via `summarizeDeepLink`, consistent with existing open-file logging — can add it to `SENSITIVE_DEEP_LINK_PARAMS` at the cost of diagnosability.
3. The runtime path reuses the production OS-open plumbing unchanged; I did not run the macOS `dev:url-handler` smoke. Windows drive-letter paths rely on `path.isAbsolute` after percent-decoding — untested on Windows.
4. Unrelated local observation while running the pre-push gate: on an en-GB-locale machine, 10 tests fail on clean `main` — 4 in `trackerDateDisplay` expect en-US date rendering, and 6 in `AgentTranscriptPanel.listenerCleanup` / `MarkdownRenderer.rtl` hit an undefined `localStorage`. Happy to file that separately if useful.

## Checks

- `npm run typecheck` ✅ (including the electron workspace after threading the reveal type through `UseIPCHandlersProps`)
- New unit tests pass; the 10 pre-existing/environment failures above reproduce on clean `main` on this machine
- `packages/electron` `npm run lint` ✅
- DCO signed-off; CHANGELOG has one user-facing line under `[Unreleased] → Added`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
