### PR TITLE
fix(settings): refuse a feature tag this build does not register

### DIFF
--- a/packages/electron/src/main/services/SettingsControlService.ts
+++ b/packages/electron/src/main/services/SettingsControlService.ts
@@ -52,6 +52,9 @@ import {
   stopExtensionBackendModules,
   getDefaultBackendModuleLifecycleDeps,
 } from '../extensions/backendModuleLifecycle';
+import { ALPHA_FEATURES } from '../../shared/alphaFeatures';
+import { BETA_FEATURES } from '../../shared/betaFeatures';
+import { DEVELOPER_FEATURES } from '../../shared/developerFeatures';
 import { FeatureUsageService, FEATURES } from './FeatureUsageService';
 import { SessionNamingService } from './SessionNamingService';
 import { setTrackerIssueKeyPrefix } from './TrackerSyncManager';
@@ -128,6 +131,23 @@ function rateLimit(sessionId: string): void {
     );
   }
 }
+
+// ─── Feature buckets ────────────────────────────────────────────────
+
+/**
+ * The three feature buckets: which app-store key each one writes, and the
+ * registry that decides which tags exist in this build. Keeping the key and
+ * the registry together is what stops an unknown bucket from falling through
+ * into `developerFeatures`.
+ */
+const FEATURE_BUCKETS = {
+  alpha: { key: 'alphaFeatures', registry: ALPHA_FEATURES },
+  beta: { key: 'betaFeatures', registry: BETA_FEATURES },
+  developer: { key: 'developerFeatures', registry: DEVELOPER_FEATURES },
+} as const satisfies Record<
+  string,
+  { key: (typeof ALLOWED_APP_KEYS)[number]; registry: readonly { tag: string }[] }
+>;
 
 // ─── Result type ─────────────────────────────────────────────────────
 
@@ -497,12 +517,33 @@ export class SettingsControlService {
   ): Promise<SettingsToolResult<boolean | undefined, boolean>> {
     rateLimit(sessionId);
     const { bucket, tag, enabled } = args;
-    const key =
-      bucket === 'alpha'
-        ? 'alphaFeatures'
-        : bucket === 'beta'
-          ? 'betaFeatures'
-          : 'developerFeatures';
+    // `tag` arrives as a free-form string from the MCP tool schema, and a flag
+    // only does anything if this build registers it. Writing an unregistered
+    // tag used to succeed: the key was persisted, Settings showed the feature
+    // as enabled, and nothing ever read it -- indistinguishable from a feature
+    // that is broken (#1501). `bucket` is unvalidated too, and every value
+    // other than 'alpha'/'beta' silently landed in `developerFeatures`.
+    const definition = FEATURE_BUCKETS[bucket];
+    if (!definition) {
+      return {
+        ok: false,
+        message: `Unknown feature bucket "${bucket}". Use alpha, beta, or developer.`,
+      };
+    }
+    const { key, registry } = definition;
+    // Checked before the Developer Mode gate on purpose: an unregistered tag
+    // can never be toggled, so answering requiresUserAction first would ask
+    // the user to turn on Developer Mode for a flag that does not exist.
+    if (!registry.some((feature) => feature.tag === tag)) {
+      const known = registry.map((feature) => feature.tag);
+      return {
+        ok: false,
+        message:
+          known.length > 0
+            ? `Unknown ${bucket} feature "${tag}". This build registers: ${known.join(', ')}.`
+            : `Unknown ${bucket} feature "${tag}". This build registers no ${bucket} features.`,
+      };
+    }
 
     if (bucket !== 'beta') {
       const devMode = getAppSetting<boolean>('developerMode') ?? false;

--- a/packages/electron/src/main/services/__tests__/SettingsControlService.test.ts
+++ b/packages/electron/src/main/services/__tests__/SettingsControlService.test.ts
@@ -79,6 +79,9 @@ vi.mock('../../extensions/backendModuleLifecycle', () => ({
   getDefaultBackendModuleLifecycleDeps: vi.fn(() => ({})),
 }));
 
+import { ALPHA_FEATURES } from '../../../shared/alphaFeatures';
+import { DEVELOPER_FEATURES } from '../../../shared/developerFeatures';
+import { getAppSetting, setAppSetting } from '../../utils/store';
 import {
   ALLOWED_APP_KEYS,
   ALLOWED_WORKSPACE_KEYS,
@@ -179,5 +182,93 @@ describe('SettingsControlService.setIssueKeyPrefix', () => {
       ok: false,
       message: 'Prefix NIM is already used by project "Nimbalyst Core". Try NIMA.',
     });
+  });
+});
+
+describe('SettingsControlService.toggleFeature', () => {
+  // Developer Mode on, so the gate is never what a failure below is about.
+  function developerModeOn() {
+    vi.mocked(getAppSetting).mockImplementation((key: string) =>
+      key === 'developerMode' ? (true as never) : (undefined as never),
+    );
+  }
+
+  it('refuses a tag this build does not register instead of writing a dead key', async () => {
+    // #1501: `alphaFeatures.session-fleet: true` was persisted and shown as
+    // enabled, while no such feature exists -- so the flag "had no effect".
+    developerModeOn();
+    vi.mocked(setAppSetting).mockClear();
+
+    const result = await SettingsControlService.getInstance().toggleFeature('session-unknown-tag', {
+      bucket: 'alpha',
+      tag: 'session-fleet',
+      enabled: true,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('session-fleet');
+    // The caller is told what it could have asked for.
+    for (const feature of ALPHA_FEATURES) {
+      expect(result.message).toContain(feature.tag);
+    }
+    expect(setAppSetting).not.toHaveBeenCalled();
+  });
+
+  it('still toggles every registered tag', async () => {
+    developerModeOn();
+
+    for (const [bucket, registry, key] of [
+      ['alpha', ALPHA_FEATURES, 'alphaFeatures'],
+      ['developer', DEVELOPER_FEATURES, 'developerFeatures'],
+    ] as const) {
+      for (const feature of registry) {
+        vi.mocked(setAppSetting).mockClear();
+        const result = await SettingsControlService.getInstance().toggleFeature(
+          `session-${bucket}-${feature.tag}`,
+          { bucket, tag: feature.tag, enabled: true },
+        );
+
+        expect(result, `${bucket}/${feature.tag} must remain toggleable`).toMatchObject({
+          ok: true,
+          after: true,
+        });
+        expect(setAppSetting).toHaveBeenCalledWith(key, { [feature.tag]: true });
+      }
+    }
+  });
+
+  it('rejects an unknown bucket rather than writing it into developerFeatures', async () => {
+    developerModeOn();
+    vi.mocked(setAppSetting).mockClear();
+
+    const result = await SettingsControlService.getInstance().toggleFeature('session-bad-bucket', {
+      // The MCP tool schema declares an enum but nothing enforces it at runtime,
+      // and the old key fallback made every unknown bucket a developer write.
+      bucket: 'gamma' as 'alpha',
+      tag: 'worktrees',
+      enabled: true,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('gamma');
+    expect(setAppSetting).not.toHaveBeenCalled();
+  });
+
+  it('reports the missing tag before asking the user for Developer Mode', async () => {
+    // Developer Mode off: an unregistered tag can never be toggled, so sending
+    // the user to Settings > Advanced first would be a dead end.
+    vi.mocked(getAppSetting).mockImplementation(() => undefined as never);
+    vi.mocked(setAppSetting).mockClear();
+
+    const result = await SettingsControlService.getInstance().toggleFeature('session-no-devmode', {
+      bucket: 'alpha',
+      tag: 'session-fleet',
+      enabled: true,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.requiresUserAction).toBeUndefined();
+    expect(result.message).toContain('session-fleet');
+    expect(setAppSetting).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #1501.

## What the reporter saw, and why

`session-fleet` is not a registered feature. `git log -S "session-fleet" --all` finds nothing in this repository, and `ALPHA_FEATURES` (`packages/electron/src/shared/alphaFeatures.ts:28-49`) contains only `super-loops`, `blitz` and `meta-agent` — on the same `0.77.5` the report was filed against.

The reason the flag nevertheless showed up as `alphaFeatures.session-fleet: true` is `SettingsControlService.toggleFeature`:

```ts
const current = (getAppSetting<Record<string, boolean>>(key) ?? {}) as Record<string, boolean>;
const before = current[tag];
const next = { ...current, [tag]: enabled };
setAppSetting(key, next);
return { ok: true, before, after: enabled };
```

`tag` is a free-form `{ "type": "string" }` in the `features_toggle` MCP tool schema (`packages/electron/src/main/mcp/settingsServer.ts:166-178`), so any string was accepted, persisted, reported as `ok: true`, and then read by nobody. From the outside that is identical to a feature that exists and is broken — which is exactly the report ("confirmed present in settings … nothing appears at any point"). So there is no dynamic-island bug here to fix; there is a settings write that should not have succeeded.

`validateAlphaFeatureTags` has existed in `alphaFeatures.ts:80` for this purpose the whole time and is called from nowhere.

## Second defect on the same path

`bucket` was unvalidated too:

```ts
const key = bucket === 'alpha' ? 'alphaFeatures' : bucket === 'beta' ? 'betaFeatures' : 'developerFeatures';
```

The tool schema declares `enum: ["alpha", "beta", "developer"]`, but nothing enforces it at the call site (`settingsServer.ts:330-337` forwards `args.bucket` as-is), so `bucket: "gamma"` wrote into `developerFeatures`.

## The change

One table pairs each bucket's app-store key with the registry that decides which tags exist in this build, and `toggleFeature` resolves both from it. An unknown bucket or tag returns `ok: false` with a message naming the valid options, and nothing is written.

Ordering choice worth a reviewer's eye: **the tag is checked before the Developer Mode gate.** An unregistered tag can never be toggled, so answering `requiresUserAction: 'developer-mode'` first would ask the user to turn on Developer Mode for a flag that does not exist. Flipping the two lines is all it takes if you prefer the gate to come first.

`BETA_FEATURES` is currently empty, so every beta tag is now refused with "This build registers no beta features." That is the truthful answer — there is nothing to toggle — but it does mean the beta branch of this tool always fails until a beta feature is registered.

## Tests

`packages/electron/src/main/services/__tests__/SettingsControlService.test.ts`, four cases:

- the reporter's exact call (`bucket: 'alpha'`, `tag: 'session-fleet'`) returns `ok: false`, names every registered alpha tag, and never calls `setAppSetting`
- every tag in `ALPHA_FEATURES` and `DEVELOPER_FEATURES` still toggles and still writes its own bucket's key — iterated from the registries, so a feature added later is covered without touching this test
- `bucket: 'gamma'` is refused instead of writing `developerFeatures`
- with Developer Mode off, an unregistered tag reports the missing tag and **not** `requiresUserAction`

Verification: `vitest run src/main/services/__tests__/SettingsControlService.test.ts` → 11 passed. Negative control — reverting only `SettingsControlService.ts` and keeping the tests → 3 failed, 8 passed, and the "still toggles every registered tag" case passes in both states, which is what makes it a regression control rather than a restatement of the fix. `tsc --noEmit` clean for `packages/electron`.

## Left alone

Whether a session fleet should exist in the dynamic island is a product question, so this PR does not add the feature; `FleetActivitySnapshot` in `packages/collab-protocol/src/personal.ts:344-391` is the phone Live Activity, not a desktop surface. If `session-fleet` is planned, registering it in `ALPHA_FEATURES` is the separate change — and with this PR the flag can no longer be turned on before that happens.
