### PR TITLE
docs: give the AppImage AppArmor profile its own name

### DIFF
--- a/docs/LINUX_INSTALL.md
+++ b/docs/LINUX_INSTALL.md
@@ -37,26 +37,35 @@ These releases set `kernel.apparmor_restrict_unprivileged_userns=1`, which stops
 
 **The simplest fix is to install the `.deb` instead** — it is unaffected.
 
-To stay on the AppImage, grant it the one permission it needs. Create `/etc/apparmor.d/nimbalyst`, replacing the path with wherever you keep the AppImage:
+To stay on the AppImage, grant it the one permission it needs. Create `/etc/apparmor.d/nimbalyst-appimage`, replacing the path with wherever you keep the AppImage:
 
 ```
 abi <abi/4.0>,
 include <tunables/global>
 
-profile nimbalyst /home/YOUR_USER/Applications/Nimbalyst-Linux.AppImage flags=(unconfined) {
+profile nimbalyst-appimage /home/YOUR_USER/Applications/Nimbalyst-Linux.AppImage flags=(unconfined) {
   userns,
 
-  include if exists <local/nimbalyst>
+  include if exists <local/nimbalyst-appimage>
 }
 ```
 
 Load it:
 
 ```bash
-sudo apparmor_parser -r /etc/apparmor.d/nimbalyst
+sudo apparmor_parser -r /etc/apparmor.d/nimbalyst-appimage
 ```
 
 The AppImage now starts, with the Chromium sandbox still on. The profile is scoped to that one path, so the rest of the system hardening is untouched. If you move or rename the AppImage, update the path in the profile and reload it.
+
+Keep the `nimbalyst-appimage` name. The `.deb` installs its own profile at `/etc/apparmor.d/nimbalyst`: installing the package overwrites that file, removing it deletes the file, and loading a profile replaces any loaded profile with the same name. With a name of its own, the AppImage profile survives the `.deb` on the same machine.
+
+If you followed an earlier version of this page, check `/etc/apparmor.d/nimbalyst`. If it names your AppImage path, it is the old profile: unload and delete it. If it names `/opt/Nimbalyst/nimbalyst`, it belongs to the `.deb`, so leave it alone.
+
+```bash
+sudo apparmor_parser -R /etc/apparmor.d/nimbalyst
+sudo rm /etc/apparmor.d/nimbalyst
+```
 
 Do not use `--no-sandbox` to work around this. It starts the app by turning off the renderer sandbox, which is the protection the error is about.
 


### PR DESCRIPTION
The page tells AppImage users to create `/etc/apparmor.d/nimbalyst`. The `.deb` writes its own profile on that exact path with `cp -f`, under the same profile name, and its postrm deletes the file (app-builder-lib 26.15.3, `templates/linux/after-install.tpl` and `after-remove.tpl`). So since the 0.76.3, installing or removing the `.deb` takes the AppImage profile away without a word, and the AppImage stops starting with the error this page is about. I flagged it in https://github.com/nimbalyst/nimbalyst/issues/1430#issuecomment-5540564807 before the issue was closed.

This renames the documented profile to `nimbalyst-appimage`, the file and the profile name both, since loading a profile replaces any loaded one with the same name. It also adds a short note for people who followed the earlier version, so they remove the old file only when it is theirs and not the `.deb` one.

Testing : the new profile passes `apparmor_parser --skip-kernel-load --debug` (AppArmor 4.0.1), the dry run the postinst itself uses. On Ubuntu 26.04 I ran this exact split, AppImage and `.deb` side by side, and both started with the sandbox on. I also checked that loading a second profile under the same name replaces the first one in the kernel.

Docs only, no CHANGELOG entry.
