### PR TITLE
fix: serve nim-asset images from a session's git worktree

### DIFF
--- a/packages/electron/src/main/protocols/__tests__/nimAssetWorktreeRoots.test.ts
+++ b/packages/electron/src/main/protocols/__tests__/nimAssetWorktreeRoots.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sep } from 'path';
+import { registerSessionWorktreeAssetRoot } from '../nimAssetWorktreeRoots';
+import { validateNimAssetPath } from '../nimAssetProtocol';
+
+const WS = `${sep}dev${sep}Foo`;
+const WORKTREE = `${sep}dev${sep}Foo_worktrees${sep}bar`;
+
+function deps(dirExists: (path: string) => boolean = () => true) {
+  return {
+    addRoot: vi.fn<(absolutePath: string) => void>(),
+    dirExists,
+    logWarn: vi.fn<(message: string) => void>(),
+  };
+}
+
+describe('registerSessionWorktreeAssetRoot (#1343)', () => {
+  it('registers the worktree directory for a worktree session', () => {
+    const d = deps();
+    expect(registerSessionWorktreeAssetRoot({ worktreePath: WORKTREE }, d)).toBe(WORKTREE);
+    expect(d.addRoot).toHaveBeenCalledWith(WORKTREE);
+  });
+
+  // The control that must go the other way: a plain session has no worktree,
+  // so nothing new may be allowed. If this ever registers, the fix has widened
+  // the protocol for every session rather than for worktree sessions.
+  it.each([
+    ['no worktreePath key', {}],
+    ['null worktreePath', { worktreePath: null }],
+    ['empty worktreePath', { worktreePath: '' }],
+    ['null session', null],
+    ['undefined session', undefined],
+  ])('registers nothing for %s', (_label, session) => {
+    const d = deps();
+    expect(registerSessionWorktreeAssetRoot(session as any, d)).toBeNull();
+    expect(d.addRoot).not.toHaveBeenCalled();
+  });
+
+  it('refuses a relative path, which would resolve against the main process cwd', () => {
+    const d = deps();
+    expect(registerSessionWorktreeAssetRoot({ worktreePath: 'Foo_worktrees/bar' }, d)).toBeNull();
+    expect(d.addRoot).not.toHaveBeenCalled();
+    expect(d.logWarn).toHaveBeenCalled();
+  });
+
+  it('refuses a stale record whose directory is gone', () => {
+    const d = deps(() => false);
+    expect(registerSessionWorktreeAssetRoot({ worktreePath: WORKTREE }, d)).toBeNull();
+    expect(d.addRoot).not.toHaveBeenCalled();
+    expect(d.logWarn).toHaveBeenCalled();
+  });
+
+  it('is safe to call on every turn', () => {
+    const d = deps();
+    for (let i = 0; i < 3; i++) registerSessionWorktreeAssetRoot({ worktreePath: WORKTREE }, d);
+    expect(d.addRoot).toHaveBeenCalledTimes(3);
+    expect(new Set(d.addRoot.mock.calls.map(([p]) => p)).size).toBe(1);
+  });
+});
+
+/**
+ * The question the unit tests above do not answer: after registering, can the
+ * image actually be served? The reporter's symptom is a 403 from
+ * `validateNimAssetPath`, so that is what has to change.
+ */
+describe('a registered worktree root makes the image servable (#1343)', () => {
+  const image = `${WORKTREE}${sep}.screenshots${sep}shot.png`;
+
+  it('is rejected when only the workspace root is allowed -- the bug', () => {
+    expect(validateNimAssetPath(image, [WS])).toBeNull();
+  });
+
+  it('is accepted once the worktree root is registered -- the fix', () => {
+    const roots: string[] = [WS];
+    registerSessionWorktreeAssetRoot(
+      { worktreePath: WORKTREE },
+      { addRoot: (p) => roots.push(p), dirExists: () => true },
+    );
+    expect(validateNimAssetPath(image, roots)).toBe(image);
+  });
+
+  it('still rejects a sibling directory that merely shares the prefix', () => {
+    // `<ws>_worktrees/bar-evil` starts with the same characters as the
+    // registered root; only a separator-aware check keeps it out.
+    const roots: string[] = [WS];
+    registerSessionWorktreeAssetRoot(
+      { worktreePath: WORKTREE },
+      { addRoot: (p) => roots.push(p), dirExists: () => true },
+    );
+    expect(validateNimAssetPath(`${WORKTREE}-evil${sep}shot.png`, roots)).toBeNull();
+  });
+
+  it('still rejects a non-image inside the registered worktree', () => {
+    const roots: string[] = [WS];
+    registerSessionWorktreeAssetRoot(
+      { worktreePath: WORKTREE },
+      { addRoot: (p) => roots.push(p), dirExists: () => true },
+    );
+    expect(validateNimAssetPath(`${WORKTREE}${sep}.env`, roots)).toBeNull();
+    expect(validateNimAssetPath(`${WORKTREE}${sep}secrets.txt`, roots)).toBeNull();
+  });
+
+  it('still rejects traversal out of the registered worktree', () => {
+    const roots: string[] = [WS];
+    registerSessionWorktreeAssetRoot(
+      { worktreePath: WORKTREE },
+      { addRoot: (p) => roots.push(p), dirExists: () => true },
+    );
+    expect(validateNimAssetPath(`${WORKTREE}${sep}..${sep}..${sep}etc${sep}x.png`, roots)).toBeNull();
+  });
+});

--- a/packages/electron/src/main/protocols/nimAssetWorktreeRoots.ts
+++ b/packages/electron/src/main/protocols/nimAssetWorktreeRoots.ts
@@ -1,0 +1,75 @@
+import { existsSync } from 'fs';
+import { isAbsolute } from 'path';
+
+/**
+ * Dependencies for {@link registerSessionWorktreeAssetRoot}. Injected so the
+ * decision unit-tests without Electron, the protocol module's global root set,
+ * or the filesystem -- the same shape as `resolveClaudeCliWorktreeCwd`.
+ */
+export interface SessionWorktreeAssetRootDeps {
+  /** Add an allowed `nim-asset://` root. Idempotent on the protocol side. */
+  addRoot: (absolutePath: string) => void;
+  /** Existence check for the worktree dir; defaults to `fs.existsSync`. */
+  dirExists?: (path: string) => boolean;
+  /** Optional warn logger for the rejected paths. */
+  logWarn?: (message: string) => void;
+}
+
+/** The part of a session this needs. Kept structural so callers pass the session as-is. */
+export interface SessionWithOptionalWorktree {
+  worktreePath?: string | null;
+}
+
+/**
+ * Allow `nim-asset://` to serve images from a session's git worktree.
+ *
+ * A worktree is a *sibling* of the workspace root (`<ws>_worktrees/<name>`),
+ * not a child, so it never matches the workspace root registered at window
+ * creation and `validateNimAssetPath` rejects everything inside it. Images the
+ * agent writes there render as inline thumbnails but fail to expand, because
+ * the expanded view fetches them over `nim-asset://` and gets a 403 (#1343).
+ *
+ * Scope: only the directory the agent for this session is already running in,
+ * taken from the session record rather than from the requested path. That is
+ * strictly narrower than what the session already has -- we spawn the agent
+ * with write access to this exact directory -- so it grants read access to
+ * somewhere it can already write, and nothing else. In particular it does NOT
+ * infer a worktree from a path shape, and it never registers a caller-supplied
+ * directory.
+ *
+ * Returns the path registered, or `null` when nothing was registered. Safe to
+ * call on every turn; the protocol's root set is a Set and `addRoot` is
+ * idempotent, which is also what makes this survive a restart without a
+ * separate startup pass.
+ */
+export function registerSessionWorktreeAssetRoot(
+  session: SessionWithOptionalWorktree | null | undefined,
+  deps: SessionWorktreeAssetRootDeps,
+): string | null {
+  const worktreePath = session?.worktreePath;
+  if (!worktreePath) return null;
+
+  // A relative path would resolve against the main process's cwd, which has
+  // nothing to do with the workspace. Refuse rather than register a root
+  // pointing somewhere arbitrary.
+  if (!isAbsolute(worktreePath)) {
+    deps.logWarn?.(
+      `[nimAssetWorktreeRoots] ignoring non-absolute worktree path: ${worktreePath}`,
+    );
+    return null;
+  }
+
+  const dirExists = deps.dirExists ?? existsSync;
+  if (!dirExists(worktreePath)) {
+    // Stale record: the worktree was removed on disk but the session still
+    // names it. Registering it would allow a later directory created at the
+    // same path to be served.
+    deps.logWarn?.(
+      `[nimAssetWorktreeRoots] worktree path missing on disk, not registering: ${worktreePath}`,
+    );
+    return null;
+  }
+
+  deps.addRoot(worktreePath);
+  return worktreePath;
+}

--- a/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
+++ b/packages/electron/src/main/services/ai/MessageStreamingHandler.ts
@@ -135,6 +135,8 @@ import { installScopedProviderListener } from './providerListenerRegistry';
 import { shouldSettleUnterminatedTurn } from './sessionSettlePolicy';
 import { captureTutorialMilestone } from '../tutorial/tutorialAnalytics';
 import { trackSendBlocked } from '../analytics/sendWallAnalytics';
+import { addNimAssetRoot } from '../../protocols/nimAssetProtocol';
+import { registerSessionWorktreeAssetRoot } from '../../protocols/nimAssetWorktreeRoots';
 import type Store from 'electron-store';
 import type { AIService } from './AIService';
 import type { HooklessAgentFileWatcher } from './HooklessAgentFileWatcher';
@@ -428,6 +430,14 @@ export class MessageStreamingHandler {
     // CRITICAL: If session has a worktree, use its path instead of workspace path
     // This ensures Claude Code runs in the worktree directory
     let effectiveWorkspacePath = session.worktreePath || workspacePath;
+
+    // #1343: a worktree is a sibling of the workspace root, so it never matches
+    // the root registered at window creation and `nim-asset://` 403s every image
+    // written inside it. Register the directory this session already runs in.
+    registerSessionWorktreeAssetRoot(session, {
+      addRoot: addNimAssetRoot,
+      logWarn: (message) => logger.ai.warn(message),
+    });
 
     // For worktree sessions, use the parent project path for permission lookups
     // This is passed through documentContext to avoid changing sendMessage signature


### PR DESCRIPTION
## What

A worktree is a sibling of the workspace root (`<ws>_worktrees/<name>`), not a child, so it never matches the root registered at window creation and `validateNimAssetPath` rejects everything inside it. Images the agent writes there render as inline thumbnails but 403 when expanded.

`addNimAssetRoot()` has five call sites and none of them is worktree-aware, exactly as the reporter traced.

The fix registers the worktree at the point the session's effective working directory is already resolved, in `MessageStreamingHandler`. Registering there rather than at worktree creation means a session resumed after a restart is covered too, without a separate startup pass, since the root set is a `Set` and the call is idempotent.

## On widening the protocol

This grants read access to a directory the session can already write to. The path comes from the session record, never from the requested URL, so a caller cannot nominate a directory. It does not infer a worktree from a path shape, and it refuses two cases that would otherwise slip through: a relative path, which would resolve against the main process cwd, and a stale record whose directory no longer exists, where a later directory created at the same path would become servable.

The extension allowlist and the realpath containment re-check in the handler are untouched.

## Verification

14 tests in a new `nimAssetWorktreeRoots.test.ts`, including the question the unit tests alone do not answer: after registering, does `validateNimAssetPath` actually accept the image. It also asserts the things that must still be refused with the worktree root in place: a sibling directory sharing the prefix (`..._worktrees/bar-evil`), a non-image inside the worktree (`.env`), and traversal out of it.

Four mutations, each killing a different set:

| Mutation | Result |
| --- | --- |
| drop the absolute-path guard | 1 fail |
| drop the directory-exists guard | 1 fail |
| drop the no-worktree guard | 4 fail |
| never register | 3 fail |

925 tests pass across `protocols`, `services/ai` and `ipc`. The existing `MessageStreamingHandler.opencodeModel.test.ts` still passes with the new import, which is worth stating because that suite mocks `electron` down to `BrowserWindow` alone; `nimAssetProtocol` only touches `app` / `protocol` / `net` inside functions, so the import is safe there.

Two `tsc` errors remain in `AnimationVideoRecorder.ts` and `CanvasSurface.tsx`. Both are pre-existing; I confirmed by stashing this branch and re-running against a clean `main`, where the same two appear and nothing else.

The logic lives in its own dependency-injected module so it tests without Electron or the filesystem, following `resolveClaudeCliWorktreeCwd`. The call site in `MessageStreamingHandler` is one statement.

## What this does not cover

The fourth row of the reporter's table, the attachment staging directory named after the worktree, is a separate defect. `getAttachmentService()` is called with the workspace path, so the staging root that reaches `addNimAssetRoot()` is derived from the parent rather than the worktree. This change does not touch that, and I would rather not guess at the intended behaviour there.

One residual gap in this change itself. Registration happens when a message is sent, so a session resumed after a restart is covered as soon as anything is sent in it, but clicking an old image before sending anything will still 403. Closing that needs a hook at session load, which I have not added.

I have not reproduced this in a running build. The root cause is confirmed in the code and the reporter's own controlled test covers the behaviour end to end, but the chain from thumbnail to 403 is theirs, not something I watched.
