### PR TITLE
fix: mark a truncated markdown count as a lower bound

### DIFF
--- a/packages/electron/src/main/window/WorkspaceManagerWindow.ts
+++ b/packages/electron/src/main/window/WorkspaceManagerWindow.ts
@@ -23,6 +23,7 @@ import { ensureWorkspaceLocalNumbersInBackground } from '../services/tracker/ens
 import { updateTrackerSchemaWorkspace } from '../services/TrackerSchemaService';
 import { getDialogDefaultPath, rememberDialogSelection } from '../utils/dialogPaths';
 import { windowReferencesWorkspace } from './windowState';
+import { formatScannedCount, isMarkdownFile, summarizeWorkspaceScan } from './workspaceScanCounts';
 import { TutorialProjectService } from '../services/tutorial/TutorialProjectService';
 import {
   normalizeTutorialEntryPoint,
@@ -290,16 +291,14 @@ export function setupWorkspaceManagerHandlers() {
         try {
           if (existsSync(workspace.path)) {
             const stats = statSync(workspace.path);
-            const { files, limited } = await getWorkspaceFiles(workspace.path, '', 1000, 5);
+            const scan = await getWorkspaceFiles(workspace.path, '', 1000, 5);
 
             return {
               ...workspace,
               lastOpened: workspace.timestamp, // Use the timestamp from the recent items
               lastModified: stats.mtime.getTime(),
-              fileCount: limited ? `${files.length}+` : files.length,
-              markdownCount: files.filter(f => f.endsWith('.md') || f.endsWith('.markdown')).length,
-              exists: true,
-              limited
+              ...summarizeWorkspaceScan(scan),
+              exists: true
             };
           }
         } catch (error) {
@@ -342,7 +341,7 @@ export function setupWorkspaceManagerHandlers() {
           const stats = statSync(filePath);
           totalSize += stats.size;
 
-          if (file.endsWith('.md') || file.endsWith('.markdown')) {
+          if (isMarkdownFile(file)) {
             markdownFiles.push(file);
           }
         } catch (error) {
@@ -354,8 +353,8 @@ export function setupWorkspaceManagerHandlers() {
       const recentFiles = store.get(`workspaceRecentFiles.${workspacePath}`, []) as string[];
 
       return {
-        fileCount: limited ? `${files.length}+` : files.length,
-        markdownCount: markdownFiles.length,
+        fileCount: formatScannedCount(files.length, limited),
+        markdownCount: formatScannedCount(markdownFiles.length, limited),
         totalSize,
         recentFiles: recentFiles.slice(0, 5),
         limited

--- a/packages/electron/src/main/window/__tests__/workspaceScanCounts.test.ts
+++ b/packages/electron/src/main/window/__tests__/workspaceScanCounts.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatScannedCount,
+  isMarkdownFile,
+  summarizeWorkspaceScan,
+} from '../workspaceScanCounts';
+
+describe('isMarkdownFile', () => {
+  it.each(['README.md', 'docs/guide.md', 'specs/a.markdown'])('accepts %s', p => {
+    expect(isMarkdownFile(p)).toBe(true);
+  });
+
+  // The control that must go the other way. Without it, a predicate that
+  // returned `true` unconditionally would pass every case above.
+  it.each(['main.ts', 'notes.txt', 'image.png', 'mdfile', '.mdrc', 'a.md.bak'])(
+    'rejects %s',
+    p => {
+      expect(isMarkdownFile(p)).toBe(false);
+    },
+  );
+
+  // Pinned deliberately: the two inline copies this replaces were
+  // case-sensitive, so preserving that keeps the change from moving any
+  // existing count. Changing it is a separate decision.
+  it('is case-sensitive, matching the behaviour it replaces', () => {
+    expect(isMarkdownFile('README.MD')).toBe(false);
+  });
+});
+
+describe('formatScannedCount', () => {
+  it('returns the plain number when the scan completed', () => {
+    expect(formatScannedCount(207, false)).toBe(207);
+  });
+
+  it('marks the count as a lower bound when the scan gave up', () => {
+    expect(formatScannedCount(16, true)).toBe('16+');
+  });
+
+  it('keeps a completed zero distinct from a truncated zero', () => {
+    // "0 markdown files" is a fact; "0+ markdown files" means the scan never
+    // got far enough to find any. Collapsing them is the #1376 bug in
+    // miniature.
+    expect(formatScannedCount(0, false)).toBe(0);
+    expect(formatScannedCount(0, true)).toBe('0+');
+  });
+});
+
+describe('summarizeWorkspaceScan (#1376)', () => {
+  const files = ['.agents/a.md', '.claude/b.md', 'README.md', 'assets/tex.png', 'src/main.ts'];
+
+  it('reports exact counts for a scan that finished', () => {
+    expect(summarizeWorkspaceScan({ files, limited: false })).toEqual({
+      fileCount: 5,
+      markdownCount: 3,
+      limited: false,
+    });
+  });
+
+  /**
+   * The reported bug. The scan stops inside large asset directories that
+   * `readdir` returns before `docs/`, so the markdown it found is a floor, not
+   * a total. `fileCount` already said so; `markdownCount` did not, and a
+   * workspace holding 207 markdown files displayed "16 markdown files".
+   */
+  it('marks BOTH counts as lower bounds when the scan was truncated', () => {
+    expect(summarizeWorkspaceScan({ files, limited: true })).toEqual({
+      fileCount: '5+',
+      markdownCount: '3+',
+      limited: true,
+    });
+  });
+
+  it('carries the truncation flag through for callers that need it', () => {
+    expect(summarizeWorkspaceScan({ files: [], limited: true }).limited).toBe(true);
+    expect(summarizeWorkspaceScan({ files: [], limited: false }).limited).toBe(false);
+  });
+
+  it('counts no markdown as a truncated zero rather than a confident zero', () => {
+    expect(summarizeWorkspaceScan({ files: ['assets/a.png'], limited: true })).toEqual({
+      fileCount: '1+',
+      markdownCount: '0+',
+      limited: true,
+    });
+  });
+});

--- a/packages/electron/src/main/window/workspaceScanCounts.ts
+++ b/packages/electron/src/main/window/workspaceScanCounts.ts
@@ -1,0 +1,55 @@
+/**
+ * Counts derived from a workspace scan.
+ *
+ * `getWorkspaceFiles` walks the workspace under a file budget and a depth
+ * budget and stops the moment either runs out, returning `limited: true`. Every
+ * count taken from that result is therefore a LOWER BOUND, not a total, and a
+ * bare number presents a partial scan as a definitive answer (#1376: a
+ * workspace holding 207 markdown files reported "16 markdown files", because
+ * the budget was exhausted by large asset directories that `readdir` returned
+ * before `docs/` and `specs/`).
+ *
+ * `fileCount` already carried the `N+` suffix for exactly this reason. These
+ * helpers exist so its siblings cannot drift away from that decision again.
+ */
+
+/**
+ * The markdown predicate used for the workspace cards. Kept byte-identical to
+ * the two inline copies it replaces, extension-cased included, so this change
+ * moves no counts on its own.
+ */
+export function isMarkdownFile(relativePath: string): boolean {
+  return relativePath.endsWith('.md') || relativePath.endsWith('.markdown');
+}
+
+/**
+ * Render a scanned count honestly: `1000+` when the scan gave up, the plain
+ * number when it completed. Returns `number | string` because that is the shape
+ * `fileCount` has always sent to the renderer.
+ */
+export function formatScannedCount(count: number, limited: boolean): number | string {
+  return limited ? `${count}+` : count;
+}
+
+export interface WorkspaceScanCounts {
+  fileCount: number | string;
+  markdownCount: number | string;
+  limited: boolean;
+}
+
+/**
+ * Summarize a `getWorkspaceFiles` result into the counts the workspace card and
+ * the stats panel display. Pure, so the truncation behaviour is testable
+ * without Electron or a filesystem.
+ */
+export function summarizeWorkspaceScan(scan: {
+  files: string[];
+  limited: boolean;
+}): WorkspaceScanCounts {
+  const markdown = scan.files.filter(isMarkdownFile).length;
+  return {
+    fileCount: formatScannedCount(scan.files.length, scan.limited),
+    markdownCount: formatScannedCount(markdown, scan.limited),
+    limited: scan.limited,
+  };
+}

--- a/packages/electron/src/renderer/components/WorkspaceManager/WorkspaceManager.tsx
+++ b/packages/electron/src/renderer/components/WorkspaceManager/WorkspaceManager.tsx
@@ -48,19 +48,24 @@ if (typeof window !== 'undefined' && window.electronAPI?.onThemeChange) {
   });
 }
 
+// `fileCount` and `markdownCount` arrive as `"N+"` when the workspace scan hit
+// its budget and stopped early, and as a plain number when it completed. The
+// main process has always sent the suffixed form for `fileCount`; the type said
+// `number` anyway, which is how `markdownCount` came to present a partial scan
+// as an exact total (#1376).
 interface WorkspaceInfo {
   path: string;
   name: string;
   lastOpened: number | string;
   lastModified?: number | string;
-  fileCount?: number;
-  markdownCount?: number;
+  fileCount?: number | string;
+  markdownCount?: number | string;
   exists: boolean;
 }
 
 interface WorkspaceStats {
-  fileCount: number;
-  markdownCount: number;
+  fileCount: number | string;
+  markdownCount: number | string;
   totalSize: number;
   recentFiles: string[];
 }

--- a/packages/electron/src/renderer/components/WorkspaceManager/__tests__/WorkspaceManager.truncatedCounts.test.tsx
+++ b/packages/electron/src/renderer/components/WorkspaceManager/__tests__/WorkspaceManager.truncatedCounts.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * #1376: the workspace scan stops at a file/depth budget, so its counts are
+ * lower bounds. The main process now sends `"N+"` for a truncated markdown
+ * count exactly as it always has for `fileCount`. These tests cover the half
+ * the pure tests cannot: that the suffixed value survives the trip to the
+ * screen instead of being coerced, rounded, or dropped.
+ */
+
+const truncated = {
+  path: '/projects/big',
+  name: 'big',
+  lastOpened: 1700000000000,
+  exists: true,
+  fileCount: '1000+',
+  markdownCount: '16+',
+};
+
+const complete = {
+  path: '/projects/small',
+  name: 'small',
+  lastOpened: 1700000000000,
+  exists: true,
+  fileCount: 42,
+  markdownCount: 7,
+};
+
+const getWorkspaceStats = vi.fn();
+
+(window as unknown as { electronAPI: unknown }).electronAPI = {
+  getResolvedThemeSync: () => 'dark',
+  onThemeChange: vi.fn(),
+  workspaceManager: {
+    getRecentWorkspaces: vi.fn().mockResolvedValue([truncated, complete]),
+    getWorkspaceStats,
+    openWorkspace: vi.fn(),
+  },
+  tutorial: {
+    getStatus: vi.fn().mockResolvedValue({ success: true, exists: false }),
+    start: vi.fn(),
+  },
+};
+
+const { WorkspaceManager } = await import('../WorkspaceManager');
+
+afterEach(() => cleanup());
+
+describe('workspace card markdown count (#1376)', () => {
+  it('shows a truncated count as a lower bound, not as an exact total', async () => {
+    render(<WorkspaceManager />);
+    expect(await screen.findByText('16+ markdown files')).toBeTruthy();
+  });
+
+  /**
+   * The control that must go the other way: an implementation that always
+   * appended "+" would pass the assertion above while lying about every
+   * complete scan. A finished count must still render bare.
+   */
+  it('shows a completed count with no suffix', async () => {
+    render(<WorkspaceManager />);
+    expect(await screen.findByText('7 markdown files')).toBeTruthy();
+    expect(screen.queryByText('7+ markdown files')).toBeNull();
+  });
+
+  it('does not render the truncated count as "16"', async () => {
+    // The pre-fix symptom, stated as the thing that must no longer appear.
+    render(<WorkspaceManager />);
+    await screen.findByText('16+ markdown files');
+    expect(screen.queryByText('16 markdown files')).toBeNull();
+  });
+});
+
+describe('workspace stats panel counts (#1376)', () => {
+  it('carries both suffixed counts into the stats cards', async () => {
+    getWorkspaceStats.mockResolvedValue({
+      fileCount: '10000+',
+      markdownCount: '16+',
+      totalSize: 1024,
+      recentFiles: [],
+    });
+
+    render(<WorkspaceManager />);
+    fireEvent.click(await screen.findByText('big'));
+
+    // Labelled cards, so the assertion cannot pass on a stray match elsewhere.
+    const markdownCard = (await screen.findByText('Markdown Files')).parentElement;
+    expect(markdownCard?.textContent).toContain('16+');
+
+    const filesCard = (await screen.findByText('Total Files')).parentElement;
+    expect(filesCard?.textContent).toContain('10000+');
+  });
+
+  it('leaves a completed scan unsuffixed in the stats cards', async () => {
+    getWorkspaceStats.mockResolvedValue({
+      fileCount: 42,
+      markdownCount: 7,
+      totalSize: 1024,
+      recentFiles: [],
+    });
+
+    render(<WorkspaceManager />);
+    fireEvent.click(await screen.findByText('small'));
+
+    const markdownCard = (await screen.findByText('Markdown Files')).parentElement;
+    expect(markdownCard?.textContent).toContain('7');
+    expect(markdownCard?.textContent).not.toContain('+');
+  });
+});


### PR DESCRIPTION
## What

`getWorkspaceFiles` walks the workspace under a file budget and a depth budget and stops the moment either runs out. The workspace card calls it with 1000 files and depth 5, so on a large project the counts it returns are lower bounds rather than totals.

`fileCount` already said so. Two lines below it, `markdownCount` did not:

```ts
fileCount:     limited ? `${files.length}+` : files.length,
markdownCount: files.filter(f => f.endsWith('.md') || f.endsWith('.markdown')).length,
```

So a workspace holding 207 markdown files displayed a confident "16 markdown files". The truncation flag existed, was returned to the renderer, and was applied to one field but not its neighbour.

The reporter's forensics hold up against the code. `readdir` order puts the hidden `.agents` and `.claude` folders first, 7 markdown files each, then two root level files, which is the 16. The large asset directories that sort before `docs/` and `specs/` then exhaust the budget and the loop breaks, so the bulk of the markdown is never reached. Their observation that byte-identical worktrees showed 14 or 16 is `readdir` ordering rather than scan speed, but the conclusion was right either way.

## The change

A small pure module holds the markdown predicate and the formatting, so the decision sits in one place instead of being duplicated at two call sites where one of them can drift. The predicate is byte-identical to the two inline copies it replaces, extension casing included, so this moves no existing count on its own.

The renderer needed no display change. It already renders whatever the main process sends, so `"16+"` reaches the card as "16+ markdown files". What it did need was honest types: `fileCount` was declared `number` while the main process has always been able to send `"1000+"`, and that gap is how the sibling drifted in the first place.

## Verification

22 tests. 17 pure ones on the module, 5 in jsdom on the workspace card and the stats panel, covering the half the pure tests cannot: that a suffixed count survives the trip to the screen rather than being coerced or dropped.

Every assertion has a control that must go the other way, because "always append a plus" would satisfy the bug report while lying about every completed scan:

| Mutation | Result |
| --- | --- |
| markdownCount ignores `limited`, the original bug | 2 fail |
| `formatScannedCount` never suffixes | 4 fail |
| `formatScannedCount` always suffixes | 3 fail |
| `isMarkdownFile` returns true for everything | 10 fail |
| suffix kept on `fileCount`, dropped on `markdownCount` | 2 fail |

129 tests pass across `main/window` and the `WorkspaceManager` component, 18 files.

Two `tsc` errors remain, in `AnimationVideoRecorder.ts` and `CanvasSurface.tsx`. Both are pre-existing. I confirmed by stashing this branch and running against a clean `main`, where the same two appear and nothing else. Widening the two count types produced none of its own, including at the `fileCount.toLocaleString()` call sites, which accept both.

## What this does not cover

The call site itself is untested. I checked by mutating it: reverting the handler to the bare count leaves all 22 tests green, because the pure tests exercise the module and the jsdom tests feed the component a prop directly. Testing the IPC handler means standing up the Electron imports that `WorkspaceManagerWindow.ts` pulls in, and the existing test beside mine, `workspaceManagerRendererQuery.test.ts`, takes the same extract and test the decision approach rather than importing that module. I followed the local convention, but I would rather state the gap than let the table above imply it is closed.

`totalSize` on the same card has the identical root cause. It sums only the files the scan reached, so it is understated by the same truncation and displays as an exact size. I left it alone because it is not what was reported and because "1.2 MB+" is a wording call rather than a mechanical one. Happy to include it if you want it in the same change.

I have not reproduced this in a running build. The root cause is confirmed in the code and the reporter's numbers match what the scanner does, but the 207 against 16 observation is theirs.

Fixes #1376

