### PR TITLE
fix(codex): namespace OpenAI model ids for Bedrock provider

### DIFF
--- a/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
+++ b/packages/runtime/src/ai/server/providers/OpenAICodexProvider.ts
@@ -1917,7 +1917,84 @@ export class OpenAICodexProvider extends BaseAgentProvider {
     // The openai.models.list() API does not include all Codex-available models
     // (e.g., gpt-5.4 works via the SDK but isn't listed in the API).
     // The SDK itself will fail with a proper error if the model doesn't exist.
-    return OpenAICodexProvider.MODEL_REPLACEMENTS.get(normalized) || resolved;
+    const finalModel = OpenAICodexProvider.MODEL_REPLACEMENTS.get(normalized) || resolved;
+    return OpenAICodexProvider.toBedrockModelId(finalModel);
+  }
+
+  /**
+   * Bedrock's OpenAI-compatible endpoint (bedrock-mantle) namespaces OpenAI
+   * models as `openai.<id>` (e.g. `openai.gpt-5.6-luna`). When Codex is
+   * configured with `model_provider = "amazon-bedrock"` (in the shared
+   * `~/.codex/config.toml`), sending the bare id (`gpt-5.6-luna`) yields a
+   * 404 "model does not exist" from bedrock-mantle.
+   *
+   * We auto-detect that provider from the same config file Codex itself reads,
+   * so no user-facing setting is required: on Bedrock we namespace bare OpenAI
+   * model ids; on the public OpenAI API (or when the provider can't be
+   * determined) we leave them bare. Model ids are matched by pattern
+   * (`gpt-`, `o<n>`, `codex`) rather than a hardcoded list, so new models are
+   * handled automatically.
+   */
+  private static toBedrockModelId(modelId: string): string {
+    if (!OpenAICodexProvider.isBedrockCodexProvider()) {
+      return modelId;
+    }
+    // Already Bedrock-namespaced (openai./amazon./anthropic. etc.) or a
+    // provider-qualified id ("openai-codex:..."): leave untouched. We match an
+    // explicit known-provider prefix rather than any "." because model ids like
+    // "gpt-5.6-luna" legitimately contain a dot in the version.
+    if (/^(openai|amazon|anthropic|meta|mistral|cohere|deepseek)\./i.test(modelId)
+        || modelId.includes(':')) {
+      return modelId;
+    }
+    if (/^(gpt-|o[0-9]|codex)/i.test(modelId)) {
+      return `openai.${modelId}`;
+    }
+    return modelId;
+  }
+
+  /** Cached result of the config-file provider probe (undefined = not yet read). */
+  private static bedrockProviderCache: boolean | undefined;
+
+  /**
+   * Test/override hook. When set, its return value replaces the config-file
+   * probe (mirrors the other static loader/resolver hooks on this class).
+   * Lets unit tests pin the provider without touching the developer's real
+   * ~/.codex/config.toml.
+   */
+  static bedrockDetectionOverride: (() => boolean) | null = null;
+
+  /**
+   * Returns true when the shared Codex config declares
+   * `model_provider = "amazon-bedrock"`. Reads `$CODEX_HOME/config.toml`
+   * (default `~/.codex/config.toml`). Fails open (returns false) when the file
+   * is missing or unreadable, so the public OpenAI path is never affected.
+   * Result is cached for the process lifetime (or supplied via the override).
+   */
+  private static isBedrockCodexProvider(): boolean {
+    if (OpenAICodexProvider.bedrockDetectionOverride) {
+      return OpenAICodexProvider.bedrockDetectionOverride();
+    }
+    if (OpenAICodexProvider.bedrockProviderCache !== undefined) {
+      return OpenAICodexProvider.bedrockProviderCache;
+    }
+    let detected = false;
+    try {
+      // Lazy require keeps this off the hot path and avoids adding top-level
+      // node builtins to a module that also runs in non-node contexts.
+      const fs = require('fs') as typeof import('fs');
+      const os = require('os') as typeof import('os');
+      const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+      const configPath = path.join(codexHome, 'config.toml');
+      const raw = fs.readFileSync(configPath, 'utf8');
+      // Match a top-level `model_provider = "amazon-bedrock"` assignment,
+      // tolerant of single/double quotes and surrounding whitespace.
+      detected = /^\s*model_provider\s*=\s*["']amazon-bedrock["']\s*$/m.test(raw);
+    } catch {
+      detected = false;
+    }
+    OpenAICodexProvider.bedrockProviderCache = detected;
+    return detected;
   }
 
   private buildCodexPrompt(options: {

--- a/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/OpenAICodexProvider.test.ts
@@ -45,6 +45,10 @@ describe('OpenAICodexProvider', () => {
     OpenAICodexProvider.setPreEditHookScriptPathResolver(null);
     OpenAICodexProvider.setPreEditSidecarDirResolver(null);
     OpenAICodexProvider.setCodexTransportResolver(null);
+    // Default: treat the Codex provider as public OpenAI (not Bedrock) so
+    // model-id assertions are deterministic regardless of the developer's real
+    // ~/.codex/config.toml. Bedrock-specific tests opt in explicitly.
+    OpenAICodexProvider.bedrockDetectionOverride = () => false;
 
     // Provide default injected dependencies required by the provider.
     OpenAICodexProvider.setTrustChecker(() => ({ trusted: true, mode: 'allow-all' as any }));
@@ -1832,6 +1836,47 @@ describe('OpenAICodexProvider', () => {
     expect(startThread).toHaveBeenCalledTimes(1);
     const startArgs = (startThread.mock.calls as unknown as [Record<string, unknown>][])[0][0];
     expect(startArgs.model).toBe('gpt-5.6-sol');
+  });
+
+  it('namespaces bare OpenAI model ids for the Bedrock provider', async () => {
+    // Simulate model_provider = "amazon-bedrock" in ~/.codex/config.toml.
+    OpenAICodexProvider.bedrockDetectionOverride = () => true;
+
+    const startThread = vi.fn((config: { model: string }) => ({
+      id: 'thread-bedrock',
+      runStreamed: async () => ({
+        events: createAsyncEventStream([
+          {
+            type: 'item.completed',
+            item: { type: 'agent_message', text: 'bedrock model mapped' },
+          },
+        ]),
+      }),
+    }));
+
+    const provider = new OpenAICodexProvider(
+      { apiKey: 'test-key' },
+      {
+        loadSdkModule: async () =>
+          ({
+            Codex: class {
+              startThread = startThread;
+              resumeThread = vi.fn();
+            },
+          }) as any,
+      }
+    );
+
+    await provider.initialize({ apiKey: 'test-key', model: 'openai-codex:gpt-5.6-luna' });
+
+    for await (const _chunk of provider.sendMessage('bedrock', undefined, 'session-bedrock', [], process.cwd())) {
+      // drain
+    }
+
+    expect(startThread).toHaveBeenCalledTimes(1);
+    const bedrockArgs = (startThread.mock.calls as unknown as [Record<string, unknown>][])[0][0];
+    // Bedrock's OpenAI-compatible endpoint requires the `openai.` namespace.
+    expect(bedrockArgs.model).toBe('openai.gpt-5.6-luna');
   });
 
   it('supports direct handleToolCall execution through the shared tool handler', async () => {


### PR DESCRIPTION
Fixes #1371.

## What
`OpenAICodexProvider.getConfiguredModel()` now routes the resolved model id through a new `toBedrockModelId()` step that prefixes bare OpenAI ids with `openai.` (e.g. `gpt-5.6-luna` → `openai.gpt-5.6-luna`) **only when** the shared Codex config declares `model_provider = "amazon-bedrock"`.

## Why
Codex on Amazon Bedrock exposes OpenAI models under an `openai.` namespace. Sending the bare id to a Bedrock-configured Codex 404s on `bedrock-mantle` (`The model 'gpt-5.6-luna' does not exist`). See #1371 for the full trace.

## How it decides (no user setting)
- Auto-detects the provider by reading `model_provider` from `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`) — the same file Codex itself consumes.
- Result is cached; detection **fails open** (missing/unreadable config → treated as public OpenAI), so the public path is untouched.
- Model ids are matched by **pattern** (`gpt-`, `o<n>`, `codex`), not a hardcoded list, so new models are handled automatically.
- Already-namespaced (`openai.`/`amazon.`/…) or provider-qualified (`…:…`) ids pass through unchanged.
- A `bedrockDetectionOverride` static hook (mirroring the existing loader/resolver hooks) makes the behavior unit-testable without touching the developer's real config.

## Tests
- Added: `namespaces bare OpenAI model ids for the Bedrock provider` (override → `openai.gpt-5.6-luna`).
- Existing alias tests now reset the override to public-OpenAI in `beforeEach`, so model-id assertions are deterministic regardless of the developer's real `~/.codex/config.toml`.
- Full `OpenAICodexProvider.test.ts` suite passes (49 passed / 1 skipped).

## Known limitation
Detection reads the shared codex config **globally, not per session**. A user running public OpenAI in-app while also having `model_provider = amazon-bedrock` in `~/.codex/config.toml` would be namespaced incorrectly. A per-session provider signal would be the more robust follow-up; happy to iterate if you'd prefer that shape or an explicit setting instead.

## Note for reviewers
This branch's local pre-push suite shows a few **pre-existing, unrelated** failures (MigrationDryRunner, AgentTranscriptPanel.listenerCleanup, MarkdownRenderer.rtl) that also fail on an unmodified v0.75.2 checkout in my environment and touch none of the files in this change.
