### PR TITLE
fix(search): use the bundled ripgrep in ElectronFileSystemService

### DIFF
--- a/packages/electron/src/main/ipc/WorkspaceHandlers.ts
+++ b/packages/electron/src/main/ipc/WorkspaceHandlers.ts
@@ -1,11 +1,9 @@
-import { BrowserWindow, app, shell, clipboard, nativeImage } from 'electron';
+import { BrowserWindow, shell, clipboard, nativeImage } from 'electron';
 import { readFileSync, readdirSync, statSync, existsSync, promises as fsPromises } from 'fs';
-import * as fs from 'fs';
 import { join, basename, dirname, extname } from 'path';
 import * as path from 'path';
 import { exec, execFile, spawn } from 'child_process';
 import { promisify } from 'util';
-import os from 'os';
 import { AnalyticsService } from '../services/analytics/AnalyticsService';
 import { openWorkspaceFile, openFile } from '../file/FileOpener';
 import { fuzzyMatchPath } from '@nimbalyst/runtime';
@@ -40,6 +38,7 @@ import {
 } from '../services/tracker/localKeyAllocator';
 import { workspaceLocalKeyStore } from '../services/tracker/workspaceLocalKeyStore';
 import { database } from '../database/PGLiteDatabaseWorker';
+import { getRipgrepPath } from '../services/ripgrepPath';
 
 /**
  * Deep merge utility for workspace state updates.
@@ -127,66 +126,6 @@ function shouldIncludeQuickOpenCacheItem(
     if (maskPatterns.length === 0) return true;
     if (item.type === 'directory') return false;
     return matchesFileMask(item.path, maskPatterns);
-}
-
-// Get the ripgrep binary path for the current platform.
-// Resolves the rg bundled by the @vscode/ripgrep package at
-// node_modules/@vscode/ripgrep/bin/rg(.exe). Result is cached for
-// the lifetime of the process — search is called frequently and
-// the binary doesn't move.
-let cachedRgPath: string | null = null;
-function getRipgrepPath(): string {
-    if (cachedRgPath !== null) return cachedRgPath;
-
-    const platform = os.platform();
-    const rgBinaryName = platform === 'win32' ? 'rg.exe' : 'rg';
-    const isPackaged = app.isPackaged;
-
-    // Use a variable to avoid Vite trying to resolve 'node_modules' as an identifier
-    const NODE_MODULES_DIR = ['node', '_', 'modules'].join('');
-    const rgRelPath = path.join(NODE_MODULES_DIR, '@vscode', 'ripgrep', 'bin', rgBinaryName);
-
-    const possibleRgPaths: string[] = [];
-
-    if (isPackaged) {
-        const resourcesPath = process.resourcesPath;
-        possibleRgPaths.push(path.join(resourcesPath, 'app.asar.unpacked', rgRelPath));
-    } else {
-        possibleRgPaths.push(
-            path.join(__dirname, '..', '..', rgRelPath),
-            path.join(process.cwd(), rgRelPath),
-        );
-        // In monorepos, node_modules may be hoisted to the repo root.
-        // Walk up from cwd to find it.
-        let searchDir = process.cwd();
-        for (let i = 0; i < 5; i++) {
-            const parent = path.dirname(searchDir);
-            if (parent === searchDir) break; // reached filesystem root
-            possibleRgPaths.push(path.join(parent, rgRelPath));
-            searchDir = parent;
-        }
-    }
-
-    for (const testPath of possibleRgPaths) {
-        if (existsSync(testPath)) {
-            // Make sure the binary is executable in production (non-Windows)
-            if (isPackaged && platform !== 'win32') {
-                try {
-                    fs.chmodSync(testPath, 0o755);
-                } catch (e) {
-                    console.warn('[SEARCH] Could not set executable permission on ripgrep:', e);
-                }
-            }
-            // console.log('[SEARCH] Found ripgrep at:', testPath);
-            cachedRgPath = testPath;
-            return testPath;
-        }
-    }
-
-    // Fall back to system rg
-    console.warn('[SEARCH] Could not find bundled ripgrep, falling back to system rg. Probed:', possibleRgPaths);
-    cachedRgPath = 'rg';
-    return 'rg';
 }
 
 async function runRipgrepFiles(rootPath: string, options?: { noIgnore?: boolean }): Promise<string[]> {

--- a/packages/electron/src/main/services/ElectronFileSystemService.ts
+++ b/packages/electron/src/main/services/ElectronFileSystemService.ts
@@ -22,6 +22,7 @@ import type {
 import { logger } from '../utils/logger';
 import { SafePathValidator } from '../security/SafePathValidator';
 import { shouldExcludeFile, shouldExcludeDir, shouldExcludePath, GLOB_EXCLUDE_PATTERNS } from '../utils/fileFilters';
+import { getRipgrepPath } from './ripgrepPath';
 
 const execFileAsync = promisify(execFile);
 
@@ -97,7 +98,7 @@ export class ElectronFileSystemService implements FileSystemService {
         args: rgArgs
       });
 
-      const { stdout } = await execFileAsync('rg', rgArgs, {
+      const { stdout } = await execFileAsync(getRipgrepPath(), rgArgs, {
         maxBuffer: 10 * 1024 * 1024,
         timeout: 30000 // 30 second timeout
       });

--- a/packages/electron/src/main/services/__tests__/ElectronFileSystemService.test.ts
+++ b/packages/electron/src/main/services/__tests__/ElectronFileSystemService.test.ts
@@ -11,6 +11,7 @@ vi.mock('node:util', async (importOriginal) => {
   };
 });
 vi.mock('fs/promises');
+vi.mock('../ripgrepPath', () => ({ getRipgrepPath: () => '/bundled/rg' }));
 vi.mock('glob');
 vi.mock('../utils/logger', () => ({
   logger: {
@@ -98,7 +99,7 @@ describe('ElectronFileSystemService', () => {
       });
 
       expect(mockExecAsync).toHaveBeenCalledWith(
-        'rg',
+        '/bundled/rg',
         expect.arrayContaining(['-g', '*.ts']),
         expect.any(Object),
       );

--- a/packages/electron/src/main/services/ripgrepPath.ts
+++ b/packages/electron/src/main/services/ripgrepPath.ts
@@ -1,0 +1,66 @@
+/**
+ * Resolve the ripgrep binary Nimbalyst ships, for every main-process caller.
+ * Spawning a bare `'rg'` instead depends on the user having ripgrep on PATH.
+ */
+
+import { app } from 'electron';
+import fs, { existsSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Cached for the lifetime of the process — search is called frequently and the
+// binary does not move.
+let cachedRgPath: string | null = null;
+
+export function getRipgrepPath(): string {
+    if (cachedRgPath !== null) return cachedRgPath;
+
+    const platform = os.platform();
+    const rgBinaryName = platform === 'win32' ? 'rg.exe' : 'rg';
+    const isPackaged = app.isPackaged;
+
+    // Use a variable to avoid Vite trying to resolve 'node_modules' as an identifier
+    const NODE_MODULES_DIR = ['node', '_', 'modules'].join('');
+    const rgRelPath = path.join(NODE_MODULES_DIR, '@vscode', 'ripgrep', 'bin', rgBinaryName);
+
+    const possibleRgPaths: string[] = [];
+
+    if (isPackaged) {
+        const resourcesPath = process.resourcesPath;
+        possibleRgPaths.push(path.join(resourcesPath, 'app.asar.unpacked', rgRelPath));
+    } else {
+        possibleRgPaths.push(
+            path.join(__dirname, '..', '..', rgRelPath),
+            path.join(process.cwd(), rgRelPath),
+        );
+        // In monorepos, node_modules may be hoisted to the repo root.
+        // Walk up from cwd to find it.
+        let searchDir = process.cwd();
+        for (let i = 0; i < 5; i++) {
+            const parent = path.dirname(searchDir);
+            if (parent === searchDir) break; // reached filesystem root
+            possibleRgPaths.push(path.join(parent, rgRelPath));
+            searchDir = parent;
+        }
+    }
+
+    for (const testPath of possibleRgPaths) {
+        if (existsSync(testPath)) {
+            // Make sure the binary is executable in production (non-Windows)
+            if (isPackaged && platform !== 'win32') {
+                try {
+                    fs.chmodSync(testPath, 0o755);
+                } catch (e) {
+                    console.warn('[SEARCH] Could not set executable permission on ripgrep:', e);
+                }
+            }
+            cachedRgPath = testPath;
+            return testPath;
+        }
+    }
+
+    // Fall back to system rg
+    console.warn('[SEARCH] Could not find bundled ripgrep, falling back to system rg. Probed:', possibleRgPaths);
+    cachedRgPath = 'rg';
+    return 'rg';
+}


### PR DESCRIPTION
## Summary

`ElectronFileSystemService.searchFiles` spawns a bare `'rg'`, so it depends on the user having ripgrep installed globally and fails with ENOENT when they do not — even though Nimbalyst ships its own binary via `@vscode/ripgrep`, and `WorkspaceHandlers` already resolves it correctly.

That resolver was a module-private function, so the second call site could not reuse it. This extracts it to `services/ripgrepPath.ts` and uses it from both, so there is one way to find the binary rather than one correct way and one bare string.

The resolver logic itself is unchanged — packaged/dev path probing, the monorepo walk-up, the caching, and the `chmod` on non-Windows all move as-is.

## Related issue

None.

## Testing

- `ElectronFileSystemService.test.ts` — the existing ripgrep assertion now expects the resolved path rather than the bare string, and passes.
- Two failures remain in that file on Windows (`src\index.ts` vs `src/index.ts`). They are pre-existing path-separator issues unrelated to this change, and `ElectronFileSystemService` is listed among the known non-portable suites in `docs/WINDOWS_PREPUSH_GATE.md`.
- `tsc --noEmit` clean for `packages/electron`.

## Notes for reviewers

`WorkspaceHandlers.ts` loses three imports — `app` from electron, `os`, and the `fs` namespace — that were only used by the extracted function. I checked each with a grep before removing, but it is a large file and a second look is welcome.
