### PR TITLE
fix: render the generic frontmatter card for scalar status keys

### DIFF
--- a/packages/runtime/src/plugins/FrontmatterPlugin/GenericFrontmatterHeader.tsx
+++ b/packages/runtime/src/plugins/FrontmatterPlugin/GenericFrontmatterHeader.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import type { DocumentHeaderComponentProps } from '../TrackerPlugin/documentHeader/DocumentHeaderRegistry';
+import { detectTrackerFromFrontmatter } from '../TrackerPlugin/documentHeader/frontmatterUtils';
 import {
   extractFrontmatterWithError,
   parseFields,
@@ -360,9 +361,21 @@ export function shouldRenderGenericFrontmatter(content: string, filePath: string
     return false;
   }
 
-  // todo: this is an aweful hack and we  need a better solution.
-  // Skip if it's a tracker document or automation (handled by specialized headers)
-  if (result.data.planStatus || result.data.decisionStatus || result.data.trackerStatus || result.data.automationStatus) {
+  // Stand down only when the tracker header will actually claim the document.
+  //
+  // This used to test a hardcoded list of status keys for truthiness, which
+  // diverged from `detectTrackerFromFrontmatter` in two ways. It was missing
+  // `bugStatus` / `taskStatus` / `ideaStatus`, and -- the reported bug -- it
+  // abdicated on any truthy value while every tracker branch requires the key
+  // to hold an *object*. A scalar `planStatus: draft` was therefore claimed by
+  // nobody: the tracker header declined it and this one stepped aside for a
+  // header that was never coming, so the document fell through to the raw text
+  // editor with nothing logged (nimbalyst#1357).
+  //
+  // Asking the detector directly keeps the two in step by construction, which
+  // is the rule `EXTENSION_OWNED_KEYS` already states for the same reason
+  // (nimbalyst#67).
+  if (detectTrackerFromFrontmatter(content) !== null) {
     return false;
   }
 

--- a/packages/runtime/src/plugins/FrontmatterPlugin/__tests__/shouldRenderGenericFrontmatter.test.ts
+++ b/packages/runtime/src/plugins/FrontmatterPlugin/__tests__/shouldRenderGenericFrontmatter.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { shouldRenderGenericFrontmatter } from '../GenericFrontmatterHeader';
+import { shouldRenderTrackerHeader } from '../../TrackerPlugin/documentHeader/TrackerDocumentHeader';
+
+const fm = (body: string): string => `---\n${body}\n---\n\n# Doc\n\nSome text.\n`;
+
+/**
+ * A markdown document must be claimed by exactly one header provider. Claimed
+ * by neither is the #1357 failure: both providers decline and the document
+ * falls through to the raw text editor, silently.
+ */
+function claimedBy(content: string, path = 'doc.md'): 'tracker' | 'generic' | 'nobody' {
+  if (shouldRenderTrackerHeader(content, path)) return 'tracker';
+  if (shouldRenderGenericFrontmatter(content, path)) return 'generic';
+  return 'nobody';
+}
+
+describe('generic frontmatter header stands down only for a real tracker doc (#1357)', () => {
+  // The regression. Every tracker branch requires the status key to hold an
+  // object, so a scalar leaves the tracker header out -- and the generic header
+  // used to step aside anyway.
+  const scalarKeys = [
+    'planStatus: draft',
+    'decisionStatus: open',
+    'automationStatus: active',
+    'trackerStatus: open',
+    'bugStatus: triage',
+    'taskStatus: todo',
+    'ideaStatus: raw',
+  ];
+
+  for (const line of scalarKeys) {
+    it(`renders the generic card for a scalar "${line.split(':')[0]}"`, () => {
+      expect(claimedBy(fm(`title: Doc\n${line}`))).toBe('generic');
+    });
+  }
+
+  // The control that must go the other way: object form is a real tracker
+  // document, and the generic header must still stand down. Asserted against
+  // the gate directly rather than through `claimedBy`, which checks the tracker
+  // header first and would report 'tracker' no matter what this gate returned.
+  // DocumentHeaderContainer renders *every* matching provider (priority only
+  // orders them), so a generic header that fails to stand down stacks a second
+  // card under the tracker UI.
+  const objectKeys = [
+    ['planStatus', 'planStatus:\n  status: draft\n  owner: me'],
+    ['decisionStatus', 'decisionStatus:\n  status: open'],
+    ['automationStatus', 'automationStatus:\n  status: active'],
+    ['bugStatus', 'bugStatus:\n  status: triage'],
+    ['taskStatus', 'taskStatus:\n  status: todo'],
+    ['ideaStatus', 'ideaStatus:\n  status: raw'],
+  ] as const;
+
+  for (const [name, block] of objectKeys) {
+    it(`stands down for an object ${name}`, () => {
+      const content = fm(`title: Doc\n${block}`);
+      expect(shouldRenderTrackerHeader(content, 'doc.md')).toBe(true);
+      expect(shouldRenderGenericFrontmatter(content, 'doc.md')).toBe(false);
+    });
+  }
+
+  it('stands down for a canonical trackerStatus block carrying a type', () => {
+    const content = fm('title: Doc\ntrackerStatus:\n  type: plan');
+    expect(shouldRenderTrackerHeader(content, 'doc.md')).toBe(true);
+    expect(shouldRenderGenericFrontmatter(content, 'doc.md')).toBe(false);
+  });
+
+  it('still renders for ordinary frontmatter with no status key', () => {
+    expect(claimedBy(fm('title: Notes\ntags: [a, b]'))).toBe('generic');
+  });
+
+  it('still declines non-markdown files', () => {
+    // Standalone YAML is out of scope by design: `---` means other things in
+    // .astro and friends, so the gate is extension-bound.
+    expect(shouldRenderGenericFrontmatter('title: Notes\n', 'config.yaml')).toBe(false);
+    expect(shouldRenderGenericFrontmatter(fm('title: Notes'), 'notes.astro')).toBe(false);
+  });
+
+  it('still declines a document with no frontmatter at all', () => {
+    expect(shouldRenderGenericFrontmatter('# Just a heading\n', 'doc.md')).toBe(false);
+  });
+
+  it('still surfaces the error banner for malformed frontmatter', () => {
+    expect(shouldRenderGenericFrontmatter('---\ntitle: [unclosed\n---\n\nbody\n', 'doc.md')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

`shouldRenderGenericFrontmatter` stood down whenever a status key was *truthy*. Every branch of `detectTrackerFromFrontmatter` requires that key to hold an **object**. A scalar `planStatus: draft` therefore fell into the gap: the tracker header declined it, the generic header stepped aside for a header that was never coming, and the document dropped through to the raw text editor with nothing logged.

`DocumentHeaderContainer` renders every matching provider, so no other provider covers for it.

Asking the detector directly closes the gap and keeps the two in step by construction. That is already the stated rule for this detection logic:

> Exported so consumers ... can use the same map and stay in sync with `detectTrackerFromFrontmatter` instead of duplicating it. See nimbalyst#67 for the consequences of having two diverging copies.

The hardcoded list was a third diverging copy. It also predates `bugStatus`, `taskStatus` and `ideaStatus`, so object-form documents with those keys matched *both* providers and stacked a second card under the tracker UI. Both fall out with the same change, and the `todo: this is an aweful hack` above it goes with them.

## Verification

18 new tests, the first coverage this gate has had. Three mutations, each killing a different set:

| Mutation | Result |
| --- | --- |
| restore the hardcoded truthy list | 7 fail |
| never stand down | 7 fail |
| always stand down | 8 fail |

Suites: 501 pass across `FrontmatterPlugin`, `TrackerPlugin` and `TabEditor`.

Two failures in `trackerDateDisplay.test.ts` and one `tsc` error in `CanvasSurface.tsx` are pre-existing. I confirmed both by stashing this branch and re-running against a clean `main`, where they fail identically.

## What this does not cover

Scoped `Refs`, not `Fixes`, because I cannot show it is the reporter's case. Their steps describe a `planStatus:` *block*, which reads as the object form, and the object form is claimed correctly both before and after this change. What I fixed is a real fall-through I could demonstrate; whether it is theirs depends on a datum I do not have.

There is a second path to the same symptom that this does not touch. `TrackerDocumentHeader` returns `null` when its data model fails to load, and by then the generic header has already stood down, so an object-form document renders nothing either. That one needs a different fix and I have not opened anything for it.

The standalone `.yaml` / `.yml` half of the report is out of scope by design. The gate is extension-bound because `---` means other things in `.astro` and similar, so that half is a feature request rather than a regression.

Other copies of the same key list exist elsewhere, for instance the regex in `ElectronDocumentService.ts`, carrying the same three missing keys. I left them alone rather than widen this.

I have not reproduced this in a running build. It came from reading the two gates against each other and testing them directly, so the chain from "claimed by nobody" to "raw text editor" is inference from `DocumentHeaderContainer`, not something I watched happen.

