### PR TITLE
fix(codex): preserve Streamable HTTP MCP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Bug fixes go here -->
 - Accepting large document rewrites preserves paragraph order, and rejecting them restores the original formatting.
 - The GitHub panel no longer shows an unrelated AI session when the selected PR or issue has no matching session.
+- Codex sessions preserve Streamable HTTP MCP servers instead of merging them into invalid stdio configurations.
 - Open files recover from missed disk changes without reloading the app, preserve unsaved edits, and refuse saves when the disk version cannot be verified.
 - Slash-command search ranks exact matches first, then prefixes, with alphabetical ordering among equally relevant matches.
 - SQLite migrations retain progress across navigation, verify the switch after restart, and preserve recovery copies when history rows cannot be copied.

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -2141,14 +2141,26 @@ app.whenReady().then(async () => {
         const enabledServers: Record<string, any> = {};
         for (const [name, config] of Object.entries(allServers)) {
             if (isMCPServerEnabledForProvider(config as MCPServerConfig, MCP_PROVIDER_IDS.CODEX)) {
+                // Codex speaks Streamable HTTP natively. Rewriting a server that is
+                // also present in ~/.codex/config.toml to an mcp-remote stdio entry
+                // makes Codex deep-merge `command` with the persisted `url`, which
+                // is an invalid mixed-transport configuration.
+                const codexHttp = await mcpConfigService.resolveMcpRemoteOptions(
+                    config as MCPServerConfig,
+                    { nativeHttpSupported: true }
+                );
                 const isAuthorized = await mcpConfigService.isOAuthAuthorized(config as MCPServerConfig, {
+                    ...codexHttp,
                     useMcpRemoteForNativeOAuth: true,
                 });
                 if (!isAuthorized) {
                     logger.mcp.info(`[MCP] Skipping unauthorized OAuth server for Codex: ${name}`);
                     continue;
                 }
-                enabledServers[name] = mcpConfigService.processServerConfigForRuntime(config as any);
+                enabledServers[name] = mcpConfigService.processServerConfigForRuntime(
+                    config as MCPServerConfig,
+                    codexHttp
+                );
             }
         }
         return enabledServers;

--- a/packages/electron/src/main/services/__tests__/mcpRemoteRequirement.test.ts
+++ b/packages/electron/src/main/services/__tests__/mcpRemoteRequirement.test.ts
@@ -36,8 +36,7 @@ describe('requiresMcpRemote', () => {
   });
 
   it('DOES require the wrapper when the CLI has no native HTTP transport', () => {
-    // Codex, Codex ACP and Copilot go through the same code path and were never
-    // verified. They keep the wrapper until someone measures them.
+    // Unknown/non-native callers keep the compatibility wrapper.
     const config = http({ headers: { Authorization: 'Bearer ghp_static' } });
     expect(requiresMcpRemote(config, { nativeHttpSupported: false })).toBe(true);
   });
@@ -93,10 +92,8 @@ describe('requiresMcpRemote', () => {
 });
 
 describe('Codex and Claude Code reach the same credential (NIM-2433)', () => {
-  // The regression guard. These two paths drifted apart once already: Codex wraps
-  // everything, Claude Code takes the native-HTTP shortcut, and a server whose
-  // only credential was a cached mcp-remote token went out bare on the Claude
-  // side and 401'd. Assert the OUTCOME matches, not the branch taken.
+  // Both CLIs speak Streamable HTTP natively. A server whose only credential is
+  // a cached mcp-remote token must still use the wrapper on both paths.
   const service = new MCPConfigService();
   let authDir: string;
 
@@ -142,7 +139,7 @@ describe('Codex and Claude Code reach the same credential (NIM-2433)', () => {
     const config = http();
     await writeCachedToken(config.url!);
 
-    const codex = await credentialSource(config, {});
+    const codex = await credentialSource(config, { nativeHttpSupported: true });
     const claudeCode = await credentialSource(config, { nativeHttpSupported: true });
 
     expect(claudeCode).toBe(codex);
@@ -157,17 +154,31 @@ describe('Codex and Claude Code reach the same credential (NIM-2433)', () => {
     await expect(credentialSource(config, { nativeHttpSupported: true }))
       .resolves.toBe('declared-config-only');
   });
+
+  it('preserves a Codex static-header server as Streamable HTTP', async () => {
+    // Regression: wrapping this as stdio and overlaying it on the same server in
+    // ~/.codex/config.toml leaves both `command` and `url`, which Codex rejects
+    // with "url is not supported for stdio" during thread/start.
+    const config = http({ headers: { Authorization: 'Key test-token' } });
+    const options = await resolveMcpRemoteRequirementOptions(config, {
+      nativeHttpSupported: true,
+    });
+
+    const runtime = service.processServerConfigForRuntime(config, options);
+
+    expect(runtime).toEqual(config);
+    expect(runtime.command).toBeUndefined();
+  });
 });
 
 describe('MCPConfigService.isOAuthAuthorized', () => {
   const service = new MCPConfigService();
 
   it('still probes mcp-remote for a native-OAuth server when the caller opted into the wrapper', async () => {
-    // Codex, Codex ACP and Copilot pass useMcpRemoteForNativeOAuth, meaning "wrap
-    // native-OAuth servers with mcp-remote". requiresMcpRemote answers "no wrapper"
-    // for anything carrying OAuth credentials, so skipping the probe on its say-so
-    // reported every such server authorized and stopped those providers dropping
-    // the unauthorized ones.
+    // Codex, Codex ACP and Copilot pass useMcpRemoteForNativeOAuth so the
+    // authorization gate still checks mcp-remote's credential state. Skipping
+    // the probe reported every such server authorized and stopped those
+    // providers dropping the unauthorized ones.
     checkMcpRemoteAuthStatus.mockResolvedValueOnce({ authorized: false });
 
     const config = http({ oauth: { clientId: 'abc' } } as Partial<MCPServerConfig>);

--- a/packages/electron/src/main/services/mcpRemoteRequirement.ts
+++ b/packages/electron/src/main/services/mcpRemoteRequirement.ts
@@ -17,10 +17,9 @@
  *   - servers answering 401 to an OAuth probe are classified as unauthorized and
  *     silently dropped, so they never reach the CLI at all
  *
- * `nativeHttpSupported` is deliberately opt-in per caller. Claude Code was
- * verified by A/B test (same PAT, identical prompt, identical tool results and
- * org access, four fewer processes). Codex, Codex ACP and Copilot share this code
- * path and have NOT been verified, so they keep the wrapper until they are.
+ * `nativeHttpSupported` is deliberately opt-in per caller. Claude Code and Codex
+ * have both been verified with their native Streamable HTTP transports. Unknown
+ * callers keep the wrapper until their transport support is verified.
  *
  * The declared config alone is NOT a sufficient discriminator (NIM-2433). A
  * server that was authorized through mcp-remote keeps its token in `~/.mcp-auth`

--- a/packages/runtime/src/ai/server/protocols/__tests__/codexConfigError.test.ts
+++ b/packages/runtime/src/ai/server/protocols/__tests__/codexConfigError.test.ts
@@ -10,17 +10,18 @@ describe('describeCodexConfigError', () => {
     expect(msg).not.toBeNull();
     expect(msg).toContain('"linear"');
     expect(msg).toContain('[mcp_servers.linear]');
-    expect(msg).toContain('mcp-remote');
-    expect(msg).toContain('Personal API Key');
-    expect(msg).toContain('LINEAR_API_KEY');
+    expect(msg).toContain('mixed transport');
+    expect(msg).toContain('url = "<url>"');
+    expect(msg).toContain('command = "<command>"');
   });
 
-  it('derives the env var name from the server name', () => {
+  it('shows mutually exclusive HTTP and stdio shapes', () => {
     const msg = describeCodexConfigError(
       'Error loading config.toml: url is not supported for stdio in mcp_servers.my-server'
     );
     expect(msg).toContain('[mcp_servers.my-server]');
-    expect(msg).toContain('MY_SERVER_API_KEY');
+    expect(msg).toContain('Streamable HTTP');
+    expect(msg).toContain('local stdio');
   });
 
   it('quotes the TOML table key when the server name contains a dot', () => {
@@ -28,8 +29,6 @@ describe('describeCodexConfigError', () => {
       'Error loading config.toml: url is not supported for stdio in mcp_servers.customer.io'
     );
     expect(msg).toContain('[mcp_servers."customer.io"]');
-    expect(msg).toContain('[mcp_servers."customer.io".env]');
-    expect(msg).toContain('CUSTOMER_IO_API_KEY');
   });
 
   it('returns null for unrelated or empty errors', () => {

--- a/packages/runtime/src/ai/server/protocols/codexConfigError.ts
+++ b/packages/runtime/src/ai/server/protocols/codexConfigError.ts
@@ -1,9 +1,8 @@
 /**
- * When Codex fails to load `config.toml` because an MCP server entry uses a
- * remote `url` that the bundled Codex build does not accept (older builds only
- * support stdio MCP servers), the raw error is opaque: "url is not supported for
- * stdio in mcp_servers.<name>". Detect that case and return actionable guidance
- * that names the offending server and shows how to convert it to a stdio entry.
+ * When Codex resolves an MCP server as stdio but the merged configuration still
+ * contains a remote `url`, the raw error does not explain that two transports
+ * were combined. Detect that case and show valid, mutually exclusive HTTP and
+ * stdio shapes.
  *
  * Returns null when the error is not a recognized url-vs-stdio MCP config error,
  * so callers can fall back to the raw message.
@@ -18,21 +17,16 @@ export function describeCodexConfigError(raw: string): string | null {
   // TOML bare keys allow only [A-Za-z0-9_-]. A name with any other character
   // (e.g. a dot) must be quoted, or `[mcp_servers.a.b]` parses as nested tables.
   const tomlKey = /^[A-Za-z0-9_-]+$/.test(name) ? name : JSON.stringify(name);
-  const envKey = `${name.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}_API_KEY`;
-
   return [
-    `The MCP server "${name}" in ~/.codex/config.toml uses a "url", which this Codex build does not support (it only launches stdio MCP servers via a "command"). Convert that entry, then restart.`,
+    `The MCP server "${name}" resolved to a mixed transport configuration containing both a stdio "command" and a remote "url". Keep exactly one transport, then restart.`,
     ``,
-    `Universal fix - wrap the remote server as a stdio process:`,
+    `For a Streamable HTTP server:`,
     `     [mcp_servers.${tomlKey}]`,
-    `     command = "npx"`,
-    `     args = ["-y", "mcp-remote", "<url>"]`,
+    `     url = "<url>"`,
     ``,
-    `If you run a local stdio build of this server (for example, a Personal API Key version that avoids OAuth token expiry), point Codex at it instead:`,
+    `For a local stdio server:`,
     `     [mcp_servers.${tomlKey}]`,
-    `     command = "python"`,
-    `     args = ["/path/to/${name}-server.py"]`,
-    `     [mcp_servers.${tomlKey}.env]`,
-    `     ${envKey} = "<your key>"`,
+    `     command = "<command>"`,
+    `     args = ["<arg>"]`,
   ].join('\n');
 }


### PR DESCRIPTION
## Summary

Preserves Streamable HTTP MCP servers when starting Codex sessions instead of rewriting them as stdio overrides that conflict with `~/.codex/config.toml`.

Updates the related error guidance to explain mixed transport configurations.

## Related issue

Closes #1503

## Testing

- Focused regression and provider tests: 67 passed, 1 skipped
- Final focused regression tests: 19 passed
- Pre-push typecheck: passed across all 26 workspaces
- Bundled Codex 0.153.1 reproduction: the previous stdio overlay returns RPC error -32600; the native HTTP overlay creates the thread

The full Vitest suite was also run on Windows. It reported 208 unrelated failures involving Windows symlink permissions, directory fsync, Unix path expectations, locale-dependent assertions, and existing test errors.

## Notes for reviewers

The main behavior to review is that static-header URL servers remain Streamable HTTP through the Codex loader, while servers backed by a cached mcp-remote OAuth token retain the compatibility wrapper.