### PR TITLE
fix: report the visible document to macOS accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 <!-- Bug fixes go here -->
+- Time trackers, screen readers, and other macOS accessibility tools now see the document you are actually viewing, instead of the last file you happened to open.
 
 ### Removed
 <!-- Removed features go here -->

--- a/packages/electron/src/main/ipc/WindowHandlers.ts
+++ b/packages/electron/src/main/ipc/WindowHandlers.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, shell, nativeImage, app, powerMonitor } from 'electron';
 import { safeHandle, safeOn } from '../utils/ipcRegistry';
 import { windowStates, windows, getWindowId } from '../window/WindowManager';
+import { syncRepresentedFilename } from '../window/windowState';
 import { basename, join } from 'path';
 import { writeFileSync, existsSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
@@ -102,6 +103,16 @@ export function registerWindowHandlers() {
         if (window) {
             window.setTitle(title);
         }
+    });
+
+    // Keep the window's represented file (AXDocument) on the visible document.
+    // The renderer sends null when none is visible, which clears it instead of
+    // leaving a stale path behind.
+    safeOn('set-represented-file', (event, filePath: string | null) => {
+        const window = BrowserWindow.fromWebContents(event.sender);
+        if (!window) return;
+
+        syncRepresentedFilename(window, filePath);
     });
 
 

--- a/packages/electron/src/main/ipc/WorkspaceHandlers.ts
+++ b/packages/electron/src/main/ipc/WorkspaceHandlers.ts
@@ -17,6 +17,8 @@ const { writeFile, mkdir, rename, unlink, rmdir, copyFile, readFile, rm, stat, c
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { windowStates, getWindowId, createWindow, markRecentlyDeleted, clearRecentlyDeleted } from '../window/WindowManager';
+// Aliased: this module has a local `windows` (BrowserWindow[]) further down.
+import { syncRepresentedFilename, windows as windowsById } from '../window/windowState';
 import { startFileWatcher, stopFileWatcher } from '../file/FileWatcher';
 import { getFolderContents } from '../utils/FileTree';
 import { decodeTextFileBuffer } from '../utils/textEncoding';
@@ -932,6 +934,10 @@ export function registerWorkspaceHandlers() {
                 if (state?.filePath === filePath) {
                     state.filePath = null;
                     state.documentEdited = false;
+                    // #1375: Clearing window state is not enough — the
+                    // represented file is OS-level and would keep pointing at
+                    // a file that is now in the trash.
+                    syncRepresentedFilename(windowsById.get(windowId), null);
                 }
             }
 

--- a/packages/electron/src/main/window/__tests__/windowState.test.ts
+++ b/packages/electron/src/main/window/__tests__/windowState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   windowStates,
   resolveActiveWorkspacePath,
@@ -6,6 +6,7 @@ import {
   resolveDocumentServicePath,
   windowReferencesWorkspace,
   anyWindowReferencesWorkspace,
+  syncRepresentedFilename,
 } from '../windowState';
 import type { WindowState } from '../../types';
 
@@ -177,6 +178,83 @@ describe('windowState helpers', () => {
     it('returns false when the only references are excluded', () => {
       windowStates.set(1, makeState({ workspacePath: '/ws/lone' }));
       expect(anyWindowReferencesWorkspace('/ws/lone', 1)).toBe(false);
+    });
+  });
+
+  describe('syncRepresentedFilename', () => {
+    const originalPlatform = process.platform;
+
+    function setPlatform(platform: string) {
+      Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+    }
+
+    function makeFakeWindow(destroyed = false) {
+      const represented: string[] = [];
+      const edited: boolean[] = [];
+      return {
+        represented,
+        edited,
+        isDestroyed: () => destroyed,
+        setRepresentedFilename: (path: string) => represented.push(path),
+        setDocumentEdited: (value: boolean) => edited.push(value),
+      };
+    }
+
+    beforeEach(() => setPlatform('darwin'));
+    afterEach(() => setPlatform(originalPlatform));
+
+    it('points the represented filename at the active file', () => {
+      const win = makeFakeWindow();
+      syncRepresentedFilename(win as never, '/ws/notes.md');
+      expect(win.represented).toEqual(['/ws/notes.md']);
+    });
+
+    it('leaves the edited indicator alone when setting a real path', () => {
+      const win = makeFakeWindow();
+      syncRepresentedFilename(win as never, '/ws/notes.md');
+      expect(win.edited).toEqual([]);
+    });
+
+    // The regression this helper exists for: setRepresentedFilename has no
+    // implicit clear, so a null path must explicitly write '' or the window
+    // keeps advertising the last file it ever represented via AXDocument.
+    it('clears the represented filename when no file is active', () => {
+      const win = makeFakeWindow();
+      syncRepresentedFilename(win as never, null);
+      expect(win.represented).toEqual(['']);
+    });
+
+    it('also clears the edited indicator when clearing the file', () => {
+      const win = makeFakeWindow();
+      syncRepresentedFilename(win as never, null);
+      expect(win.edited).toEqual([false]);
+    });
+
+    it('clears a previously set path when the file goes away', () => {
+      const win = makeFakeWindow();
+      syncRepresentedFilename(win as never, '/ws/notes.md');
+      syncRepresentedFilename(win as never, null);
+      expect(win.represented).toEqual(['/ws/notes.md', '']);
+    });
+
+    it('no-ops off darwin, where represented filenames do not exist', () => {
+      setPlatform('win32');
+      const win = makeFakeWindow();
+      syncRepresentedFilename(win as never, '/ws/notes.md');
+      syncRepresentedFilename(win as never, null);
+      expect(win.represented).toEqual([]);
+      expect(win.edited).toEqual([]);
+    });
+
+    it('no-ops for a destroyed window', () => {
+      const win = makeFakeWindow(true);
+      syncRepresentedFilename(win as never, null);
+      expect(win.represented).toEqual([]);
+    });
+
+    it('tolerates a missing window', () => {
+      expect(() => syncRepresentedFilename(null, null)).not.toThrow();
+      expect(() => syncRepresentedFilename(undefined, '/ws/notes.md')).not.toThrow();
     });
   });
 });

--- a/packages/electron/src/main/window/windowState.ts
+++ b/packages/electron/src/main/window/windowState.ts
@@ -105,3 +105,31 @@ export function anyWindowReferencesWorkspace(path: string, excludeWindowId?: num
     }
     return false;
 }
+
+/**
+ * #1375: Keep the window's represented file in lockstep with the document on
+ * screen.
+ *
+ * Our windows use `titleBarStyle: 'hiddenInset'`, so the proxy icon this
+ * normally draws is never rendered. What it still feeds is AXDocument, which
+ * macOS hands to every accessibility client -- screen readers, automation,
+ * time trackers -- as "the document this window is showing". That is the whole
+ * payload here; there is nothing visual to check.
+ *
+ * Pass null when no document is visible. `setRepresentedFilename` has no
+ * implicit clear, so without this the window keeps advertising the last file it
+ * ever represented -- possibly one the user has since deleted, since clearing
+ * window state on delete does not touch the OS-level value.
+ *
+ * No-ops off darwin, where represented filenames do not exist.
+ */
+export function syncRepresentedFilename(
+    window: BrowserWindow | null | undefined,
+    filePath: string | null,
+): void {
+    if (process.platform !== 'darwin') return;
+    if (!window || window.isDestroyed()) return;
+
+    window.setRepresentedFilename(filePath ?? '');
+    if (!filePath) window.setDocumentEdited(false);
+}

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -373,6 +373,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Window operations
   setDocumentEdited: (edited: boolean) => ipcRenderer.send('set-document-edited', edited),
   setTitle: (title: string) => ipcRenderer.send('set-title', title),
+  /** Point the window's AXDocument at the visible document; null clears it. */
+  setRepresentedFile: (filePath: string | null) => ipcRenderer.send('set-represented-file', filePath),
   openAccountSettings: () => ipcRenderer.invoke('app:open-account-settings'),
   /** Report user activity for sync presence awareness */
   reportUserActivity: () => ipcRenderer.send('user-activity'),

--- a/packages/electron/src/renderer/components/AgentMode/AgentWorkstreamPanel.tsx
+++ b/packages/electron/src/renderer/components/AgentMode/AgentWorkstreamPanel.tsx
@@ -38,6 +38,8 @@ import {
 import { ModelIdentifier } from '@nimbalyst/runtime/ai/server/types';
 import type { TranscriptFileLocation } from '@nimbalyst/runtime/ui/AgentTranscript/components/MarkdownRenderer';
 import { WorkstreamEditorTabs, type WorkstreamEditorTabsRef } from './WorkstreamEditorTabs';
+import { usePushRepresentedFile } from '../../hooks/useRepresentedFileSync';
+import { resolveRepresentedFile } from '../../utils/representedFile';
 import { WorkstreamSessionTabs } from './WorkstreamSessionTabs';
 import { FilesEditedSidebar } from './FilesEditedSidebar';
 import { AgentReviewPanel } from './AgentReviewPanel';
@@ -1350,6 +1352,14 @@ export const AgentWorkstreamPanel = React.memo(React.forwardRef<AgentWorkstreamP
   const sessionDocumentContext = React.useMemo(
     () => ({ filePath: showEditorTabs ? (activeEditorFile ?? '') : '' }),
     [showEditorTabs, activeEditorFile]
+  );
+
+  // #1375: report the visible document to macOS as this window's AXDocument.
+  // Lives here, not in WorkstreamEditorTabs, because that unmounts entirely in
+  // the transcript-only layout and so could never clear what it had set.
+  usePushRepresentedFile(
+    isActive,
+    showEditorTabs ? resolveRepresentedFile(activeEditorFile) : null
   );
 
   // Open pending file once editor mounts after layout mode change

--- a/packages/electron/src/renderer/components/EditorMode/EditorMode.tsx
+++ b/packages/electron/src/renderer/components/EditorMode/EditorMode.tsx
@@ -3,6 +3,7 @@ import { useSetAtom, useAtomValue, useAtom } from 'jotai';
 import type { ConfigTheme } from '@nimbalyst/runtime';
 import { asTeamJwt } from '@nimbalyst/runtime/auth/jwtScopes';
 import { useTabsActions, useTabNavigationShortcuts, type TabData } from '../../contexts/TabsContext';
+import { useRepresentedFileSync } from '../../hooks/useRepresentedFileSync';
 import { store, editorDirtyAtom, makeEditorKey } from '@nimbalyst/runtime/store';
 import { fileDeletedAtomFamily } from '../../store/atoms/fileWatch';
 import { pushNavigationEntryAtom, isRestoringNavigationAtom, historyDialogFileAtom } from '../../store';
@@ -188,6 +189,7 @@ const EditorMode = forwardRef<EditorModeRef, EditorModeProps>(function EditorMod
   // Get tab actions from context (doesn't subscribe to state - no re-renders)
   const tabsActions = useTabsActions();
   useTabNavigationShortcuts(isActive);
+  useRepresentedFileSync(isActive);
 
   // Refs for imperative DOM updates - NO re-renders for tab visibility
   const tabsContainerRef = useRef<HTMLDivElement>(null);

--- a/packages/electron/src/renderer/contexts/TabsContext.tsx
+++ b/packages/electron/src/renderer/contexts/TabsContext.tsx
@@ -65,7 +65,7 @@ export function isTrackerTabPath(filePath: string): boolean {
 }
 
 /** True when a tab represents a non-filesystem resource (virtual/collab/tracker). */
-function isNonFilesystemTab(filePath: string): boolean {
+export function isNonFilesystemTab(filePath: string): boolean {
   return (
     filePath.startsWith('virtual://') ||
     isCollabUri(filePath) ||

--- a/packages/electron/src/renderer/electron.d.ts
+++ b/packages/electron/src/renderer/electron.d.ts
@@ -372,6 +372,7 @@ interface ElectronAPI {
 
   setDocumentEdited: (edited: boolean) => void;
   setTitle: (title: string) => void;
+  setRepresentedFile: (filePath: string | null) => void;
   openAccountSettings: () => Promise<{ success: boolean; error?: string }>;
   sendToMainWindow?: (channel: string, data: unknown) => Promise<void>;
   reportUserActivity?: () => void;

--- a/packages/electron/src/renderer/hooks/useRepresentedFileSync.ts
+++ b/packages/electron/src/renderer/hooks/useRepresentedFileSync.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+import { useTabs } from '../contexts/TabsContext';
+import { resolveRepresentedFile } from '../utils/representedFile';
+
+/**
+ * #1375: Push the window's represented file (AXDocument) to the main process.
+ *
+ * Call from a component that stays mounted for as long as it could own the
+ * window's identity. Agent mode unmounts its editor tabs in the
+ * transcript-only layout, and an unmounted component cannot clear what it set.
+ *
+ * `isActive` marks the owner. The memo of what was last sent resets when this
+ * instance goes inactive, so the next activation re-asserts its own file
+ * rather than trusting what another owner left behind.
+ */
+export function usePushRepresentedFile(isActive: boolean, filePath: string | null): void {
+    const lastSentRef = useRef<string | null | undefined>(undefined);
+
+    useEffect(() => {
+        if (!isActive) {
+            lastSentRef.current = undefined;
+            return;
+        }
+        if (filePath === lastSentRef.current) return;
+
+        lastSentRef.current = filePath;
+        window.electronAPI?.setRepresentedFile?.(filePath);
+    }, [isActive, filePath]);
+}
+
+/**
+ * Represent the active tab of the surrounding TabsProvider. For editor-mode
+ * style hosts, whose tabs and visibility live and die together.
+ */
+export function useRepresentedFileSync(isActive: boolean): void {
+    const { activeTab } = useTabs();
+    usePushRepresentedFile(isActive, resolveRepresentedFile(activeTab?.filePath));
+}

--- a/packages/electron/src/renderer/utils/__tests__/representedFile.test.ts
+++ b/packages/electron/src/renderer/utils/__tests__/representedFile.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { resolveRepresentedFile } from '../representedFile';
+
+describe('resolveRepresentedFile', () => {
+    it('represents a real file path', () => {
+        expect(resolveRepresentedFile('/ws/notes.md')).toBe('/ws/notes.md');
+    });
+
+    // The regression this exists for: no active file must clear, not linger on
+    // whatever was represented last.
+    it('returns null when no file is active', () => {
+        expect(resolveRepresentedFile(null)).toBeNull();
+        expect(resolveRepresentedFile(undefined)).toBeNull();
+        expect(resolveRepresentedFile('')).toBeNull();
+    });
+
+    it.each([
+        ['collab', 'collab://org:abc123:doc:xyz789'],
+        ['tracker', 'tracker://item-42'],
+        ['virtual', 'virtual://scratch'],
+    ])('ignores %s URIs, which are not filesystem paths', (_kind, filePath) => {
+        expect(resolveRepresentedFile(filePath)).toBeNull();
+    });
+});

--- a/packages/electron/src/renderer/utils/representedFile.ts
+++ b/packages/electron/src/renderer/utils/representedFile.ts
@@ -1,0 +1,17 @@
+import { isNonFilesystemTab } from '../contexts/TabsContext';
+
+/**
+ * #1375: Resolve which file the window's AXDocument should point at, given the
+ * path of the document currently on screen.
+ *
+ * Returns null when there is nothing to represent -- no document, or one whose
+ * path is a virtual/collab/tracker resource rather than a real file. Callers
+ * pass null through to clear; `setRepresentedFilename` has no implicit clear.
+ */
+export function resolveRepresentedFile(
+    activeFilePath: string | null | undefined,
+): string | null {
+    if (!activeFilePath) return null;
+
+    return isNonFilesystemTab(activeFilePath) ? null : activeFilePath;
+}


### PR DESCRIPTION
## Summary

Reports the document you are actually viewing to the macOS accessibility layer.

The window's represented file — surfaced as `AXDocument` — previously latched the last file any code path happened to read and was never cleared, so screen readers, automation, and time trackers attributed activity to a file you may have closed long ago. After a delete it pointed into the trash.

There is no visual change: our windows use `titleBarStyle: 'hiddenInset'`, so the title-bar proxy icon this attribute normally draws is never rendered. The entire effect is on what macOS reports to other software.

## Related issue

Fixes #1375

## Testing

- 14 unit tests covering the main-process clear and the path resolution. Each was verified to fail with the fix reverted, then pass with it restored.
- Verified live through the accessibility API: opening a file sets `AXDocument`, the transcript-only layout clears it, and returning to split re-asserts it.
- `npm run typecheck` and `npm run test:prepush` both green on Node 24 (1333 files, 10691 tests).

## Notes for reviewers

The sync lives in `AgentWorkstreamPanel` rather than `WorkstreamEditorTabs`. The latter unmounts entirely in the transcript-only layout, so it could never clear what it had set — that unmount is the actual mechanism behind the stale value.

Tab state is per-`TabsProvider` (EditorMode owns one, each workstream in agent mode owns another), so there is no central place to read "the active document" from. `AgentWorkstreamPanel` consumes the same `showEditorTabs ? activeEditorFile : null` signal that selection chips already use for this question.

Worth a second opinion on: `usePushRepresentedFile` resets its last-sent memo when it goes inactive, so the next active owner always re-asserts rather than trusting what the previous one left behind. That is deliberate, but it does mean a redundant IPC message on each mode switch.
