### PR TITLE
fix: stop blaming the user for permission denies nobody answered

### DIFF
--- a/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
+++ b/packages/electron/src/main/mcp/tools/interactiveToolHandlers.ts
@@ -587,7 +587,11 @@ function waitForToolPermissionAnswer(
       request: undefined,
       extra: { signal },
       toolName: 'ToolPermission',
-      onAbort: () => settle({ decision: 'deny', scope: 'once', cancelled: true }, 'client-abort'),
+      onAbort: () =>
+        settle(
+          { decision: 'deny', scope: 'once', cancelled: true, unansweredReason: 'client-abort' },
+          'client-abort',
+        ),
     });
 
     const POLL_INTERVAL = 1000;
@@ -612,7 +616,10 @@ function waitForToolPermissionAnswer(
       console.warn(
         `[MCP Server] ToolPermission timed out (deny): requestId=${requestId}`,
       );
-      settle({ decision: "deny", scope: "once", cancelled: true }, "timeout");
+      settle(
+        { decision: "deny", scope: "once", cancelled: true, unansweredReason: "timeout" },
+        "timeout",
+      );
     }, MAX_WAIT);
   });
 }

--- a/packages/electron/src/main/services/ai/__tests__/claudeCliToolPermission.attribution.test.ts
+++ b/packages/electron/src/main/services/ai/__tests__/claudeCliToolPermission.attribution.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildToolPermissionBehaviorResult,
+  buildToolPermissionResultPayload,
+  normalizeToolPermissionAnswer,
+  resolveClaudeCliToolPermission,
+  toToolPermissionMcpResult,
+  type ToolPermissionAnswer,
+  type ToolPermissionDeps,
+  type ToolPermissionUnansweredReason,
+} from '../claudeCliToolPermission';
+
+/**
+ * #1348: three fail-closed paths settled as `cancelled: true`, which is also
+ * what a real user cancellation sets, so the CLI was told "Tool call cancelled
+ * by user" for prompts no user was ever shown. The deny is right. Who it is
+ * attributed to was not.
+ */
+
+const input = { file_path: '/w/a.ts', content: 'x' };
+const REASONS: ToolPermissionUnansweredReason[] = ['client-abort', 'timeout', 'wait-failed'];
+
+function messageFor(answer: ToolPermissionAnswer): string {
+  const r = buildToolPermissionBehaviorResult(answer, input);
+  expect(r.behavior).toBe('deny');
+  return (r as { behavior: 'deny'; message: string }).message;
+}
+
+describe('unanswered denies are not attributed to the user (#1348)', () => {
+  it.each(REASONS)('%s says no user decision was made', reason => {
+    const message = messageFor({ decision: 'deny', scope: 'once', cancelled: true, unansweredReason: reason });
+    expect(message).toContain('No user decision was made');
+    expect(message).toContain('not answered');
+  });
+
+  it.each(REASONS)('%s never claims the user cancelled or denied', reason => {
+    const message = messageFor({ decision: 'deny', scope: 'once', cancelled: true, unansweredReason: reason });
+    expect(message).not.toContain('by user');
+  });
+
+  it('gives each reason its own message, so the cause is diagnosable', () => {
+    const messages = REASONS.map(reason =>
+      messageFor({ decision: 'deny', scope: 'once', cancelled: true, unansweredReason: reason }),
+    );
+    expect(new Set(messages).size).toBe(REASONS.length);
+    expect(messages[0]).toContain('session ended');
+    expect(messages[1]).toContain('timed out');
+    expect(messages[2]).toContain('could not be delivered');
+  });
+});
+
+/**
+ * The controls that must go the other way. A change that simply reworded every
+ * deny would satisfy the block above while destroying the real distinction, so
+ * a genuine user decision has to keep saying so.
+ */
+describe('a real user decision is still attributed to the user', () => {
+  it('a user deny still reads as denied by user', () => {
+    expect(messageFor({ decision: 'deny', scope: 'once' })).toBe('Tool call denied by user');
+  });
+
+  it('a user cancellation still reads as cancelled by user', () => {
+    expect(messageFor({ decision: 'deny', scope: 'once', cancelled: true })).toBe(
+      'Tool call cancelled by user',
+    );
+  });
+
+  it('a cancelled allow is still a deny attributed to the user', () => {
+    expect(messageFor({ decision: 'allow', scope: 'once', cancelled: true })).toBe(
+      'Tool call cancelled by user',
+    );
+  });
+
+  it('an allow is unaffected', () => {
+    expect(buildToolPermissionBehaviorResult({ decision: 'allow', scope: 'once' }, input)).toEqual({
+      behavior: 'allow',
+      updatedInput: input,
+    });
+  });
+
+  it('an unanswered reason cannot turn an allow into a deny on its own', () => {
+    // Defensive: the field describes attribution, not the decision. An allow
+    // that somehow carries one must still allow, or a stray field could start
+    // blocking approved calls.
+    expect(
+      buildToolPermissionBehaviorResult(
+        { decision: 'allow', scope: 'once', unansweredReason: 'timeout' },
+        input,
+      ),
+    ).toEqual({ behavior: 'allow', updatedInput: input });
+  });
+});
+
+describe('a surface cannot forge an unanswered reason', () => {
+  it.each(REASONS)('drops %s arriving in an IPC payload', reason => {
+    // "Unanswered" means nobody answered. An answer that arrived cannot be one,
+    // and a renderer must not be able to dress its own decision as an
+    // infrastructure failure.
+    const answer = normalizeToolPermissionAnswer({ decision: 'deny', scope: 'once', unansweredReason: reason });
+    expect(answer.unansweredReason).toBeUndefined();
+    expect(messageFor(answer)).toBe('Tool call denied by user');
+  });
+
+  it('drops it from a nested response payload too', () => {
+    const answer = normalizeToolPermissionAnswer({
+      response: { decision: 'deny', scope: 'once', cancelled: true, unansweredReason: 'timeout' },
+    });
+    expect(answer.unansweredReason).toBeUndefined();
+    expect(messageFor(answer)).toBe('Tool call cancelled by user');
+  });
+
+  // The control: normalize is not simply discarding everything it is handed.
+  it('still carries the fields a surface is allowed to set', () => {
+    expect(normalizeToolPermissionAnswer({ decision: 'allow', scope: 'always', cancelled: false })).toEqual({
+      decision: 'allow',
+      scope: 'always',
+      cancelled: false,
+    });
+  });
+});
+
+describe('the persisted widget payload records the distinction', () => {
+  it('carries the reason when there was no answer', () => {
+    expect(
+      buildToolPermissionResultPayload({
+        decision: 'deny',
+        scope: 'once',
+        cancelled: true,
+        unansweredReason: 'client-abort',
+      }),
+    ).toEqual({ decision: 'deny', scope: 'once', cancelled: true, unansweredReason: 'client-abort' });
+  });
+
+  it('omits the key entirely for a real user answer', () => {
+    const payload = buildToolPermissionResultPayload({ decision: 'deny', scope: 'once', cancelled: true });
+    expect(payload).toEqual({ decision: 'deny', scope: 'once', cancelled: true });
+    expect('unansweredReason' in payload).toBe(false);
+  });
+});
+
+/**
+ * The pure tests above prove the message is right for a given reason. This one
+ * proves the reason is actually attached where it happens, which no assertion
+ * on the helpers can show.
+ */
+describe('a failed wait reaches the CLI as unanswered, end to end (#1348)', () => {
+  function makeDeps(overrides: Partial<ToolPermissionDeps> = {}): ToolPermissionDeps {
+    return {
+      isPatternApproved: vi.fn(() => false),
+      markPatternApproved: vi.fn(),
+      persistToolUse: vi.fn(async () => {}),
+      persistToolResult: vi.fn(async () => {}),
+      setWaitingStatus: vi.fn(),
+      applySettle: vi.fn(),
+      savePattern: vi.fn(async () => {}),
+      notifyBlocked: vi.fn(),
+      makeRequestId: vi.fn(() => 'req-attribution'),
+      waitForAnswer: async () => ({ decision: 'allow', scope: 'once' }) as ToolPermissionAnswer,
+      ...overrides,
+    } as ToolPermissionDeps;
+  }
+
+  async function resolveWith(deps: ToolPermissionDeps) {
+    const result = await resolveClaudeCliToolPermission(
+      { args: { tool_name: 'Read', input: { file_path: '/w/a.ts' } }, sessionId: 's1', workspacePath: '/w' },
+      deps,
+    );
+    return JSON.parse(result.content[0].text) as { behavior: string; message?: string };
+  }
+
+  it('does not tell the CLI the user cancelled when the wait rejected', async () => {
+    const behavior = await resolveWith(
+      makeDeps({
+        waitForAnswer: async () => {
+          throw new Error('socket closed');
+        },
+      }),
+    );
+    expect(behavior.behavior).toBe('deny');
+    expect(behavior.message).toContain('No user decision was made');
+    expect(behavior.message).not.toContain('by user');
+  });
+
+  it('records the unanswered state on the persisted widget result', async () => {
+    const persistToolResult = vi.fn<ToolPermissionDeps['persistToolResult']>(async () => {});
+    await resolveWith(
+      makeDeps({
+        persistToolResult,
+        waitForAnswer: async () => {
+          throw new Error('socket closed');
+        },
+      }),
+    );
+    expect(persistToolResult).toHaveBeenCalledTimes(1);
+    expect(persistToolResult.mock.calls[0][0]).toMatchObject({
+      result: { decision: 'deny', cancelled: true, unansweredReason: 'wait-failed' },
+      isError: true,
+    });
+  });
+
+  // The control that must go the other way: a wait that RESOLVES with a real
+  // user deny must still be attributed to the user, or this change would have
+  // erased the distinction it exists to draw.
+  it('still attributes a real user deny to the user', async () => {
+    const behavior = await resolveWith(
+      makeDeps({ waitForAnswer: async () => ({ decision: 'deny', scope: 'once' }) }),
+    );
+    expect(behavior.message).toBe('Tool call denied by user');
+  });
+
+  it('still allows when the user allows', async () => {
+    const behavior = await resolveWith(makeDeps());
+    expect(behavior.behavior).toBe('allow');
+  });
+});
+
+describe('the CLI return contract is unchanged in shape', () => {
+  it.each(REASONS)('%s is still a normal deny response, not a tool error', reason => {
+    const behavior = buildToolPermissionBehaviorResult(
+      { decision: 'deny', scope: 'once', cancelled: true, unansweredReason: reason },
+      input,
+    );
+    const mcp = toToolPermissionMcpResult(behavior);
+    expect(mcp.isError).toBe(false);
+    expect(JSON.parse(mcp.content[0].text)).toEqual(behavior);
+  });
+});

--- a/packages/electron/src/main/services/ai/claudeCliToolPermission.ts
+++ b/packages/electron/src/main/services/ai/claudeCliToolPermission.ts
@@ -68,10 +68,32 @@ export function decideAutoPermission(args: {
 }
 
 /** Decision + scope the `ToolPermissionWidget` sends back. */
+/**
+ * Why a permission request settled without anyone answering it.
+ *
+ * Every one of these fail-closed paths used to settle as `cancelled: true`,
+ * which is also what a real user cancellation sets, so the CLI was told "Tool
+ * call cancelled by user" for requests no user was ever shown (#1348). The
+ * deny is correct; the attribution was not.
+ */
+export type ToolPermissionUnansweredReason =
+  /** The requesting CLI went away, so the approval surface answers nobody. */
+  | 'client-abort'
+  /** MAX_WAIT elapsed with no response from any surface. */
+  | 'timeout'
+  /** The wait itself rejected, so the prompt never reached a person. */
+  | 'wait-failed';
+
 export interface ToolPermissionAnswer {
   decision: 'allow' | 'deny';
   scope: 'once' | 'session' | 'always' | 'always-all';
   cancelled?: boolean;
+  /**
+   * Set only when the request settled with no human involved. Absent means the
+   * answer came from a person. Never accepted from a renderer payload — see
+   * `normalizeToolPermissionAnswer`.
+   */
+  unansweredReason?: ToolPermissionUnansweredReason;
 }
 
 export interface ToolPermissionResponseRecord {
@@ -181,14 +203,24 @@ export function buildToolPermissionResultPayload(answer: ToolPermissionAnswer): 
   decision: 'allow' | 'deny';
   scope: ToolPermissionAnswer['scope'];
   cancelled: boolean;
+  unansweredReason?: ToolPermissionUnansweredReason;
 } {
   return {
     decision: answer.decision,
     scope: answer.scope,
     cancelled: answer.cancelled === true,
+    // Persisted so the transcript record distinguishes an unshown prompt from a
+    // dismissed one. The widget does not read it yet.
+    ...(answer.unansweredReason ? { unansweredReason: answer.unansweredReason } : {}),
   };
 }
 
+/**
+ * Normalize an answer that arrived from a surface (IPC payload, mobile, DB
+ * record). `unansweredReason` is deliberately NOT read here: it means "no one
+ * answered", so an answer that arrived cannot carry it, and a renderer must not
+ * be able to make its own decision look like an infrastructure failure.
+ */
 export function normalizeToolPermissionAnswer(payload: any): ToolPermissionAnswer {
   const r = (payload && payload.response) || payload || {};
   const decision = r.decision === 'allow' ? 'allow' : 'deny';
@@ -239,6 +271,24 @@ export function parseToolPermissionResponseRecord(
   }
 }
 
+/**
+ * The message the agent receives when a request settled with nobody answering.
+ * The shared tail is the load-bearing part: it tells the agent not to report
+ * this as a user decision, which is what made #1348's failure read as a script
+ * defect rather than an unshown prompt.
+ */
+const UNANSWERED_DENY_MESSAGES: Record<ToolPermissionUnansweredReason, string> = {
+  'client-abort':
+    'Permission request was not answered: the requesting session ended before the prompt could be answered.',
+  timeout:
+    'Permission request was not answered: it timed out waiting for a response.',
+  'wait-failed':
+    'Permission request was not answered: it could not be delivered for approval.',
+};
+
+/** Appended to every unanswered deny so the distinction cannot be missed. */
+const NO_USER_DECISION = 'Denied by default. No user decision was made, and no prompt was answered.';
+
 /** Map a widget answer to the Claude Code permission-prompt-tool return contract. */
 export function buildToolPermissionBehaviorResult(
   answer: ToolPermissionAnswer,
@@ -246,6 +296,12 @@ export function buildToolPermissionBehaviorResult(
 ): ToolPermissionBehaviorResult {
   if (answer.decision === 'allow' && !answer.cancelled) {
     return { behavior: 'allow', updatedInput: input };
+  }
+  if (answer.unansweredReason) {
+    return {
+      behavior: 'deny',
+      message: `${UNANSWERED_DENY_MESSAGES[answer.unansweredReason]} ${NO_USER_DECISION}`,
+    };
   }
   return {
     behavior: 'deny',
@@ -383,9 +439,10 @@ export async function resolveClaudeCliToolPermission(
   try {
     answer = await deps.waitForAnswer({ sessionId, requestId });
   } catch (err) {
-    // Aborted / failed wait → deny (fail closed) and settle.
+    // Aborted / failed wait → deny (fail closed) and settle. The reason is
+    // carried so the CLI is not told the user cancelled something no user saw.
     deps.log?.(`[ToolPermission] wait failed for ${requestId}: ${err instanceof Error ? err.message : String(err)}`);
-    answer = { decision: 'deny', scope: 'once', cancelled: true };
+    answer = { decision: 'deny', scope: 'once', cancelled: true, unansweredReason: 'wait-failed' };
   }
 
   await deps.persistToolResult({


### PR DESCRIPTION
## What

A tool permission request can settle without any human being involved. There are three such paths, and all three set `cancelled: true`:

- `client-abort`, the requesting CLI went away, so the approval surface would answer nobody
- `timeout`, `MAX_WAIT` elapsed with no response from any surface
- the `waitForAnswer` call itself rejected, so the prompt never reached a person

`cancelled: true` is also what a genuine user cancellation sets. `buildToolPermissionBehaviorResult` reads only that flag, so all four cases returned **"Tool call cancelled by user"** to the CLI.

The deny is correct and should stay. Failing closed is the right posture for all three. What was wrong is who it got attributed to. In #1348 the reporter watched six agents get refused while sitting in front of the app, was shown nothing, and got a final error that read as a defect in their own workflow. It was not.

## The change

`ToolPermissionAnswer` gains an optional `unansweredReason`, set only on the three unattended paths, and the deny message says plainly that nobody answered and no user decision was made. A real deny still reads "Tool call denied by user" and a real cancellation still reads "Tool call cancelled by user", so the distinction the messages were supposed to carry now exists.

Each reason gets its own wording, because "the session ended", "it timed out" and "it could not be delivered" send you to three different places when you go looking. The reason is also persisted on the widget result payload, so the transcript record holds the truth. The widget does not read it yet.

`normalizeToolPermissionAnswer` deliberately does not read the field off an incoming payload. Unanswered means nobody answered, so an answer that arrived cannot be one, and a renderer should not be able to dress its own decision as an infrastructure failure.

## What this does not fix

**It does not fix the root cause of #1348**, which is why the waiters started aborting about 74 seconds into a five-subagent fan-out. I cannot reproduce that, and I would rather not guess at it. This makes that failure legible instead of silent: the agent stops reporting a user decision that never happened, the reason names which of the three paths fired, and the existing `[MCP Server] ToolPermission settled via <source>` log line now has a matching record on the message. Hence `Refs`, not `Fixes`.

It also does not surface anything new in the UI. The reporter's other complaint, that nothing indicated requests were pending or being refused, needs the widget to render the state this change persists, and that is a design call rather than a mechanical one.

## Verification

55 tests, 22 new plus the 29 existing ones in `claudeCliToolPermission.test.ts`, which pass unchanged. Those existing tests assert the user-attributed wording, so they are a standing control on this change: anything that erased the distinction would take them down with it.

Every claim has a control that must go the other way, since a change that simply reworded every deny would satisfy the bug report while destroying the thing it is for:

| Mutation | Result |
| --- | --- |
| revert the fix, no unanswered branch | 8 fail |
| every deny claims nobody answered | 9 fail |
| `normalizeToolPermissionAnswer` trusts the payload's reason | 4 fail |
| widget payload always stamps a reason | 2 fail |
| two reasons share one message | 1 fail |
| the `wait-failed` call site stops passing its reason | 2 fail |

The last row is the one worth naming. A round-trip test drives `resolveClaudeCliToolPermission` with a rejecting `waitForAnswer` and asserts what the CLI actually receives, because no assertion on the helpers can show that the reason is attached where the failure happens.

1145 tests pass across `services/ai`, `mcp` and `ipc`, 122 files.

Two `tsc` errors remain, in `AnimationVideoRecorder.ts` and `CanvasSurface.tsx`. Both are pre-existing, confirmed by stashing this branch and running against a clean `main`.

## The two call sites I could not cover

The `client-abort` and `timeout` sites live inside `waitForToolPermissionAnswer`, which is private to `interactiveToolHandlers.ts`. I checked rather than assumed: removing the reason at either site leaves all 55 tests green. The module's own lifecycle tests simulate the MCP server instead of importing the waiter, so following that pattern would test my simulation rather than your code, and exporting the waiter purely to reach it widens the module's surface for a test. That felt like your call rather than mine, so I left both sites explicit and readable and stated the gap here instead of letting the table above imply it is closed. Happy to export it, or to derive the reason from the `source` argument `settle` already receives, if you would rather have it covered.

Refs #1348

