### PR TITLE
fix(git-commit): don't fire a blocked-on-human push when auto-commit is on

### DIFF
--- a/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
@@ -871,6 +871,24 @@ export async function handleGitCommitProposal(
 
   const targetSessionId = sessionId || "unknown";
 
+  // Check if auto-commit is enabled.
+  //
+  // This must be read BEFORE the proposal is announced. When auto-commit is
+  // on, this handler resolves the proposal itself a few lines below, so the
+  // session is never actually blocked on a human -- but marking it pending
+  // fires a forced "Waiting for your response" mobile push (see
+  // notifyMobileOfBlockedSession in services/ai/pendingPromptPersistence.ts,
+  // which passes force: true) for a commit that lands milliseconds later
+  // without any input. Reading the setting first lets us skip the announce.
+  let isAutoCommit = false;
+  try {
+    const Store = (await import("electron-store")).default;
+    const aiSettingsStore = new Store({ name: "ai-settings" });
+    isAutoCommit = aiSettingsStore.get("autoCommitEnabled", false) as boolean;
+  } catch {
+    // If we can't read settings, fall through to manual mode
+  }
+
   // Persist the proposal to database for durability
   try {
     const now = new Date();
@@ -951,21 +969,15 @@ export async function handleGitCommitProposal(
       console.warn("[MCP Server] No commitWindow found to send IPC event");
     }
 
-    // Persist pending-prompt bit + push to mobile (this also notifies the tray)
-    void setSessionPendingPrompt(targetSessionId, true);
+    // Persist pending-prompt bit + push to mobile (this also notifies the tray).
+    // Under auto-commit nothing is waiting on the user, so announcing a pending
+    // prompt would be a false "blocked on human" signal.
+    if (!isAutoCommit) {
+      void setSessionPendingPrompt(targetSessionId, true);
+    }
   } catch (error) {
     console.error("[MCP Server] Failed to persist git commit proposal:", error);
     // Continue anyway - worst case is no durability
-  }
-
-  // Check if auto-commit is enabled
-  let isAutoCommit = false;
-  try {
-    const Store = (await import("electron-store")).default;
-    const aiSettingsStore = new Store({ name: "ai-settings" });
-    isAutoCommit = aiSettingsStore.get("autoCommitEnabled", false) as boolean;
-  } catch {
-    // If we can't read settings, fall through to manual mode
   }
 
   if (isAutoCommit) {


### PR DESCRIPTION
Forwarded: pending (this PR is the forward)
Applied-Upstream: no
Last-Checked: 2026-08-23
Justification: not required (Applied-Upstream is no). Verified path-scoped against upstream/main @ 913c65c06 -- interactiveToolHandlers.ts still calls setSessionPendingPrompt(targetSessionId, true) at L955 and reads autoCommitEnabled at L961, so the defect is unfixed upstream and this change is not already absorbed.

---

## Problem

`handleGitCommitProposal` marks the session as having a pending prompt **before** it reads the `autoCommitEnabled` setting.

`setSessionPendingPrompt(id, true)` calls `notifyMobileOfBlockedSession`, which requests a mobile push with `force: true`:

```ts
// services/ai/pendingPromptPersistence.ts
await requestMobilePush(sessionId, title, 'Waiting for your response', {
  force: true,
  reason: 'awaiting_human',
});
```

So with auto-commit enabled, **every** commit proposal sends an unsuppressable "Waiting for your response" push, then auto-commits and clears the flag milliseconds later without any user input.

Current order in `interactiveToolHandlers.ts`:

| line | what |
|---|---|
| 954-955 | `void setSessionPendingPrompt(targetSessionId, true)` -- pending bit set, **forced push sent** |
| 961-969 | `autoCommitEnabled` read from the settings store |
| 971+ | if auto-commit then `executeGitCommit(...)` |
| 1055 | pending bit cleared |

Observed on every commit the widget produced: the widget renders unchecked, the phone buzzes, the checkbox flips, the commit lands untouched. The session was never blocked on anyone.

Because the push is forced, #1268 made this particular false positive *unsuppressable* -- it now reliably reaches the phone, and it burns one of the 5-per-60s forced-push budget slots on a commit nobody needs to look at. The forcing itself is right; it is just sitting downstream of a bit that gets set too early.

## Fix

Read `autoCommitEnabled` before announcing the proposal, and skip the pending-prompt bit when auto-commit is going to resolve it. This also removes the set-then-clear flap at 955/1055, so the tray and sidebar stop flickering through a "blocked" state that never existed.

## Behaviour

- **auto-commit off** -- no change whatsoever; identical code path.
- **auto-commit on** -- no pending-prompt bit, no forced push, no tray flap. The commit still runs, the widget still resolves, the response row is still persisted.
- **settings store unreadable** -- still falls through to manual mode, exactly as before. The `catch` is unchanged; it just runs earlier.

## Verification

- `npx tsc --noEmit -p packages/electron/tsconfig.json` -> exit 0
- Pure statement reorder within one function -- no new identifiers, no signature or type changes

I could not run the full pre-push suite: `check-identity-scopes` fails on 35 stale baseline entries in auth/team/sync files. I confirmed that is pre-existing and unrelated by checking out the base commit with zero of my changes and getting byte-identical failures -- worth a separate look, but it is not this PR.

No test added. A unit test around `handleGitCommitProposal` would need mocks for `BrowserWindow`, `AgentMessagesRepository`, `PGLiteDatabaseWorker`, `electron-store`, `GitCommitService` and `pendingPromptPersistence`. I would rather not add a test I cannot execute, but happy to add coverage if you want it, or to take a different shape if you prefer one.

## Possibly broader

`setSessionPendingPrompt(sessionId, true)` is also called at lines 315, 728 and 1572 of the same file. The commit path is just the one with a 100%-reproducible trigger. If other call sites can also fire ahead of an auto-resolution, a short settle window inside `notifyMobileOfBlockedSession` that a resolution can cancel might be the more robust shape -- but the narrow fix here is the safer thing to land first, and I did not want to widen the diff uninvited.

## Why this is worth merging

Auto-commit means no human response is required. Marking the session as blocked first sends a false forced notification, consumes scarce attention budget, and teaches users not to trust urgent alerts. Reading the setting before publishing pending state removes that false alarm and UI flicker without changing manual commit proposals or the fallback when settings cannot be read.

## v16c level-set evidence

This outcome was ported onto upstream v0.77.5 during the v16c level set and included in the G5-accepted packaged candidate: a 48-commit carry tested against an OS-quarantined copy of the real 8.5 GB workspace database with zero writes to live state. That adds current-architecture integration evidence to this PR's focused checks.
