### PR TITLE
fix(typeahead): rank slash commands by match quality before name

### DIFF
--- a/packages/electron/src/renderer/components/Typeahead/__tests__/slashCommandAutocomplete.test.ts
+++ b/packages/electron/src/renderer/components/Typeahead/__tests__/slashCommandAutocomplete.test.ts
@@ -3,22 +3,40 @@ import { describe, expect, it } from 'vitest';
 import { buildSlashCommandOptions, supportsWorkspaceSlashCommands, type SlashCommandEntry } from '../slashCommandAutocomplete';
 
 describe('buildSlashCommandOptions', () => {
-  it('sorts search matches alphabetically regardless of incoming order or match score', () => {
-    const commands: SlashCommandEntry[] = [
-      { name: 'investigate-performance', source: 'project' },
-      { name: 'investigate', source: 'user', argumentHint: '<problem>' },
-      { name: 'debug-investigate', source: 'plugin' },
-      { name: 'review', source: 'builtin' },
-    ];
+  const commands: SlashCommandEntry[] = [
+    { name: 'investigate-performance', source: 'project' },
+    { name: 'investigate', source: 'user', argumentHint: '<problem>' },
+    { name: 'debug-investigate', source: 'plugin' },
+    { name: 'review', source: 'builtin' },
+  ];
 
-    for (const query of ['inv', 'INV', 'investigate']) {
-      expect(buildSlashCommandOptions(commands, query, 'commands').map(option => option.id)).toEqual([
-        'debug-investigate',
-        'investigate',
-        'investigate-performance',
-      ]);
+  const ids = (query: string) => buildSlashCommandOptions(commands, query, 'commands').map(option => option.id);
+
+  it('ranks the exact name first, then prefix matches, then other matches', () => {
+    expect(ids('investigate')).toEqual(['investigate', 'investigate-performance', 'debug-investigate']);
+  });
+
+  it('ranks prefix matches above word-boundary matches regardless of incoming order or case', () => {
+    for (const query of ['inv', 'INV']) {
+      expect(ids(query)).toEqual(['investigate', 'investigate-performance', 'debug-investigate']);
     }
     expect(commands[0].name).toBe('investigate-performance');
+  });
+
+  it('does not let an alphabetically earlier substring match outrank the typed name', () => {
+    const entries: SlashCommandEntry[] = [
+      { name: 'autocompact', source: 'builtin' },
+      { name: 'compact', source: 'builtin' },
+    ];
+    expect(buildSlashCommandOptions(entries, 'compact', 'commands').map(option => option.id)).toEqual([
+      'compact',
+      'autocompact',
+    ]);
+  });
+
+  it('sorts alphabetically within a tier and for an empty query', () => {
+    expect(ids('')).toEqual(['debug-investigate', 'investigate', 'investigate-performance', 'review']);
+    expect(ids('i')).toEqual(['investigate', 'investigate-performance', 'debug-investigate', 'review']);
   });
 });
 

--- a/packages/electron/src/renderer/components/Typeahead/slashCommandAutocomplete.ts
+++ b/packages/electron/src/renderer/components/Typeahead/slashCommandAutocomplete.ts
@@ -125,9 +125,12 @@ export function buildSlashCommandOptions(
       score: scoreCommand(command.name, query),
     }))
     .filter(({ score }) => score > 0)
-    .sort((a, b) => hasQuery
-      ? a.command.name.localeCompare(b.command.name, undefined, { sensitivity: 'base' })
-      : b.score - a.score)
+    // Best match first (exact > prefix > word boundary > substring), alphabetical
+    // within a tier. Sorting purely by name let an alphabetically earlier substring
+    // match (/autocompact) outrank the exact name the user typed (/compact).
+    .sort((a, b) =>
+      b.score - a.score
+      || a.command.name.localeCompare(b.command.name, undefined, { sensitivity: 'base' }))
     .map(({ command }) => ({
       id: command.name,
       label: command.argumentHint


### PR DESCRIPTION
## Summary

Typing the exact name of a slash command left a *different* command highlighted at the top of the typeahead, so Enter/Tab committed the wrong one: `/compact` put `/autocompact` first because `a` sorts before `c`. `buildSlashCommandOptions` scores every candidate (exact 100, prefix 80, word boundary 60, substring 40) but, as soon as a query was present, ordered purely by name and used the score only to decide *whether* an entry appears.

The list is now sorted by score first and alphabetically within a tier. The alphabetical order introduced by cdbfb9a9 (NIM-5718) is preserved among equally good matches and for the empty query, where every command scores the same, so that fix's intent survives; only the ranking across tiers changes.

## Related issue

Closes #1494

## Testing

```
npx vitest run packages/electron/src/renderer/components/Typeahead/__tests__/slashCommandAutocomplete.test.ts
# 7 passed
npx eslint src/renderer/components/Typeahead/slashCommandAutocomplete.ts src/renderer/components/Typeahead/__tests__/slashCommandAutocomplete.test.ts   # in packages/electron, clean
```

The existing test asserted the regression (exact query `investigate` returning `debug-investigate` first); it is replaced by four cases: exact name first (`investigate`, then the prefix match, then the word-boundary match), prefix above word-boundary for `inv`/`INV` without mutating the input order, the issue's `/compact` vs `/autocompact` case, and alphabetical order within a tier and for the empty query.

## Notes for reviewers

Commit is DCO-signed and SSH-signed. If the intent of NIM-5718 was strictly alphabetical results even across tiers, an alternative would be to pin only the exact match to the top; I went with score-then-name because it also fixes `/comp` vs `/autocompact`.
