### PR TITLE
fix: open the database that holds the data, not the one the flag names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+
+### Removed
+<!-- Removed features go here -->
+
+## [0.74.4] - 2026-08-22
+
+
+### Added
+<!-- New features go here -->
+
+### Changed
+<!-- Changes to existing functionality go here -->
+
+### Fixed
+<!-- Bug fixes go here -->
 - Installs that came up with an empty database now open the one that actually holds their sessions.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Installs that came up with an empty database now open the one that actually holds their sessions.
 
 ### Removed
 <!-- Removed features go here -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -24501,7 +24501,7 @@
     },
     "packages/electron": {
       "name": "@nimbalyst/electron",
-      "version": "0.74.3",
+      "version": "0.74.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbalyst/electron",
-  "version": "0.74.3",
+  "version": "0.74.4",
   "private": true,
   "license": "MIT",
   "author": "Nimbalyst Team",

--- a/packages/electron/src/main/database/initialize.ts
+++ b/packages/electron/src/main/database/initialize.ts
@@ -235,6 +235,18 @@ export async function initializeDatabase(): Promise<SessionStore> {
       await timeStartupPhase('SQLite.initialize', () => database.initialize());
       logger.main.info('[Database] SQLite initialized successfully (worker-hosted)');
     } else {
+      // Opening PGLite here CREATES `pglite-db/` when it is absent, so this is
+      // the exact point at which #1347 turned a bad flag file into an empty
+      // database. `resolveBackend` now heals that contradiction before we get
+      // here, which leaves only two ways to reach this line without a store:
+      // a rollback install whose PGLite was moved by hand, or a bug in the
+      // guard. Neither may be silent again.
+      if (!fs.existsSync(dbPath)) {
+        logger.main.error(
+          `[Database] Resolved to PGLite (reason: ${backendChoice.reason}) but ${dbPath} does not exist; ` +
+            'a new empty database is about to be created. If this install had sessions, they are not in PGLite.',
+        );
+      }
       backupService = new DatabaseBackupService(dbPath, legacyPgliteDatabase);
       await timeStartupPhase('BackupService.initialize', () => backupService!.initialize());
       legacyPgliteDatabase.setBackupService(backupService);

--- a/packages/electron/src/main/database/sqlite/BackendSelector.ts
+++ b/packages/electron/src/main/database/sqlite/BackendSelector.ts
@@ -151,12 +151,19 @@ const SQLITE_DB_RELPATH = path.join('sqlite-db', 'nimbalyst.sqlite');
 /**
  * Below this a `nimbalyst.sqlite` is a stub, not a store. The floor exists only
  * to reject a zero-byte or half-created file -- the contradiction itself is
- * what carries the decision, so this is deliberately generous. Erring low is
- * the safe direction: when the flag's own backend has no store on disk, booting
- * it creates an empty database, so there is no case where honouring the flag
- * beats switching to the store that does exist.
+ * what carries the decision.
+ *
+ * Keep it far below a real database. A schema-only store at migration v34
+ * measures ~836 KB before a single message is written, so a floor anywhere near
+ * a megabyte silently excludes light-but-genuine installs: the first draft of
+ * this guard used 1 MB and failed to heal a 7-session fixture.
+ *
+ * Erring low is the safe direction. When the flag's own backend has no store on
+ * disk, booting it creates an empty database, so there is no case where
+ * honouring the flag beats switching to the store that does exist -- even a
+ * near-empty one. The floor is a sanity check, not a judgement about value.
  */
-const SQLITE_PLAUSIBLE_MIN_BYTES = 1024 * 1024;
+const SQLITE_PLAUSIBLE_MIN_BYTES = 64 * 1024;
 
 export interface BackendContradictionFacts {
   /** What the flag file claims. */

--- a/packages/electron/src/main/database/sqlite/BackendSelector.ts
+++ b/packages/electron/src/main/database/sqlite/BackendSelector.ts
@@ -52,7 +52,9 @@ export interface BackendState {
     | 'user-migration'
     | 'auto-migration'
     | 'auto-migration-deferred'
-    | 'rollback';
+    | 'rollback'
+    /** Written by `resolveBackend` when the flag contradicted the disk (#1347). */
+    | 'contradiction-heal';
   /** Optional pointer to the preserved pre-migration PGLite directory. */
   pgliteMigratedDir?: string;
   /** Auto-migration back-off bookkeeping. Absent until the first failure. */
@@ -139,7 +141,91 @@ export type BackendReason =
   | 'flag-file-pglite-rollback'
   | 'flag-file-sqlite'
   | 'fresh-install-defaults-sqlite'
-  | 'existing-pglite-migration-due';
+  | 'existing-pglite-migration-due'
+  | 'flag-contradiction-healed-sqlite'
+  | 'flag-contradiction-healed-pglite';
+
+/** Live SQLite store, relative to userData. */
+const SQLITE_DB_RELPATH = path.join('sqlite-db', 'nimbalyst.sqlite');
+
+/**
+ * Below this a `nimbalyst.sqlite` is a stub, not a store. The floor exists only
+ * to reject a zero-byte or half-created file -- the contradiction itself is
+ * what carries the decision, so this is deliberately generous. Erring low is
+ * the safe direction: when the flag's own backend has no store on disk, booting
+ * it creates an empty database, so there is no case where honouring the flag
+ * beats switching to the store that does exist.
+ */
+const SQLITE_PLAUSIBLE_MIN_BYTES = 1024 * 1024;
+
+export interface BackendContradictionFacts {
+  /** What the flag file claims. */
+  flagBackend: DatabaseBackend;
+  flagSetBy: BackendState['setBy'];
+  pgliteDirExists: boolean;
+  /** Size of `sqlite-db/nimbalyst.sqlite`; 0 when absent. */
+  sqliteDbBytes: number;
+}
+
+export type BackendContradictionVerdict =
+  | { action: 'honor' }
+  | { action: 'override'; backend: DatabaseBackend; reason: string };
+
+/**
+ * Does the flag file name a backend whose store is not on disk, while the other
+ * backend's store is?
+ *
+ * Pure, and every input is a fact from OUTSIDE the flag file, because a flag
+ * file cannot vouch for itself -- the same reasoning as `assessMigrationSource`
+ * (NIM-3632) and required by `.claude/rules/destructive-data-paths.md`.
+ *
+ * This exists because pre-0.74.2 builds wrote `{backend: 'pglite', setBy:
+ * 'auto-migration-deferred'}` over installs that were running on SQLite, and
+ * `b8f33e474` only stopped new writes. An install poisoned before it upgraded
+ * still resolves to PGLite, and because PGLite *creates* `pglite-db/` when it
+ * is missing, it boots an empty database and orphans the real one (#1347).
+ */
+export function assessBackendContradiction(
+  facts: BackendContradictionFacts,
+): BackendContradictionVerdict {
+  // A rollback is the user telling us SQLite went badly for them. Their PGLite
+  // store may legitimately be missing (restored by hand, moved, not yet copied
+  // back); overriding it would be exactly the surprise they opted out of.
+  if (facts.flagSetBy === 'rollback') return { action: 'honor' };
+
+  const sqliteIsPlausible = facts.sqliteDbBytes >= SQLITE_PLAUSIBLE_MIN_BYTES;
+
+  if (facts.flagBackend === 'pglite' && !facts.pgliteDirExists && sqliteIsPlausible) {
+    return {
+      action: 'override',
+      backend: 'sqlite',
+      reason:
+        'flag file says pglite but there is no pglite-db/ on disk, while ' +
+        'sqlite-db/nimbalyst.sqlite holds data',
+    };
+  }
+
+  if (facts.flagBackend === 'sqlite' && !sqliteIsPlausible && facts.pgliteDirExists) {
+    return {
+      action: 'override',
+      backend: 'pglite',
+      reason:
+        'flag file says sqlite but there is no usable sqlite-db/nimbalyst.sqlite, ' +
+        'while pglite-db/ exists',
+    };
+  }
+
+  return { action: 'honor' };
+}
+
+/** Size of a file, or 0 when it is missing or unreadable. */
+function fileBytes(filePath: string): number {
+  try {
+    return fs.statSync(filePath).size;
+  } catch {
+    return 0;
+  }
+}
 
 export interface ResolvedBackend {
   backend: DatabaseBackend;
@@ -154,10 +240,14 @@ export interface ResolvedBackend {
 }
 
 /**
- * Resolve which backend should be active on launch. Reads the filesystem;
- * never writes (the migration flow does that).
+ * Resolve which backend should be active on launch.
  *
  * Decision tree:
+ *   0. Flag file contradicted by the disk -> heal it, and persist the
+ *      correction so this is a one-time event (see
+ *      `assessBackendContradiction`). Checked first: every branch below trusts
+ *      the flag, and a flag that names a store which is not there cannot be
+ *      trusted by any of them.
  *   1. Flag file says sqlite -> SQLite. Done, nothing due.
  *   2. Flag file says pglite via `rollback` -> PGLite, permanently. The user
  *      migrated, hit a problem, and chose to go back. Never auto-migrate them.
@@ -165,10 +255,47 @@ export interface ResolvedBackend {
  *      migration) -> PGLite, migration due.
  *   4. No flag file but `pglite-db/` exists -> PGLite, migration due.
  *   5. Otherwise -> fresh install, SQLite.
+ *
+ * Writes only in case 0, and only to correct itself. The write is wrapped
+ * because a read-only userData must not turn a recoverable boot into a failed
+ * one -- an un-persisted heal still resolves correctly, it just re-runs next
+ * launch.
  */
 export function resolveBackend(input: ResolveBackendInput): ResolvedBackend {
   const state = readBackendState(input.userDataPath);
   if (state) {
+    const verdict = assessBackendContradiction({
+      flagBackend: state.backend,
+      flagSetBy: state.setBy,
+      pgliteDirExists: fs.existsSync(path.join(input.userDataPath, 'pglite-db')),
+      sqliteDbBytes: fileBytes(path.join(input.userDataPath, SQLITE_DB_RELPATH)),
+    });
+    if (verdict.action === 'override') {
+      const healed: BackendState = {
+        ...state,
+        backend: verdict.backend,
+        setAt: new Date().toISOString(),
+        setBy: 'contradiction-heal',
+      };
+      try {
+        writeBackendState(input.userDataPath, healed);
+      } catch {
+        // Resolution below still uses `healed`; the correction just is not
+        // durable, so the next launch heals again. Never fail the boot here.
+      }
+      return {
+        backend: verdict.backend,
+        reason:
+          verdict.backend === 'sqlite'
+            ? 'flag-contradiction-healed-sqlite'
+            : 'flag-contradiction-healed-pglite',
+        state: healed,
+        // A healed install is on the store that actually holds its data. It may
+        // still be a migration candidate later, but not on the launch where we
+        // just discovered the flag was lying.
+        migrationDue: false,
+      };
+    }
     if (state.backend === 'sqlite') {
       return { backend: 'sqlite', reason: 'flag-file-sqlite', state, migrationDue: false };
     }

--- a/packages/electron/src/main/database/sqlite/__tests__/BackendSelector.test.ts
+++ b/packages/electron/src/main/database/sqlite/__tests__/BackendSelector.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -107,5 +108,89 @@ describe('BackendSelector', () => {
     fs.writeFileSync(path.join(tmp, 'database-backend.json'), '{not json');
     const result = resolveBackend({ userDataPath: tmp });
     expect(result.backend).toBe('sqlite'); // no pglite-db -> fresh install
+  });
+
+  // #1347, second variant. The write-side fix above stops NEW poison; these
+  // cover installs whose flag file was already wrong when they upgraded.
+  // Every signal here comes from outside the flag file, because a flag file
+  // cannot vouch for itself -- see `migrationSourcePlausibility.ts` (NIM-3632).
+  describe('contradicted flag file (NIM-3686)', () => {
+    /** A SQLite store with plausible content in it. */
+    const writeSqliteDb = (bytes: number) => {
+      fs.mkdirSync(path.join(tmp, 'sqlite-db'), { recursive: true });
+      fs.writeFileSync(path.join(tmp, 'sqlite-db', 'nimbalyst.sqlite'), Buffer.alloc(bytes));
+    };
+
+    /** The exact state pre-0.74.2 builds wrote over a fresh SQLite install. */
+    const writePoisonedFlag = () => {
+      fs.writeFileSync(
+        path.join(tmp, 'database-backend.json'),
+        JSON.stringify({
+          backend: 'pglite',
+          setAt: '2026-08-20T15:00:46.561Z',
+          setBy: 'auto-migration-deferred',
+          forceMigrationFlag: false,
+        }),
+      );
+    };
+
+    it('refuses a pglite flag when pglite-db is absent and sqlite-db holds data', () => {
+      writePoisonedFlag();
+      writeSqliteDb(64 * 1024 * 1024);
+      const result = resolveBackend({ userDataPath: tmp });
+      expect(result.backend).toBe('sqlite');
+      expect(result.reason).toBe('flag-contradiction-healed-sqlite');
+      expect(result.migrationDue).toBe(false);
+    });
+
+    // Two boots, because the bug only appears on launch two and because
+    // `commitFreshInstallSqlite` was once green-tested with zero callers.
+    it('persists the correction so the second launch is no longer contradicted', () => {
+      writePoisonedFlag();
+      writeSqliteDb(64 * 1024 * 1024);
+
+      resolveBackend({ userDataPath: tmp }); // boot 1: heals
+      expect(readBackendState(tmp)?.backend).toBe('sqlite');
+
+      const second = resolveBackend({ userDataPath: tmp }); // boot 2: ordinary
+      expect(second.backend).toBe('sqlite');
+      expect(second.reason).toBe('flag-file-sqlite');
+      expect(second.migrationDue).toBe(false);
+    });
+
+    it('heals the symmetric case: sqlite flag, no sqlite-db, pglite-db present', () => {
+      fs.mkdirSync(path.join(tmp, 'pglite-db'));
+      commitMigrationToSqlite(tmp, '/some/pglite-db.migrated-12345');
+      const result = resolveBackend({ userDataPath: tmp });
+      expect(result.backend).toBe('pglite');
+      expect(result.reason).toBe('flag-contradiction-healed-pglite');
+    });
+
+    it('honours the flag when both stores exist -- that is the ordinary migration path', () => {
+      fs.mkdirSync(path.join(tmp, 'pglite-db'));
+      writePoisonedFlag();
+      writeSqliteDb(64 * 1024 * 1024);
+      const result = resolveBackend({ userDataPath: tmp });
+      expect(result.backend).toBe('pglite');
+      expect(result.reason).toBe('existing-pglite-migration-due');
+      expect(result.migrationDue).toBe(true);
+    });
+
+    // A zero-byte or half-created file is not evidence of anything, and
+    // overriding on it would be its own way to strand a user.
+    it('does not heal on a stub sqlite file below the floor', () => {
+      writePoisonedFlag();
+      writeSqliteDb(1024);
+      const result = resolveBackend({ userDataPath: tmp });
+      expect(result.reason).toBe('existing-pglite-migration-due');
+    });
+
+    it('leaves a rollback install alone even with no pglite-db on disk', () => {
+      commitRollbackToPglite(tmp);
+      writeSqliteDb(64 * 1024 * 1024);
+      const result = resolveBackend({ userDataPath: tmp });
+      expect(result.backend).toBe('pglite');
+      expect(result.reason).toBe('flag-file-pglite-rollback');
+    });
   });
 });

--- a/packages/electron/src/main/database/sqlite/__tests__/BackendSelector.test.ts
+++ b/packages/electron/src/main/database/sqlite/__tests__/BackendSelector.test.ts
@@ -185,6 +185,18 @@ describe('BackendSelector', () => {
       expect(result.reason).toBe('existing-pglite-migration-due');
     });
 
+    // The floor must sit below a schema-only store, not above it. An empty
+    // database at migration v34 is ~836 KB before any message is written; the
+    // first draft used a 1 MB floor and left exactly this install booting
+    // empty. Sized from a real fixture, not guessed.
+    it('heals a light install whose store is barely larger than the bare schema', () => {
+      writePoisonedFlag();
+      writeSqliteDb(856_064);
+      const result = resolveBackend({ userDataPath: tmp });
+      expect(result.backend).toBe('sqlite');
+      expect(result.reason).toBe('flag-contradiction-healed-sqlite');
+    });
+
     it('leaves a rollback install alone even with no pglite-db on disk', () => {
       commitRollbackToPglite(tmp);
       writeSqliteDb(64 * 1024 * 1024);

--- a/support/force-restore-database-backup.md
+++ b/support/force-restore-database-backup.md
@@ -2,60 +2,80 @@
 
 When a user's Nimbalyst database is in a bad state, they can manually restore from the most recent verified backup.
 
+## Step 0: find out which storage engine the install is using
+
+**Do this first.** Nimbalyst runs on one of two storage engines, each with its own database and its own backups. Restoring the wrong engine's backup will not recover anything, and can overwrite a good database with an empty one.
+
+Check the flag file:
+
+```bash
+cat "<app data>/database-backend.json"
+```
+
+Or read the first line the database layer logs at startup, in `<app data>/logs/main.log`:
+
+```
+[Database] Backend selector resolved to 'sqlite' (reason: flag-file-sqlite)
+```
+
+`<app data>` is:
+
+| Platform | Path |
+| --- | --- |
+| macOS | `~/Library/Application Support/@nimbalyst/electron` |
+| Windows | `%APPDATA%\@nimbalyst\electron` |
+| Linux | `~/.config/@nimbalyst/electron` |
+
+Then follow the matching section below. If the two engines disagree, or the flag names an engine whose folder does not exist, go to [When the flag file is wrong](#when-the-flag-file-is-wrong).
+
 ## Background
 
-Nimbalyst maintains rolling backups of the PGLite database:
-- `pglite-db.backup-current` - most recent verified backup
-- `pglite-db.backup-previous` - second most recent
-- `pglite-db.backup-oldest` - third most recent
+Both engines keep three rolling backups, created every 4 hours and verified before being stored.
 
-Backups are created every 4 hours and verified before being stored.
+| Engine | Live database | Backups |
+| --- | --- | --- |
+| SQLite | `sqlite-db/nimbalyst.sqlite` | `sqlite-db.backups/nimbalyst.backup-{current,previous,oldest}.sqlite` |
+| PGLite | `pglite-db/` | `db-backups/pglite-db.backup-{current,previous,oldest}` |
 
-## Instructions
+A PGLite install may also have a `pglite-db.backup-<timestamp>` folder sitting directly in the app data folder. That is a database an older build renamed aside when it failed to open; it is usually the user's real data and is worth checking before anything else.
 
-### macOS
+## Restoring on SQLite
 
 ```bash
-# 1. Quit Nimbalyst completely (Cmd+Q)
+# 1. Quit Nimbalyst completely (Cmd+Q on macOS)
 
-# 2. Open Terminal and navigate to the app data folder
-cd ~/Library/Application\ Support/Nimbalyst
+# 2. Navigate to the app data folder (see the table above)
+cd ~/Library/Application\ Support/@nimbalyst/electron
 
-# 3. Rename the corrupted database (preserves it just in case)
-mv pglite-db pglite-db.bad
+# 3. Move the bad database aside, including its WAL/SHM siblings
+mkdir -p sqlite-db.bad && mv sqlite-db/nimbalyst.sqlite* sqlite-db.bad/
 
 # 4. Copy the most recent backup into place
-cp -r db-backups/pglite-db.backup-current pglite-db
+cp sqlite-db.backups/nimbalyst.backup-current.sqlite sqlite-db/nimbalyst.sqlite
 
 # 5. Start Nimbalyst
 ```
 
-### Windows (PowerShell)
+Use `nimbalyst.backup-previous.sqlite` or `nimbalyst.backup-oldest.sqlite` if the most recent one is also bad.
+
+On Windows, the same steps in PowerShell:
 
 ```powershell
-# 1. Quit Nimbalyst completely
-
-# 2. Open PowerShell and navigate to app data
-cd "$env:APPDATA\Nimbalyst"
-
-# 3. Rename the corrupted database
-Rename-Item pglite-db pglite-db.bad
-
-# 4. Copy the backup
-Copy-Item -Recurse db-backups\pglite-db.backup-current pglite-db
-
-# 5. Start Nimbalyst
+cd "$env:APPDATA\@nimbalyst\electron"
+New-Item -ItemType Directory -Force sqlite-db.bad
+Move-Item sqlite-db\nimbalyst.sqlite* sqlite-db.bad\
+Copy-Item sqlite-db.backups\nimbalyst.backup-current.sqlite sqlite-db\nimbalyst.sqlite
 ```
 
-### Linux
+## Restoring on PGLite
 
 ```bash
-# 1. Quit Nimbalyst completely
+# 1. Quit Nimbalyst completely (Cmd+Q on macOS)
 
-# 2. Navigate to the config folder
-cd ~/.config/Nimbalyst
+# 2. Navigate to the app data folder (see the table above)
+cd ~/Library/Application\ Support/@nimbalyst/electron
 
-# 3. Rename the corrupted database
+# 3. Rename the bad database (preserves it just in case)
 mv pglite-db pglite-db.bad
 
 # 4. Copy the most recent backup into place
@@ -64,17 +84,37 @@ cp -r db-backups/pglite-db.backup-current pglite-db
 # 5. Start Nimbalyst
 ```
 
-## Using an Older Backup
+Use `pglite-db.backup-previous` or `pglite-db.backup-oldest` if the most recent one is also bad.
 
-If the most recent backup is also corrupted, try an older one:
+On Windows, the same steps in PowerShell:
 
-```bash
-# Use the previous backup
-cp -r db-backups/pglite-db.backup-previous pglite-db
-
-# Or the oldest backup
-cp -r db-backups/pglite-db.backup-oldest pglite-db
+```powershell
+cd "$env:APPDATA\@nimbalyst\electron"
+Rename-Item pglite-db pglite-db.bad
+Copy-Item -Recurse db-backups\pglite-db.backup-current pglite-db
 ```
+
+## When the flag file is wrong
+
+Some 0.74.0 and 0.74.1 builds wrote `"backend": "pglite"` into `database-backend.json` on installs that were actually running on SQLite. On the next launch the app opened PGLite, created an empty database, and came up looking normal with every session missing. The real data was never touched — it is still in `sqlite-db/`.
+
+The fingerprint, from `logs/main.log`:
+
+```
+[Database] Backend selector resolved to 'pglite' (reason: existing-pglite-migration-due)
+[PGLite] initialize() called - starting fresh initialization
+[autoMigrate] skipping (flag-disabled)
+```
+
+**Do not restore a PGLite backup in this case.** `db-backups/pglite-db.backup-current` will be a backup of the empty database — around 30 MB — and copying it over anything is pure loss. Check sizes before you act: `du -sh sqlite-db pglite-db db-backups/* 2>/dev/null`.
+
+Nimbalyst 0.74.4 and later detect this at startup and correct the flag automatically, so upgrading is the fix. To repair it by hand on an older build, quit the app and point the flag at the engine that actually holds the data:
+
+```json
+{ "backend": "sqlite", "setAt": "2026-01-01T00:00:00.000Z", "setBy": "user-migration", "forceMigrationFlag": false }
+```
+
+The next launch will log `flag-file-sqlite` and open the real database.
 
 ## What Gets Restored
 
@@ -93,5 +133,5 @@ The database backup contains:
 Once you've confirmed the restore worked, you can delete the bad database:
 
 ```bash
-rm -rf pglite-db.bad
+rm -rf pglite-db.bad sqlite-db.bad
 ```


### PR DESCRIPTION
Merge-back of the 0.74.4 hotfix, cut from `v0.74.3`.

Some 0.74.0/0.74.1 builds wrote `"backend": "pglite"` into `database-backend.json` on installs that were running on SQLite. `b8f33e474` (0.74.2) stopped the bad writes but did not heal a flag file that was already wrong, so an affected install still resolves to PGLite on its next launch — and because PGLite creates `pglite-db/` when it is missing, it boots an empty database and orphans the real one.

`resolveBackend` now checks the flag against what is on disk. If the flag names an engine whose store is absent while the other engine's store is present, it uses the one that exists and persists the correction. The decision is a pure function over facts from outside the flag file, since a flag file cannot vouch for itself.

Also:
- `initialize.ts` logs an error if PGLite is ever opened with no database directory, so this cannot be silent again.
- `support/force-restore-database-backup.md` now asks which storage engine you are on before giving any restore commands. The previous version was PGLite-only and would have told an affected user to copy a ~30 MB empty backup over their real database.

Tests went red (3 failures) before the fix and green (16/16) after. Full gate run once: typecheck across 23 workspaces, 10,317 tests.

Still outstanding, deliberately left off the hotfix: making the backup listing engine-aware so `sqlite-db.backups/` appears in the failure dialog. `findRestorableBackups` is shared by three callers including both migration-plausibility paths, and widening it needs the plausibility callers filtered to PGLite first.

Refs #1347