### PR TITLE
fix: reap background sub-agents when a queued prompt interrupts the turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Sending a queued prompt while a background sub-agent is running no longer leaves the session stuck on "Thinking..." or later claims a sub-agent was interrupted when none was.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
+++ b/packages/runtime/src/ai/server/providers/ClaudeCodeProvider.ts
@@ -2359,6 +2359,19 @@ export class ClaudeCodeProvider extends BaseAgentProvider {
       console.warn('[CLAUDE-CODE] interruptCurrentTurn: interrupt() failed (transport may be closed):', err);
     }
 
+    // Background sub-agent tasks stream their task_notification on the query we
+    // just interrupted, and the streaming loop breaks on that interrupt, so a
+    // terminal status can no longer reach handleSystemTask -- the same reason
+    // abort() reaps them. Left 'running', they make the NEXT turn's `result`
+    // defer teardown to the drain loop: the session sits 'running' with its
+    // queued prompts stalled behind it, and a silent drain then tells the
+    // session a sub-agent was interrupted when none was. #1269.
+    const orphanedTasks = reapRunningTasks(this.activeTasks.values());
+    if (orphanedTasks.length > 0) {
+      console.warn(`[CLAUDE-CODE] SUBAGENT_TASK: interrupt orphaned ${orphanedTasks.length} running task(s); marking stopped. tasks=[${orphanedTasks.join(', ')}]`);
+      this.emitTaskUpdate(this.currentSessionId).catch(() => {});
+    }
+
     return { method: 'interrupt' };
   }
 

--- a/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.taskReap.test.ts
+++ b/packages/runtime/src/ai/server/providers/__tests__/ClaudeCodeProvider.taskReap.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 /**
- * abort() must reap background sub-agent tasks (NIM-2458).
+ * Every path that kills a query must reap its background sub-agent tasks
+ * (NIM-2458, #1269).
  *
  * A background Task/Bash sub-agent runs inside the SDK subprocess. abort()
  * kills that subprocess, so the task's terminal `task_notification` can never
@@ -8,6 +9,10 @@
  * `result` sees hasRunningTasks() === true and defers teardown to the drain
  * loop — the session stays 'running' and its queued prompts stall until the
  * drain grace expires. Observed as a ~5 minute stall on 2026-08-04.
+ *
+ * interruptCurrentTurn() leaves the same wreckage: the streaming loop breaks on
+ * the interrupt, so no terminal notification can land afterwards, and the drain
+ * that would otherwise reap never runs because an interrupt is not an abort.
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -30,7 +35,21 @@ import { ClaudeCodeProvider } from '../ClaudeCodeProvider';
 type ProviderInternals = {
   activeTasks: Map<string, { taskId: string; description: string; status: string }>;
   hasRunningTasks: () => boolean;
+  leadQuery: unknown;
 };
+
+function seedTasks(state: ProviderInternals): void {
+  state.activeTasks.set('bkxaizroy', {
+    taskId: 'bkxaizroy',
+    description: 'Block until suite finishes',
+    status: 'running',
+  });
+  state.activeTasks.set('done', {
+    taskId: 'done',
+    description: 'Already finished',
+    status: 'completed',
+  });
+}
 
 function internals(provider: ClaudeCodeProvider): ProviderInternals {
   return provider as unknown as ProviderInternals;
@@ -40,22 +59,29 @@ describe('ClaudeCodeProvider background task reaping', () => {
   it('marks tasks orphaned by abort() stopped so the next turn does not defer teardown', () => {
     const provider = new ClaudeCodeProvider();
     const state = internals(provider);
-    state.activeTasks.set('bkxaizroy', {
-      taskId: 'bkxaizroy',
-      description: 'Block until suite finishes',
-      status: 'running',
-    });
-    state.activeTasks.set('done', {
-      taskId: 'done',
-      description: 'Already finished',
-      status: 'completed',
-    });
+    seedTasks(state);
 
     provider.abort();
 
     expect(state.hasRunningTasks()).toBe(false);
     expect(state.activeTasks.get('bkxaizroy')?.status).toBe('stopped');
     // A task that already settled keeps its own terminal status.
+    expect(state.activeTasks.get('done')?.status).toBe('completed');
+  });
+
+  it('marks tasks orphaned by interruptCurrentTurn() stopped', async () => {
+    const provider = new ClaudeCodeProvider();
+    const state = internals(provider);
+    const interrupt = vi.fn(async () => {});
+    state.leadQuery = { interrupt };
+    seedTasks(state);
+
+    const outcome = await provider.interruptCurrentTurn();
+
+    expect(outcome.method).toBe('interrupt');
+    expect(interrupt).toHaveBeenCalledTimes(1);
+    expect(state.hasRunningTasks()).toBe(false);
+    expect(state.activeTasks.get('bkxaizroy')?.status).toBe('stopped');
     expect(state.activeTasks.get('done')?.status).toBe('completed');
   });
 });


### PR DESCRIPTION
`interruptCurrentTurn()` has exactly one production caller: "send now" on a queued prompt. When that interrupt lands on a turn that is still generating and has a background sub-agent running, nothing reaps it. Reaping happens in `abort()` (the Stop button) and in `finalizeBackgroundDrain()`, and the latter returns early while no drain is active — an interrupt is not an abort.

The task stays `running` in `activeTasks`, which is instance state and is never cleared per turn. The *next* completed turn sees it, defers teardown to a drain, and hangs on a task whose subprocess is already gone.

Two user-visible symptoms:

- The session stays `running` and the UI shows "Thinking…" indefinitely. Not bounded by the drain grace window: the timer re-arms on every post-`result` chunk, so any activity keeps it pinned. Measured 24 minutes with one chunk every 4 minutes.
- On a fully silent stream the drain does settle after the grace window — and reports `autoContinue`, so the session is told a sub-agent "did not finish — its process was interrupted before returning results". That message is false; nothing of the sort happened in that turn.

Measured on a clean `main` (`d81e689f") by driving the real `sendMessage` generator with only the CLI subprocess faked. The added test fails without the change (`expected true to be false` on `hasRunningTasks()`).

The fix mirrors what `abort()` already does, with the same reasoning: the tasks ran inside the subprocess this interrupt kills, so their terminal `task_notification` can never arrive.

Deliberately out of scope: `interruptWithMessage()` takes the same path and would leave the same orphans, but it belongs to the teammate flow rather than "send now" — separate concern, and I have not measured whether it is reachable with tasks running.

Refs #1269
