### PR TITLE
feat: add search to the model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 <!-- New features go here -->
+- Search the model picker by model name, ID, or provider.
 
 ### Changed
 <!-- Changes to existing functionality go here -->

--- a/packages/electron/src/renderer/components/UnifiedAI/ModelSelector.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/ModelSelector.tsx
@@ -72,6 +72,7 @@ export function ModelSelector({
   const [providerLabels, setProviderLabels] = useState<Record<string, string>>({});
   const [providerIcons, setProviderIcons] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
   const aiProviderSettings = useAtomValue(aiProviderSettingsAtom);
   const advancedSettings = useAtomValue(advancedSettingsAtom);
   const { providers } = aiProviderSettings;
@@ -148,11 +149,15 @@ export function ModelSelector({
   useEffect(() => resetTypeahead, [resetTypeahead]);
 
   useEffect(() => {
-    if (!isOpen) resetTypeahead();
+    if (!isOpen) {
+      resetTypeahead();
+      setSearchQuery('');
+    }
   }, [isOpen, resetTypeahead]);
 
   const handleModelSelect = (modelId: string) => {
     resetTypeahead();
+    setSearchQuery('');
     onModelChange(modelId);
     setIsOpen(false);
   };
@@ -207,10 +212,15 @@ export function ModelSelector({
       event.preventDefault();
       event.stopPropagation();
       resetTypeahead();
+      setSearchQuery('');
       setIsOpen(false);
       onKeyboardDismiss?.();
       return;
     }
+
+    // Let the search field handle text entry without triggering the picker's
+    // existing typeahead navigation.
+    if (event.target instanceof HTMLInputElement) return;
 
     if (
       event.key.length !== 1
@@ -247,6 +257,12 @@ export function ModelSelector({
       .sort((a, b) => a.score - b.score);
 
     matches[0]?.option.focus();
+  };
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'ArrowDown') return;
+    event.preventDefault();
+    getEnabledModelOptions()[0]?.focus();
   };
 
   const getSettingsCategoryForModel = (modelId: string): SettingsCategory => {
@@ -372,8 +388,25 @@ export function ModelSelector({
     })),
   );
 
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+  const filteredModels = Object.fromEntries(
+    Object.entries(visibleModels)
+      .map(([provider, providerModels]) => [
+        provider,
+        providerModels.filter(model => {
+          if (!normalizedSearchQuery) return true;
+          return `${model.name} ${model.id} ${getProviderLabel(provider)}`
+            .toLowerCase()
+            .includes(normalizedSearchQuery);
+        }),
+      ] as const)
+      .filter(([, providerModels]) => providerModels.length > 0),
+  );
+  const hasVisibleModels = Object.keys(visibleModels).length > 0;
+  const hasFilteredModels = Object.keys(filteredModels).length > 0;
+
   // Group providers by type (agents vs models)
-  const groupedProviders = Object.entries(visibleModels).reduce((acc, [provider, providerModels]) => {
+  const groupedProviders = Object.entries(filteredModels).reduce((acc, [provider, providerModels]) => {
     const isAgent = getProviderType(provider) === 'agent';
     const type = isAgent ? 'agents' : 'models';
     if (!acc[type]) acc[type] = {};
@@ -431,12 +464,32 @@ export function ModelSelector({
             tabIndex={-1}
             {...getFloatingProps({ onKeyDown: handleMenuKeyDown })}
           >
+          {!loading && hasVisibleModels && (
+            <div className="model-selector-search sticky top-0 z-10 p-1 bg-[var(--nim-bg)]">
+              <div className="flex items-center gap-1.5 rounded border border-[var(--nim-border)] bg-[var(--nim-bg-secondary)] px-2 focus-within:border-[var(--nim-primary)]">
+                <MaterialSymbol icon="search" size={14} className="shrink-0 text-[var(--nim-text-faint)]" />
+                <input
+                  type="search"
+                  aria-label="Search models"
+                  data-testid="model-picker-search"
+                  className="min-w-0 flex-1 border-none bg-transparent py-1.5 text-xs text-[var(--nim-text)] outline-none placeholder:text-[var(--nim-text-faint)]"
+                  placeholder="Search models..."
+                  value={searchQuery}
+                  onChange={event => setSearchQuery(event.target.value)}
+                  onKeyDown={handleSearchKeyDown}
+                />
+              </div>
+            </div>
+          )}
           {loading ? (
             <div className="model-selector-loading p-3 text-center text-xs text-[var(--nim-text-faint)]">Loading models...</div>
-          ) : Object.keys(visibleModels).length === 0 ? (
+          ) : !hasVisibleModels ? (
             <div className="model-selector-empty p-3 text-center text-xs text-[var(--nim-text-faint)]">No models available</div>
           ) : (
             <>
+              {!hasFilteredModels && (
+                <div className="model-selector-empty p-3 text-center text-xs text-[var(--nim-text-faint)]">No matching models</div>
+              )}
               {/* Agents Section */}
               {groupedProviders.agents && Object.keys(groupedProviders.agents).length > 0 && (
                 <>

--- a/packages/electron/src/renderer/components/UnifiedAI/__tests__/modelPickerKeyboard.test.tsx
+++ b/packages/electron/src/renderer/components/UnifiedAI/__tests__/modelPickerKeyboard.test.tsx
@@ -314,3 +314,56 @@ describe('AI model picker provider visibility', () => {
     expect(screen.queryByRole('button', { name: 'Local Model' })).toBeNull();
   });
 });
+
+describe('AI model picker search', () => {
+  it('filters models by name, ID, and provider while keeping keyboard navigation available', async () => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        aiGetModels: vi.fn().mockResolvedValue({
+          success: true,
+          grouped: {
+            opencode: [
+              { id: 'opencode:kimi-k2', name: 'Kimi K2', provider: 'opencode' },
+              { id: 'opencode:deepseek-v3', name: 'DeepSeek V3', provider: 'opencode' },
+            ],
+            claude: [{ id: 'claude:haiku', name: 'Haiku', provider: 'claude' }],
+          },
+        }),
+      },
+    });
+
+    renderModelSelector(
+      <ModelSelector currentModel="opencode:kimi-k2" onModelChange={() => {}} />,
+      true,
+    );
+
+    fireEvent.click(screen.getByTestId('model-picker'));
+    const search = await screen.findByRole('searchbox', { name: 'Search models' });
+
+    fireEvent.change(search, { target: { value: 'deepseek' } });
+    const deepSeek = screen.getByRole('button', { name: 'DeepSeek V3' });
+    expect(screen.queryByRole('button', { name: 'Kimi K2' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Haiku' })).toBeNull();
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(deepSeek);
+
+    fireEvent.change(search, { target: { value: 'OpenCode' } });
+    screen.getByRole('button', { name: 'Kimi K2' });
+    screen.getByRole('button', { name: 'DeepSeek V3' });
+    expect(screen.queryByRole('button', { name: 'Haiku' })).toBeNull();
+
+    fireEvent.change(search, { target: { value: 'claude:haiku' } });
+    screen.getByRole('button', { name: 'Haiku' });
+    expect(screen.queryByRole('button', { name: 'Kimi K2' })).toBeNull();
+
+    fireEvent.change(search, { target: { value: 'not-a-model' } });
+    screen.getByText('No matching models');
+    screen.getByRole('button', { name: 'Configure models' });
+
+    fireEvent.keyDown(search, { key: 'Escape' });
+    fireEvent.click(screen.getByTestId('model-picker'));
+    expect((await screen.findByRole('searchbox', { name: 'Search models' }) as HTMLInputElement).value).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

OpenCode can expose hundreds of models in the model picker, which makes finding a specific model by scrolling slow and frustrating.

This change adds a sticky, full-width search field at the top of the picker. It filters the existing catalog by model name, raw model ID, or provider label while preserving the current provider grouping and model-selection behavior.

The interaction remains keyboard-friendly:

- Arrow Down moves from the search field into the first available result.
- The existing model-option arrow navigation and typeahead behavior remain intact.
- An explicit empty state appears when no models match.
- The query resets whenever the picker closes.

## Related issue

No linked issue. This is a focused model-picker usability improvement, particularly for large OpenCode catalogs.

## Testing

- All required GitHub checks pass: Unit Tests, TypeScript Check, and Transcript Bundle.
- `npx vitest --run packages/electron/src/renderer/components/UnifiedAI/__tests__/modelPickerKeyboard.test.tsx` — 9 tests passed.
- `npm run typecheck` — all 25 workspaces passed.

The full pre-push suite was also attempted locally on Windows. Unrelated environment-specific failures occurred in native SQLite, symlink, POSIX-path, and locale-dependent tests; the repository's required GitHub checks are green.

## Notes for reviewers

The main interaction to review is the boundary between the new search input and the picker's existing keyboard typeahead. Text entered in the search field is allowed to behave normally, while keyboard events from model options continue through the existing typeahead path.

The implementation is intentionally limited to the existing `ModelSelector`, its behavior tests, and the changelog. It does not change model discovery, provider configuration, dependencies, or persisted settings.