### PR TITLE
feat(transcript): show elapsed time while a turn is running

### DIFF
--- a/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/RichTranscriptView.tsx
@@ -25,6 +25,7 @@ import { isAppleMobileWebKit } from '../../../utils/platform';
 import { usePendingPermissionNavigation } from './usePendingPermissionNavigation';
 import { usePendingQuestionNavigation } from './usePendingQuestionNavigation';
 import { AttachmentStagingDeniedCard } from './AttachmentStagingDeniedCard';
+import { useElapsedTimeRef } from './CustomToolWidgets/useElapsedTime';
 
 // Per-session VList cache - survives component remounts so returning to a session
 // doesn't re-measure all items from scratch
@@ -1351,6 +1352,21 @@ export const RichTranscriptView = React.forwardRef<
     return false;
   }, [messages, sessionStatus, isProcessing, hasPendingInteractivePrompt, runningTeammates]);
 
+  /**
+   * Anchored to the last user message, the same anchor "Finished in ..." uses.
+   * A turn resumed without a fresh user message reads high; inherited.
+   */
+  const turnStartedAt = useMemo(() => {
+    if (!isWaitingForResponse) return undefined;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].type === 'user_message') return messages[i].createdAt?.getTime();
+    }
+    return undefined;
+  }, [isWaitingForResponse, messages]);
+
+  // Ref callback rather than state; see the hook for why.
+  const turnElapsedRef = useElapsedTimeRef(turnStartedAt);
+
   // Compute waiting indicator text — show agent/teammate count when lead is idle but agents are running
   const waitingText = useMemo(() => {
     if (!isWaitingForResponse) return '';
@@ -2503,6 +2519,13 @@ export const RichTranscriptView = React.forwardRef<
                         <div className="rich-transcript-waiting-dot w-2 h-2 rounded-full bg-[var(--nim-primary)]" />
                       </div>
                       <span className="rich-transcript-waiting-text">{waitingText}</span>
+                      {turnStartedAt !== undefined && (
+                        <span
+                          ref={turnElapsedRef}
+                          className="rich-transcript-waiting-elapsed tabular-nums not-italic text-[var(--nim-text-faint)]"
+                          data-testid="turn-elapsed"
+                        />
+                      )}
                     </div>
                   )}
               </VList>

--- a/packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.turnElapsed.test.tsx
+++ b/packages/runtime/src/ui/AgentTranscript/components/__tests__/RichTranscriptView.turnElapsed.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * The live elapsed counter beside "Thinking...".
+ *
+ * Why it exists: the Gemini/Antigravity transport returns a whole turn in one
+ * buffered call, so the transcript shows nothing at all for minutes at a time
+ * and a long turn is indistinguishable from a hung one. A real workload ran
+ * 8m6s before failing, and the reporter's read was "it looked stuck". A
+ * climbing number does not make the turn faster, it just stops it looking dead.
+ *
+ * The gating is the part worth testing: it must not appear when idle, and it
+ * must not appear when there is no message to anchor to.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TranscriptViewMessage } from '../../../../ai/server/transcript/TranscriptProjector';
+import { RichTranscriptView } from '../RichTranscriptView';
+
+vi.mock('virtua', async () => {
+  const ReactModule = await import('react');
+  return {
+    VList: ReactModule.forwardRef(({ children }: { children: React.ReactNode }, ref) => {
+      ReactModule.useImperativeHandle(ref, () => ({
+        cache: undefined,
+        scrollOffset: 0,
+        scrollSize: 300,
+        viewportSize: 100,
+        findItemIndex: () => 0,
+        scrollToIndex: vi.fn(),
+        scrollBy: vi.fn(),
+      }));
+      return <div data-testid="mock-vlist">{ReactModule.Children.toArray(children)}</div>;
+    }),
+  };
+});
+
+function makeMessage(
+  index: number,
+  overrides: Partial<TranscriptViewMessage>,
+): TranscriptViewMessage {
+  return {
+    id: index + 1,
+    sequence: index + 1,
+    createdAt: new Date(1_784_648_445_000 + index),
+    type: 'assistant_message',
+    subagentId: null,
+    ...overrides,
+  };
+}
+
+const userTurn = makeMessage(0, { type: 'user_message', text: 'do a long thing' });
+
+function view(messages: TranscriptViewMessage[], isProcessing: boolean) {
+  return (
+    <RichTranscriptView
+      sessionId="elapsed"
+      sessionStatus={isProcessing ? 'running' : 'idle'}
+      isProcessing={isProcessing}
+      messages={messages}
+      provider="antigravity-gemini-agent"
+      persistScrollState={false}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal('CSS', { highlights: { delete: vi.fn(), set: vi.fn() } });
+});
+
+describe('live turn elapsed counter', () => {
+  it('appears while a turn is in flight', () => {
+    render(view([userTurn], true));
+    expect(screen.getByTestId('turn-elapsed')).toBeTruthy();
+  });
+
+  it('does not appear when the session is idle', () => {
+    // An idle session already shows "Finished in ..." on the completed turn.
+    // A second, still-counting clock next to it would be actively misleading.
+    render(view([userTurn, makeMessage(1, { text: 'done' })], false));
+    expect(screen.queryByTestId('turn-elapsed')).toBeNull();
+  });
+
+  it('does not appear when there is no message to measure from', () => {
+    // Nothing to anchor to means any number shown would be invented.
+    render(view([], true));
+    expect(screen.queryByTestId('turn-elapsed')).toBeNull();
+  });
+
+  it('anchors to the latest user message, matching "Finished in"', () => {
+    // The number a user watches climb has to be the number they end up with,
+    // or the live and completed displays contradict each other.
+    const later = makeMessage(4, { type: 'user_message', text: 'and another' });
+    render(view([userTurn, makeMessage(1, { text: 'reply' }), later], true));
+    expect(screen.getByTestId('turn-elapsed')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

A provider whose transport returns a whole turn in one buffered call shows nothing in the transcript for the entire turn, so a long turn is indistinguishable from a hung one. This adds a live elapsed counter beside the existing "Thinking..." indicator.

It reuses what is already in the codebase rather than adding machinery:

- `useElapsedTimeRef` — the rAF-driven ref callback `BashWidget` and `FileChangeWidget` already use. Its docblock explains why setState/setInterval is the wrong shape here, and that applies with more force to a virtualised transcript ticking for the length of a turn.
- The same last-user-message anchor the completed "Finished in ..." line uses, so the number a user watches climb is the number they end up with rather than two clocks that disagree.

Renderer-only: no IPC, no new atom, no provider change.

## Related issue

None.

## Testing

`RichTranscriptView.turnElapsed.test.tsx` — 4 cases: appears while a turn is in flight; absent when the session is idle; absent when there is no message to measure from; anchors to the latest user message when several exist.

## Notes for reviewers

The gating is the part worth checking. A turn resumed without a fresh user message — a queued prompt, or a send from mobile — anchors to an older message and reads high. That is inherited from how "Finished in" already behaves rather than introduced here, but it is a real edge case.

The alternative anchor, `max(lastUserMessage, lastAssistantMessage)`, would reset the counter on each tool call. That reads as "time in this step" rather than "time in this turn"; I chose continuity with the completed display instead, but I can switch it if the other reading is preferred.
