### PR TITLE
fix: complete Codex web search tool cards when status is absent

### DIFF
--- a/packages/runtime/src/ai/server/protocols/CodexAppServerProtocol.ts
+++ b/packages/runtime/src/ai/server/protocols/CodexAppServerProtocol.ts
@@ -1199,7 +1199,10 @@ export class CodexAppServerProtocol implements AgentProtocol {
     const record = item as Record<string, unknown>;
     const args: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(record)) {
-      if (value === undefined) continue;
+      // Generic started items can carry null/empty output placeholders (for
+      // example webSearch's `action`, `results`, and empty `query`). Do not
+      // expose those placeholders as user-visible tool arguments.
+      if (value == null || value === '') continue;
       if (['id', 'type', 'status', 'result', 'error', 'aggregated_output', 'exit_code', 'text', 'content', 'items'].includes(key)) {
         continue;
       }
@@ -1211,18 +1214,22 @@ export class CodexAppServerProtocol implements AgentProtocol {
   private buildGenericToolLikeResult(item: AnyItem): ToolResult | string {
     const record = item as Record<string, unknown>;
     const error = record.error as { message?: string } | undefined;
+    // This helper is called only from item/completed. The envelope is the
+    // lifecycle authority: current Codex webSearch payloads omit `status`, so
+    // equality with the optional duplicate field would mislabel success.
+    const success = record.status !== 'failed' && !error?.message;
     if (error?.message) {
       return { success: false, error: error.message } as ToolResult;
     }
     if (record.result !== undefined) {
       return {
-        success: record.status === 'completed',
+        success,
         result: record.result,
       } as ToolResult;
     }
     if (typeof record.aggregated_output === 'string' || typeof record.exit_code === 'number') {
       return {
-        success: record.status === 'completed',
+        success,
         output: record.aggregated_output,
         exit_code: record.exit_code,
       } as ToolResult;
@@ -1235,7 +1242,7 @@ export class CodexAppServerProtocol implements AgentProtocol {
       summary[key] = value;
     }
     return {
-      success: record.status === 'completed',
+      success,
       result: summary,
     } as ToolResult;
   }

--- a/packages/runtime/src/ai/server/protocols/__tests__/CodexAppServerProtocol.test.ts
+++ b/packages/runtime/src/ai/server/protocols/__tests__/CodexAppServerProtocol.test.ts
@@ -931,6 +931,70 @@ describe('CodexAppServerProtocol', () => {
     protocol.cleanupSession(session);
   });
 
+  it('does not leak null placeholders and treats item/completed as success when webSearch omits status', async () => {
+    const protocol = new CodexAppServerProtocol();
+    const sessionPromise = protocol.createSession({ workspacePath: '/tmp/ws' });
+    const initReq = await nextWrittenMatching(child, 'initialize');
+    child.emitLine({ id: initReq.id, result: { codexHome: '/fake', platformFamily: 'unix', platformOs: 'macos', userAgent: 'fake/0' } });
+    const startReq = await nextWrittenMatching(child, 'thread/start');
+    child.emitLine({ id: startReq.id, result: { thread: { id: 't-web-production-shape' } } });
+    const session = await sessionPromise;
+
+    const events: ProtocolEvent[] = [];
+    const collector = (async () => {
+      for await (const ev of protocol.sendMessage(session, { content: 'search the web' })) {
+        events.push(ev);
+      }
+    })();
+
+    const turnReq = await nextWrittenMatching(child, 'turn/start');
+    child.emitLine({ id: turnReq.id, result: { turn: { id: 'turn-1', items: [], status: 'inProgress' } } });
+    child.emitLine({
+      method: 'item/started',
+      params: {
+        threadId: 't-web-production-shape',
+        turnId: 'turn-1',
+        item: {
+          id: 'web-production-shape-1',
+          type: 'webSearch',
+          status: null,
+          query: '',
+          action: null,
+          results: null,
+        },
+      },
+    });
+    child.emitLine({
+      method: 'item/completed',
+      params: {
+        threadId: 't-web-production-shape',
+        turnId: 'turn-1',
+        item: {
+          id: 'web-production-shape-1',
+          type: 'webSearch',
+          status: null,
+          query: 'writing process representations',
+          action: { type: 'search', queries: ['writing process representations'] },
+          results: [{ title: 'Result', url: 'https://example.com' }],
+        },
+      },
+    });
+    child.emitLine({ method: 'turn/completed', params: { threadId: 't-web-production-shape', turn: { id: 'turn-1', status: 'completed' } } });
+    await collector;
+
+    const toolCalls = events.filter((event) => event.type === 'tool_call');
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0].toolCall?.arguments).toEqual({});
+    expect(toolCalls[1].toolCall?.result).toMatchObject({
+      success: true,
+      result: {
+        results: [{ title: 'Result', url: 'https://example.com' }],
+      },
+    });
+
+    protocol.cleanupSession(session);
+  });
+
   it('does not duplicate notifications across multiple sendMessage calls on the same session', async () => {
     const protocol = new CodexAppServerProtocol();
     const sessionPromise = protocol.createSession({ workspacePath: '/tmp/ws' });

--- a/packages/runtime/src/ai/server/transcript/__tests__/CodexAppServerRawParser.test.ts
+++ b/packages/runtime/src/ai/server/transcript/__tests__/CodexAppServerRawParser.test.ts
@@ -480,4 +480,56 @@ describe('CodexAppServerRawParser', () => {
       result: 'search complete',
     });
   });
+
+  it('completes generic tools from the lifecycle envelope when optional status and singular result are absent', async () => {
+    const parser = new CodexAppServerRawParser();
+    const context = makeContext();
+    const started = await parser.parseMessage(makeRawMessage({
+      id: 60,
+      content: envelope('item/started', {
+        threadId: 't-1',
+        turnId: 'turn-1',
+        item: {
+          id: 'web-production-shape-1',
+          type: 'webSearch',
+          status: null,
+          query: '',
+          action: null,
+          results: null,
+        },
+      }),
+    }), context);
+
+    expect(started).toHaveLength(1);
+    expect(started[0]).toMatchObject({
+      type: 'tool_call_started',
+      toolName: 'webSearch',
+      arguments: {},
+    });
+    const providerToolCallId = (started[0] as { providerToolCallId: string }).providerToolCallId;
+
+    const completed = await parser.parseMessage(makeRawMessage({
+      id: 61,
+      content: envelope('item/completed', {
+        threadId: 't-1',
+        turnId: 'turn-1',
+        item: {
+          id: 'web-production-shape-1',
+          type: 'webSearch',
+          status: null,
+          query: 'writing process representations',
+          action: { type: 'search', queries: ['writing process representations'] },
+          results: [{ title: 'Result', url: 'https://example.com' }],
+        },
+      }),
+    }), context);
+
+    expect(completed).toEqual([expect.objectContaining({
+      type: 'tool_call_completed',
+      providerToolCallId,
+      status: 'completed',
+      isError: false,
+    })]);
+    expect((completed[0] as { result: string }).result).toContain('"results"');
+  });
 });

--- a/packages/runtime/src/ai/server/transcript/parsers/CodexAppServerRawParser.ts
+++ b/packages/runtime/src/ai/server/transcript/parsers/CodexAppServerRawParser.ts
@@ -277,7 +277,7 @@ export class CodexAppServerRawParser implements IRawMessageParser {
     }
 
     if (this.isGenericToolLikeItem(item)) {
-      return this.parseGenericToolLikeItem(msg, item, context);
+      return this.parseGenericToolLikeItem(msg, item, context, false);
     }
 
     return [];
@@ -323,7 +323,7 @@ export class CodexAppServerRawParser implements IRawMessageParser {
       }
       default: {
         if (this.isGenericToolLikeItem(item)) {
-          descriptors.push(...await this.parseGenericToolLikeItem(msg, item, context));
+          descriptors.push(...await this.parseGenericToolLikeItem(msg, item, context, true));
         }
         break;
       }
@@ -472,6 +472,7 @@ export class CodexAppServerRawParser implements IRawMessageParser {
     msg: RawMessage,
     item: AppServerItem,
     context: ParseContext,
+    completedNotification: boolean,
   ): Promise<CanonicalEventDescriptor[]> {
     if (!item.id || !item.type) return [];
 
@@ -495,8 +496,12 @@ export class CodexAppServerRawParser implements IRawMessageParser {
       });
     }
 
-    if (item.status === 'completed' || item.status === 'failed') {
-      const isError = item.status !== 'completed';
+    // `item/completed` is the lifecycle authority. Generic Codex items such
+    // as webSearch may omit `status` entirely even on their terminal
+    // notification, so requiring a duplicated payload status leaves the
+    // started tool call unresolved forever after live render or reparse.
+    if (completedNotification) {
+      const isError = item.status === 'failed' || !!item.error;
       descriptors.push({
         type: 'tool_call_completed',
         providerToolCallId: editGroupId,
@@ -738,7 +743,10 @@ export class CodexAppServerRawParser implements IRawMessageParser {
     const record = item as Record<string, unknown>;
     const args: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(record)) {
-      if (value === undefined) continue;
+      // App-server started notifications include null/empty output
+      // placeholders (`action`, `results`, and an empty `query`) for some
+      // generic tools. They are lifecycle state, not call arguments.
+      if (value == null || value === '') continue;
       if (['id', 'type', 'status', 'result', 'error', 'aggregated_output', 'aggregatedOutput', 'exit_code', 'exitCode', 'text', 'content', 'items'].includes(key)) {
         continue;
       }


### PR DESCRIPTION
## Summary

- Treat the item/completed envelope as lifecycle authority for generic Codex app-server tools when the optional item status is absent.
- Omit null and empty output placeholders from generic tool arguments.
- Add production-shaped regression coverage for both live streaming and raw transcript replay.

The production webSearch shape starts with status: null, query: "", action: null, and results: null. Its item/completed notification also has status: null but carries the populated query, action, and plural results fields. Requiring item.status === "completed" left the replayed tool call unresolved, while the live path mislabeled the completed result as unsuccessful.

## Related issue

None found.

## Testing

- Runtime TypeScript check passes.
- 9 affected Codex test files pass: 119 passed, 1 skipped.
- Focused live and replay regression files pass: 42 passed.
- git diff --check passes.

## Notes for reviewers

The lifecycle decision is deliberately based on the item/completed notification. Explicit failed status or an error payload still produces an error. The result summarizer preserves the plural results payload used by webSearch.