### PR TITLE
fix(scripts): compare identity-scope paths with POSIX separators

### DIFF
--- a/scripts/check-identity-scopes.mjs
+++ b/scripts/check-identity-scopes.mjs
@@ -104,7 +104,10 @@ export function scanIdentityScopeViolations({
               : null;
         if (!rule || hasEscape(lines, lineIndex)) return;
         const violation = {
-          file: path.relative(root, filePath),
+          // POSIX separators: the baseline is checked in with forward slashes,
+          // so a Windows path.relative() matches nothing and every baselined
+          // entry reports as both a violation and stale.
+          file: path.relative(root, filePath).split(path.sep).join('/'),
           line: lineIndex + 1,
           rule,
           source: line.trim(),


### PR DESCRIPTION
## Summary

`scripts/identity-scope-baseline.json` is checked in with forward-slash paths, but `check-identity-scopes.mjs` builds each violation's path with `path.relative`, which yields backslashes on Windows. No baseline entry ever matches, so every baselined declaration is reported as a fresh violation *and* every baseline entry is simultaneously reported as stale — 3 of the 6 subtests fail.

That fails `npm run test:prepush-gate`, which `.githooks/pre-push` runs unconditionally. It is not covered by the Windows Vitest skip described in `docs/WINDOWS_PREPUSH_GATE.md`, so on Windows the gate blocks every push, including one that changes nothing it inspects.

Normalising the separators where the path is recorded is a no-op on POSIX, where `path.sep` is already `/`.

## Related issue

None — found while trying to push an unrelated branch from Windows.

## Testing

- `node --test scripts/__tests__/check-identity-scopes.test.mjs` — 6/6 pass on Windows. Before the change, 3 of the 6 fail (`a baselined declaration is forgiven exactly once per occurrence`, `the repository identity paths satisfy the gate, modulo the recorded baseline`, and `every baseline entry still matches a real declaration`).
- `npm run test:prepush-gate` — passes end to end; it did not before.
- No behaviour change on POSIX.

## Notes for reviewers

Worth a sanity check on where the normalisation belongs. I normalised at the recording site rather than when loading the baseline, on the reasoning that the checked-in baseline is the canonical artifact and should stay in its committed form — but the other placement is defensible.

Related precedent: #1227 fixed the same class of Windows pre-push portability problem.
